### PR TITLE
Updated the old blog link present on the page

### DIFF
--- a/modules/developer-guide/pages/sub-doc-api.adoc
+++ b/modules/developer-guide/pages/sub-doc-api.adoc
@@ -40,7 +40,7 @@ In the context of social gaming, this may be thought of as sending messages betw
 ====
 The following blogs explain how the sub-document API is expressed using different SDKs:
 
-* http://blog.couchbase.com/2016/february/subdocument-couchbase-java-sdk[Java Walk-through of the Sub-document API^]
+* https://blog.couchbase.com/subdocument-couchbase-java-sdk/[Java Walk-through of the Sub-document API^]
 * http://blog.couchbase.com/2016/february/preview-of-the-subdocument-api-using-go[GO Walk-through of the Sub-document API^]
 ====
 


### PR DESCRIPTION
updated the old blog link "http://blog.couchbase.com/2016/february/subdocument-couchbase-java-sdk" to "https://blog.couchbase.com/subdocument-couchbase-java-sdk".