### PR TITLE
DOC-4958 Remove top-level tools page

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -534,7 +534,7 @@ include::cli:partial$cbcli/nav.adoc[]
    **** xref:rest-api:rest-encryption.adoc[Encryption On-the-Wire API]
    **** xref:rest-api:rest-secret-mgmt.adoc[Secret Management API]
  ** xref:rest-api:api-explorer.adoc[Admin API Explorer]
-* xref:tools:tools-ref.adoc[Couchbase Server Tools]
+* Couchbase Server Tools
  ** Query Tools
   *** xref:tools:cbq-shell.adoc[cbq: The Command Line Shell for N1QL]
   *** xref:tools:query-workbench.adoc[Query Workbench]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -534,7 +534,7 @@ include::cli:partial$cbcli/nav.adoc[]
    **** xref:rest-api:rest-encryption.adoc[Encryption On-the-Wire API]
    **** xref:rest-api:rest-secret-mgmt.adoc[Secret Management API]
  ** xref:rest-api:api-explorer.adoc[Admin API Explorer]
-* Couchbase Server Tools
+* xref:tools:tools-ref.adoc[Couchbase Server Tools]
  ** Query Tools
   *** xref:tools:cbq-shell.adoc[cbq: The Command Line Shell for N1QL]
   *** xref:tools:query-workbench.adoc[Query Workbench]

--- a/modules/tools/pages/tools-ref.adoc
+++ b/modules/tools/pages/tools-ref.adoc
@@ -1,1 +1,0 @@
-= Couchbase Server Tools

--- a/modules/tools/pages/tools-ref.adoc
+++ b/modules/tools/pages/tools-ref.adoc
@@ -1,0 +1,1 @@
+= Couchbase Server Tools


### PR DESCRIPTION
Currently, the following page has no content:
https://docs.couchbase.com/server/6.0/tools/tools-ref.html

I looked back, and this originated around 4.1/4.5: https://github.com/couchbase/docs-cb4/commit/cd55abba0725f1449a0ce1f99b87f9844e9760f3

I haven't found any references in the docs to this topic, so I think we should delete it and turn the xref in the nav into a normal nav listing.