### PR TITLE
DOC-4455 Analytics upgrade note to release notes

### DIFF
--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -526,6 +526,13 @@ You can now use the following syntax to connect all datasets in a dataverse:
 CONNECT LINK (dataverse_name.)? Local (, (dataverse_name.)? Local)*
 ----
 
+[IMPORTANT]
+====
+Analytics data from Developer Preview releases cannot be upgraded.
+
+If you plan to use the production release of Couchbase Analytics in version 6.0, you must perform a fresh installation of Couchbase Server 6.0 on any existing Analytics nodes that are running a previous version; otherwise, the Analytics Service will not function properly.
+====
+
 [#deprecation-600]
 === Deprecated Platforms
 


### PR DESCRIPTION
This note is verbatim from the 6.0 upgrade section. The goal is to try and call extra attention to the Analytics upgrade limitation until the upgrade section redesign in Mad Hatter is ported to 6.0.x.

Ticket: [DOC-4455](https://issues.couchbase.com/browse/DOC-4455)