### PR TITLE
Improve non-root steps

### DIFF
--- a/modules/install/pages/rhel-suse-install-intro.adoc
+++ b/modules/install/pages/rhel-suse-install-intro.adoc
@@ -115,14 +115,16 @@ Installing on RHEL as a non-root, non-sudo user on a single machine.
 
 A non-sudo, non-root installation still runs Couchbase Server and all Couchbase command-line tools.
 
-. After downloading the Couchbase Server RPM, go to the directory where it is located and extract it:
+. Place the Couchbase Server RPM into a directory where Couchbase Server is to be installed.
+. Go to that directory and extract the RPM:
 +
 [source,bash]
 ----
+cd /home/me/couchbase-non-root/
 rpm2cpio couchbase-server-enterprise_version.rpm | cpio --extract --make-directories --no-absolute-filenames
 ----
 +
-In the directory where the files were extracted, the `opt` and `etc` sub-directories are available.
+In the directory where the files were extracted, the `opt` and `etc` sub-directories are now available.
 
 . After you extract the Couchbase Server installation files, go to the sub-directory:
 +
@@ -131,7 +133,7 @@ In the directory where the files were extracted, the `opt` and `etc` sub-directo
 cd opt/couchbase
 ----
 
-. Run the following script to relocate the Couchbase Server installation to the present working directory (PWD):
+. Run the following script to complete the non-root Couchbase Server installation:
 +
 [source,bash]
 ----

--- a/modules/install/pages/rhel-suse-install-intro.adoc
+++ b/modules/install/pages/rhel-suse-install-intro.adoc
@@ -116,11 +116,16 @@ Installing on RHEL as a non-root, non-sudo user on a single machine.
 A non-sudo, non-root installation still runs Couchbase Server and all Couchbase command-line tools.
 
 . Place the Couchbase Server RPM into a directory where Couchbase Server is to be installed.
+
 . Go to that directory and extract the RPM:
 +
 [source,bash]
 ----
 cd /home/me/couchbase-non-root/
+----
++
+[source,bash]
+----
 rpm2cpio couchbase-server-enterprise_version.rpm | cpio --extract --make-directories --no-absolute-filenames
 ----
 +


### PR DESCRIPTION
I followed the non-root instructions and found them to be a little confusing, my issue was mainly that it wasn't clear that when I perform the cpio (step 1) the directory I am in is the directory where the install will reside, reading the steps as they are lead me to think that I could cpio in the download directory and then direct the install to anywhere (the reloc.sh step)

It appeared that the reloc.sh script would move the extracted files to anywhere I want, but it doesn't, there seemed to be no choice other than "reloc.sh pwd", any other path and it failed.

So i've added what I think are some changes to help clarify that the download directory is the final installation directory as well.