### PR TITLE
Updated the old blog link present on the page

### DIFF
--- a/modules/install/pages/migrating.adoc
+++ b/modules/install/pages/migrating.adoc
@@ -12,4 +12,4 @@ The upgrade processes from Apache CouchDB and MySQL are explained in the followi
 * http://blog.couchbase.com/2016/february/moving-from-oracle-to-couchbase[Oracle to Couchbase^]
 * http://blog.couchbase.com/2016/february/moving-from-mongodb-to-couchbase-server[MongoDB to Couchbase^]
 * http://blog.couchbase.com/2016/january/moving-sql-database-content-to-couchbase[Postgres to Couchbase, part 1^]
-* http://blog.couchbase.com/2016/january/moving-sql-business-logic-to-the-application-layer[Postgres to Couchbase, part 2^]
+* https://blog.couchbase.com/moving-sql-business-logic-to-the-application-layer[Postgres to Couchbase, part 2^]


### PR DESCRIPTION
Updated the old blog link "http://blog.couchbase.com/2016/january/moving-sql-business-logic-to-the-application-layer" to "https://blog.couchbase.com/moving-sql-business-logic-to-the-application-layer/".