### PR TITLE
DOC-5085: 4xx Page aliases for query

### DIFF
--- a/modules/learn/pages/data/n1ql-versus-sql.adoc
+++ b/modules/learn/pages/data/n1ql-versus-sql.adoc
@@ -1,5 +1,6 @@
 = N1QL versus SQL
 :page-topic-type: concept
+:page-aliases: n1ql:n1ql-intro/n1ql-sql-differences
 
 [abstract]
 The most important difference between N1QL and SQL is the _data model_.

--- a/modules/rest-api/pages/rest-buckets-streamingURI.adoc
+++ b/modules/rest-api/pages/rest-buckets-streamingURI.adoc
@@ -1,5 +1,6 @@
 = Getting Bucket Streaming URI
 :page-topic-type: reference
+:page-aliases: rest-buckets-streaminguri
 
 [abstract]
 To retrieve the streaming URI, use `GET /pools/default/buckets/default` HTTP method and URI.

--- a/modules/tools/pages/query-workbench.adoc
+++ b/modules/tools/pages/query-workbench.adoc
@@ -1,4 +1,5 @@
 = Query Workbench
+:page-aliases: developer-guide:query-workbench-intro
 
 [abstract]
 The [.ui]*Query Workbench* provides a rich graphical user interface to perform query development.


### PR DESCRIPTION
Porting #471 to Mad Hatter

- string-functions is release/4.6 only
- rest-bucket-auth not ported because of alias conflict, see #488 

- [x] https://docs.couchbase.com/server/6.0/n1ql/n1ql-intro/n1ql-sql-differences.html
- [x] https://docs.couchbase.com/server/6.0/rest-api/rest-buckets-streaminguri.html
- [x] https://docs.couchbase.com/server/6.0/developer-guide/query-workbench-intro.html