### PR TITLE
Update the old blog link

### DIFF
--- a/modules/fts/pages/full-text-intro.adoc
+++ b/modules/fts/pages/full-text-intro.adoc
@@ -83,4 +83,4 @@ curl -X POST -H "Content-Type: application/json" \
 That's it!
 You should be ready to explore, or read on to learn more about creating and querying indexes.
 
-NOTE: Also, you may want to take a look at the following blog that explains how the full text search API (experimental) is expressed using the Java SDK: http://blog.couchbase.com/2016/february/cbftjavapreview[^]
+NOTE: Also, you may want to take a look at the following blog that explains how the full text search API (experimental) is expressed using the Java SDK: https://blog.couchbase.com/cbftjavapreview/[^]


### PR DESCRIPTION
I have updated the old blog link "http://blog.couchbase.com/2016/february/cbftjavapreview" to "https://blog.couchbase.com/cbftjavapreview/".