### PR TITLE
DOC-4432: Fix bad link in Array Indexing page

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/indexing-arrays.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/indexing-arrays.adoc
@@ -90,7 +90,7 @@ NOTE: Couchbase 4.6.2 release introduces the following enhancements to array ind
 * Allow arbitrary variable names in array index selection.
 That is, a SELECT query or DML that needs to use the array index can use different variable names in the query from those used in the array index definition.
 In earlier releases, the variable names must exactly match.
-See https://developer.couchbase.com/documentation/server/4.5/n1ql/n1ql-language-reference/indexing-arrays.html[4.5 documentation^] for details.
+See the xref:4.5@n1ql-language-reference/indexing-arrays.adoc[Couchbase Server 4.5 documentation] for details.
 * Support [.var]`simple_array_expr`, which provides simpler syntax for array indexing when all array elements are indexed as is, without requiring to use the ARRAY operator in the index definition.
 
 +
@@ -163,7 +163,7 @@ In the above example, you can directly use `schedule` instead of the `array_expr
 
 == Examples
 
-The following samples use the https://developer.couchbase.com/documentation/server/4.6/sdk/sample-application.html[travel-sample^] keyspace that is shipped with the product.
+The following examples use the xref:manage:manage-settings/install-sample-buckets.adoc[travel-sample] keyspace that is shipped with the product.
 
 *Example 1*: Indexing all DISTINCT elements in an array
 


### PR DESCRIPTION
* Update link to Couchbase Server 4.5 documentation to use correct AsciiDoc markup.

* Update link to travel-sample to point to Sample Buckets topic — it's nothing to do with the sample application in this case.
