### PR TITLE
DOC-5284: Create "full text query syntax help" page (5.5)

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -114,6 +114,7 @@
  ** xref:fts:fts-using-analyzers.adoc[Understanding Analyzers]
  ** xref:fts:fts-queries.adoc[Understanding Queries]
   *** xref:fts:fts-query-types.adoc[Query Types]
+   **** xref:fts:query-string-queries.adoc[Query String Queries]
    **** xref:fts:fts-geospatial-queries.adoc[Geospatial Queries]
   *** xref:fts:fts-sorting.adoc[Sorting Query Results]
   *** xref:fts:fts-response-object-schema.adoc[Handling Response Objects]

--- a/modules/fts/pages/fts-query-types.adoc
+++ b/modules/fts/pages/fts-query-types.adoc
@@ -12,26 +12,27 @@ This page describes the purpose of each query-type, and provides sample JSON obj
 
 Available query-types include:
 
-* _Simple Queries_: Accept input-text in the form of words and phrases, and attempt to find matches across bodies of text that have been _indexed_.
+Simple Queries:: Accept input-text in the form of words and phrases, and attempt to find matches across bodies of text that have been _indexed_.
 _Analyzers_ are applied to both input and target, potentially to strip out unnecessary characters, reduce words to the basic stems on which matching should occur, handle punctuation, and more.
 Additionally, match accuracy-levels can be specified; and multiple queries can be expressed together, with their respective priorities _boosted_, (to ensure their results' prominence in the eventual result-set).
-* _Compound Queries_: Accept multiple queries simultaneously, and return either the _conjunction_ of results from the result-sets, or a _disjunction_.
-* _Range Queries_: Accept ranges for dates and numbers, and return documents that contain values within those ranges.
-* _Query String Queries_: Accept _query strings_, which express query-requirements in a special syntax.
-* _Geospatial Queries_: Accept _longitude_-_latitude_ coordinate pairs, in order to return documents that specify a geographical location.
-* _Non-Analytic Queries_: Accept words and phrases on which exact matches only are returned.
+Compound Queries:: Accept multiple queries simultaneously, and return either the _conjunction_ of results from the result-sets, or a _disjunction_.
+Range Queries:: Accept ranges for dates and numbers, and return documents that contain values within those ranges.
+Query String Queries:: Accept _query strings_, which express query-requirements in a special syntax.
+Geospatial Queries:: Accept _longitude_-_latitude_ coordinate pairs, in order to return documents that specify a geographical location.
+Non-Analytic Queries:: Accept words and phrases on which exact matches only are returned.
 No analysis is performed.
-* _Special Queries_: For testing purposes, return either all of the documents in an index, or none.
+Special Queries:: For testing purposes, return either all of the documents in an index, or none.
 
 These query-types are explained in greater detail below.
 Examples are provided, using the Couchbase REST API query-syntax.
-(Note that Full Text Search can also be performed with the Couchbase Web Console and the Couchbase SDK.) The JSON data refers to the  `travel-sample` bucket, and assumes the existence of a Full Text Index named `hotel`.
+(Note that Full Text Search can also be performed with the Couchbase Web Console and the Couchbase SDK.)
+The JSON data refers to the `travel-sample` bucket, and assumes that demonstration full text indexes have been created, as described in xref:fts-demonstration-indexes.adoc[Demonstration Indexes].
 
 To run the examples using `curl`, use the following syntax:
 
-[source,json]
+[source,console]
 ----
-curl -u Administrator:password -X POST -H "Content-Type: application/json" \
+$ curl -u Administrator:password -X POST -H "Content-Type: application/json" \
   -d '{your query in JSON here...}' \
   http://localhost:8094/api/index/index_name/query
 ----
@@ -56,19 +57,21 @@ For more information on using the REST API to perform queries, see xref:fts-sear
 [#simple-queries]
 == Simple Queries
 
-[[match-query]]*Match Query*::
+[[match-query]]
+=== Match Query
+
 A match query _analyzes_ input text, and uses the results to query an index.
 Options include specifying an analyzer, performing a _fuzzy match_, and performing a _prefix match_.
 By default, the analyzer used for the input-text is that previously used on the target-text, during index-creation.
 For information on analyzers, see xref:fts-using-analyzers.adoc[Understanding Analyzers].
-+
+
 When fuzzy matching is used, if the single parameter is set to a non-zero integer, the analyzed text is matched with a corresponding level of fuzziness.
-The maximum fuzziness is 2.
-+
+The maximum supported fuzziness is 2.
+
 When a prefix match is used, the [.param]`prefix_length` parameter specifies that for a match to occur, a prefix of specified length must be shared by the input-term and the target text-element.
-+
+
 The following JSON object demonstrates specification of a match query:
-+
+
 [source,json]
 ----
 {
@@ -79,17 +82,19 @@ The following JSON object demonstrates specification of a match query:
  "prefix_length": 4
 }
 ----
-+
+
 A match query is also demonstrated by means of the Java SDK, in xref:java-sdk::full-text-searching-with-sdk.adoc[Searching with the SDK].
 
-[[match-phrase-query]]*Match Phrase Query*::
+[[match-phrase-query]]
+=== Match Phrase Query
+
 The input text is analyzed, and a phrase query is built with the terms resulting from the analysis.
 This type of query searches for terms in the target that occur _in the positions and offsets indicated by the input_: this depends on _term vectors_, which must have been included in the creation of the index used for the search.
-+
+
 For example, a match phrase query for `location for functions` is matched with `locate the function`, if the standard analyzer is used: this analyzer uses a _stemmer_, which tokenizes `location` and `locate` to `locat`, and reduces `functions` and `function` to `function`.
 Additionally, the analyzer employs _stop_ removal, which removes small and less significant words from input and target text, so that matches are attempted on only the more significant elements of vocabulary: in this case  `for` and `the` are removed.
 Following this processing, the tokens `locat` and `function` are recognized as _common to both input and target_; and also as being both _in the same sequence as_, and _at the same distance from_ one another; and therefore a match is made.
-+
+
 [source,json]
 ----
 {
@@ -97,16 +102,17 @@ Following this processing, the tokens `locat` and `function` are recognized as _
  "field": "reviews.content"
 }
 ----
-+
+
 A match phrase query is also demonstrated by means of the Java SDK, in xref:java-sdk::full-text-searching-with-sdk.adoc[Searching with the SDK].
 
-*Fuzzy Query*::
+=== Fuzzy Query
+
 A _fuzzy query_ matches terms within a specified _edit_ (or _Levenshtein_) distance: meaning that terms are considered to match when they are to a specified degree _similar_, rather than _exact_.
 A common prefix of a stated length may be also specified as a requirement for matching.
-+
+
 Fuzziness is specified by means of a single integer.
 For example:
-+
+
 [source,json]
 ----
 {
@@ -115,13 +121,14 @@ For example:
  "fuzziness": 2
 }
 ----
-+
-__Fuzziness__s is  demonstrated by means of the Java SDK, in the context of the _term query_ (see below), in xref:java-sdk::full-text-searching-with-sdk.adoc[Searching with the SDK].
+
+__Fuzziness__ is demonstrated by means of the Java SDK, in the context of the _term query_ (see below), in xref:java-sdk::full-text-searching-with-sdk.adoc[Searching with the SDK].
 Note that two such queries are specified, with the difference in fuzziness between them resulting in different forms of match, and different sizes of result-sets.
 
-*Prefix Query*::
+=== Prefix Query
+
 A _prefix_ query finds documents containing terms that start with the specified prefix.
-+
+
 [source,json]
 ----
 {
@@ -130,9 +137,10 @@ A _prefix_ query finds documents containing terms that start with the specified 
 }
 ----
 
-*Regexp Query*::
+=== Regexp Query
+
 A _regexp_ query finds documents containing terms that match the specified regular expression.
-+
+
 [source,json]
 ----
 {
@@ -140,14 +148,15 @@ A _regexp_ query finds documents containing terms that match the specified regul
  "field": "reviews.content"
 }
 ----
-+
+
 A regexp query is also demonstrated by means of the Java SDK, in xref:java-sdk::full-text-searching-with-sdk.adoc[Searching with the SDK].
 
-*Wildcard Query*::
+=== Wildcard Query
+
 A _wildcard_ query uses a wildcard expression, to search within individual terms for matches.
 Wildcard expressions can be any single character (`?`) or zero to many characters (`*`).
 Wildcard expressions can appear in the middle or end of a term, but not at the beginning.
-+
+
 [source,json]
 ----
 {
@@ -155,13 +164,14 @@ Wildcard expressions can appear in the middle or end of a term, but not at the b
  "field": "reviews.content"
 }
 ----
-+
+
 A wildcard query is also demonstrated by means of the Java SDK, in xref:java-sdk::full-text-searching-with-sdk.adoc[Searching with the SDK].
 
-*Boolean Field Query*::
+=== Boolean Field Query
+
 A _boolean field_ query searches fields that contain boolean `true` or `false` values.
 A boolean field query searches the actual content of the field, and should not be confused with the <<boolean-query,boolean queries>> (described below, in the section on compound queries) that modify whether a query must, should, or must not be present.
-+
+
 [source,json]
 ----
 {
@@ -173,10 +183,11 @@ A boolean field query searches the actual content of the field, and should not b
 [#compound-queries]
 == Compound Queries
 
-*Conjunction Query (AND)*::
+=== Conjunction Query (AND)
+
 A _conjunction_ query contains multiple _child queries_.
 Its result documents must satisfy all of the child queries.
-+
+
 [source,json]
 ----
 {
@@ -186,15 +197,16 @@ Its result documents must satisfy all of the child queries.
  ]
 }
 ----
-+
+
 A conjunction query is also demonstrated by means of the Java SDK, in xref:java-sdk::full-text-searching-with-sdk.adoc[Searching with the SDK].
 
-*Disjunction Query (OR)*::
+=== Disjunction Query (OR)
+
 A _disjunction_ query contains multiple _child queries_.
 Its result documents must satisfy a configurable `min` number of child queries.
 By default this `min` is set to 1.
 For example, if three child queries — A, B, and C — are specified, a `min` of 1 specifies that the result documents should be those returned uniquely for A (with all returned uniquely for B and C, and all returned commonly for A, B, and C, omitted).
-+
+
 [source,json]
 ----
 {
@@ -204,10 +216,12 @@ For example, if three child queries — A, B, and C — are specified, a `min` o
  ]
 }
 ----
-+
+
 A disjunction query is also demonstrated by means of the Java SDK, in xref:java-sdk::full-text-searching-with-sdk.adoc[Searching with the SDK].
 
-[[boolean-query]]*Boolean Query*::
+[[boolean-query]]
+=== Boolean Query
+
 A _boolean query_ is a combination of conjunction and disjunction queries.
 A boolean query takes three lists of queries:
 
@@ -215,7 +229,6 @@ A boolean query takes three lists of queries:
 * `should`: Result documents should satisfy these queries.
 * `must not`: Result documents must not satisfy any of these queries.
 
-+
 [source,json]
 ----
 {
@@ -228,27 +241,30 @@ A boolean query takes three lists of queries:
 }
 ----
 
-*Doc ID Query*::
+=== Doc ID Query
+
 A _doc ID_ query returns the indexed document or documents among the specified set.
 This is typically used in conjunction queries, to restrict the scope of other queries’ output.
-+
+
 [source,json]
 ----
 { "ids": [ "hotel_10158", "hotel_10159" ] }
 ----
-+
+
 A doc ID Query is demonstrated by means of the Java SDK, in xref:java-sdk::full-text-searching-with-sdk.adoc[Searching with the SDK].
 
 [#range-queries]
 == Range Queries
 
-*Date Range Query*::
+[[date-range]]
+=== Date Range Query
+
 A _date range_ query finds documents containing a date value, in the specified field within the specified range.
 Dates should be in the format specified by https://www.ietf.org/rfc/rfc3339.txt[RFC-3339^], which is a specific profile of ISO-8601.
 Define the endpoints using the fields [.param]`start` and [.param]`end`.
 One endpoint can be omitted, but not both.
 The [.param]`inclusiveStart` and [.param]`inclusiveEnd` properties in the query JSON control whether or not the endpoints are included or excluded.
-+
+
 [source,json]
 ----
 {
@@ -260,13 +276,15 @@ The [.param]`inclusiveStart` and [.param]`inclusiveEnd` properties in the query 
 }
 ----
 
-*Numeric Range Query*::
+[[numeric-range]]
+=== Numeric Range Query
+
 A _numeric range_ query finds documents containing a numeric value in the specified field within the specified range.
 Define the endpoints using the fields [.param]`min` and [.param]`max`.
 You can omit one endpoint, but not both.
 The [.param]`inclusiveMin` and [.param]`inclusiveMax` properties control whether or not the endpoints are included or excluded.
 By default, [.param]`min` is inclusive and [.param]`max` is exclusive.
-+
+
 [source,json]
 ----
 {
@@ -276,7 +294,7 @@ By default, [.param]`min` is inclusive and [.param]`max` is exclusive.
  "field": "id"
 }
 ----
-+
+
 A numeric range Query is also demonstrated by means of the Java SDK, in xref:java-sdk::full-text-searching-with-sdk.adoc[Searching with the SDK].
 
 [#query-string-query-syntax]
@@ -296,40 +314,7 @@ Note also that the Full Text Searches conducted with the Couchbase Web Console t
 Certain queries supported by FTS are not yet supported by the query string syntax.
 This includes wildcards, regexp, and date range queries.
 
-Using the query string syntax, the following query types can be performed:
-
-*Match*::
-A term without any other syntax is interpreted as a match query for the term in the default field.
-The default field is `_all`.
-+
-For example, `water` performs a <<match-query,Match Query>> for the term `water`.
-
-*Match Phrases*::
-Placing the search terms in quotes performs a match phrase query.
-For example: [.in]`light beer` performs a <<match-phrase-query,match phrase query>> for the phrase `light beer`.
-
-*Field Scoping*::
-The specified field in which to search can be specified by prefixing the term with a field-name, separated by a colon.
-For example, [.in]`description:water` performs a <<match-query,match query>> for the term `water`, in the `description` field.
-
-*Required, Optional, and Exclusion*::
-When a query string includes multiple items, by default these are placed into the SHOULD clause of a http://www.blevesearch.com/docs/Query/#boolean:8f767fbc41af8ff1ddcf4c60ed8c0fe9[boolean query^].
-This can be adjusted, by prefixing items with either `+` or `-`.
-Prefixing with `+` places that item in the MUST portion of the boolean query.
-Prefixing with `-` places that item in the MUST NOT portion of the boolean query.
-+
-For example, `+description:water -light beer` performs a boolean query that MUST satisfy the match query for the term `water` in the `description` field, MUST NOT satisfy the match query for the term `light` in the `default` field, and SHOULD satisfy the match query for the term `beer` in the `default` field.
-Result documents satisfying the SHOULD clause score higher than those that do not.
-
-*Boosting*::
-When multiple query-clauses are specified, the relative importance a given clause can be specified by suffixing it with the `^` operator, followed by a number.
-For example, `description:water name:water^5` performs Match Queries for `water` in both the `name` and `description` fields, but documents having the term in the `name` field score higher.
-
-*Numeric Ranges*::
-Numeric ranges can be specified with the >, >=, <, and \<= operators, each followed by a numeric value.
-For example, `abv:>10` performs a numeric range query on the `abv` field, for values greater than 10.
-+
-A numeric range query is demonstrated by means of the Java SDK, in xref:java-sdk::full-text-searching-with-sdk.adoc[Searching with the SDK].
+More detailed information is provided in xref:query-string-queries.adoc[Query String Queries].
 
 [#non-analytic-queries]
 == Non-Analytic Queries
@@ -340,10 +325,11 @@ This means that only exact matches are returned.
 In most cases, given the benefits of using analyzers, use of match and match phrase queries is preferable to that of term and phrase.
 For information on analyzers, see xref:fts-using-analyzers.adoc[Understanding Analyzers].
 
-*Term Query*::
+=== Term Query
+
 A _term_ query is the simplest possible query.
 It performs an exact match in the index for the provided term.
-+
+
 [source,json]
 ----
 {
@@ -351,13 +337,14 @@ It performs an exact match in the index for the provided term.
   "field": "reviews.content"
 }
 ----
-+
+
 Term queries are also demonstrated by means of the Java SDK, in xref:java-sdk::full-text-searching-with-sdk.adoc[Searching with the SDK].
 
-*Phrase Query*::
+=== Phrase Query
+
 A _phrase query_ searches for terms occurring in the specified position and offsets.
 It performs an exact term-match for all the phrase-constituents, without using an analyzer.
-+
+
 [source,json]
 ----
 {
@@ -365,7 +352,7 @@ It performs an exact term-match for all the phrase-constituents, without using a
   "field": "reviews.content"
 }
 ----
-+
+
 A phrase query is also demonstrated by means of the Java SDK, in xref:java-sdk::full-text-searching-with-sdk.adoc[Searching with the SDK].
 
 [#geospatial-queries]
@@ -389,18 +376,20 @@ More detailed information is provided in xref:fts-geospatial-queries.adoc[Geospa
 
 _Special_ queries are usually employed either in combination with other queries, or to test the system.
 
-*Match All Query*::
+=== Match All Query
+
 Matches _all_ documents in an index, irrespective of terms.
 For example, if an index is created on the `travel-sample` bucket for documents of type `zucchini`, the _match all_ query returns all document IDs from the `travel-sample` bucket, even though the bucket contains no documents of type `zucchini`.
-+
+
 [source,json]
 ----
 { "match_all": {} }
 ----
 
-*Match None Query*::
+=== Match None Query
+
 Matches no documents in the index.
-+
+
 [source,json]
 ----
 { "match_none": {} }

--- a/modules/fts/pages/fts-query-types.adoc
+++ b/modules/fts/pages/fts-query-types.adoc
@@ -312,7 +312,7 @@ Note also that the Full Text Searches conducted with the Couchbase Web Console t
 (See xref:fts-searching-from-the-ui.adoc[Searching from the UI].)
 
 Certain queries supported by FTS are not yet supported by the query string syntax.
-This includes wildcards, regexp, and date range queries.
+These include wildcards and regular expressions.
 
 More detailed information is provided in xref:query-string-queries.adoc[Query String Queries].
 

--- a/modules/fts/pages/query-string-queries.adoc
+++ b/modules/fts/pages/query-string-queries.adoc
@@ -1,0 +1,51 @@
+= Query String Queries
+
+[abstract]
+Query strings enable humans to describe complex queries using a simple syntax.
+
+Using the query string syntax, the following query types can be performed:
+
+== Match
+
+A term without any other syntax is interpreted as a match query for the term in the default field.
+The default field is `_all`.
+
+For example, `pool` performs a xref:fts-query-types.adoc#match-query[match query] for the term `pool`.
+
+== Match Phrases
+
+Placing the search terms in quotes performs a match phrase query.
+
+For example, `"continental breakfast"` performs a xref:fts-query-types.adoc#match-phrase-query[match phrase query] for the phrase `continental breakfast`.
+
+== Field Scoping
+
+You can specify the field in which to search by prefixing the term with a field-name, separated by a colon.
+
+The field-name may be a path to a field, using dot notation.
+The path must use Search syntax rather than N1QL syntax; in other words, you cannot specify array locations such as `[*]` or `[3]` in the path.
+
+For example, `description:pool` performs a xref:fts-query-types.adoc#match-query[match query] for the term `pool`, in the `description` field.
+
+== Required, Optional, and Exclusion
+
+When a query string includes multiple items, by default these are placed into the SHOULD clause of a xref:fts-query-types.adoc#boolean-query[boolean query].
+You can adjust this by prefixing items with either `+` or `-`.
+
+* Prefixing with `+` places that item in the MUST portion of the boolean query.
+* Prefixing with `-` places that item in the MUST NOT portion of the boolean query.
+
+For example, `+description:pool -continental breakfast` performs a boolean query that MUST satisfy the match query for the term `pool` in the `description` field, MUST NOT satisfy the match query for the term `continental` in the `default` field, and SHOULD satisfy the match query for the term `breakfast` in the `default` field.
+Result documents satisfying the SHOULD clause score higher than those that do not.
+
+== Boosting
+
+When multiple query-clauses are specified, you can specify the relative importance a given clause by suffixing it with the `^` operator, followed by a number.
+
+For example, `description:pool name:pool^5` performs Match Queries for `pool` in both the `name` and `description` fields, but documents having the term in the `name` field score higher.
+
+== Numeric Ranges
+
+You can specify numeric ranges with the `>`, `>=`, `<`, and `\<=` operators, each followed by a numeric value.
+
+For example, `reviews.ratings.Cleanliness:>4` performs a xref:fts-query-types.adoc#numeric-range[Numeric Range Query] on the `reviews.ratings.Cleanliness` field, for values greater than 4.

--- a/modules/fts/pages/query-string-queries.adoc
+++ b/modules/fts/pages/query-string-queries.adoc
@@ -30,7 +30,7 @@ For example, `description:pool` performs a xref:fts-query-types.adoc#match-query
 == Required, Optional, and Exclusion
 
 When a query string includes multiple items, by default these are placed into the SHOULD clause of a xref:fts-query-types.adoc#boolean-query[boolean query].
-You can adjust this by prefixing items with either `+` or `-`.
+You can adjust this by prefixing items with `+` or `-`.
 
 * Prefixing with `+` places that item in the MUST portion of the boolean query.
 * Prefixing with `-` places that item in the MUST NOT portion of the boolean query.
@@ -48,4 +48,28 @@ For example, `description:pool name:pool^5` performs Match Queries for `pool` in
 
 You can specify numeric ranges with the `>`, `>=`, `<`, and `\<=` operators, each followed by a numeric value.
 
-For example, `reviews.ratings.Cleanliness:>4` performs a xref:fts-query-types.adoc#numeric-range[Numeric Range Query] on the `reviews.ratings.Cleanliness` field, for values greater than 4.
+For example, `reviews.ratings.Cleanliness:>4` performs a xref:fts-query-types.adoc#numeric-range[numeric range query] on the `reviews.ratings.Cleanliness` field, for values greater than 4.
+
+== Date Ranges
+
+You can perform date range searches by using the `>`, `>=`, `<`, and `\<=` operators, followed by a date value in quotes.
+
+For example, `created:>"2016-09-21"` will perform a xref:fts-query-types.adoc#date-range[date range query] on the `created` field for values after September 21, 2016.
+
+== Escaping
+
+The following quoted string enumerates the characters which may be escaped:
+
+----
+"+-=&|><!(){}[]^\"~*?:\\/ "
+----
+
+NOTE: This list contains the space character.
+
+In order to escape these characters, they are prefixed with the `\` (backslash) character.
+In all cases, using the escaped version produces the character itself and is not interpreted by the lexer.
+
+For example:
+
+* `my\ name` is interpreted as a single argument to a match query with the value "my name".
+* `"contains a\" character"` is interpreted as a single argument to a phrase query with the value `contains a " character`.


### PR DESCRIPTION
Backport of #512 and #514 to release/5.5.

* [Query Types](https://simon-dew.github.io/docs-site/DOC-5284/server/6.0/fts/fts-query-types.html) — updated formatting, removed Query String syntax
* [Query String Queries](https://simon-dew.github.io/docs-site/DOC-5284/server/6.0/fts/query-string-queries.html) — created separate page for Query String syntax

Documentation issue [DOC-5284](https://issues.couchbase.com/browse/DOC-5284).