### PR TITLE
DOC-4142: Instructions to initialize Analytics service

### DIFF
--- a/modules/install/pages/init-setup.adoc
+++ b/modules/install/pages/init-setup.adoc
@@ -107,10 +107,10 @@ For production environments, it is recommended that database files and indexes _
 You can enter more than one location to store Analytics data.
 Click btn:[+] to specify an additional location for Analytics data, or click btn:[-] to remove a location.
 
-* [.ui]*Java Runtime Path*: If desired, enter the location for an alternate Java Runtime Environment (JRE) on the current node that you want to use for the Analytics Service.
+* [.ui]*Java Runtime Path*: If desired, enter the location for an alternative Java Runtime Environment (JRE) on the current node that you want to use for the Analytics Service.
 +
 Couchbase Server is supplied with the Oracle Java 8 JRE.
-If you don't specify a location for an alternate JRE, the supplied JRE is used by default.
+If you don't specify a location for an alternative JRE, the supplied JRE is used by default.
 
 * [.ui]*Service Memory Quotas*: Select the Couchbase xref:learn:services-and-indexes/services/services.adoc[Services] that you want enabled on the current node, and specify how much memory should be allocated to each of those services.
 +
@@ -250,26 +250,65 @@ Once the [.ui]*Dashboard* screen appears, the new node has been successfully add
 
 Rather than using the Couchbase Web Console, you may elect to initialize your Couchbase cluster by means of the Couchbase Command Line Interface (CLI).
 
-The following CLI syntax can be used for the initial set-up of a single-node Couchbase Server cluster.
-It allows the establishing of administrative credentials, and of port number.
-It adds all services; sets separate RAM quotas for Data, Index, Search, Eventing, and Analytics services, and sets the Index Storage Setting (the default being to support memory-optimized global indexes):
+First you must use the xref:cli:cbcli/couchbase-cli-node-init.adoc[node-init] command to initialize the first node in the cluster.
+The following CLI syntax sets the locations where data files for each service will be stored on the node, sets the location of an alternative JRE on the node, and specifies the hostname that the cluster will use for this node.
 
-[source,bash]
+[source,bash,subs=+quotes]
 ----
-couchbase-cli cluster-init OPTIONS:
-  --cluster-username=USER                     // new admin username
-  --cluster-password=PASSWORD                 // new admin password
-  --cluster-port=PORT                         // new cluster REST/http port
-  --services=data,index,query,fts,analytics   // services that server runs
-  --cluster-ramsize=RAMSIZEMB           // per node data service ram quota in MB
-  --cluster-index-ramsize=RAMSIZEMB     // per node index service ram quota in MB
-  --cluster-fts-ramsize=RAMSIZEMB       // per node fts service ram quota in MB
-  --cluster-eventing-ramsize=RAMSIZEMB  // per node eventing ram quota in MB
-  --cluster-analytics-ramsize=RAMSIZEMB // per node analytics ram quota in MB
-  --index-storage-setting=SETTING       // index storage type [default, memopt]
+couchbase-cli node-init
+    --cluster [.var]_url_ <1>
+    --username [.var]_user_ <2>
+    --password [.var]_password_ <3>
+    --node-init-data-path [.var]_path_ <4>
+    --node-init-index-path [.var]_path_ <5>
+    --node-init-analytics-path [.var]_path_ <6>
+    --node-init-hostname [.var]_hostname_ <7>
+    --node-init-java-home [.var]_path_ <8>
+----
+<1> Hostname of first node in cluster.
+<2> User executing the command.
+<3> Password of user executing the command.
+<4> Location where database files will be stored.
+<5> Location where indexes will be stored.
+<6> Location where Analytics data will be stored.
+<7> Hostname that the cluster will use for this node.
+<8> Location of alternative JRE for the Analytics service.
+
+After initializing the first node, you can use the xref:cli:cbcli/couchbase-cli-cluster-init.adoc[cluster-init] command to initialize the cluster.
+The following CLI syntax allows the establishing of administrative credentials and port number.
+It adds all services, sets separate RAM quotas for Data, Index, Search, Eventing, and Analytics services, and sets the Index Storage Setting, the default being to support memory-optimized global indexes.
+
+[source,bash,subs=+quotes]
+----
+couchbase-cli cluster-init
+    --cluster [.var]_url_ <1>
+    --cluster-username [.var]_user_ <2>
+    --cluster-password [.var]_password_ <3>
+    --cluster-port [.var]_port_ <4>
+    --cluster-ramsize [.var]_ramsizemb_ <5>
+    --cluster-name [.var]_ramsizemb_ <6>
+    --cluster-index-ramsize [.var]_ramsizemb_ <7>
+    --cluster-fts-ramsize [.var]_ramsizemb_ <8>
+    --cluster-eventing-ramsize [.var]_ramsizemb_ <9>
+    --cluster-analytics-ramsize [.var]_ramsizemb_ <10>
+    --index-storage-setting [.var]_settings_ <11>
+    --services data,index,query,fts,analytics <12>
 ----
 
-NOTE: You can use the Couchbase CLI xref:cli:cbcli/couchbase-cli-node-init.adoc[node-init] command to initialize a Couchbase Server node and join an existing cluster.
+<1>  Hostname of first node in cluster.
+<2>  New cluster administrator username.
+<3>  New cluster administrator password.
+<4>  New cluster REST/http port.
+<5>  Per-node data service RAM quota in MB.
+<6>  Per-node data service RAM quota in MB.
+<7>  Per-node index service RAM quota in MB.
+<8>  Per-node search service RAM quota in MB.
+<9>  Per-node eventing service RAM quota in MB.
+<10> Per-node analytics service RAM quota in MB.
+<11> Index storage type: `default` or `memopt`.
+<12> Services to run on first node in cluster.
+
+After setting up the cluster, you can use the xref:cli:cbcli/couchbase-cli-node-init.adoc[node-init] command to initialize further Couchbase Server nodes, and use the xref:cli:cbcli/couchbase-cli-server-add.adoc[server-add] command to add these nodes to an existing cluster.
 
 [#initialize-cluster-rest]
 == Initializing the Cluster Using the REST API

--- a/modules/install/pages/init-setup.adoc
+++ b/modules/install/pages/init-setup.adoc
@@ -250,8 +250,32 @@ Once the [.ui]*Dashboard* screen appears, the new node has been successfully add
 
 Rather than using the Couchbase Web Console, you may elect to initialize your Couchbase cluster by means of the Couchbase Command Line Interface (CLI).
 
-The following CLI syntax can be used for the initial set-up of a single-node Couchbase Server cluster.
-It allows the establishing of administrative credentials, and of port number.
+First you must use the xref:cli:cbcli/couchbase-cli-node-init.adoc[node-init] command to initialize the first node in the cluster.
+
+[source,bash]
+----
+couchbase-cli node-init
+    [--cluster <url>] <1>
+    [--username <user>] <2>
+    [--password <password>] <3>
+    [--node-init-data-path <path>] <4>
+    [--node-init-index-path <path>] <5>
+    [--node-init-analytics-path <path>] <6>
+    [--node-init-hostname <hostname>] <7>
+    [--node-init-java-home <path>] <8>
+----
+<1> hostname of a node in the cluster to
+<2> user executing the command
+<3> password of person executing the command
+<4> data path/ 1st node must have data service.
+<5> index path
+<6> analytics path
+<7> hostname for server
+<8> JRE
+
+After initializing the first node, you can use the xref:cli:cbcli/couchbase-cli-cluster-init.adoc[cluster-init] command to initialize the cluster.
+
+The following CLI syntax allows the establishing of administrative credentials, and of port number.
 It adds all services; sets separate RAM quotas for Data, Index, Search, Eventing, and Analytics services, and sets the Index Storage Setting (the default being to support memory-optimized global indexes):
 
 [source,bash]
@@ -269,7 +293,7 @@ couchbase-cli cluster-init OPTIONS:
   --index-storage-setting=SETTING       // index storage type [default, memopt]
 ----
 
-NOTE: You can use the Couchbase CLI xref:cli:cbcli/couchbase-cli-node-init.adoc[node-init] command to initialize a Couchbase Server node and join an existing cluster.
+After setting up the cluster, you can use the xref:cli:cbcli/couchbase-cli-node-init.adoc[node-init] command to initialize further Couchbase Server nodes, and use the xref:cli:cbcli/couchbase-cli-server-add.adoc[server-add] command to add these nodes to an existing cluster.
 
 [#initialize-cluster-rest]
 == Initializing the Cluster Using the REST API


### PR DESCRIPTION
Clarify that when using couchbase-cli to initialize a cluster, you need to use `node-init` first to set the node options, then use `cluster-init` to set the cluster options. 