### PR TITLE
DOC-5293: Bitwise functions (port to Query)

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -214,7 +214,7 @@
   *** xref:n1ql:n1ql-language-reference/functions.adoc[Functions Overview]
   *** xref:n1ql:n1ql-language-reference/aggregatefun.adoc[Aggregate Functions]
   *** xref:n1ql:n1ql-language-reference/arrayfun.adoc[Array Functions]
-  *** xref:n1ql:n1ql-language-reference/bitwisefun.adoc[Bitwise Functions in N1QL]
+  *** xref:n1ql:n1ql-language-reference/bitwisefun.adoc[Bitwise Functions]
   *** xref:n1ql:n1ql-language-reference/comparisonfun.adoc[Comparison Functions]
   *** xref:n1ql:n1ql-language-reference/condfununknown.adoc[Conditional Functions for Unknowns]
   *** xref:n1ql:n1ql-language-reference/condfunnum.adoc[Conditional Functions for Numbers]

--- a/modules/n1ql/pages/n1ql-language-reference/bitwisefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/bitwisefun.adoc
@@ -1,4 +1,4 @@
-= Bitwise Functions in N1QL
+= Bitwise Functions
 
 All Bit/Binary functions can only operate on 64-bit signed integers.
 
@@ -6,286 +6,469 @@ NOTE: All non-integer numbers and other data types result in null.
 
 NOTE: Couchbase Server uses two's complement representation.
 
-When looking at the value in binary form, bit 1 is the Least Significant Bit (LSB) and bit 32 is the Most Significant Bit.
+When looking at the value in binary form, bit 1 is the Least Significant Bit (LSB) and bit 32 is the Most Significant Bit (MSB).
 
 (MSB) Bit 32 → `0000 0000 0000 0000 0000 0000 0000 0000` ← Bit 1 (LSB)
 
 [#BitAND]
-== BITAND ([.var]`int_value1`, [.var]`int_value2`, \... , [.var]`int_valueX`)
+== BITAND ([.var]`int_value1`, [.var]`int_value2`, \...)
 
-Description::
+=== Description
+
 Returns the result of a bitwise AND operation performed on all input integer values.
-+
+
 The bitwise AND operation compares each bit of [.var]`int_value1` to the corresponding bit of every other [.var]`int_value`.
-If both bits are 1, then the corresponding result bit is set to 1; otherwise it is set to 0 (zero).
+If all bits are 1, then the corresponding result bit is set to 1; otherwise it is set to 0 (zero).
 
-Arguments::
-int_value1, int_value2, \... , int_valueX;; Integers, or any valid xref:n1ql-language-reference/index.adoc[expressions] which evaluates to integers, that are used to compare.
+=== Arguments
 
-Return Value:: An integer, representing the bitwise AND between all of the input integers.
+int_value1, int_value2, \...:: Integers, or any valid xref:n1ql-language-reference/index.adoc[expressions] which evaluate to integers, that are used to compare.
 
-Limitations:: Input values must be integers (such as 1 or 1.0) and cannot contain decimals (such as 1.2).
+=== Return Value
 
-*Example AND-1*: Compare 3 (0011 in binary) and 6 (0110 in binary).
+An integer, representing the bitwise AND between all of the input integers.
 
+=== Limitations
+
+Input values must be integers (such as 1 or 1.0) and cannot contain decimals (such as 1.2).
+
+=== Examples
+
+.AND-1
+====
+Compare 3 (0011 in binary) and 6 (0110 in binary).
+
+[source,n1ql]
 ----
 SELECT BITAND(3,6) AS BitAND;
+----
 
-results: [
-   "BitAND": 2
+.Results
+[source,json]
+----
+[
+  {
+    "BitAND": 2
+  }
 ]
 ----
 
 This results in 2 (0010 in binary) because only bit 2 is set in both 3 (00**1**1) and 6 (01**1**0).
+====
 
- 
+.AND-2
+====
+Compare 4.5 and 3 (0011 in binary).
 
-*Example AND-2*: Compare 4.5 and 3 (0011 in binary).
-
+[source,n1ql]
 ----
 SELECT BITAND(4.5,3) AS BitAND;
+----
 
-results: [
-   "BitAND": null
+.Results
+[source,json]
+----
+[
+  {
+    "BitAND": null
+  }
 ]
 ----
 
 The result is null because 4.5 is not an integer.
+====
 
-*Example AND-3*: Compare 4.0 (0100 in binary) and 3 (0011 in binary).
+.AND-3
+====
+Compare 4.0 (0100 in binary) and 3 (0011 in binary).
 
+[source,n1ql]
 ----
 SELECT BITAND(4.0,3) AS BitAND;
+----
 
-results: [
-   "BitAND": 0
+.Results
+[source,json]
+----
+[
+  {
+    "BitAND": 0
+  }
 ]
 ----
 
 This results in 0 (zero) because 4.0 (0100) and 3 (0011) do not share any bits that are both 1.
+====
 
-*Example AND-4*: Compare 3 (0011 in binary) and 6 (0110 in binary) and 15 (1111 in binary).
+.AND-4
+====
+Compare 3 (0011 in binary) and 6 (0110 in binary) and 15 (1111 in binary).
 
+[source,n1ql]
 ----
 SELECT BITAND(3,6,15) AS BitAND;
+----
 
-results: [
-   "BitAND": 2
+.Results
+[source,json]
+----
+[
+  {
+    "BitAND": 2
+  }
 ]
 ----
 
 This results in 2 (0010 in binary) because only the 2nd bit from the right is 1 in all three numbers.
+====
 
+[#BitCLEAR]
 == BITCLEAR ([.var]`int_value`, [.var]`positions`)
 
-Description::
+=== Description
+
 Returns the result after clearing the specified bit, or array of bits in `int_value` using the given `positions`.
 Specifying a negative or zero bit position does not result in any change to the value.
-+
+
 NOTE: Specifying a negative or zero bit position makes the function return a null.
 
-Arguments::
-int_value;; An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, that contains the target bit or bits to clear.
+=== Arguments
 
-positions;; An integer or an array of integers specifying the position or positions to be cleared.
+int_value:: An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, that contains the target bit or bits to clear.
 
-Return Value:: An integer, representing the result after clearing the bit or bits specified.
+positions:: An integer or an array of integers specifying the position or positions to be cleared.
 
-Limitations:: Input values must be integers (such as 1 or 1.0) and cannot contain decimals (such as 1.2).
+=== Return Value
 
-*Example CLEAR-1*: Clear bit 1 from 6 (0110 in binary).
+An integer, representing the result after clearing the bit or bits specified.
 
+=== Limitations
+
+Input values must be integers (such as 1 or 1.0) and cannot contain decimals (such as 1.2).
+
+=== Examples
+
+.CLEAR-1
+====
+Clear bit 1 from 6 (0110 in binary).
+
+[source,n1ql]
 ----
 SELECT BITCLEAR(6,1) AS BitCLEAR;
+----
 
-results: [
-   "BitCLEAR": 6
+.Results
+[source,json]
+----
+[
+  {
+    "BitCLEAR": 6
+  }
 ]
 ----
 
 This results in 6 (011**0** in binary) because bit 1 was already zero.
+====
 
-*Example CLEAR-2*: Clear bits 1 and 2 from 6 (01**10** in binary).
+.CLEAR-2
+====
+Clear bits 1 and 2 from 6 (01**10** in binary).
 
+[source,n1ql]
 ----
 SELECT BITCLEAR(6,[1,2]) AS BitCLEAR;
+----
 
-results: [
-   "BitCLEAR": 4
+.Results
+[source,json]
+----
+[
+  {
+    "BitCLEAR": 4
+  }
 ]
 ----
 
 This results in 4 (01**0**0 in binary) because bit 2 changed to zero.
+====
 
-*Example CLEAR-3*: Clear bits 1, 2, 4, and 5 from 31 (0**11**1**11** in binary).
+.CLEAR-3
+====
+Clear bits 1, 2, 4, and 5 from 31 (0**11**1**11** in binary).
 
+[source,n1ql]
 ----
 SELECT BITCLEAR(31,[1,2,4,5]) AS BitCLEAR;
+----
 
-results: [
-   "BitCLEAR": 4
+.Results
+[source,json]
+----
+[
+  {
+    "BitCLEAR": 4
+  }
 ]
 ----
 
 This results in 4 (0**00**1**00**) because bits 1, 2, 4, and 5 changed to zero.
+====
 
+[#BitNOT]
 == BITNOT ([.var]`int_value`)
 
-Description::
+=== Description
+
 Returns the results of a bitwise logical NOT operation performed on an integer value.
-+
+
 The bitwise logical NOT operation reverses the bits in the value.
 For each value bit that is 1, the corresponding result bit will be set to 0 (zero); and for each value bit that is 0 (zero), the corresponding result bit will be set to 1.
-+
+
 NOTE: All bits of the integer will be altered by this operation.
 
-Arguments::
-int_value;; An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, that contains the target bit or bits to clear.
+=== Arguments
 
-Return Value:: An integer, representing the result after performing the logical NOT operation.
+int_value:: An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, that contains the target bit or bits to reverse.
 
-Limitations:: Input values must be integers (such as 1 or 1.0) and cannot contain decimals (such as 1.2).
+=== Return Value
 
-*Example NOT-1*: Perform the NOT operation on 3 (0000 0000 0000 0000 0000 0000 0000 0011 in binary).
+An integer, representing the result after performing the logical NOT operation.
 
+=== Limitations
+
+Input values must be integers (such as 1 or 1.0) and cannot contain decimals (such as 1.2).
+
+=== Examples
+
+.NOT-1
+====
+Perform the NOT operation on 3 (0000 0000 0000 0000 0000 0000 0000 0011 in binary).
+
+[source,n1ql]
 ----
 SELECT BITNOT(3) AS BitNOT;
+----
 
-results: [
-   "BitNOT": -4
+.Results
+[source,json]
+----
+[
+  {
+    "BitNOT": -4
+  }
 ]
 ----
 
 This results in -4 (*1111 1111 1111 1111 1111 1111 1111 1100* in binary) because all bits changed.
+====
 
-== BITOR ([.var]`int_value1`, [.var]`int_value2`, \... , [.var]`int_valueX`)
+[#BitOR]
+== BITOR ([.var]`int_value1`, [.var]`int_value2`, \...)
 
-Description::
+=== Description
+
 Returns the result of a bitwise inclusive OR operation performed on all input integer values.
-+
-The bitwise inclusive OR operation compares each bit of int1 to the corresponding bit of int2.
-If either bit is 1, the corresponding result bit is set to 1; otherwise, it is set to 0 (zero).
 
-Arguments::
-int_value1, int_value2, \... , int_valueX;; Integers, or any valid xref:n1ql-language-reference/index.adoc[expressions] which evaluate to integers, that are used to compare.
+compares each bit of [.var]`int_value1` to the corresponding bit of every other [.var]`int_value`.
+If any bit is 1, the corresponding result bit is set to 1; otherwise, it is set to 0 (zero).
 
-Return Value:: An integer, representing the bitwise OR between all of the input integers.
+=== Arguments
 
-Limitations:: Input values must be integers (such as 1 or 1.0) and cannot contain decimals (such as 1.2).
+int_value1, int_value2, \...:: Integers, or any valid xref:n1ql-language-reference/index.adoc[expressions] which evaluate to integers, that are used to compare.
 
-*Example OR-1*: Perform OR on 3 (0011 in binary) and 6 (0110 in binary).
+=== Return Value
 
+An integer, representing the bitwise OR between all of the input integers.
+
+=== Limitations
+
+Input values must be integers (such as 1 or 1.0) and cannot contain decimals (such as 1.2).
+
+=== Examples
+
+.OR-1
+====
+Perform OR on 3 (0011 in binary) and 6 (0110 in binary).
+
+[source,n1ql]
 ----
 SELECT BITOR(3,6) AS BitOR;
+----
 
-results: [
-   "BitOR": 7
+.Results
+[source,json]
+----
+[
+  {
+    "BitOR": 7
+  }
 ]
 ----
 
 This results in 7 (0**111** in binary) because at least 1 bit of each (00**11** and 0**11**0) is 1 in bits 1, 2, and 3.
+====
 
-*Example OR-2*: Perform OR on 3 (0011 in binary) and -4 (1000 0000 0000 \... 0000 1100 in binary).
+.OR-2
+====
+Perform OR on 3 (0011 in binary) and -4 (1000 0000 0000 \... 0000 1100 in binary).
 
+[source,n1ql]
 ----
 SELECT BITOR(3,-4) AS BitOR;
+----
 
-results: [
-   "BitOR": -1
+.Results
+[source,json]
+----
+[
+  {
+    "BitOR": -1
+  }
 ]
 ----
 
 This results in -1 (*1111 1111 1111 \... 1111 1111* in binary) because the two 1 bits in 3 fill in the two 0 bits in -4 to turn on all the bits.
+====
 
-*Example OR-3*: Perform OR on 3 (0011 in binary) and 6 (0110 in binary) and 15 (1111 in binary).
+.OR-3
+====
+Perform OR on 3 (0011 in binary) and 6 (0110 in binary) and 15 (1111 in binary).
 
+[source,n1ql]
 ----
 SELECT BITOR(3,6,15) AS BitOR;
+----
 
-results: [
-   "BitOR": 15
+.Results
+[source,json]
+----
+[
+  {
+    "BitOR": 15
+  }
 ]
 ----
 
 This results in 15 (1111 in binary) because there is at least one 1 in each of the four rightmost bits.
+====
 
+[#BitSET]
 == BITSET ([.var]`int_value`, [.var]`positions`)
 
-Description::
+=== Description
+
 Returns the result after setting the specified bit `position`, or array of bit positions, to 1 in the given `int_value`.
-+
+
 NOTE: Specifying a negative or zero position makes the function return a null.
 
-Arguments::
-int_value;; An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, that contains the target bit or bits to clear.
+=== Arguments
 
-positions;; An integer or an array of integers specifying the position or positions to be set.
+int_value:: An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, that contains the target bit or bits to set.
 
-Return Value::
+positions:: An integer or an array of integers specifying the position or positions to be set.
+
+=== Return Value
+
 An integer, representing the result after setting the bit or bits specified.
 If the bit is already set, then it stays set.
 
-Limitations:: Input values must be integers (such as 1 or 1.0) and cannot contain decimals (such as 1.2).
+=== Limitations
 
-*Example SET-1*: Set bit 1 in the value 6 (011**0** in binary).
+Input values must be integers (such as 1 or 1.0) and cannot contain decimals (such as 1.2).
 
+=== Examples
+
+.SET-1
+====
+Set bit 1 in the value 6 (011**0** in binary).
+
+[source,n1ql]
 ----
 SELECT BITSET(6,1) AS BitSET;
+----
 
-results: [
-   "BitSET": 7
+.Results
+[source,json]
+----
+[
+  {
+    "BitSET": 7
+  }
 ]
 ----
 
 This results in 7 (011**1** in binary) because bit 1 changed to 1.
+====
 
-*Example 2*: Set bits 1 and 2 in the value 6 (01**10** in binary).
+.SET-2
+====
+Set bits 1 and 2 in the value 6 (01**10** in binary).
 
+[source,n1ql]
 ----
 SELECT BITSET(6,[1,2]) AS BitSET;
+----
 
-results: [
-   "BitSET": 7
+.Results
+[source,json]
+----
+[
+  {
+    "BitSET": 7
+  }
 ]
 ----
 
 This also results in 7 (01**11** in binary) because bit 1 changed while bit 2 remained the same.
+====
 
-*Example 3*: Set bits 1 and 4 in the value 6 (**0**11**0** in binary).
+.SET-3
+====
+Set bits 1 and 4 in the value 6 (**0**11**0** in binary).
 
+[source,n1ql]
 ----
 SELECT BITSET(6,[1,4]) AS BitSET;
+----
 
-results: [
-   "BitSET": 15
+.Results
+[source,json]
+----
+[
+  {
+    "BitSET": 15
+  }
 ]
 ----
 
 This results in 15 (**1**11**1** in binary) because bit 1 and 4 changed to ones.
+====
 
+[#BitSHIFT]
 == BITSHIFT ([.var]`int_value`, [.var]`shift_amount`, [.var]`rotate`)
 
-Description::
+=== Description
+
 Returns the result of a bit shift operation performed on the integer value `int`.
 The `shift_amount` supports left and right shifts.
 These are logical shifts.
 The third parameter `rotate` supports circular shift.
 This is similar to the BitROTATE function in Oracle.
 
-Arguments::
-int_value;; An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, that contains the target bit or bits to shift.
+=== Arguments
 
-shift_amount;;
+int_value:: An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, that contains the target bit or bits to shift.
+
+shift_amount::
 An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, that contains the number of bits to shift.
 +
 A positive (+) number means this is a LEFT shift.
 +
 A negative (-) number means this is a RIGHT shift.
 
-rotate;; [optional; FALSE by default] A boolean, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a boolean, where:
+rotate:: [Optional; FALSE by default] A boolean, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a boolean, where:
 
 * FALSE means this is a LOGICAL shift, where bits shifted off the end of a value are considered lost.
-
 
 * TRUE means this is a CIRCULAR shift (shift-and-rotate operation), where bits shifted off the end of a value are rotated back onto the value at the _other_ end.
 In other words, the bits rotate in what might be thought of as a circular pattern; therefore, these bits are not lost.
@@ -332,12 +515,12 @@ For comparison, see the below table.
 | 6 (0000 0110)
 | -2
 | 1 (0000 0001)
-| -9223372036854776000 (1000 0000 \... 0000 0001)
+| -9223372036854775807 (1000 0000 \... 0000 0001)
 
 | 6 (0000 0110)
 | -3
 | 0 (0000 0000)
-| -4611686018427388000 (1100 0000 \... 0000 0000)
+| -4611686018427387904 (1100 0000 \... 0000 0000)
 
 | 6 (0000 0110)
 | -4
@@ -345,86 +528,135 @@ For comparison, see the below table.
 | 6917529027641081856 (0110 0000 \... 0000 0000)
 |===
 
-Return Value:: An integer, representing the result of either a logical or circular shift of the given integer.
+=== Return Value
 
-Limitations:: Input values must be integers (such as 1 or 1.0) and cannot contain decimals (such as 1.2).
+An integer, representing the result of either a logical or circular shift of the given integer.
 
-*Example SHIFT-1*: Logical left shift of the number 6 (0110 in binary) by one bit.
+=== Limitations
 
+Input values must be integers (such as 1 or 1.0) and cannot contain decimals (such as 1.2).
+
+=== Examples
+
+.SHIFT-1
+====
+Logical left shift of the number 6 (0110 in binary) by one bit.
+
+[source,n1ql]
 ----
 SELECT BITSHIFT(6,1,FALSE) AS BitSHIFT;
+----
 
-results: [
-   "BitSHIFT": 12
+.Results
+[source,json]
+----
+[
+  {
+    "BitSHIFT": 12
+  }
 ]
 ----
 
 This results in 12 (1100 in binary) because the 1-bits moved from positions 2 and 3 to positions 3 and 4.
+====
 
-*Example SHIFT-2*: Logical right shift of the number 6 (0110 in binary) by two bits.
+.SHIFT-2
+====
+Logical right shift of the number 6 (0110 in binary) by two bits.
 
+[source,n1ql]
 ----
 SELECT BITSHIFT(6,-2) AS BitSHIFT;
+----
 
-results: [
-   "BitSHIFT": 1
+.Results
+[source,json]
+----
+[
+  {
+    "BitSHIFT": 1
+  }
 ]
 ----
 
 This results in 1 (0001 in binary) because the 1-bit in position 3 moved to position 1 and the 1-bit in position 2 was dropped.
+====
 
-*Example SHIFT-2b*: Circular right shift of the number 6 (0110 in binary) by two bits.
+.SHIFT-2b
+====
+Circular right shift of the number 6 (0110 in binary) by two bits.
 
+[source,n1ql]
 ----
 SELECT BITSHIFT(6,-2,TRUE) AS BitSHIFT;
+----
 
-results: [
-   "BitSHIFT": -9223372036854776000
+.Results
+[source,json]
+----
+[
+  {
+    "BitSHIFT": -9223372036854775807
+  }
 ]
 ----
 
-This results in -9223372036854776000 (1100 0000 0000 0000 0000 0000 0000 0000 in binary) because the two 1-bits wrapped right, around to the Most Significant Digit position and changed the integer's sign to negative.
+This results in -9223372036854775807 (1100 0000 0000 0000 0000 0000 0000 0000 in binary) because the two 1-bits wrapped right, around to the Most Significant Digit position and changed the integer's sign to negative.
+====
 
-*Example SHIFT-3*: Circular left shift of the number 524288 (1000 0000 0000 0000 0000 in binary) by 45 bits.
+.SHIFT-3
+====
+Circular left shift of the number 524288 (1000 0000 0000 0000 0000 in binary) by 45 bits.
 
+[source,n1ql]
 ----
 SELECT BITSHIFT(524288,45,TRUE) AS BitSHIFT;
+----
 
-results: [
-   "BitSHIFT": 1
+.Results
+[source,json]
+----
+[
+  {
+    "BitSHIFT": 1
+  }
 ]
 ----
 
 This results in 1 because the 1-bit wrapped left, around to the Least Significant Digit position.
+====
 
 [#section_unf_2sv_s1b]
 == BITTEST ([.var]`int_value`, [.var]`positions [, all_set]`)
 
-Description::
-`BitTEST()` and `IsBitSet()` are synonyms.
-+
+This function has a synonym <<IsBitSET,ISBITSET()>>.
+
+=== Description
+
 Returns TRUE if the specified bit, or bits, is a 1; otherwise, returns FALSE if the specified bit, or bits, is a 0 (zero).
-+
-NOTE: Specifying a negative or zero bit position will result in 0 (zero) being returned.
 
-Arguments::
-int_value;; An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, that contains the target bit or bits to test.
+NOTE: Specifying a negative or zero bit position will result in NULL being returned.
 
-positions;; An integer or an array of integers specifying the position or positions to be cleared.
+=== Arguments
 
-all_set;;
-[OPTIONAL; default is TRUE] A boolean, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a boolean.
+int_value:: An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, that contains the target bit or bits to test.
+
+positions:: An integer or an array of integers specifying the position or positions to be tested.
+
+all_set::
+[Optional; FALSE by default] A boolean, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a boolean.
 +
 When `all_set` is FALSE, then it returns TRUE even if one bit in one of the positions is set.
 +
 When `all_set` is TRUE, then it returns TRUE only if all input positions are set.
 
-Return Value::
+=== Return Value
+
 A boolean, that follows the below table:
-+
+
 [cols="2,1,1"]
 |===
-| [.var]`int` | [.var]`all_set` | Return Value
+| [.var]`int_value` | [.var]`all_set` | Return Value
 
 | _all_ specified bits are TRUE
 | FALSE
@@ -443,59 +675,106 @@ A boolean, that follows the below table:
 | FALSE
 |===
 
-Limitations:: Input values must be integers (such as 1 or 1.0) and cannot contain decimals (such as 1.2).
+=== Limitations
 
-*Example TEST-1*: In the number 6 (0110 in binary), is bit 1 set?
+Input values must be integers (such as 1 or 1.0) and cannot contain decimals (such as 1.2).
 
+=== Examples
+
+.TEST-1
+====
+In the number 6 (0110 in binary), is bit 1 set?
+
+[source,n1ql]
 ----
 SELECT ISBITSET(6,1) AS IsBitSET;
+----
 
-results: [
-   "IsBitSET": FALSE
+.Results
+[source,json]
+----
+[
+  {
+    "IsBitSET": FALSE
+  }
 ]
 ----
 
 This returns FALSE because bit 1 of 6 (011**0** in binary) is not set to 1.
+====
 
-*Example TEST-2*: In the number 1, is either bit 1 or bit 2 set?
+.TEST-2
+====
+In the number 1, is either bit 1 or bit 2 set?
 
+[source,n1ql]
 ----
 SELECT BITTEST(1,[1,2],FALSE) AS BitTEST;
+----
 
-results: [
-   "BitTEST": TRUE
+.Results
+[source,json]
+----
+[
+  {
+    "BitTEST": TRUE
+  }
 ]
 ----
 
 This returns TRUE because bit 1 of the number 1 (000**1** in binary) is set to 1.
+====
 
-*Example TEST-3*: In the number 6 (0110 in binary), are both bits 2 and 3 set?
+.TEST-3
+====
+In the number 6 (0110 in binary), are both bits 2 and 3 set?
 
+[source,n1ql]
 ----
 SELECT ISBITSET(6,[2,3],TRUE) AS IsBitSET;
+----
 
-results: [
-   "IsBitSET": TRUE
+.Results
+[source,json]
+----
+[
+  {
+    "IsBitSET": TRUE
+  }
 ]
 ----
 
 This returns TRUE because both bits 2 and 3 in the number 6 (0**11**0 in binary) are set to 1.
+====
 
-*Example TEST-4*: In the number 6 (0110 in binary), are all the bits in positions 1 through 3 set?
+.TEST-4
+====
+In the number 6 (0110 in binary), are all the bits in positions 1 through 3 set?
 
+[source,n1ql]
 ----
 SELECT BITTEST(6,[1,3],TRUE) AS BitTEST;
+----
 
-results: [
-   "BitTEST": FALSE
+.Results
+[source,json]
+----
+[
+  {
+    "BitTEST": FALSE
+  }
 ]
 ----
 
 This returns FALSE because bit 1 in the number 6 (011**0** in binary) is set to 0 (zero).
+====
 
-*Example TEST-5*: Find only flights that have 1 layover (to rest and walk around).
+.TEST-5
+====
+Find only flights that have 1 layover (to rest and walk around).
 That is, flight stops of 1 (0001 in binary) only.
 
+[source,n1ql]
 ----
 SELECT airline, stops, schedule[0].day FROM `travel-sample`
 WHERE type = "route" AND stops = 1;
@@ -503,22 +782,26 @@ WHERE type = "route" AND stops = 1;
 
 The above query returns the exact same results as the below query which uses a bit operation.
 
+[source,n1ql]
 ----
 SELECT airline, stops, schedule[0].day FROM `travel-sample`
 WHERE type = "route" AND BITTEST(stops,1);
 ----
+====
 
-== BITXOR ([.var]`int_value1`, [.var]`int_value2`, \... , [.var]`int_valueX`)
+[#BitXOR]
+== BITXOR ([.var]`int_value1`, [.var]`int_value2`, \...)
 
-Description::
+=== Description
+
 Returns the result of a bitwise Exclusive OR operation performed on two integer values.
-+
+
+The bitwise Exclusive OR operation compares each bit of `int_value1` to the corresponding bit of `int_value2`.
+
 If there are more than two input values, the first two are compared; then their result is compared to the next input value; and so on.
-+
-The bitwise Exclusive OR operation compares each bit of `int1` to the corresponding bit of `int2`.
-+
+
 When the compared bits do not match, the result bit is 1; otherwise, the compared bits do match, and the result bit is 0 (zero), as summarized:
-+
+
 [cols="^1,^1,^2"]
 |===
 | Bit 1 | Bit 2 | XOR Result Bit
@@ -540,45 +823,72 @@ When the compared bits do not match, the result bit is 1; otherwise, the compare
 | 0
 |===
 
-Arguments::
-int_value1, int_value2, \... , int_valueX;; Integers, or any valid xref:n1ql-language-reference/index.adoc[expressions] which evaluate to integers, that are used to compare.
+=== Arguments
 
-Return Value:: An integer, representing the bitwise XOR between the two input integers.
+int_value1, int_value2, \...:: Integers, or any valid xref:n1ql-language-reference/index.adoc[expressions] which evaluate to integers, that are used to compare.
 
-Limitations:: Input values must be integers (such as 1 or 1.0) and cannot contain decimals (such as 1.2).
+=== Return Value
 
-*Example XOR-1*: Perform the XOR operation on 3 (0011 in binary) and 6 (0110 in binary).
+An integer, representing the bitwise XOR between the two input integers.
 
+=== Limitations
+
+Input values must be integers (such as 1 or 1.0) and cannot contain decimals (such as 1.2).
+
+=== Examples
+
+.XOR-1
+====
+Perform the XOR operation on 3 (0011 in binary) and 6 (0110 in binary).
+
+[source,n1ql]
 ----
 SELECT BITXOR(3,6) AS BitXOR;
+----
 
-results: [
-   "BitXOR": 5
+.Results
+[source,json]
+----
+[
+  {
+    "BitXOR": 5
+  }
 ]
 ----
 
 This returns 5 (0101 in binary) because the 1st bit pair and 3rd bit pair are different (resulting in 1) while the 2nd bit pair and 4th bit pair are the same (resulting in 0):
 
-`0011` (3)
+----
+0011 (3)
+0110 (6)
+========
+0101 (5)
+----
+====
 
-`0110` (6)
+.XOR-2:
+====
+Perform the XOR operation on 3 (0011 in binary) and 6 (0110 in binary) and 15 (1111 in binary).
 
-{empty}=============
-
-`0101` (5)
-
-Example XOR-2: Perform the XOR operation on 3 (0011 in binary) and 6 (0110 in binary) and 15 (1111 in binary).
-
+[source,n1ql]
 ----
 SELECT BITXOR(3,6,15) AS BitXOR;
+----
 
-results: [
-   "BitXOR": 10
+.Results
+[source,json]
+----
+[
+  {
+    "BitXOR": 10
+  }
 ]
 ----
 
 This returns 10 (1010 in binary) because 3 XOR 6 equals 5 (0101 in binary), and then 5 XOR 15 equals 10 (1010 in binary).
+====
 
-== IsBitSET → see BITTEST
+[#IsBitSET]
+== ISBITSET → see BITTEST
 
-This function is a synonym of BitSET and has been detailed within the <<section_unf_2sv_s1b,BITTEST>> function.
+Synonym of <<section_unf_2sv_s1b,BITTEST()>>.

--- a/modules/n1ql/pages/n1ql-language-reference/bitwisefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/bitwisefun.adoc
@@ -128,7 +128,6 @@ This results in 2 (0010 in binary) because only the 2nd bit from the right is 1 
 === Description
 
 Returns the result after clearing the specified bit, or array of bits in `int_value` using the given `positions`.
-Specifying a negative or zero bit position does not result in any change to the value.
 
 NOTE: Specifying a negative or zero bit position makes the function return a null.
 
@@ -228,7 +227,7 @@ NOTE: All bits of the integer will be altered by this operation.
 
 === Arguments
 
-int_value:: An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, that contains the target bit or bits to reverse.
+int_value:: An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, that contains the target bits to reverse.
 
 === Return Value
 
@@ -695,7 +694,7 @@ SELECT ISBITSET(6,1) AS IsBitSET;
 ----
 [
   {
-    "IsBitSET": FALSE
+    "IsBitSET": false
   }
 ]
 ----
@@ -717,7 +716,7 @@ SELECT BITTEST(1,[1,2],FALSE) AS BitTEST;
 ----
 [
   {
-    "BitTEST": TRUE
+    "BitTEST": true
   }
 ]
 ----
@@ -739,7 +738,7 @@ SELECT ISBITSET(6,[2,3],TRUE) AS IsBitSET;
 ----
 [
   {
-    "IsBitSET": TRUE
+    "IsBitSET": true
   }
 ]
 ----
@@ -761,7 +760,7 @@ SELECT BITTEST(6,[1,3],TRUE) AS BitTEST;
 ----
 [
   {
-    "BitTEST": FALSE
+    "BitTEST": false
   }
 ]
 ----
@@ -794,7 +793,7 @@ WHERE type = "route" AND BITTEST(stops,1);
 
 === Description
 
-Returns the result of a bitwise Exclusive OR operation performed on two integer values.
+Returns the result of a bitwise Exclusive OR operation performed on two or more integer values.
 
 The bitwise Exclusive OR operation compares each bit of `int_value1` to the corresponding bit of `int_value2`.
 
@@ -829,7 +828,7 @@ int_value1, int_value2, \...:: Integers, or any valid xref:n1ql-language-referen
 
 === Return Value
 
-An integer, representing the bitwise XOR between the two input integers.
+An integer, representing the bitwise XOR between the input integers.
 
 === Limitations
 


### PR DESCRIPTION
Backport of #554 to release/6.0.

These changes were errors that @htowaileb spotted in the N1QL for Query bitwise function documentation. The corrections have been checked and approved.

Documentation issue: [DOC-5293](https://issues.couchbase.com/browse/DOC-5293)