### PR TITLE
DOC-4857: ANSI OUTER JOIN to ANSI INNER JOIN transformation

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/join.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/join.adoc
@@ -118,6 +118,16 @@ WHERE r.sourceairport = "SFO"
 ----
 |===
 
+[NOTE]
+--
+In Couchbase Server 6.5 and later, if you create either of the following:
+
+* A LEFT OUTER JOIN with a xref:n1ql-language-reference/where.adoc[WHERE clause] which filters out all the NULL or MISSING results on the right-hand side, or
+* A RIGHT OUTER JOIN with a xref:n1ql-language-reference/where.adoc[WHERE clause] which filters out all the NULL or MISSING results on the left-hand side,
+
+The query is transformed internally into an INNER join for greater efficiency.
+--
+
 [#ansi-join-predicate]
 ==== Join Predicate
 

--- a/modules/n1ql/pages/n1ql-language-reference/join.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/join.adoc
@@ -122,10 +122,10 @@ WHERE r.sourceairport = "SFO"
 --
 In Couchbase Server 6.5 and later, if you create either of the following:
 
-* A LEFT OUTER JOIN with a xref:n1ql-language-reference/where.adoc[WHERE clause] which filters out all the NULL or MISSING results on the right-hand side, or
-* A RIGHT OUTER JOIN with a xref:n1ql-language-reference/where.adoc[WHERE clause] which filters out all the NULL or MISSING results on the left-hand side,
+* A LEFT OUTER JOIN where all the NULL or MISSING results on the right-hand side are filtered out by the xref:n1ql-language-reference/where.adoc[WHERE clause] or by the ON clause of a subsequent INNER JOIN, or
+* A RIGHT OUTER JOIN where all the NULL or MISSING results on the left-hand side are filtered out by the xref:n1ql-language-reference/where.adoc[WHERE clause] or by the ON clause of a subsequent INNER JOIN,
 
-The query is transformed internally into an INNER join for greater efficiency.
+Then the query is transformed internally into an INNER JOIN for greater efficiency.
 --
 
 [#ansi-join-predicate]


### PR DESCRIPTION
UPDATE: Draft documentation has now been removed. Please see updated documentation here:

* [JOIN Clause › ANSI JOIN Clause › Syntax › Join Type](https://docs-staging.couchbase.com/server/6.5/n1ql/n1ql-language-reference/join.html#ansi-join-type)

The only change is the new NOTE section.