### PR TITLE
DOC-4433: Fix formatting and spelling in SELECT overview page

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/selectintro.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/selectintro.adoc
@@ -17,41 +17,46 @@ To query on a keyspace, you must either specify the document keys or use an inde
 
 *RBAC Privileges*
 
-User executing the SELCET statement must have the _Query Select_ privileges granted on all keyspaces referred in the query.
-Note that, the SELECT query may not refer to any keyspace or with JOIN queries or subqueries, it may refer to multiple keyspaces.
+The user executing the SELECT statement must have the _Query Select_ privileges granted on all keyspaces referred in the query.
+// Note that, the SELECT query may not refer to any keyspace or with JOIN queries or subqueries, it may refer to multiple keyspaces.
 For more details about user roles, see
 xref:learn:security/authorization-overview.adoc[Authorization].
 
 For example,
 
-To execute the following statement, user does not need any special privileges.
+To execute the following statement, the user does not need any special privileges.
 
+[source,N1QL]
 ----
 SELECT 1
 ----
 
-To execute the following statement, user must have the  _Query Select_ privilege on `pass:c[`travel-sample`]`.
+To execute the following statement, the user must have the  _Query Select_ privilege on `pass:c[`travel-sample`]`.
 
+[source,N1QL]
 ----
 SELECT * FROM `travel-sample`
 ----
 
-To execute the following statement, user must have the _Query Select_ privilege on `pass:c[`travel-sample`]` and `pass:c[`beer-sample`]`.
+To execute the following statement, the user must have the _Query Select_ privilege on `pass:c[`travel-sample`]` and `pass:c[`beer-sample`]`.
 
+[source,N1QL]
 ----
 SELECT * FROM `travel-sample` t
 JOIN `beer-sample` b ON KEYS ["aldaris", "ale_asylum"]
 ----
 
-To execute the following statement, user must have the _Query Select_ privilege on `pass:c[`travel-sample`]` and `pass:c[`beer-sample`]`.
+To execute the following statement, the user must have the _Query Select_ privilege on `pass:c[`travel-sample`]` and `pass:c[`beer-sample`]`.
 
+[source,N1QL]
 ----
 SELECT * FROM `travel-sample`
 WHERE city IN (SELECT raw city FROM `beer-sample`)
 ----
 
-To execute the following statement, user must have the _Query Select_ privilege on `pass:c[`travel-sample`]` and `pass:c[`beer-sample`]`.
+To execute the following statement, the user must have the _Query Select_ privilege on `pass:c[`travel-sample`]` and `pass:c[`beer-sample`]`.
 
+[source,N1QL]
 ----
 SELECT * FROM `travel-sample` WHERE type = "hotel"
 UNION
@@ -60,7 +65,9 @@ SELECT * FROM `beer-sample` WHERE type = "brewery"
 
 The following example uses an index to query the keyspace for airports that are in the America/Anchorage timezone and at an altitude of 2100ft or higher, and returns an array with the airport name and city name for each airport that satisfies the conditions.
 
+====
 .Query
+[source,N1QL]
 ----
 SELECT t.airportname, t.city
 FROM   `travel-sample` t
@@ -70,6 +77,7 @@ WHERE  type = "airport"
 ----
 
 .Results
+[source,JSON]
 ----
 [
    {
@@ -78,15 +86,19 @@ WHERE  type = "airport"
    }
 ]
 ----
+====
 
 The next example queries the keyspace using the document key "[.in]``airport_3469``".
 
+====
 .Query
+[source,N1QL]
 ----
 SELECT * FROM `travel-sample` USE KEYS "airport_3469";
 ----
 
-.Result
+.Results
+[source,JSON]
 ----
 [
   {
@@ -108,6 +120,7 @@ SELECT * FROM `travel-sample` USE KEYS "airport_3469";
   }
 ]
 ----
+====
 
 With projections, you retrieve just the fields that you need and not the entire document.
 This is especially useful when querying for a large dataset as it results in shorter processing times and better performance.
@@ -193,14 +206,17 @@ The possible elements and operations in a query include:
 
 == Data Processing Capabilities
 
-[[filtering]]Filtering::
+[#filtering]
+=== Filtering
 You can filter the query results using the WHERE clause.
 Consider the following example which queries for all airports in the America/Anchorage timezone that are at an altitude of 2000ft or more.
 The WHERE clause specifies the conditions that must be satisfied by the documents to be included in the resultset, and the resultset is returned as an array of airports that satisfy the condition.
-+
+
 NOTE: The keys in the result object are ordered alphabetically at each level.
-+
+
+====
 .Query
+[source,N1QL]
 ----
 SELECT *
 FROM   `travel-sample`
@@ -208,8 +224,9 @@ WHERE  type = "airport"
        AND tz = "America/Anchorage"
        AND geo.alt >= 2000;
 ----
-+
+
 .Result
+[source,JSON]
 ----
 [
    {
@@ -248,26 +265,29 @@ WHERE  type = "airport"
    }
 ]
 ----
+====
 
-[[query-across-relationships]]Querying Across Relationships::
+[#query-across-relationships]
+=== Querying Across Relationships
 You can use the SELECT statement to query across relationships using the JOIN clause or subqueries.
-+
-*JOIN Clause*
-+
+
+==== JOIN Clause
 Before we delve into examples, let's take a look at the data model of the travel-sample keyspace, which is used in the following examples.
 For more details about the data model, see xref:java-sdk::sample-application.adoc#datamodel[Travel App Data Model].
-+
+
 .Data model of travel-sample keyspace
 image::travel-app/travel-app-data-model.png[,570]
-+
-The first example (*Example 1*) uses a JOIN clause to find the distinct airline details which have routes that start from SFO.
+
+The <<example_1,first example>> uses a JOIN clause to find the distinct airline details which have routes that start from SFO.
 This example JOINS the document of type "route" with documents of type "airline" using the KEY "airlineid".
 
 * Documents of type "route" are on the left side of JOIN, and documents of type "airline" are on the right side of JOIN.
 * The documents of type "route" (on the left) contain the foreign key "airlineid" of documents of type "airline" (on the right).
 
-+
-.Example 1: Query
+[[example_1]]
+====
+.Query
+[source,N1QL]
 ----
 SELECT DISTINCT airline.name, airline.callsign, route.destinationairport, route.stops, route.airline
 FROM `travel-sample` route
@@ -278,8 +298,9 @@ WHERE route.type = "route"
   AND route.sourceairport = "SFO"
 LIMIT 2;
 ----
-+
-.Example 1: Results
+
+.Results
+[source,JSON]
 ----
 [
    {
@@ -299,29 +320,33 @@ LIMIT 2;
    }
 ]
 ----
-+
-Let's consider another example (*Example 2)* which finds the number of distinct airports where AA has routes.
+====
+
+Let's consider <<example_2,another example>> which finds the number of distinct airports where AA has routes.
 In this example:
 
 * Documents of type "airline" are on the left side of JOIN, and documents of type "route" are on the right side.
 * The WHERE clause predicate airline.iata = "AA" is on the right side keyspace "airlines".
 
-+
 This example illustrates a special kind of JOIN where the documents on the right side of JOIN contain the foreign key reference to the documents on the left side.
 Such JOINs are referred to as index JOIN.
 For details, see xref:n1ql-language-reference/from.adoc#lookup-join[Lookup JOIN Clause].
-+
+
+[[example_2]]
+====
 Index JOIN requires a special inverse index [.param]`route_airlineid` on the JOIN key ‘route.airlineid’.
 Create this index using the following command:
-+
+
+[source,N1QL]
 ----
 CREATE INDEX route_airlineid ON `travel-sample`(airlineid)
 WHERE type = "route";
 ----
-+
+
 Now we can execute the following query.
-+
-.Example 2: Query
+
+.Query
+[source,N1QL]
 ----
 SELECT Count(DISTINCT route.sourceairport) AS distinctairports1
 FROM `travel-sample` airline
@@ -331,8 +356,9 @@ WHERE  route.type = "route"
   AND    airline.type = "airline"
   AND    airline.iata = "AA";
 ----
-+
-.Example 2: Results
+
+.Results
+[source,JSON]
 ----
 [
    {
@@ -340,16 +366,18 @@ WHERE  route.type = "route"
    }
 ]
 ----
-+
-*Subqueries*
-+
+====
+
+==== Subqueries
 A subquery is an expression that is evaluated by executing an inner SELECT query.
 Subqueries can be used in most places where you can use an expression such as projections, FROM clauses, and WHERE clauses.
-+
+
 A subquery is executed once for every input document to the outer statement and it returns an array every time it is evaluated.
 See xref:n1ql-language-reference/subqueries.adoc[Subqueries] for more details.
-+
+
+====
 .Query
+[source,N1QL]
 ----
 SELECT *
 FROM   (SELECT t.airportname
@@ -359,8 +387,9 @@ FROM   (SELECT t.airportname
                        AND country = "United States"
                 LIMIT  1) AS s1) AS s2;
 ----
-+
+
 .Results
+[source,JSON]
 ----
 [
    {
@@ -370,16 +399,21 @@ FROM   (SELECT t.airportname
    }
 ]
 ----
+====
 
-[[deep-traversal-nested-docs]]Deep Traversal for Nested Documents::
+[#deep-traversal-nested-docs]
+=== Deep Traversal for Nested Documents
 When querying a bucket with nested documents, SELECT provides an easy way to traverse deep nested documents using the dot notation and NEST and UNNEST clauses.
-+
-The following query looks for the schedule, and accesses the flight id for destinationaiport=ALG.
+
+==== Dot Notation
+The following query looks for the schedule, and accesses the flight id for destinationairport=ALG.
 Since a given flight has multiple schedules, attribute "schedule" is an array containing all schedules for the specified flight.
 You can access the individual array elements using the array indexes.
 For brevity, we’re limiting the number of results in the query to 1.
-+
+
+====
 .Query
+[source,N1QL]
 ----
 SELECT t.schedule[0].flight AS flightid
 FROM `travel-sample` t
@@ -387,8 +421,9 @@ WHERE type="route"
   AND destinationairport="ALG"
 LIMIT 1;
 ----
-+
+
 .Results
+[source,JSON]
 ----
 [
    {
@@ -397,17 +432,18 @@ LIMIT 1;
    }
 ]
 ----
-+
-*NEST and UNNEST*
-+
+====
+
+==== NEST and UNNEST
 Note that, an array is created with the matching nested documents.
 In this example:
 
 * The ‘airline’ field in the result is an array of the `travel-sample` documents that are matched with the key route.airlineid.
 * Hence, the projection is accessed as airline[0] to pick the first element of the array.
 
-+
+====
 .Query
+[source,N1QL]
 ----
 SELECT DISTINCT route.sourceairport,
                 route.airlineid,
@@ -418,8 +454,9 @@ WHERE route.type = "route"
   AND route.airline = "AA"
 LIMIT 4;
 ----
-+
+
 .Results
+[source,JSON]
 ----
 [
    {
@@ -444,18 +481,22 @@ LIMIT 4;
    }
 ]
 ----
-+
+====
+
 The following example uses the UNNEST clause to retrieve the author names from the reviews object.
-+
+
+====
 .Query
+[source,N1QL]
 ----
 SELECT r.author
 FROM `travel-sample` t UNNEST t.reviews r
 WHERE t.type = "hotel"
 LIMIT 4;
 ----
-+
+
 .Results
+[source,JSON]
 ----
 [
    {
@@ -472,21 +513,26 @@ LIMIT 4;
    }
 ]
 ----
+====
 
-[[aggregation]]Aggregation::
+[#aggregation]
+=== Aggregation
 As part of a single SELECT statement, you can also perform aggregation using the SUM, COUNT, AVG, MIN, MAX, or ARRAY AVG functions.
-+
+
 The following example counts the total number of flights to SFO:
-+
+
+====
 .Query
+[source,N1QL]
 ----
 SELECT count(schedule[*]) AS totalflights
 FROM `travel-sample` t
 WHERE type="route"
   AND destinationairport="SFO";
 ----
-+
+
 .Results
+[source,JSON]
 ----
 [
    {
@@ -494,13 +540,17 @@ WHERE type="route"
    }
 ]
 ----
+====
 
-[[combine-resultsets]]Combining Resultsets Using Operators::
+[#combine-resultsets]
+=== Combining Resultsets Using Operators
 You can combine the result sets using the UNION or INTERSECT operators.
-+
+
 Consider the following example which looks for the first schedule for flights to "SFO" and "BOS":
-+
+
+====
 .Query
+[source,N1QL]
 ----
 (SELECT t.schedule[0]
  FROM `travel-sample` t
@@ -514,8 +564,9 @@ UNION ALL
    AND destinationairport = "BOS"
  LIMIT  1);
 ----
-+
+
 .Results
+[source,JSON]
 ----
 [
    {
@@ -534,15 +585,19 @@ UNION ALL
    }
 ]
 ----
+====
 
-[[group-sort-limit]]Grouping, Sorting, and Limiting Results::
+[#group-sort-limit]
+=== Grouping, Sorting, and Limiting Results
 You can perform further processing on the data in your result set before the final projection is generated.
 You can group data using the GROUP BY clause, sort data using the ORDER BY clause, and you can limit the number of results included in the result set using the LIMIT clause.
-+
-The following example looks for the number of airports at an altitude of 5000 ft or higher and groups the results by country and timezone.
+
+The following example looks for the number of airports at an altitude of 5000ft or higher and groups the results by country and timezone.
 It then sorts the results by country names and timezones (ascending order by default).
-+
+
+====
 .Query
+[source,N1QL]
 ----
 SELECT COUNT(*)  AS count,
        t.country AS country,
@@ -553,8 +608,9 @@ WHERE type = "airport"
 GROUP BY t.country, t.tz
 ORDER BY t.country, t.tz;
 ----
-+
+
 .Results
+[source,JSON]
 ----
 [
    {
@@ -584,3 +640,4 @@ ORDER BY t.country, t.tz;
    }
 ]
 ----
+====


### PR DESCRIPTION
Please see draft build [here](https://simon-dew.github.io/docs-site/DOC-4433/server/6.0/n1ql/n1ql-language-reference/selectintro.html).