### PR TITLE
Updated the old support page link

### DIFF
--- a/modules/security/pages/security-report-vulnerability.adoc
+++ b/modules/security/pages/security-report-vulnerability.adoc
@@ -5,7 +5,7 @@ If you believe you have discovered a vulnerability, or have otherwise experience
 
 == Reporting an Issue
 
-To report an issue, please either submit a request via the http://support.couchbase.com/home[Couchbase Support Portal^], or open a http://issues.couchbase.com[JIRA ticket^].
+To report an issue, please either submit a request via the https://support.couchbase.com/hc/en-us/restricted?return_to=https%3A%2F%2Fsupport.couchbase.com%2Fhc%2Fen-us[Couchbase Support Portal^], or open a http://issues.couchbase.com[JIRA ticket^].
 Each procedure associates the reported issue with an identification number; which can be used for tracking purposes.
 
 == Providing Information


### PR DESCRIPTION
Updated the old support page link "http://support.couchbase.com/home" to "https://support.couchbase.com/hc/en-us/restricted?return_to=https%3A%2F%2Fsupport.couchbase.com%2Fhc%2Fen-us"