### PR TITLE
DOC-5667: namespace-name can't be specified in N1QL

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
@@ -59,6 +59,7 @@ image::n1ql-language-reference/from-keyspace-ref.png["(namespace ':')? keyspace"
 
 namespace::
 (Optional) An xref:n1ql-language-reference/identifiers.adoc[identifier] that refers to the xref:n1ql-intro/sysinfo.adoc#logical-heirarchy[namespace] of the bucket to be indexed.
+Currently, only the `default` namespace is available.
 If the namespace name is omitted, the default namespace in the current session is used.
 
 keyspace::

--- a/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
@@ -65,7 +65,7 @@ keyspace::
 (Required) An xref:n1ql-language-reference/identifiers.adoc[identifier] that refers to the bucket name or xref:n1ql-intro/sysinfo.adoc#logical-hierarchy[keyspace].
 It specifies the bucket as the source for which the index needs to be created.
 
-For example, `main:customer` indicates the customer keyspace in the main namespace.
+For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.
 
 [[index-term,index-term]]
 === Index Term

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -70,7 +70,7 @@ You can add an optional namespace name to the keyspace name in this way:
 namespace-name : keyspace-name
 ----
 +
-For example, `main:customer` indicates the customer keyspace in the main namespace.
+For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.
 If the namespace name is omitted, the default namespace in the current session is used.
 
 expression1, expression2, \... , expressionX;;

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -70,6 +70,7 @@ You can add an optional namespace name to the keyspace name in this way:
 namespace-name : keyspace-name
 ----
 +
+Currently, only the `default` namespace is available.
 For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.
 If the namespace name is omitted, the default namespace in the current session is used.
 

--- a/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
@@ -66,6 +66,7 @@ You can add an optional namespace name to the keyspace name in this way:
 namespace-name : keyspace-name
 ----
 +
+Currently, only the `default` namespace is available.
 For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.
 If the namespace name is omitted, the default namespace in the current session is used.
 

--- a/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
@@ -66,7 +66,7 @@ You can add an optional namespace name to the keyspace name in this way:
 namespace-name : keyspace-name
 ----
 +
-For example, `main:customer` indicates the `customer` keyspace in the main namespace.
+For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.
 If the namespace name is omitted, the default namespace in the current session is used.
 
 USING GSI | USING VIEW;;

--- a/modules/n1ql/pages/n1ql-language-reference/delete.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/delete.adoc
@@ -21,7 +21,7 @@ You can add an optional namespace name to the keyspace name in this way:
 [ (namespace-name :)] keyspace-name
 ----
 
-For example, `main:customer` indicates the customer keyspace in the main namespace.
+For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.
 If the namespace name is omitted, the default namespace in the current session is used.
 
 *USE KEYS clause*_(optional)_

--- a/modules/n1ql/pages/n1ql-language-reference/delete.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/delete.adoc
@@ -21,6 +21,7 @@ You can add an optional namespace name to the keyspace name in this way:
 [ (namespace-name :)] keyspace-name
 ----
 
+Currently, only the `default` namespace is available.
 For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.
 If the namespace name is omitted, the default namespace in the current session is used.
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
@@ -29,7 +29,7 @@ You can add an optional namespace name to the keyspace name in this way:
 
 _namespace-name : keyspace-name_
 
-For example, main:customer indicates the customer keyspace in the main namespace.
+For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.
 If the namespace name is omitted, the default namespace in the current session is used.
 
 _USING GSI | VIEW_

--- a/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
@@ -29,6 +29,7 @@ You can add an optional namespace name to the keyspace name in this way:
 
 _namespace-name : keyspace-name_
 
+Currently, only the `default` namespace is available.
 For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.
 If the namespace name is omitted, the default namespace in the current session is used.
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
@@ -25,6 +25,7 @@ You can add an optional namespace name to the keyspace name in this way:
 
 _namespace-name : keyspace-name_
 
+Currently, only the `default` namespace is available.
 For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.
 If the namespace name is omitted, the default namespace in the current session is used.
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
@@ -25,7 +25,7 @@ You can add an optional namespace name to the keyspace name in this way:
 
 _namespace-name : keyspace-name_
 
-For example, main:customer indicates the customer keyspace in the main namespace.
+For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.
 If the namespace name is omitted, the default namespace in the current session is used.
 
 _USING GSI | VIEW_

--- a/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
@@ -65,7 +65,7 @@ You can add an optional namespace-name to the keyspace-name in this way:
 
 [.var]`namespace-name`:[.var]``keyspace-name``.
 
-For example, `main:customer` indicates the [.param]`customer` keyspace in the [.param]`main` namespace.
+For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.
 If the namespace name is omitted, the default namespace in the current session is used.
 
 [.var]`insert-values`: Specifies the values to be upserted.

--- a/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
@@ -65,6 +65,7 @@ You can add an optional namespace-name to the keyspace-name in this way:
 
 [.var]`namespace-name`:[.var]``keyspace-name``.
 
+Currently, only the `default` namespace is available.
 For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.
 If the namespace name is omitted, the default namespace in the current session is used.
 


### PR DESCRIPTION
Porting #713 to mad-hatter

Documentation issue: [DOC-5667](https://issues.couchbase.com/browse/DOC-5667)