### PR TITLE
Minor wordsmithing & removed duplicate image

### DIFF
--- a/modules/developer-preview/pages/preview-mode.adoc
+++ b/modules/developer-preview/pages/preview-mode.adoc
@@ -3,11 +3,9 @@
 [abstract]
 Developer Preview mode (or Preview mode for short), provides early access to features which may be GA in a future release and enables you to play with these features and get a sense of how they work. Preview mode features are not supported by Couchbase Legal Agreements, may not be functionally complete, and are not intended for production use. They are intended for development and testing purposes only.
 
-Introduced in Couchbase Server Enterprise Edition 6.5 Beta, Developer Preview mode is enabled by default during the Beta release. When the Preview mode is enabled, the cluster is converted to a Developer Preview cluster and cannot be switched back. Given that the Developer Preview features are under development, Couchbase cannot guarantee the stability of these features. As a result, clusters in Preview mode cannot be upgraded to subsequent releases.
+Introduced in Couchbase Server Enterprise Edition 6.5 Beta, Developer Preview mode is enabled by default during the Beta release. When Preview mode is enabled, the cluster is converted to a Developer Preview cluster and cannot be switched back. Preview mode features are under development and as such Couchbase cannot guarantee the stability of these features. Additionally, clusters in Preview mode cannot be upgraded to subsequent releases.
 
 Developer Preview Mode can be enabled using the CLI or REST API, however as noted above, once enabled, it cannot be disabled.
-
-image::preview-mode-verify-ui.png[,720,align=left]
 
 Note that the commands on this page assume a Ubuntu Linux environment. For the appropriate command-paths, see xref:cli:cli-intro.adoc[CLI Reference].
 
@@ -17,20 +15,20 @@ If your cluster is in Developer Preview mode, the Admin console displays the fol
 
 image::preview-mode-verify-ui.png[,720,align=left]
 
-You can also verify if Developer Preview mode has been enabled on your cluster by running the `couchbase-cli enable-developer-preview` command with the `--list` flag, and specifying the cluster-address, and the Full Administrator username and password as shown:
+You can also verify whether Preview mode has been enabled on your cluster by running the `couchbase-cli enable-developer-preview` command with the `--list` flag, and specifying the cluster-address, and the Full Administrator username and password as shown:
 
 ----
 /opt/couchbase/bin/couchbase-cli enable-developer-preview \
 --list -c localhost:8091 -u Administrator -p password
 ----
 
-If the cluster is not in Developer Preview Mode, the following output is displayed:
+If the cluster is not in Preview Mode, the following output is displayed:
 
 ----
 Cluster is NOT in developer preview mode
 ----
 
-If the cluster _is_ in Developer Preview Mode, the output is as follows:
+If the cluster _is_ in Preview Mode, the output is as follows:
 
 ----
 Cluster is in developer preview mode


### PR DESCRIPTION
* Wordsmithing changes to use "Preview mode" more in place of "Developer Preview mode" in a number of places. Also other minor changes.
* The image showing the UI with the "PREVIEW MODE" indication is displayed twice. Removed the first of these images.