### PR TITLE
DOC-4550: differences between REGEXP_LIKE and REGEXP_CONTAINS

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/patternmatchingfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/patternmatchingfun.adoc
@@ -14,14 +14,17 @@ From Couchbase Server 5.0, The Go Programming Language version 1.8 is supported.
 == REGEXP_CONTAINS(`expression`, `pattern`)
 
 === Arguments
+
 expression:: String, or any N1QL expression that evaluates to a string.
 
 pattern:: String representing a supported regular expression.
 
 === Return Value
+
 Returns TRUE if the string value contains any sequence that matches the regular expression pattern.
 
 === Example
+
 ====
 [source,N1QL]
 ----
@@ -58,14 +61,17 @@ LIMIT 5;
 == REGEXP_LIKE(`expression`, `pattern`)
 
 === Arguments
+
 expression:: String, or any N1QL expression that evaluates to a string.
 
 pattern:: String representing a supported regular expression.
 
 === Return Value
+
 Returns TRUE if the string value exactly matches the regular expression pattern.
 
 === Example
+
 ====
 [source,N1QL]
 ----
@@ -102,16 +108,19 @@ LIMIT 5;
 == REGEXP_POSITION(`expression`, `pattern`)
 
 === Arguments
+
 expression:: String, or any N1QL expression that evaluates to a string.
 
 pattern:: String representing a supported regular expression.
 
 === Return Value
+
 Returns first position of the occurrence of the regular expression _pattern_ within the input string _expression_.
 Returns -1 if no match is found.
 Position counting starts from zero.
 
 === Example
+
 ====
 The following query finds positions of first occurrence of vowels in each word of the _name_ attribute.
 
@@ -151,6 +160,7 @@ LIMIT 2;
 == REGEXP_REPLACE(`expression`, `pattern`, `repl` [, `n`])
 
 === Arguments
+
 expression:: String, or any N1QL expression that evaluates to a string.
 
 pattern:: String representing a supported regular expression.
@@ -160,6 +170,7 @@ repl:: String, or any N1QL expression that evaluates to a string.
 n:: [Optional] The maximum number of times to find and replace the matching pattern.
 
 === Return Value
+
 Returns new string with occurrences of pattern replaced with _repl_.
 If _n_ is given, at the most _n_ replacements are performed.
 If _n_ is not provided, all matching occurrences are replaced.

--- a/modules/n1ql/pages/n1ql-language-reference/patternmatchingfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/patternmatchingfun.adoc
@@ -2,26 +2,28 @@
 :page-topic-type: concept
 
 Pattern-matching functions allow you to find regular expression patterns in strings or attributes.
-Regular expressions can formally represent various string search patterns using different special characters to indicate wildcards, positional characters, repetition, optional or mandatory sequences of letters etc.
+Regular expressions can formally represent various string search patterns using different special characters to indicate wildcards, positional characters, repetition, optional or mandatory sequences of letters, etc.
 N1QL functions are available to find matching patterns, find position of matching pattern, or replace a pattern with a new string.
 
-For more information on all supported REGEX patterns, see https://golang.org/pkg/regexp/syntax/[^]
+For more information on all supported REGEX patterns, see https://golang.org/pkg/regexp/syntax/[^].
 
 NOTE: Couchbase Server 4.x N1QL supports regular expressions supported by The Go Programming Language version 1.4.2.
 From Couchbase Server 5.0, The Go Programming Language version 1.8 is supported.
 
 [#section_regex_contains]
-== REGEXP_CONTAINS(expression, pattern)
+== REGEXP_CONTAINS(`expression`, `pattern`)
 
-*Arguments*::
-*expression*: string, or any N1QL expression that evaluates to a string
-+
-*pattern*: string representing a supported regular expression
+=== Arguments
+expression:: String, or any N1QL expression that evaluates to a string.
 
-*Return Value*:: Returns True if the string value contains the regular expression pattern.
+pattern:: String representing a supported regular expression.
 
-*Example*::
-+
+=== Return Value
+Returns True if the string value contains the regular expression pattern.
+
+=== Example
+====
+[source,N1QL]
 ----
 SELECT name
 FROM `travel-sample`
@@ -29,8 +31,8 @@ WHERE type = "landmark" AND REGEX_CONTAINS(name, ".*In+")
 LIMIT 2;
 ----
 
-*Results*::
-+
+.Results
+[source,json]
 ----
 [
   {
@@ -41,19 +43,22 @@ LIMIT 2;
   }
 ]
 ----
+====
 
 [#section_regex_like]
-== REGEXP_LIKE(expression, pattern)
+== REGEXP_LIKE(`expression`, `pattern`)
 
-*Arguments*::
-*expression*: string, or any N1QL expression that evaluates to a string
-+
-*pattern*: string representing a supported regular expression
+=== Arguments
+expression:: String, or any N1QL expression that evaluates to a string.
 
-*Return Value*:: Returns True if the string value contains the regular expression pattern.
+pattern:: String representing a supported regular expression.
 
-*Example*::
-+
+=== Return Value
+Returns True if the string value contains the regular expression pattern.
+
+=== Example
+====
+[source,N1QL]
 ----
 SELECT name
 FROM `travel-sample`
@@ -61,8 +66,8 @@ WHERE type = "hotel" and REGEX_LIKE(name, "In+.*")
 LIMIT 4;
 ----
 
-*Results*::
-+
+.Results
+[source,json]
 ----
 [
   {
@@ -79,23 +84,26 @@ LIMIT 4;
   }
 ]
 ----
+====
 
 [#section_regex_position]
-== REGEXP_POSITION(expression, pattern)
+== REGEXP_POSITION(`expression`, `pattern`)
 
-*Arguments*::
-*expression*: string, or any N1QL expression that evaluates to a string
-+
-*pattern*: string representing a supported regular expression
+=== Arguments
+expression:: String, or any N1QL expression that evaluates to a string.
 
-*Return Value*::
+pattern:: String representing a supported regular expression.
+
+=== Return Value
 Returns first position of the occurrence of the regular expression _pattern_ within the input string _expression_.
 Returns -1 if no match is found.
 Position counting starts from zero.
 
-*Example*::
+=== Example
+====
 The following query finds positions of first occurrence of vowels in each word of the _name_ attribute.
-+
+
+[source,N1QL]
 ----
 SELECT name, ARRAY REGEX_POSITION(x, "[aeiou]") FOR x IN TOKENS(name) END
 FROM `travel-sample`
@@ -103,8 +111,8 @@ WHERE type = "hotel"
 LIMIT 2;
 ----
 
-*Results*::
-+
+.Results
+[source,json]
 ----
 [
   {
@@ -125,34 +133,38 @@ LIMIT 2;
   }
 ]
 ----
+====
 
 [#section_regex_relace]
-== REGEXP_REPLACE(expression, pattern, repl [, n])
+== REGEXP_REPLACE(`expression`, `pattern`, `repl` [, `n`])
 
-*Arguments*::
-*expression*: string, or any N1QL expression that evaluates to a string
-+
-*pattern*: string representing a supported regular expression
-+
-*repl*: string, or any N1QL expression that evaluates to a string
-+
-*n*: the maximum number of times to find and replace the matching pattern
+=== Arguments
+expression:: String, or any N1QL expression that evaluates to a string.
 
-*Return Value*::
+pattern:: String representing a supported regular expression.
+
+repl:: String, or any N1QL expression that evaluates to a string.
+
+n:: [Optional] The maximum number of times to find and replace the matching pattern.
+
+=== Return Value
 Returns new string with occurrences of pattern replaced with _repl_.
 If _n_ is given, at the most _n_ replacements are performed.
 If _n_ is not provided, all matching occurrences are replaced.
 
-*Example 1*::
-+
+=== Examples
+
+.{blank}
+====
+[source,N1QL]
 ----
 SELECT REGEX_REPLACE("N1QL is Sql(infact, sql++) for NoSql", "[sS][qQ][lL]", "SQL"),
        REGEX_REPLACE("Winning innings Inn", "[Ii]n+", "Hotel", 6),
        REGEX_REPLACE("Winning innings Inn", "[IiNn]+g", upper("inning"), 2);
 ----
 
-*Results*::
-+
+.Results
+[source,json]
 ----
 [
   {
@@ -162,18 +174,21 @@ SELECT REGEX_REPLACE("N1QL is Sql(infact, sql++) for NoSql", "[sS][qQ][lL]", "SQ
   }
 ]
 ----
+====
 
-*Example 2*::
+.{blank}
+====
 In this example, the query retrieves first 4 documents and replaces the pattern of repeating n with emphasized ‘NNNN’.
-+
+
+[source,N1QL]
 ----
 SELECT name, REGEX_REPLACE(name, "n+", "NNNN") as new_name
 FROM `travel-sample`
 LIMIT 4;
 ----
 
-*Results*::
-+
+.Results
+[source,json]
 ----
 [
   {
@@ -194,3 +209,4 @@ LIMIT 4;
   }
 ]
 ----
+====

--- a/modules/n1ql/pages/n1ql-language-reference/patternmatchingfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/patternmatchingfun.adoc
@@ -19,7 +19,7 @@ expression:: String, or any N1QL expression that evaluates to a string.
 pattern:: String representing a supported regular expression.
 
 === Return Value
-Returns True if the string value contains the regular expression pattern.
+Returns TRUE if the string value contains any sequence that matches the regular expression pattern.
 
 === Example
 ====
@@ -27,8 +27,8 @@ Returns True if the string value contains the regular expression pattern.
 ----
 SELECT name
 FROM `travel-sample`
-WHERE type = "landmark" AND REGEX_CONTAINS(name, ".*In+")
-LIMIT 2;
+WHERE type = "landmark" AND REGEX_CONTAINS(name, "In+.*")
+LIMIT 5;
 ----
 
 .Results
@@ -40,6 +40,15 @@ LIMIT 2;
   },
   {
     "name": "Sportsman Inn"
+  },
+  {
+    "name": "In-N-Out Burger"
+  },
+  {
+    "name": "Mel's Drive-In"
+  },
+  {
+    "name": "Inverness Castle"
   }
 ]
 ----
@@ -54,7 +63,7 @@ expression:: String, or any N1QL expression that evaluates to a string.
 pattern:: String representing a supported regular expression.
 
 === Return Value
-Returns True if the string value contains the regular expression pattern.
+Returns TRUE if the string value exactly matches the regular expression pattern.
 
 === Example
 ====
@@ -62,8 +71,8 @@ Returns True if the string value contains the regular expression pattern.
 ----
 SELECT name
 FROM `travel-sample`
-WHERE type = "hotel" and REGEX_LIKE(name, "In+.*")
-LIMIT 4;
+WHERE type = "landmark" and REGEX_LIKE(name, "In+.*")
+LIMIT 5;
 ----
 
 .Results
@@ -71,16 +80,19 @@ LIMIT 4;
 ----
 [
   {
-    "name": "Inveraray Youth Hostel"
+    "name": "In-N-Out Burger"
   },
   {
-    "name": "Inverness Youth Hostel"
+    "name": "Inverness Castle"
   },
   {
-    "name": "Indian Cove Campground"
+    "name": "Inverness Museum & Art Gallery"
   },
   {
-    "name": "Inn at Marina del Rey"
+    "name": "Inverness Botanic Gardens"
+  },
+  {
+    "name": "International Petroleum Exchange"
   }
 ]
 ----


### PR DESCRIPTION
Please see draft documentation here:

* [Pattern-matching Functions](https://simon-dew.github.io/docs-site/DOC-4550/server/6.0/n1ql/n1ql-language-reference/patternmatchingfun.html)