### PR TITLE
Add clarifying statement to MB-31481 release note

### DIFF
--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -258,7 +258,7 @@ The notable fixes in this release are listed below. See the Couchbase https://is
 | *Summary*: Fetching a random key from the Data service may hang if the bucket contains zero documents.
 
 | https://issues.couchbase.com/browse/MB-31481[MB-31481^]
-| *Summary*: The data service engine may not send STREAM_END message to consumers if non-infinity end sequence number and cursor dropping occurs.
+| *Summary*: The data service engine may not send STREAM_END message to consumers if non-infinity end sequence number and cursor dropping occurs. This could cause clients such as cbbackupmgr to hang indefinitely.
 
 | https://issues.couchbase.com/browse/MB-31175[MB-31175^]
 | *Summary*: Ephemeral buckets can have tombstones purged before the configured metadata purge interval.


### PR DESCRIPTION
The effect of MB-31481 is not that clear based on the current description. Added a short summary of what the effect on cbbackupmgr is.