### PR TITLE
DOC-4961: Remove Admin API Explorer until it is updated

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -539,7 +539,6 @@ include::cli:partial$cbcli/nav.adoc[]
    **** xref:rest-api:security-encrypted-access.adoc[Using REST for Encrypted Access]
    **** xref:rest-api:rest-encryption.adoc[Encryption On-the-Wire API]
    **** xref:rest-api:rest-secret-mgmt.adoc[Secret Management API]
- ** xref:rest-api:api-explorer.adoc[Admin API Explorer]
 * Couchbase Server Tools
  ** Query Tools
   *** xref:tools:cbq-shell.adoc[cbq: The Command Line Shell for N1QL]


### PR DESCRIPTION
The Admin API Explorer is in beta and has not been updated since Couchbase Server 5.0. Removing it from the documentation until we've had a chance to update it.