### PR TITLE
DOC-5157: Document system keyspaces

### DIFF
--- a/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
+++ b/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
@@ -1946,7 +1946,7 @@ For more examples, take a look at the blog: https://blog.couchbase.com/optimize-
 
 include::ROOT:partial$developer-preview.adoc[tag=admonition]
 
-This catalog maintains a list of all user-defined functions.
+This catalog maintains a list of all user-defined functions across all nodes.
 To see the list of all user-defined functions, use:
 
 [source,n1ql]
@@ -1962,23 +1962,9 @@ This will result in a list similar to:
   {
     "functions": {
       "definition": {
-        "#language": "javascript",
-        "library": "math77",
-        "object": "add"
-      },
-      "identity": {
-        "name": "javaScriptAdd",
-        "namespace": "default",
-        "type": "global"
-      }
-    }
-  },
-  {
-    "functions": {
-      "definition": {
-        "#language": "inline",
-        "expression": "substr0(`vString`, (length(`vString`) - `vLen`), `vLen`)",
-        "parameters": [
+        "#language": "inline", // <1>
+        "expression": "substr0(`vString`, (length(`vString`) - `vLen`), `vLen`)", // <2>
+        "parameters": [ // <3>
           "vString",
           "vLen"
         ]
@@ -1989,27 +1975,42 @@ This will result in a list similar to:
         "type": "global"
       }
     }
+  },
+  {
+    "functions": {
+      "definition": {
+        "#language": "javascript",
+        "library": "math77", // <4>
+        "object": "add" // <5>
+      },
+      "identity": {
+        "name": "javaScriptAdd", // <6>
+        "namespace": "default", // <7>
+        "type": "global" // <8>
+      }
+    }
   }
 ]
 ----
 
 This query returns the following attributes:
 
-* [.out]`definition.#language`: string (the language of the function, for example, inline)
-* [.out]`definition.expression`: string (for inline functions only: the expression defining the function)
-* [.out]`definition.library`: string (for JavaScript functions only: the library containing the function)
-* [.out]`definition.object`: string (for JavaScript functions only: the object defining the function)
-* [.out]`definition.parameters`: array of strings (the parameters required by the function)
-* [.out]`identity.name`: string (the name of the function)
-* [.out]`identity.namespace`: string (the namespace of the function, for example, default)
-* [.out]`identity.type`: string (the type of the function, for example, global)
+<1> [.out]`definition.#language`: string (the language of the function, for example, inline)
+<2> [.out]`definition.expression`: string (for inline functions only: the expression defining the function)
+<3> [.out]`definition.parameters`: array of strings (the parameters required by the function)
+<4> [.out]`definition.library`: string (for JavaScript functions only: the library containing the function)
+<5> [.out]`definition.object`: string (for JavaScript functions only: the object defining the function)
+<6> [.out]`identity.name`: string (the name of the function)
+<7> [.out]`identity.namespace`: string (the namespace of the function, for example, default)
+<8> [.out]`identity.type`: string (the type of the function, for example, global)
 
 [#sys-functions-cache]
 == system:functions_cache
 
 include::ROOT:partial$developer-preview.adoc[tag=admonition]
 
-This catalog maintains a list of recently-used user-defined functions.
+This catalog maintains a list of recently-used user-defined functions across all nodes.
+The catalog also lists user-defined functions that have been called recently, but do not exist.
 To see the list of recently-used user-defined functions, use:
 
 [source,n1ql]
@@ -2024,37 +2025,51 @@ This will result in a list similar to:
 [
   {
     "functions_cache": {
-      "#language": "javascript",
-      "avgServiceTime": "674.264µs",
+      "#language": "inline", // <1>
+      "avgServiceTime": "8.926µs",
+      "expression": "substr0(`vString`, (length(`vString`) - `vLen`), `vLen`)", // <2>
       "lastUse": "2019-08-06 06:08:35.37498882 -0700 PDT m=+2236.523899555",
-      "library": "math77",
-      "maxServiceTime": "674.264µs",
+      "maxServiceTime": "8.926µs",
       "minServiceTime": "0s",
-      "name": "javaScriptAdd",
-      "namespace": "default",
+      "name": "rstr", // <3>
+      "namespace": "default", // <4>
       "node": "127.0.0.1:8091",
-      "object": "add",
+      "parameters": [ // <5>
+        "vString",
+        "vLen"
+      ],
       "type": "global",
       "uses": 1
     }
   },
   {
     "functions_cache": {
-      "#language": "inline",
-      "avgServiceTime": "8.926µs",
-      "expression": "substr0(`vString`, (length(`vString`) - `vLen`), `vLen`)",
+      "#language": "javascript",
+      "avgServiceTime": "674.264µs",
       "lastUse": "2019-08-06 06:10:50.681845642 -0700 PDT m=+2371.830756442",
-      "maxServiceTime": "8.926µs",
+      "library": "math77", // <6>
+      "maxServiceTime": "674.264µs",
       "minServiceTime": "0s",
-      "name": "rstr",
+      "name": "javaScriptAdd",
       "namespace": "default",
       "node": "127.0.0.1:8091",
-      "parameters": [
-        "vString",
-        "vLen"
-      ],
-      "type": "global",
+      "object": "add", // <7>
+      "type": "global", // <8>
       "uses": 1
+    }
+  },
+  {
+    "functions_cache": {
+      "avgServiceTime": "22.79µs", // <9>
+      "lastUse": "2019-08-06 16:59:51.630317391 +0100 BST m=+17.966707065", // <10>
+      "maxServiceTime": "22.79µs", // <11>
+      "minServiceTime": "0s", // <12>
+      "name": "notFound",
+      "namespace": "default",
+      "node": "127.0.0.1:8091", // <13>
+      "type": "global",
+      "undefined_function": true, // <14>
+      "uses": 1 // <15>
     }
   }
 ]
@@ -2062,19 +2077,23 @@ This will result in a list similar to:
 
 This query returns the following attributes:
 
-* [.out]`#language`: string (the language of the function, for example, inline)
-* [.out]`expression`: string (for inline functions only: the expression defining the function)
-* [.out]`library`: string (for JavaScript functions only: the library containing the function)
-* [.out]`object`: string (for JavaScript functions only: the object defining the function)
-* [.out]`parameters`: array of strings (the parameters required by the function)
-* [.out]`name`: string (the name of the function)
-* [.out]`namespace`: string (the namespace of the function, for example, default)
-* [.out]`type`: string (the type of the function, for example, global)
-* [.out]`avgServiceTime`: string (the mean service time for the function)
-* [.out]`maxServiceTime`: string (the maximum service time for the function)
-* [.out]`minServiceTime`: string (the minimum service time for the function)
-* [.out]`lastUse`: string (the date and time when the function was last used)
-* [.out]`uses`: number (the number of uses of the function)
+<1>  [.out]`#language`: string (the language of the function, for example, inline)
+<2>  [.out]`expression`: string (for inline functions only: the expression defining the function)
+<3>  [.out]`name`: string (the name of the function)
+<4>  [.out]`namespace`: string (the namespace of the function, for example, default)
+<5>  [.out]`parameters`: array of strings (the parameters required by the function)
+<6>  [.out]`library`: string (for JavaScript functions only: the library containing the function)
+<7>  [.out]`object`: string (for JavaScript functions only: the object defining the function)
+<8>  [.out]`type`: string (the type of the function, for example, global)
+<9>  [.out]`avgServiceTime`: string (the mean service time for the function)
+<10> [.out]`lastUse`: string (the date and time when the function was last used)
+<11> [.out]`maxServiceTime`: string (the maximum service time for the function)
+<12> [.out]`minServiceTime`: string (the minimum service time for the function)
+<13> [.out]`node`: string (the query node where the function is cached)
+<14> [.out]`undefined_function`: boolean (whether the function exists or is undefined)
+<15> [.out]`uses`: number (the number of uses of the function)
+
+Each query node keeps its own cache of recently-used user-defined functions, so you may see the same function listed for multiple nodes.
 
 == Related Links
 

--- a/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
+++ b/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
@@ -1944,8 +1944,9 @@ For more examples, take a look at the blog: https://blog.couchbase.com/optimize-
 [#sys-functions]
 == system:functions
 
-This catalog maintains a list of all user-defined functions.
+include::ROOT:partial$developer-preview.adoc[tag=admonition]
 
+This catalog maintains a list of all user-defined functions.
 To see the list of all user-defined functions, use:
 
 [source,n1ql]
@@ -2006,8 +2007,9 @@ This query returns the following attributes:
 [#sys-functions-cache]
 == system:functions_cache
 
-This catalog maintains a list of recently-used user-defined functions.
+include::ROOT:partial$developer-preview.adoc[tag=admonition]
 
+This catalog maintains a list of recently-used user-defined functions.
 To see the list of recently-used user-defined functions, use:
 
 [source,n1ql]

--- a/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
+++ b/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
@@ -43,6 +43,8 @@ a|
 * <<sys-completed-req,system:completed_requests>>
 * <<sys-active-req,system:active_requests>>
 * <<sys_my-user-info,system:my_user_info>>
+* <<sys-functions,system:functions>>
+* <<sys-functions-cache,system:functions_cache>>
 
 | Security Catalogs
 a|
@@ -1938,3 +1940,140 @@ This will result in a list similar to:
 ----
 
 For more examples, take a look at the blog: https://blog.couchbase.com/optimize-n1ql-performance-using-request-profiling/[Optimize N1QL performance using request profiling^].
+
+[#sys-functions]
+== system:functions
+
+This catalog maintains a list of all user-defined functions.
+
+To see the list of all user-defined functions, use:
+
+[source,n1ql]
+----
+SELECT * FROM system:functions;
+----
+
+This will result in a list similar to:
+
+[source,json]
+----
+[
+  {
+    "functions": {
+      "definition": {
+        "#language": "javascript",
+        "library": "math77",
+        "object": "add"
+      },
+      "identity": {
+        "name": "javaScriptAdd",
+        "namespace": "default",
+        "type": "global"
+      }
+    }
+  },
+  {
+    "functions": {
+      "definition": {
+        "#language": "inline",
+        "expression": "substr0(`vString`, (length(`vString`) - `vLen`), `vLen`)",
+        "parameters": [
+          "vString",
+          "vLen"
+        ]
+      },
+      "identity": {
+        "name": "rstr",
+        "namespace": "default",
+        "type": "global"
+      }
+    }
+  }
+]
+----
+
+This query returns the following attributes:
+
+* [.out]`definition.#language`: string (the language of the function, for example, inline)
+* [.out]`definition.expression`: string (for inline functions only: the expression defining the function)
+* [.out]`definition.library`: string (for JavaScript functions only: the library containing the function)
+* [.out]`definition.object`: string (for JavaScript functions only: the object defining the function)
+* [.out]`definition.parameters`: array of strings (the parameters required by the function)
+* [.out]`identity.name`: string (the name of the function)
+* [.out]`identity.namespace`: string (the namespace of the function, for example, default)
+* [.out]`identity.type`: string (the type of the function, for example, global)
+
+[#sys-functions-cache]
+== system:functions_cache
+
+This catalog maintains a list of recently-used user-defined functions.
+
+To see the list of recently-used user-defined functions, use:
+
+[source,n1ql]
+----
+SELECT * FROM system:functions_cache;
+----
+
+This will result in a list similar to:
+
+[source,json]
+----
+[
+  {
+    "functions_cache": {
+      "#language": "javascript",
+      "avgServiceTime": "674.264µs",
+      "lastUse": "2019-08-06 06:08:35.37498882 -0700 PDT m=+2236.523899555",
+      "library": "math77",
+      "maxServiceTime": "674.264µs",
+      "minServiceTime": "0s",
+      "name": "javaScriptAdd",
+      "namespace": "default",
+      "node": "127.0.0.1:8091",
+      "object": "add",
+      "type": "global",
+      "uses": 1
+    }
+  },
+  {
+    "functions_cache": {
+      "#language": "inline",
+      "avgServiceTime": "8.926µs",
+      "expression": "substr0(`vString`, (length(`vString`) - `vLen`), `vLen`)",
+      "lastUse": "2019-08-06 06:10:50.681845642 -0700 PDT m=+2371.830756442",
+      "maxServiceTime": "8.926µs",
+      "minServiceTime": "0s",
+      "name": "rstr",
+      "namespace": "default",
+      "node": "127.0.0.1:8091",
+      "parameters": [
+        "vString",
+        "vLen"
+      ],
+      "type": "global",
+      "uses": 1
+    }
+  }
+]
+----
+
+This query returns the following attributes:
+
+* [.out]`#language`: string (the language of the function, for example, inline)
+* [.out]`expression`: string (for inline functions only: the expression defining the function)
+* [.out]`library`: string (for JavaScript functions only: the library containing the function)
+* [.out]`object`: string (for JavaScript functions only: the object defining the function)
+* [.out]`parameters`: array of strings (the parameters required by the function)
+* [.out]`name`: string (the name of the function)
+* [.out]`namespace`: string (the namespace of the function, for example, default)
+* [.out]`type`: string (the type of the function, for example, global)
+* [.out]`avgServiceTime`: string (the mean service time for the function)
+* [.out]`maxServiceTime`: string (the maximum service time for the function)
+* [.out]`minServiceTime`: string (the minimum service time for the function)
+* [.out]`lastUse`: string (the date and time when the function was last used)
+* [.out]`uses`: number (the number of uses of the function)
+
+== Related Links
+
+* Refer to xref:n1ql:n1ql-intro/sysinfo.adoc[Getting System Information] for more information on the system namespace.

--- a/modules/n1ql/pages/n1ql-intro/sysinfo.adoc
+++ b/modules/n1ql/pages/n1ql-intro/sysinfo.adoc
@@ -69,7 +69,7 @@ The query returns the following attributes:
 
 * [.out]`id`: string (id for the namespace)
 * [.out]`name`: string (name for the namespace)
-* [.out]`store_id`: string (id for the datastore to which the namespace belongs)
+* [.out]`datastore_id`: string (id for the datastore to which the namespace belongs)
 
 [#querying-keyspaces]
 == Querying Keyspaces
@@ -85,7 +85,7 @@ The query returns the following attributes:
 * [.out]`id`: string (id for the keyspace)
 * [.out]`name`: string (name for the keyspace)
 * [.out]`namespace_id`: string (id for the namespace to which the keyspace belongs)
-* [.out]`store_id`: string (id for the datastore to which the keyspace belongs)
+* [.out]`datastore_id`: string (id for the datastore to which the keyspace belongs)
 
 [#querying-indexes]
 == Querying Indexes
@@ -101,10 +101,11 @@ The query returns the following attributes:
 * [.out]`id`: string (id for the index)
 * [.out]`name`: string (name for the index)
 * [.out]`index_key`: array of strings (list of index keys)
-* [.out]`index_type`: string (type of index, for example, view index)
+* [.out]`using`: string (type of index, for example, gsi)
+* [.out]`state`: string (state of index, for example, online)
 * [.out]`keyspace_id`: string (id for the keyspace to which the index belongs)
 * [.out]`namespace_id`: string (id for the namespace to which the index belongs)
-* [.out]`store_id`: string (id for the datastore to which the index belongs)
+* [.out]`datastore_id`: string (id for the datastore to which the index belongs)
 
 [#querying-dual]
 == Querying Dual
@@ -116,3 +117,7 @@ SELECT 2+5 FROM system:dual
 ----
 
 The query returns the result of the  expression, 7 in this case.
+
+== Related Links
+
+* Refer to xref:manage:monitor/monitoring-n1ql-query.adoc[Monitor Queries] for more information on the system namespace.

--- a/modules/n1ql/pages/n1ql-language-reference/createfunction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createfunction.adoc
@@ -305,5 +305,5 @@ EXECUTE FUNCTION javaScriptAdd(2, 3);
 
 * To execute user-defined functions, refer to xref:n1ql-language-reference/execfunction.adoc[EXECUTE FUNCTION].
 * To include user-defined functions in an expression, refer to xref:n1ql-language-reference/userfun.adoc[User-Defined Functions].
-* To view user-defined functions, refer to xref:n1ql-intro/sysinfo.adoc[Getting System Information].
+* To view user-defined functions, refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-functions[Monitor Queries].
 * To drop user-defined functions, refer to xref:n1ql-language-reference/dropfunction.adoc[DROP FUNCTION].

--- a/modules/n1ql/pages/n1ql-language-reference/dropfunction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropfunction.adoc
@@ -81,4 +81,4 @@ $ curl -v -X GET http://localhost:8093/functions/v1/libraries -H 'content-type: 
 * To create user-defined functions, refer to xref:n1ql-language-reference/createfunction.adoc[CREATE FUNCTION].
 * To execute user-defined functions, refer to xref:n1ql-language-reference/execfunction.adoc[EXECUTE FUNCTION].
 * To include user-defined functions in an expression, refer to xref:n1ql-language-reference/userfun.adoc[User-Defined Functions].
-* To view user-defined functions, refer to xref:n1ql-intro/sysinfo.adoc[Getting System Information].
+* To view user-defined functions, refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-functions[Monitor Queries].

--- a/modules/n1ql/pages/n1ql-language-reference/execfunction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/execfunction.adoc
@@ -56,5 +56,5 @@ For examples, refer to xref:n1ql-language-reference/createfunction.adoc#examples
 
 * To create user-defined functions, refer to xref:n1ql-language-reference/createfunction.adoc[CREATE FUNCTION].
 * To include user-defined functions in an expression, refer to xref:n1ql-language-reference/userfun.adoc[User-Defined Functions].
-* To view user-defined functions, refer to xref:n1ql-intro/sysinfo.adoc[Getting System Information].
+* To view user-defined functions, refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-functions[Monitor Queries].
 * To drop user-defined functions, refer to xref:n1ql-language-reference/dropfunction.adoc[DROP FUNCTION].

--- a/modules/n1ql/pages/n1ql-language-reference/userfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/userfun.adoc
@@ -149,5 +149,5 @@ WHERE l.city = "Gillingham";
 
 * To create user-defined functions, refer to xref:n1ql-language-reference/createfunction.adoc[CREATE FUNCTION].
 * To execute user-defined functions, refer to xref:n1ql-language-reference/execfunction.adoc[EXECUTE FUNCTION].
-* To view user-defined functions, refer to xref:n1ql-intro/sysinfo.adoc[Getting System Information].
+* To view user-defined functions, refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-functions[Monitor Queries].
 * To drop user-defined functions, refer to xref:n1ql-language-reference/dropfunction.adoc[DROP FUNCTION].


### PR DESCRIPTION
The following documentation is ready for review:

* [Monitor Queries › system:functions](https://simon-dew.github.io/docs-site/DOC-4941/server/6.5/manage/monitor/monitoring-n1ql-query.html#sys-functions)
* [Monitor Queries › system:functions_cache](https://simon-dew.github.io/docs-site/DOC-4941/server/6.5/manage/monitor/monitoring-n1ql-query.html#sys-functions-cache)

Documentation issue: [DOC-5157](https://issues.couchbase.com/browse/DOC-5157)