### PR TITLE
DOC-5058: Admin API page gives AsciiDoctor WARNINGs at build time

### DIFF
--- a/modules/n1ql/pages/n1ql-rest-api/admin.adoc
+++ b/modules/n1ql/pages/n1ql-rest-api/admin.adoc
@@ -35,6 +35,14 @@ __Version__ : 6.0
 [[_paths]]
 == Paths
 
+:name: \{name}
+:cluster: \{cluster}
+:node: \{node}
+:request: \{request}
+
+// Dummy attributes for path parameters
+
+
 [[_admin_clusters_get]]
 === GET /admin/clusters
 
@@ -44,7 +52,7 @@ Returns information about all clusters.
 
 ==== Responses
 
-[options="header", cols=".^2a,.^14a,.^4a"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |**200**|An array of objects, each of which gives information about one cluster.|< <<_clusters,Clusters>> > array
@@ -53,7 +61,7 @@ Returns information about all clusters.
 
 ==== Security
 
-[options="header", cols=".^3a,.^4a"]
+[options="header", cols=".^3,.^4"]
 |===
 |Type|Name
 |**basic**|**<<_default,Default>>**
@@ -69,7 +77,7 @@ Returns information about the specified cluster.
 
 ==== Parameters
 
-[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
+[options="header", cols=".^2,.^3,.^9,.^4"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**cluster** +
@@ -79,7 +87,7 @@ __required__|The name of a cluster.|string
 
 ==== Responses
 
-[options="header", cols=".^2a,.^14a,.^4a"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |**200**|An object giving information about the specified cluster.|<<_clusters,Clusters>>
@@ -88,7 +96,7 @@ __required__|The name of a cluster.|string
 
 ==== Security
 
-[options="header", cols=".^3a,.^4a"]
+[options="header", cols=".^3,.^4"]
 |===
 |Type|Name
 |**basic**|**<<_default,Default>>**
@@ -104,7 +112,7 @@ Returns information about all nodes in the specified cluster.
 
 ==== Parameters
 
-[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
+[options="header", cols=".^2,.^3,.^9,.^4"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**cluster** +
@@ -114,7 +122,7 @@ __required__|The name of a cluster.|string
 
 ==== Responses
 
-[options="header", cols=".^2a,.^14a,.^4a"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |**200**|An array of objects, each of which gives information about one node.|< <<_nodes,Nodes>> > array
@@ -123,7 +131,7 @@ __required__|The name of a cluster.|string
 
 ==== Security
 
-[options="header", cols=".^3a,.^4a"]
+[options="header", cols=".^3,.^4"]
 |===
 |Type|Name
 |**basic**|**<<_default,Default>>**
@@ -139,7 +147,7 @@ Returns information about the specified node in the specified cluster.
 
 ==== Parameters
 
-[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
+[options="header", cols=".^2,.^3,.^9,.^4"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**cluster** +
@@ -151,7 +159,7 @@ __required__|The name of a node.|string
 
 ==== Responses
 
-[options="header", cols=".^2a,.^14a,.^4a"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |**200**|An object giving information about the specified node.|<<_nodes,Nodes>>
@@ -160,7 +168,7 @@ __required__|The name of a node.|string
 
 ==== Security
 
-[options="header", cols=".^3a,.^4a"]
+[options="header", cols=".^3,.^4"]
 |===
 |Type|Name
 |**basic**|**<<_default,Default>>**
@@ -176,7 +184,7 @@ Returns the configuration of the query service on the cluster.
 
 ==== Responses
 
-[options="header", cols=".^2a,.^14a,.^4a"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |**200**|An object giving information about the specified node.|<<_nodes,Nodes>>
@@ -185,7 +193,7 @@ Returns the configuration of the query service on the cluster.
 
 ==== Security
 
-[options="header", cols=".^3a,.^4a"]
+[options="header", cols=".^3,.^4"]
 |===
 |Type|Name
 |**basic**|**<<_default,Default>>**
@@ -205,7 +213,7 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-prepared[Get Prepare
 
 ==== Responses
 
-[options="header", cols=".^2a,.^14a,.^4a"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |**200**|An array of objects, each of which contains information about one prepared statement.|< <<_statements,Statements>> > array
@@ -214,7 +222,7 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-prepared[Get Prepare
 
 ==== Security
 
-[options="header", cols=".^3a,.^4a"]
+[options="header", cols=".^3,.^4"]
 |===
 |Type|Name
 |**basic**|**<<_default,Default>>**
@@ -234,7 +242,7 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-prepared[Get Prepare
 
 ==== Parameters
 
-[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
+[options="header", cols=".^2,.^3,.^9,.^4"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**name** +
@@ -245,7 +253,7 @@ This may be a UUID that was assigned automatically, or a name that was user-spec
 
 ==== Responses
 
-[options="header", cols=".^2a,.^14a,.^4a"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |**200**|An object containing information about the specified prepared statement.|<<_statements,Statements>>
@@ -254,7 +262,7 @@ This may be a UUID that was assigned automatically, or a name that was user-spec
 
 ==== Security
 
-[options="header", cols=".^3a,.^4a"]
+[options="header", cols=".^3,.^4"]
 |===
 |Type|Name
 |**basic**|**<<_default,Default>>**
@@ -274,7 +282,7 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-prepared[Delete Prep
 
 ==== Parameters
 
-[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
+[options="header", cols=".^2,.^3,.^9,.^4"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**name** +
@@ -285,7 +293,7 @@ This may be a UUID that was assigned automatically, or a name that was user-spec
 
 ==== Responses
 
-[options="header", cols=".^2a,.^14a,.^4a"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |**200**|True if the prepared statement was successfully deleted.|boolean
@@ -295,7 +303,7 @@ This may be a UUID that was assigned automatically, or a name that was user-spec
 
 ==== Security
 
-[options="header", cols=".^3a,.^4a"]
+[options="header", cols=".^3,.^4"]
 |===
 |Type|Name
 |**basic**|**<<_default,Default>>**
@@ -315,7 +323,7 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-active-req[Get Activ
 
 ==== Responses
 
-[options="header", cols=".^2a,.^14a,.^4a"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |**200**|An array of objects, each of which contains information about one active request.|< <<_requests,Requests>> > array
@@ -324,7 +332,7 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-active-req[Get Activ
 
 ==== Security
 
-[options="header", cols=".^3a,.^4a"]
+[options="header", cols=".^3,.^4"]
 |===
 |Type|Name
 |**basic**|**<<_default,Default>>**
@@ -344,7 +352,7 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-active-req[Get Activ
 
 ==== Parameters
 
-[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
+[options="header", cols=".^2,.^3,.^9,.^4"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**request** +
@@ -355,7 +363,7 @@ This is the `requestID` that was assigned automatically when the statement was c
 
 ==== Responses
 
-[options="header", cols=".^2a,.^14a,.^4a"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |**200**|An object containing information about the specified active request.|<<_requests,Requests>>
@@ -364,7 +372,7 @@ This is the `requestID` that was assigned automatically when the statement was c
 
 ==== Security
 
-[options="header", cols=".^3a,.^4a"]
+[options="header", cols=".^3,.^4"]
 |===
 |Type|Name
 |**basic**|**<<_default,Default>>**
@@ -384,7 +392,7 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-active-req[Terminate
 
 ==== Parameters
 
-[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
+[options="header", cols=".^2,.^3,.^9,.^4"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**request** +
@@ -395,7 +403,7 @@ This is the `requestID` that was assigned automatically when the statement was c
 
 ==== Responses
 
-[options="header", cols=".^2a,.^14a,.^4a"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |**200**|True if the active request was successfully terminated.|boolean
@@ -405,7 +413,7 @@ This is the `requestID` that was assigned automatically when the statement was c
 
 ==== Security
 
-[options="header", cols=".^3a,.^4a"]
+[options="header", cols=".^3,.^4"]
 |===
 |Type|Name
 |**basic**|**<<_default,Default>>**
@@ -425,7 +433,7 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-req[Get Co
 
 ==== Responses
 
-[options="header", cols=".^2a,.^14a,.^4a"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |**200**|An array of objects, each of which contains information about one completed request.|< <<_requests,Requests>> > array
@@ -434,7 +442,7 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-req[Get Co
 
 ==== Security
 
-[options="header", cols=".^3a,.^4a"]
+[options="header", cols=".^3,.^4"]
 |===
 |Type|Name
 |**basic**|**<<_default,Default>>**
@@ -454,7 +462,7 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-req[Get Co
 
 ==== Parameters
 
-[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
+[options="header", cols=".^2,.^3,.^9,.^4"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**request** +
@@ -465,7 +473,7 @@ This is the `requestID` that was assigned automatically when the statement was c
 
 ==== Responses
 
-[options="header", cols=".^2a,.^14a,.^4a"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |**200**|An object containing information about the specified active request.|<<_requests,Requests>>
@@ -474,7 +482,7 @@ This is the `requestID` that was assigned automatically when the statement was c
 
 ==== Security
 
-[options="header", cols=".^3a,.^4a"]
+[options="header", cols=".^3,.^4"]
 |===
 |Type|Name
 |**basic**|**<<_default,Default>>**
@@ -494,7 +502,7 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-req[Purgin
 
 ==== Parameters
 
-[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
+[options="header", cols=".^2,.^3,.^9,.^4"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**request** +
@@ -505,7 +513,7 @@ This is the `requestID` that was assigned automatically when the statement was c
 
 ==== Responses
 
-[options="header", cols=".^2a,.^14a,.^4a"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |**200**|True if the completed request was successfully purged.|boolean
@@ -515,7 +523,7 @@ This is the `requestID` that was assigned automatically when the statement was c
 
 ==== Security
 
-[options="header", cols=".^3a,.^4a"]
+[options="header", cols=".^3,.^4"]
 |===
 |Type|Name
 |**basic**|**<<_default,Default>>**
@@ -536,7 +544,7 @@ Returns all prepared index statements.
 
 ==== Responses
 
-[options="header", cols=".^2a,.^14a,.^4a"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |**200**|An array of strings, each of which is the name of a prepared index statement.|< string > array
@@ -545,7 +553,7 @@ Returns all prepared index statements.
 
 ==== Security
 
-[options="header", cols=".^3a,.^4a"]
+[options="header", cols=".^3,.^4"]
 |===
 |Type|Name
 |**basic**|**<<_default,Default>>**
@@ -566,7 +574,7 @@ Returns all active index requests.
 
 ==== Responses
 
-[options="header", cols=".^2a,.^14a,.^4a"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |**200**|An array of strings, each of which is the requestID of an active index request.|< string (uuid) > array
@@ -575,7 +583,7 @@ Returns all active index requests.
 
 ==== Security
 
-[options="header", cols=".^3a,.^4a"]
+[options="header", cols=".^3,.^4"]
 |===
 |Type|Name
 |**basic**|**<<_default,Default>>**
@@ -596,7 +604,7 @@ Returns all completed index requests.
 
 ==== Responses
 
-[options="header", cols=".^2a,.^14a,.^4a"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |**200**|An array of strings, each of which is the requestID of a completed index request.|< string (uuid) > array
@@ -605,7 +613,7 @@ Returns all completed index requests.
 
 ==== Security
 
-[options="header", cols=".^3a,.^4a"]
+[options="header", cols=".^3,.^4"]
 |===
 |Type|Name
 |**basic**|**<<_default,Default>>**
@@ -621,7 +629,7 @@ Returns a minimal response, indicating that the service is running and reachable
 
 ==== Responses
 
-[options="header", cols=".^2a,.^14a,.^4a"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |**200**|An empty object.|object
@@ -630,7 +638,7 @@ Returns a minimal response, indicating that the service is running and reachable
 
 ==== Security
 
-[options="header", cols=".^3a,.^4a"]
+[options="header", cols=".^3,.^4"]
 |===
 |Type|Name
 |**basic**|**<<_none,None>>**
@@ -662,7 +670,7 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#vitals[Get System Vitals
 
 ==== Responses
 
-[options="header", cols=".^2a,.^14a,.^4a"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |**200**|An object containing all vital statistics.|<<_vitals,Vitals>>
@@ -671,7 +679,7 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#vitals[Get System Vitals
 
 ==== Security
 
-[options="header", cols=".^3a,.^4a"]
+[options="header", cols=".^3,.^4"]
 |===
 |Type|Name
 |**basic**|**<<_default,Default>>**
@@ -687,7 +695,7 @@ Returns all statistics.
 
 ==== Responses
 
-[options="header", cols=".^2a,.^14a,.^4a"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |**200**|An object containing all statistics.
@@ -698,7 +706,7 @@ Each statistic has a different set of metrics.|<<_statistics,Statistics>>
 
 ==== Security
 
-[options="header", cols=".^3a,.^4a"]
+[options="header", cols=".^3,.^4"]
 |===
 |Type|Name
 |**basic**|**<<_default,Default>>**
@@ -714,7 +722,7 @@ Returns the specified statistic.
 
 ==== Parameters
 
-[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
+[options="header", cols=".^2,.^3,.^9,.^4"]
 |===
 |Type|Name|Description|Schema
 |**Path**|**stat** +
@@ -726,7 +734,7 @@ You cannot specify a metric.|enum (active_requests, at_plus, cancelled, deletes,
 
 ==== Responses
 
-[options="header", cols=".^2a,.^14a,.^4a"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |**200**|An object containing all metrics for the specified statistic.
@@ -736,7 +744,7 @@ Each statistic has a different set of metrics.|<<_metrics,Metrics>>
 
 ==== Security
 
-[options="header", cols=".^3a,.^4a"]
+[options="header", cols=".^3,.^4"]
 |===
 |Type|Name
 |**basic**|**<<_default,Default>>**
@@ -752,16 +760,16 @@ Currently unused.
 
 ==== Responses
 
-[options="header", cols=".^2a,.^14a,.^4a"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
-|**302**|Redirects to the <<_get_stats>> endpoint.|text/html
+|**302**|Redirects to the <<_get_stats>> endpoint.|No Content
 |===
 
 
 ==== Security
 
-[options="header", cols=".^3a,.^4a"]
+[options="header", cols=".^3,.^4"]
 |===
 |Type|Name
 |**basic**|**<<_none,None>>**
@@ -792,7 +800,7 @@ Refer to xref:settings:query-settings.adoc[Query Settings] for more information 
 
 ==== Responses
 
-[options="header", cols=".^2a,.^14a,.^4a"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |**200**|An object giving service-level query settings.|<<_settings,Settings>>
@@ -801,7 +809,7 @@ Refer to xref:settings:query-settings.adoc[Query Settings] for more information 
 
 ==== Security
 
-[options="header", cols=".^3a,.^4a"]
+[options="header", cols=".^3,.^4"]
 |===
 |Type|Name
 |**basic**|**<<_default,Default>>**
@@ -821,7 +829,7 @@ Refer to xref:settings:query-settings.adoc[Query Settings] for more information 
 
 ==== Parameters
 
-[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
+[options="header", cols=".^2,.^3,.^9,.^4"]
 |===
 |Type|Name|Description|Schema
 |**Body**|**Settings** +
@@ -831,7 +839,7 @@ __optional__|An object specifying service-level query settings.|<<_settings,Sett
 
 ==== Responses
 
-[options="header", cols=".^2a,.^14a,.^4a"]
+[options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
 |**200**|An object giving service-level query settings, including the latest changes.|<<_settings,Settings>>
@@ -840,7 +848,7 @@ __optional__|An object specifying service-level query settings.|<<_settings,Sett
 
 ==== Security
 
-[options="header", cols=".^3a,.^4a"]
+[options="header", cols=".^3,.^4"]
 |===
 |Type|Name
 |**basic**|**<<_default,Default>>**
@@ -855,7 +863,7 @@ __optional__|An object specifying service-level query settings.|<<_settings,Sett
 [[_clusters]]
 === Clusters
 
-[options="header", cols=".^3a,.^11a,.^4a"]
+[options="header", cols=".^3,.^11,.^4"]
 |===
 |Name|Description|Schema
 |**accountstore** +
@@ -874,7 +882,7 @@ __optional__||string
 [[_nodes]]
 === Nodes
 
-[options="header", cols=".^3a,.^11a,.^4a"]
+[options="header", cols=".^3,.^11,.^4"]
 |===
 |Name|Description|Schema
 |**adminEndpoint** +
@@ -897,7 +905,7 @@ __optional__|The HTTPS URL of the query endpoint.|string
 [[_requests]]
 === Requests
 
-[options="header", cols=".^3a,.^11a,.^4a"]
+[options="header", cols=".^3,.^11,.^4"]
 |===
 |Name|Description|Schema
 |**clientContextID** +
@@ -941,7 +949,7 @@ __optional__|Username with whose privileges the query is run.|string
 [[_statements]]
 === Statements
 
-[options="header", cols=".^3a,.^11a,.^4a"]
+[options="header", cols=".^3,.^11,.^4"]
 |===
 |Name|Description|Schema
 |**encoded_plan** +
@@ -963,7 +971,7 @@ __optional__||number
 [[_vitals]]
 === Vitals
 
-[options="header", cols=".^3a,.^11a,.^4a"]
+[options="header", cols=".^3,.^11,.^4"]
 |===
 |Name|Description|Schema
 |**cores** +
@@ -1028,7 +1036,7 @@ __optional__|The version of the query engine.|string
 [[_statistics]]
 === Statistics
 
-[options="header", cols=".^3a,.^11a,.^4a"]
+[options="header", cols=".^3,.^11,.^4"]
 |===
 |Name|Description|Schema
 |**active_requests.count** +
@@ -1152,7 +1160,7 @@ __optional__|The total number of N1QL warnings returned so far.|number
 [[_metrics]]
 === Metrics
 
-[options="header", cols=".^3a,.^11a,.^4a"]
+[options="header", cols=".^3,.^11,.^4"]
 |===
 |Name|Description|Schema
 |**15m.rate** +
@@ -1189,7 +1197,7 @@ __optional__|The standard deviation.|number
 [[_settings]]
 === Settings
 
-[options="header", cols=".^3a,.^11a,.^4a"]
+[options="header", cols=".^3,.^11,.^4"]
 |===
 |Name|Description|Schema
 |**completed-limit** +

--- a/modules/n1ql/pages/n1ql-rest-api/admin.adoc
+++ b/modules/n1ql/pages/n1ql-rest-api/admin.adoc
@@ -3,6 +3,10 @@
 
 [[_overview]]
 == Overview
+
+// This file is created automatically by Swagger2Markup.
+// DO NOT EDIT!
+
 The Admin REST API is a secondary API provided by the Query service.
 This API enables you to retrieve statistics about the clusters and nodes running the Query service; view or specify service-level settings; and view or delete requests.
 


### PR DESCRIPTION
The auto-generated Admin API document contains the path parameters `{name}`, `{cluster}`, `{node}`, and `{request}`. These are interpreted by Antora as AsciiDoc attributes. Since none of these attributes is defined, Antora gave warning messages at build time.

I cannot change the format of the path parameters, as they are necessary for the validity of the Swagger spec from which the Admin API document is generated.

In this fix I have added dummy attribute definitions to the Paths section of the document. These define the AsciiDoc attributes `{name}`, `{cluster}`, `{node}`, and `{request}` as escaped versions of the corresponding path parameter names. The output is identical, but Antora no longer generates warnings at build time.

I have also updated to the latest snapshot of Swagger2Markup, which means the table definitions have also changed in the Admin API document.