### PR TITLE
adding filterExpression to example

### DIFF
--- a/modules/rest-api/pages/rest-xdcr-create-replication.adoc
+++ b/modules/rest-api/pages/rest-xdcr-create-replication.adoc
@@ -28,6 +28,7 @@ curl -v -X POST -u [admin]:[password]
   -d replicationType=continuous
   -d type=[capi | xmem]
   -d compressionType=["None" | "Auto" | "Snappy"]
+  -d filterExpression=[regular expression (optional)]
 ----
 
 NOTE: The `type` values, capi and xmem, are represented by version1 and version2 in the web console.


### PR DESCRIPTION
It doesn't seem like filterExpression is explicitly documented, but it does work, so I added it to the example. (See this discussion on StackOverflow: https://stackoverflow.com/questions/53591638/rest-api-for-enabling-advanced-filtering-in-couchbase-xdcr/53615931)