### PR TITLE
DOC-5667: namespace-name can't be specified in N1QL

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
@@ -63,7 +63,7 @@ You can add an optional namespace name to the keyspace name in this way:
 namespace-name : keyspace-name
 ----
 
-For example, `main:customer` indicates the customer keyspace in the main namespace.
+For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.
 If the namespace name is omitted, the default namespace in the current session is used.
 
 ----

--- a/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
@@ -63,6 +63,7 @@ You can add an optional namespace name to the keyspace name in this way:
 namespace-name : keyspace-name
 ----
 
+Currently, only the `default` namespace is available.
 For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.
 If the namespace name is omitted, the default namespace in the current session is used.
 

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -70,7 +70,7 @@ You can add an optional namespace name to the keyspace name in this way:
 namespace-name : keyspace-name
 ----
 +
-For example, `main:customer` indicates the customer keyspace in the main namespace.
+For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.
 If the namespace name is omitted, the default namespace in the current session is used.
 
 expression1, expression2, \... , expressionX;;

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -70,6 +70,7 @@ You can add an optional namespace name to the keyspace name in this way:
 namespace-name : keyspace-name
 ----
 +
+Currently, only the `default` namespace is available.
 For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.
 If the namespace name is omitted, the default namespace in the current session is used.
 

--- a/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
@@ -66,6 +66,7 @@ You can add an optional namespace name to the keyspace name in this way:
 namespace-name : keyspace-name
 ----
 +
+Currently, only the `default` namespace is available.
 For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.
 If the namespace name is omitted, the default namespace in the current session is used.
 

--- a/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
@@ -66,7 +66,7 @@ You can add an optional namespace name to the keyspace name in this way:
 namespace-name : keyspace-name
 ----
 +
-For example, `main:customer` indicates the `customer` keyspace in the main namespace.
+For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.
 If the namespace name is omitted, the default namespace in the current session is used.
 
 USING GSI | USING VIEW;;

--- a/modules/n1ql/pages/n1ql-language-reference/delete.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/delete.adoc
@@ -21,7 +21,7 @@ You can add an optional namespace name to the keyspace name in this way:
 [ (namespace-name :)] keyspace-name
 ----
 
-For example, `main:customer` indicates the customer keyspace in the main namespace.
+For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.
 If the namespace name is omitted, the default namespace in the current session is used.
 
 *USE KEYS clause*_(optional)_

--- a/modules/n1ql/pages/n1ql-language-reference/delete.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/delete.adoc
@@ -21,6 +21,7 @@ You can add an optional namespace name to the keyspace name in this way:
 [ (namespace-name :)] keyspace-name
 ----
 
+Currently, only the `default` namespace is available.
 For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.
 If the namespace name is omitted, the default namespace in the current session is used.
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
@@ -29,7 +29,7 @@ You can add an optional namespace name to the keyspace name in this way:
 
 _namespace-name : keyspace-name_
 
-For example, main:customer indicates the customer keyspace in the main namespace.
+For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.
 If the namespace name is omitted, the default namespace in the current session is used.
 
 _USING GSI | VIEW_

--- a/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
@@ -29,6 +29,7 @@ You can add an optional namespace name to the keyspace name in this way:
 
 _namespace-name : keyspace-name_
 
+Currently, only the `default` namespace is available.
 For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.
 If the namespace name is omitted, the default namespace in the current session is used.
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
@@ -25,6 +25,7 @@ You can add an optional namespace name to the keyspace name in this way:
 
 _namespace-name : keyspace-name_
 
+Currently, only the `default` namespace is available.
 For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.
 If the namespace name is omitted, the default namespace in the current session is used.
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
@@ -25,7 +25,7 @@ You can add an optional namespace name to the keyspace name in this way:
 
 _namespace-name : keyspace-name_
 
-For example, main:customer indicates the customer keyspace in the main namespace.
+For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.
 If the namespace name is omitted, the default namespace in the current session is used.
 
 _USING GSI | VIEW_

--- a/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
@@ -65,7 +65,7 @@ You can add an optional namespace-name to the keyspace-name in this way:
 
 [.var]`namespace-name`:[.var]``keyspace-name``.
 
-For example, `main:customer` indicates the [.param]`customer` keyspace in the [.param]`main` namespace.
+For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.
 If the namespace name is omitted, the default namespace in the current session is used.
 
 [.var]`insert-values`: Specifies the values to be upserted.

--- a/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
@@ -65,6 +65,7 @@ You can add an optional namespace-name to the keyspace-name in this way:
 
 [.var]`namespace-name`:[.var]``keyspace-name``.
 
+Currently, only the `default` namespace is available.
 For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.
 If the namespace name is omitted, the default namespace in the current session is used.
 


### PR DESCRIPTION
Further to [this forum post](https://forums.couchbase.com/t/couchbase-bucket-vbucket-namespace-keyspace-hash-key-definitions-plus-best-practice-for-key-definitions/22560/14), only the `default` and `system` namespaces are currently supported. Remove references to the `main` namespace in the N1QL documentation.

Documentation issue: [DOC-5667](https://issues.couchbase.com/browse/DOC-5667)