### PR TITLE
DOC-4578: Document new pattern-matching functions

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/patternmatchingfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/patternmatchingfun.adoc
@@ -22,7 +22,6 @@ pattern:: string representing a supported regular expression
 Returns True if the string value contains the regular expression pattern.
 
 === Example
-.{empty}
 ====
 [source,n1ql]
 ----
@@ -58,7 +57,6 @@ pattern:: string representing a supported regular expression
 Returns True if the string value contains the regular expression pattern.
 
 === Example
-.{empty}
 ====
 [source,n1ql]
 ----
@@ -101,7 +99,6 @@ Returns an array of all substrings matching the expression _pattern_ within the 
 Returns an empty array if no match is found.
 
 === Examples
-.{empty}
 ====
 The following query finds all words beginning with upper or lower case B.
 
@@ -132,7 +129,6 @@ SELECT REGEXP_MATCHES("So, 'twas better Betty Botter bought a bit of better butt
 <1> The backslash that introduces an escape sequence in the regular expression must itself be escaped by another backslash in the N1QL query.
 So `\b` (word boundary) must be entered as `\\b` and `\w` (word character) must be entered as `\\w`.
 
-.{empty}
 ====
 The following query finds sequences of two words beginning with upper or lower case B.
 
@@ -172,7 +168,6 @@ Returns -1 if no match is found.
 Position counting starts from zero.
 
 === Example
-.{empty}
 ====
 The following query finds positions of first occurrence of vowels in each word of the _name_ attribute.
 
@@ -226,7 +221,6 @@ If _n_ is given, at the most _n_ replacements are performed.
 If _n_ is not provided, all matching occurrences are replaced.
 
 === Examples
-.{empty}
 ====
 [source,n1ql]
 ----
@@ -248,7 +242,6 @@ SELECT REGEXP_REPLACE("N1QL is Sql (in fact, sql++) for NoSql", "[sS][qQ][lL]", 
 ----
 ====
 
-.{empty}
 ====
 In this example, the query retrieves first 4 documents and replaces the pattern of repeating n with emphasized ‘NNNN’.
 
@@ -296,7 +289,6 @@ Returns an array of all the substrings created by splitting the input string _ex
 Returns an empty array if no match is found.
 
 === Example
-.{empty}
 ====
 [source,n1ql]
 ----

--- a/modules/n1ql/pages/n1ql-language-reference/patternmatchingfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/patternmatchingfun.adoc
@@ -138,7 +138,7 @@ LIMIT 2;
 ----
 ====
 
-[#section_regex_relace]
+[#section_regex_replace]
 == REGEXP_REPLACE(`expression`, `pattern`, `repl` [, `n`])
 
 === Arguments
@@ -170,7 +170,7 @@ SELECT REGEXP_REPLACE("N1QL is Sql (in fact, sql++) for NoSql", "[sS][qQ][lL]", 
 ----
 [
   {
-    "$1": "N1QL is SQL(infact, SQL++) for NoSQL",
+    "$1": "N1QL is SQL (in fact, SQL++) for NoSQL",
     "$2": "WHotelHotelg HotelHotelgs Hotel",
     "$3": "WINNING INNINGs Inn"
   }

--- a/modules/n1ql/pages/n1ql-language-reference/patternmatchingfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/patternmatchingfun.adoc
@@ -282,3 +282,50 @@ LIMIT 4;
 ]
 ----
 ====
+
+[#section_regex_split]
+== REGEXP_SPLIT(`expression`, `pattern`)
+
+=== Arguments
+expression:: string, or any N1QL expression that evaluates to a string
+
+pattern:: string representing a supported regular expression
+
+=== Return Value
+Returns an array of all the substrings created by splitting the input string _expression_ at  each occurrence of the expression _pattern_.
+Returns an empty array if no match is found.
+
+=== Example
+.{empty}
+====
+[source,n1ql]
+----
+SELECT REGEXP_SPLIT("C:\\Program Files\\couchbase\\server\\bin", "[\\\\]") AS Windows, <1>
+REGEXP_SPLIT("/opt/couchbase/bin", "/") AS Unix;
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "Unix": [
+      "", <2>
+      "opt",
+      "couchbase",
+      "bin"
+    ],
+    "Windows": [
+      "C:",
+      "Program Files",
+      "couchbase",
+      "server",
+      "bin"
+    ]
+  }
+]
+----
+====
+
+<1> The regular expression `[\\\\]` matches the escaped backslash `\\`.
+<2> The `REGEXP_SPLIT` function returns any zero-length matches that occur at the start of the _expression_ string, or immediately after a previous match.

--- a/modules/n1ql/pages/n1ql-language-reference/patternmatchingfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/patternmatchingfun.adoc
@@ -28,7 +28,7 @@ Returns True if the string value contains the regular expression pattern.
 ----
 SELECT name
 FROM `travel-sample`
-WHERE type = "landmark" AND REGEX_CONTAINS(name, ".*In+")
+WHERE type = "landmark" AND REGEXP_CONTAINS(name, ".*In+")
 LIMIT 2;
 ----
 
@@ -64,7 +64,7 @@ Returns True if the string value contains the regular expression pattern.
 ----
 SELECT name
 FROM `travel-sample`
-WHERE type = "hotel" and REGEX_LIKE(name, "In+.*")
+WHERE type = "hotel" and REGEXP_LIKE(name, "In+.*")
 LIMIT 4;
 ----
 
@@ -108,7 +108,7 @@ The following query finds positions of first occurrence of vowels in each word o
 
 [source,n1ql]
 ----
-SELECT name, ARRAY REGEX_POSITION(x, "[aeiou]") FOR x IN TOKENS(name) END
+SELECT name, ARRAY REGEXP_POSITION(x, "[aeiou]") FOR x IN TOKENS(name) END
 FROM `travel-sample`
 WHERE type = "hotel"
 LIMIT 2;
@@ -160,9 +160,9 @@ If _n_ is not provided, all matching occurrences are replaced.
 ====
 [source,n1ql]
 ----
-SELECT REGEX_REPLACE("N1QL is Sql(infact, sql++) for NoSql", "[sS][qQ][lL]", "SQL"),
-       REGEX_REPLACE("Winning innings Inn", "[Ii]n+", "Hotel", 6),
-       REGEX_REPLACE("Winning innings Inn", "[IiNn]+g", upper("inning"), 2);
+SELECT REGEXP_REPLACE("N1QL is Sql (in fact, sql++) for NoSql", "[sS][qQ][lL]", "SQL"),
+       REGEXP_REPLACE("Winning innings Inn", "[Ii]n+", "Hotel", 6),
+       REGEXP_REPLACE("Winning innings Inn", "[IiNn]+g", upper("inning"), 2);
 ----
 
 .Results
@@ -184,7 +184,7 @@ In this example, the query retrieves first 4 documents and replaces the pattern 
 
 [source,n1ql]
 ----
-SELECT name, REGEX_REPLACE(name, "n+", "NNNN") as new_name
+SELECT name, REGEXP_REPLACE(name, "n+", "NNNN") as new_name
 FROM `travel-sample`
 LIMIT 4;
 ----

--- a/modules/n1ql/pages/n1ql-language-reference/patternmatchingfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/patternmatchingfun.adoc
@@ -88,6 +88,76 @@ LIMIT 4;
 ----
 ====
 
+[#section_regex_matches]
+== REGEXP_MATCHES(`expression`, `pattern`)
+
+=== Arguments
+expression:: string, or any N1QL expression that evaluates to a string
+
+pattern:: string representing a supported regular expression
+
+=== Return Value
+Returns an array of all substrings matching the expression _pattern_ within the input string _expression_.
+Returns an empty array if no match is found.
+
+=== Examples
+.{empty}
+====
+The following query finds all words beginning with upper or lower case B.
+
+[source,n1ql]
+----
+SELECT REGEXP_MATCHES("So, 'twas better Betty Botter bought a bit of better butter", "\\b[Bb]\\w+"); <1>
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "$1": [
+      "better",
+      "Betty",
+      "Botter",
+      "bought",
+      "bit",
+      "better",
+      "butter"
+    ]
+  }
+]
+----
+====
+
+<1> The backslash that introduces an escape sequence in the regular expression must itself be escaped by another backslash in the N1QL query.
+So `\b` (word boundary) must be entered as `\\b` and `\w` (word character) must be entered as `\\w`.
+
+.{empty}
+====
+The following query finds sequences of two words beginning with upper or lower case B.
+
+[source,n1ql]
+----
+SELECT REGEXP_MATCHES("So, 'twas better Betty Botter bought a bit of better butter", "\\b[Bb]\\w+ \\b[Bb]\\w+");
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "$1": [
+      "better Betty",
+      "Botter bought", <1>
+      "better butter"
+    ]
+  }
+]
+----
+====
+
+<1> Note that `Betty Botter` is not found in this example, because `Betty` has already been found by the first match.
+
 [#section_regex_position]
 == REGEXP_POSITION(`expression`, `pattern`)
 

--- a/modules/n1ql/pages/n1ql-language-reference/patternmatchingfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/patternmatchingfun.adoc
@@ -5,23 +5,26 @@ Pattern-matching functions allow you to find regular expression patterns in stri
 Regular expressions can formally represent various string search patterns using different special characters to indicate wildcards, positional characters, repetition, optional or mandatory sequences of letters etc.
 N1QL functions are available to find matching patterns, find position of matching pattern, or replace a pattern with a new string.
 
-For more information on all supported REGEX patterns, see https://golang.org/pkg/regexp/syntax/[^]
+For more information on all supported REGEX patterns, see https://golang.org/pkg/regexp/syntax[^].
 
 NOTE: Couchbase Server 4.x N1QL supports regular expressions supported by The Go Programming Language version 1.4.2.
 From Couchbase Server 5.0, The Go Programming Language version 1.8 is supported.
 
 [#section_regex_contains]
-== REGEXP_CONTAINS(expression, pattern)
+== REGEXP_CONTAINS(`expression`, `pattern`)
 
-*Arguments*::
-*expression*: string, or any N1QL expression that evaluates to a string
-+
-*pattern*: string representing a supported regular expression
+=== Arguments
+expression:: string, or any N1QL expression that evaluates to a string
 
-*Return Value*:: Returns True if the string value contains the regular expression pattern.
+pattern:: string representing a supported regular expression
 
-*Example*::
-+
+=== Return Value
+Returns True if the string value contains the regular expression pattern.
+
+=== Example
+.{empty}
+====
+[source,n1ql]
 ----
 SELECT name
 FROM `travel-sample`
@@ -29,8 +32,8 @@ WHERE type = "landmark" AND REGEX_CONTAINS(name, ".*In+")
 LIMIT 2;
 ----
 
-*Results*::
-+
+.Results
+[source,json]
 ----
 [
   {
@@ -41,19 +44,23 @@ LIMIT 2;
   }
 ]
 ----
+====
 
 [#section_regex_like]
-== REGEXP_LIKE(expression, pattern)
+== REGEXP_LIKE(`expression`, `pattern`)
 
-*Arguments*::
-*expression*: string, or any N1QL expression that evaluates to a string
-+
-*pattern*: string representing a supported regular expression
+=== Arguments
+expression:: string, or any N1QL expression that evaluates to a string
 
-*Return Value*:: Returns True if the string value contains the regular expression pattern.
+pattern:: string representing a supported regular expression
 
-*Example*::
-+
+=== Return Value
+Returns True if the string value contains the regular expression pattern.
+
+=== Example
+.{empty}
+====
+[source,n1ql]
 ----
 SELECT name
 FROM `travel-sample`
@@ -61,8 +68,8 @@ WHERE type = "hotel" and REGEX_LIKE(name, "In+.*")
 LIMIT 4;
 ----
 
-*Results*::
-+
+.Results
+[source,json]
 ----
 [
   {
@@ -79,23 +86,27 @@ LIMIT 4;
   }
 ]
 ----
+====
 
 [#section_regex_position]
-== REGEXP_POSITION(expression, pattern)
+== REGEXP_POSITION(`expression`, `pattern`)
 
-*Arguments*::
-*expression*: string, or any N1QL expression that evaluates to a string
-+
-*pattern*: string representing a supported regular expression
+=== Arguments
+expression:: string, or any N1QL expression that evaluates to a string
 
-*Return Value*::
+pattern:: string representing a supported regular expression
+
+=== Return Value
 Returns first position of the occurrence of the regular expression _pattern_ within the input string _expression_.
 Returns -1 if no match is found.
 Position counting starts from zero.
 
-*Example*::
+=== Example
+.{empty}
+====
 The following query finds positions of first occurrence of vowels in each word of the _name_ attribute.
-+
+
+[source,n1ql]
 ----
 SELECT name, ARRAY REGEX_POSITION(x, "[aeiou]") FOR x IN TOKENS(name) END
 FROM `travel-sample`
@@ -103,8 +114,8 @@ WHERE type = "hotel"
 LIMIT 2;
 ----
 
-*Results*::
-+
+.Results
+[source,json]
 ----
 [
   {
@@ -125,34 +136,37 @@ LIMIT 2;
   }
 ]
 ----
+====
 
 [#section_regex_relace]
-== REGEXP_REPLACE(expression, pattern, repl [, n])
+== REGEXP_REPLACE(`expression`, `pattern`, `repl` [, `n`])
 
-*Arguments*::
-*expression*: string, or any N1QL expression that evaluates to a string
-+
-*pattern*: string representing a supported regular expression
-+
-*repl*: string, or any N1QL expression that evaluates to a string
-+
-*n*: the maximum number of times to find and replace the matching pattern
+=== Arguments
+expression:: string, or any N1QL expression that evaluates to a string
 
-*Return Value*::
+pattern:: string representing a supported regular expression
+
+repl:: string, or any N1QL expression that evaluates to a string
+
+n:: the maximum number of times to find and replace the matching pattern
+
+=== Return Value
 Returns new string with occurrences of pattern replaced with _repl_.
 If _n_ is given, at the most _n_ replacements are performed.
 If _n_ is not provided, all matching occurrences are replaced.
 
-*Example 1*::
-+
+=== Examples
+.{empty}
+====
+[source,n1ql]
 ----
 SELECT REGEX_REPLACE("N1QL is Sql(infact, sql++) for NoSql", "[sS][qQ][lL]", "SQL"),
        REGEX_REPLACE("Winning innings Inn", "[Ii]n+", "Hotel", 6),
        REGEX_REPLACE("Winning innings Inn", "[IiNn]+g", upper("inning"), 2);
 ----
 
-*Results*::
-+
+.Results
+[source,json]
 ----
 [
   {
@@ -162,18 +176,21 @@ SELECT REGEX_REPLACE("N1QL is Sql(infact, sql++) for NoSql", "[sS][qQ][lL]", "SQ
   }
 ]
 ----
+====
 
-*Example 2*::
+.{empty}
+====
 In this example, the query retrieves first 4 documents and replaces the pattern of repeating n with emphasized ‘NNNN’.
-+
+
+[source,n1ql]
 ----
 SELECT name, REGEX_REPLACE(name, "n+", "NNNN") as new_name
 FROM `travel-sample`
 LIMIT 4;
 ----
 
-*Results*::
-+
+.Results
+[source,json]
 ----
 [
   {
@@ -194,3 +211,4 @@ LIMIT 4;
   }
 ]
 ----
+====


### PR DESCRIPTION
UPDATE: Draft documentation build removed. Please see updated documentation [here](https://docs-staging.couchbase.com/server/6.5/n1ql/n1ql-language-reference/patternmatchingfun.html).

New functions in this pull request: REGEXP_MATCHES(), REGEXP_SPLIT().