### PR TITLE
Replaced old webinar links

### DIFF
--- a/modules/getting-started/pages/first-n1ql-query.adoc
+++ b/modules/getting-started/pages/first-n1ql-query.adoc
@@ -189,7 +189,7 @@ The tutorial covers SELECT statements in detail, including examples of JOIN, NES
 * The http://docs.couchbase.com/files/Couchbase-N1QL-CheatSheet.pdf[N1QL cheat sheet^] provides a concise summary of the basic syntax elements.
 Print it out and keep it on your desk where it'll be handy for quick reference.
 * The xref:n1ql:n1ql-language-reference/index.adoc[N1QL Language Reference] contains details about N1QL syntax and usage.
-* Live and recorded http://www.couchbase.com/nosql-resources/webinar[Webinars^] presented by Couchbase engineers and product managers highlight features and use cases of Couchbase Server, including N1QL.
-Here are some links to webinars devoted entirely to N1QL: https://event.on24.com/eventRegistration/EventLobbyServlet?target=reg20.jsp&eventid=962567&sessionid=1&key=00929333AAF46D0054877324FBC3CB85&sourcepage=register[Couchbase 103: Querying^] and http://info.couchbase.com/webinar-N1QL-ad-hoc-querying-for-NoSQL-applications.html[Ad hoc Querying for NoSQL^].
+* Live and recorded https://www.couchbase.com/resources/webinars[Webinars^] presented by Couchbase engineers and product managers highlight features and use cases of Couchbase Server, including N1QL.
+Here are some links to webinars devoted entirely to N1QL: https://event.on24.com/eventRegistration/EventLobbyServlet?target=reg20.jsp&eventid=962567&sessionid=1&key=00929333AAF46D0054877324FBC3CB85&sourcepage=register[Couchbase 103: Querying^] and https://www.couchbase.com/resources/webinars[Ad hoc Querying for NoSQL^].
 * http://blog.couchbase.com[Couchbase blogs^] include articles written by Couchbase SDK developers.
 * The https://forums.couchbase.com/c/n1ql[Couchbase forum^] is a community resource where you can ask questions, find answers, and discuss N1QL with other developers and the Couchbase team.


### PR DESCRIPTION
Replaced webinar link "http://info.couchbase.com/webinar-N1QL-ad-hoc-querying-for-NoSQL-applications.html" to                      
 "https://www.couchbase.com/resources/webinars".
Replaced webinar link "http://www.couchbase.com/nosql-resources/webinar" to "https://www.couchbase.com/resources/webinars".