### PR TITLE
DOC-4958 Remove top-level tools page (#413)

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -540,7 +540,7 @@ include::cli:partial$cbcli/nav.adoc[]
    **** xref:rest-api:rest-encryption.adoc[Encryption On-the-Wire API]
    **** xref:rest-api:rest-secret-mgmt.adoc[Secret Management API]
  ** xref:rest-api:api-explorer.adoc[Admin API Explorer]
-* xref:tools:tools-ref.adoc[Couchbase Server Tools]
+* Couchbase Server Tools
  ** Query Tools
   *** xref:tools:cbq-shell.adoc[cbq: The Command Line Shell for N1QL]
   *** xref:tools:query-workbench.adoc[Query Workbench]


### PR DESCRIPTION
* DOC-4958 Remove top-level tools page

* Revert "DOC-4958 Remove top-level tools page"

This reverts commit 2c320dec5c6f5e38c0711300a08cdda00b3da55e.

* DOC-4598 Fix nav, but keep file for later use