### PR TITLE
DOC-4972: There's an extra comma (,) after the object in the sort specification

### DIFF
--- a/modules/fts/pages/fts-sorting.adoc
+++ b/modules/fts/pages/fts-sorting.adoc
@@ -99,7 +99,7 @@ For instructions on creating a default Full Text Index by means of the Couchbase
        "field" : "reviews.ratings.Overall",
        "mode" : "max",
        "missing" : "last"
-      },
+      }
    ]
 }
 ----


### PR DESCRIPTION
See [fts-sorting.adoc](https://github.com/couchbase/docs-server/pull/444/files) for fix.