### PR TITLE
Updated the old blog links present on the page

### DIFF
--- a/modules/security/pages/security-passwords.adoc
+++ b/modules/security/pages/security-passwords.adoc
@@ -14,6 +14,6 @@ As a security best practice, choose passwords that are strong and periodically u
 * Passwords should be rotated periodically, based on an organization's requirements.
 * CRAM-MD5 is deprecated in Couchbase Server version 4.5.
 Use SCRAM-SHA enabled SDKs instead.
-See these two blogs for more information: http://blog.couchbase.com/2016/may/improved-security-couchbase-4.5-scram-sha[^], http://blog.couchbase.com/2016/watching-scram-authentication-in-java[^].
+See these two blogs for more information: https://blog.couchbase.com/improved-security-couchbase-4.5-scram-sha/[^], https://blog.couchbase.com/watching-scram-authentication-in-java/[^].
 
 You can reset any forgotten administrative passwords using the xref:cli:cbcli/reset-admin-password.adoc[couchbase-cli reset-admin-password] command.


### PR DESCRIPTION
Updated the two old blog links present on the page.
1) old link: http://blog.couchbase.com/2016/may/improved-security-couchbase-4.5-scram-sha to https://blog.couchbase.com/improved-security-couchbase-4.5-scram-sha/
2) old link: http://blog.couchbase.com/2016/watching-scram-authentication-in-java to https://blog.couchbase.com/watching-scram-authentication-in-java/