### PR TITLE
DOC-4418for4.1:Self referencing x-ref. Hence removed.

### DIFF
--- a/modules/developer-guide/pages/views-development.adoc
+++ b/modules/developer-guide/pages/views-development.adoc
@@ -65,5 +65,3 @@ This moves the view from development into production, and renames the index (so 
 Individual views are created as part of a design document.
 Each design document can have multiple views, and each Couchbase bucket can have multiple design documents.
 You can therefore have both development and production views within the same bucket while you development different indexes on your data.
-
-For information about working with the view editor and promoting views from development to production, see xref:ui:ui-views-editor.adoc[Views].


### PR DESCRIPTION
PR for broken X-ref DOC-4418 for Release 4.1. Looks like to be a self-referencing link. Hence removed. 

