### PR TITLE
DOC-5685: CREATE FUNCTION external example is wrong

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/createfunction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createfunction.adoc
@@ -276,7 +276,7 @@ The following command registers a JavaScript function called `add` in a library 
 
 [source,console]
 ----
-$ curl -v -X POST http://localhost:8093/functions/v1/libraries -H 'content-type: application/json' -d '{"name":"math","code":"function add(a, b) { let data = a + b; return data; }"}' -u Administrator:password
+$ curl -v -X POST http://localhost:8093/functions/v1/libraries/math/functions/add -H 'content-type: application/json' -d '{"name": "add", "code": "function add(a, b) { let data = a + b; return data; }"}' -u Administrator:password
 ----
 
 The following statement creates a function called `javaScriptAdd`, which calls the JavaScript `add` function from the `math` library.


### PR DESCRIPTION
Documentation issue: [DOC-5685](https://issues.couchbase.com/browse/DOC-5685)