### PR TITLE
Updated the blog link present on the page

### DIFF
--- a/modules/performance/pages/index-scans.adoc
+++ b/modules/performance/pages/index-scans.adoc
@@ -28,7 +28,7 @@ For example, the Sort phase can be skipped when there is no ORDER BY clause in t
 [#inside_a_query_node]
 image::n1ql/n1ql-language-reference/query_service.png[]
 
-http://blog.couchbase.com/sql-for-documents-n1ql-brief-introduction-to-query-planning[This brief introduction to query planning^] has details of query planner.
+https://blog.couchbase.com/sql-for-documents-n1ql-brief-introduction-to-query-planning/[This brief introduction to query planning^] has details of query planner.
 When the Index path is chosen, query engine requests the scan by providing the range of values to return.
 This range is represented as a SPAN in the query plan.
 The index spans will play major roles in optimal plan generation and execution.


### PR DESCRIPTION
Updated the blog link "http://blog.couchbase.com/sql-for-documents-n1ql-brief-introduction-to-query-planning" to "https://blog.couchbase.com/sql-for-documents-n1ql-brief-introduction-to-query-planning/".