### PR TITLE
DOC-4064: Removed eventing-function-export page

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -122,7 +122,6 @@
  ** xref:eventing:eventing-Terminologies.adoc[Terminology]
  ** xref:eventing:eventing-language-constructs.adoc[Language Constructs]
  ** xref:eventing:eventing-adding-function.adoc[Adding a Couchbase Function]
- ** xref:eventing:eventing-function-export.adoc[Exporting Functions]
  ** xref:eventing:eventing-examples.adoc[Examples: Using the Eventing Service]
  ** xref:eventing:eventing-debugging-and-diagnosability.adoc[Debugging and Diagnosability]
  ** xref:eventing:eventing-statistics.adoc[Statistics]


### PR DESCRIPTION
DOC-4064: Removing eventing-function-export page 