### PR TITLE
Remove reference and broken link to 4.5 DP Doc page

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -30,9 +30,6 @@ The following error is reported if a second index creation operation is kicked o
 
 You can create multiple identical secondary indexes on a bucket for better index availability and place them on separate nodes using the "nodes" clause.
 
-NOTE: Couchbase Server 4.5 Developer Preview release adds the capability to create global indexes on array elements and optimizes the execution of queries involving array elements.
-See http://developer.couchbase.com/documentation/server/4.5-dp/indexing-arrays.html[Array Indexing^] for details.
-
 _create-index:_
 
 ----


### PR DESCRIPTION
This reference to 4.5 Developer Preview is outdated and doesn't have benefit in the 4.1 Docs.