### PR TITLE
Update rest-node-provisioning.adoc

### DIFF
--- a/modules/rest-api/pages/rest-node-provisioning.adoc
+++ b/modules/rest-api/pages/rest-node-provisioning.adoc
@@ -21,7 +21,7 @@ curl -u Administrator:password -v -X POST http://[localhost]:8091/node/controlle
 
 // Setup Services
 curl -u Administrator:password -v -X POST http://[localhost]:8091/node/controller/setupServices
-  -d services=[data | index | n1ql | fts]
+  -d services=[kv | index | n1ql | fts]
 
 // Setup Administrator username and password
 curl -u Administrator:password -v -X POST http://[localhost]:8091/settings/web


### PR DESCRIPTION
data is not a valid parameter to pass `node/controller/setupServices`. Updated to reflect the example.

```
// Setup Services
curl  -u Administrator:password -v -X POST http://192.168.42.101:8091/node/controller/setupServices \
  -d 'services=kv%2Cn1ql%2Cindex%2Cfts'
```