### PR TITLE
DOC-5731: ADVISOR function

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -244,6 +244,7 @@
    **** xref:n1ql:n1ql-language-reference/datefun.adoc[Date Functions]
    **** xref:n1ql:n1ql-language-reference/jsonfun.adoc[JSON Functions]
    **** xref:n1ql:n1ql-language-reference/metafun.adoc[Miscellaneous Utility Functions]
+    ***** xref:n1ql:n1ql-language-reference/advisor.adoc[ADVISOR Function]
     ***** xref:n1ql:n1ql-language-reference/curl.adoc[CURL Function]
    **** xref:n1ql:n1ql-language-reference/numericfun.adoc[Number Functions]
    **** xref:n1ql:n1ql-language-reference/objectfun.adoc[Object Functions]

--- a/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
+++ b/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
@@ -2156,9 +2156,9 @@ This query returns the following attributes:
 <6>  [.out]`state`: string (the class of the task -- `scheduled`, `cancelled`, `completed`)
 <7>  [.out]`subClass`: string (the subclass of the task; for example, `analyze`)
 <8>  [.out]`submitTime`: string (the date and time when the task was submitted)
-<9>  [.out]`results`: array (completed tasks only: the results of the task)
-<10> [.out]`startTime`: string (completed tasks only: the date and time when the task started)
-<11> [.out]`stopTime`: string (completed tasks only: the date and time when the task stopped)
+<9>  [.out]`results`: array (not scheduled tasks: the results of the task)
+<10> [.out]`startTime`: string (not scheduled tasks: the date and time when the task started)
+<11> [.out]`stopTime`: string (not scheduled tasks: the date and time when the task stopped)
 
 Refer to xref:n1ql:n1ql-language-reference/advisor.adoc[ADVISOR Function] for more information on index advisor sessions.
 

--- a/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
+++ b/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
@@ -2101,8 +2101,8 @@ Each query node keeps its own cache of recently-used user-defined functions, so 
 
 include::ROOT:partial$developer-preview.adoc[tag=admonition]
 
-This catalog maintains a list of recently-used index advisor sessions.
-To see the list of recently-used index advisor sessions, use:
+This catalog maintains a list of recently-used scheduled tasks, such as index advisor sessions.
+To see the list of recently-used scheduled tasks, use:
 
 [source,n1ql]
 ----
@@ -2118,77 +2118,29 @@ This will result in a list similar to:
     "tasks_cache": {
       "class": "advisor", // <1>
       "delay": "1h0m0s", // <2>
-      "id": "8a086aae-3aec-5148-a1b0-a0f5e3635e7c", // <3>
-      "name": "8f3b67ec-8bee-47be-b8e1-972ccd004408", // <4>
+      "id": "bcd9f8e4-b324-504c-a98b-ace90dba869f", // <3>
+      "name": "aa7f688a-bf29-438f-888f-eeaead87ca40", // <4>
       "node": "10.143.192.101:8091", // <5>
       "state": "scheduled", // <6>
       "subClass": "analyze", // <7>
-      "submitTime": "2019-09-13 06:09:58.731749255 -0700 PDT m=+13405.291049586" // <8>
+      "submitTime": "2019-09-17 05:18:12.903122381 -0700 PDT m=+8460.550715992" // <8>
     }
   },
   {
     "tasks_cache": {
       "class": "advisor",
       "delay": "5m0s",
-      "id": "7bc1a91f-a509-5de1-adeb-4617a3be7398",
-      "name": "096c06d5-7969-4328-a876-0eb7958750a2",
+      "id": "254abec5-5782-543e-9ee0-d07da146b94e",
+      "name": "ca2cfe56-01fa-4563-8eb0-a753af76d865",
       "node": "10.143.192.101:8091",
       "results": [ // <9>
-        {
-          "current_used_indexes": [
-            {
-              "index": "CREATE INDEX def_type ON `travel-sample`(`type`)",
-              "statements": [
-                {
-                  "run_count": 1,
-                  "statement": "SELECT h.name, a.airportname FROM `travel-sample` h JOIN `travel-sample` a ON h.city = a.city WHERE h.type = 'hotel' LIMIT 5;"
-                },
-                {
-                  "run_count": 1,
-                  "statement": "SELECT d.id, d.destinationairport, RATIO_TO_REPORT(d.distance) OVER ( PARTITION BY d.destinationairport ) AS `distance-ratio` FROM `travel-sample` AS d WHERE d.type='route' LIMIT 7;"
-                }
-              ]
-            },
-            ...
-          ],
-          "recommended_covering_indexes": [
-            {
-              "index": "CREATE INDEX adv_city_type_name ON `travel-sample`(`city`,`name`) WHERE `type` = 'hotel'",
-              "statements": [
-                {
-                  "run_count": 1,
-                  "statement": "SELECT h.name, a.airportname FROM `travel-sample` h JOIN `travel-sample` a ON h.city = a.city WHERE h.type = 'hotel' LIMIT 5;"
-                }
-              ]
-            },
-            {
-              "index": "CREATE INDEX adv_city_airportname ON `travel-sample`(`city`,`airportname`)",
-              "statements": [
-                {
-                  "run_count": 1,
-                  "statement": "SELECT h.name, a.airportname FROM `travel-sample` h JOIN `travel-sample` a ON h.city = a.city WHERE h.type = 'hotel' LIMIT 5;"
-                }
-              ]
-            }
-          ],
-          "recommended_indexes": [
-            {
-              "index": "CREATE INDEX adv_city_type ON `travel-sample`(`city`) WHERE `type` = 'hotel'",
-              "statements": [
-                {
-                  "run_count": 1,
-                  "statement": "SELECT h.name, a.airportname FROM `travel-sample` h JOIN `travel-sample` a ON h.city = a.city WHERE h.type = 'hotel' LIMIT 5;"
-                }
-              ]
-            }
-          ]
-        }
+        ...
       ],
-      "startTime": "2019-09-17 06:17:34.765551322 -0700 PDT m=+12022.413144960", // <10>
+      "startTime": "2019-09-17 05:03:31.821597725 -0700 PDT m=+7579.469191487", // <10>
       "state": "completed",
-      "stopTime": "2019-09-17 06:17:34.811307672 -0700 PDT m=+12022.458901260", // <11>
+      "stopTime": "2019-09-17 05:03:31.963133954 -0700 PDT m=+7579.610727539", // <11>
       "subClass": "analyze",
-      "submitTime": "2019-09-17 06:12:34.765135808 -0700 PDT m=+11722.412729419"
+      "submitTime": "2019-09-17 04:58:31.821230131 -0700 PDT m=+7279.468823737"
     }
   }
 ]
@@ -2196,19 +2148,19 @@ This will result in a list similar to:
 
 This query returns the following attributes:
 
-<1>  [.out]`class`: string (the class of the session; in this case, `advisor`)
-<2>  [.out]`delay`: string (the scheduled duration of the session)
-<3>  [.out]`id`: string (the internal ID of the session)
-<4>  [.out]`name`: string (the name of the session)
-<5>  [.out]`node`: string (the node where the session was started)
-<6>  [.out]`state`: string (the state of the session -- `scheduled`, `cancelled`, `completed`)
-<7>  [.out]`subClass`: string (the subclass of the session; in this case, `analyze`)
-<8>  [.out]`submitTime`: string (the date and time when the function was called to start the session)
-<9>  [.out]`results`: array (completed sessions only: the index advisor results)
-<10> [.out]`startTime`: string (completed sessions only: the date and time when the session started)
-<11> [.out]`stopTime`: string (completed sessions only: the date and time when the session stopped)
+<1>  [.out]`class`: string (the class of the task; for example, `advisor`)
+<2>  [.out]`delay`: string (the scheduled duration of the task)
+<3>  [.out]`id`: string (the internal ID of the task)
+<4>  [.out]`name`: string (the name of the task)
+<5>  [.out]`node`: string (the node where the task was started)
+<6>  [.out]`state`: string (the class of the task -- `scheduled`, `cancelled`, `completed`)
+<7>  [.out]`subClass`: string (the subclass of the task; for example, `analyze`)
+<8>  [.out]`submitTime`: string (the date and time when the task was submitted)
+<9>  [.out]`results`: array (completed tasks only: the results of the task)
+<10> [.out]`startTime`: string (completed tasks only: the date and time when the task started)
+<11> [.out]`stopTime`: string (completed tasks only: the date and time when the task stopped)
 
-Refer to xref:n1ql:n1ql-language-reference/advisor.adoc#results[ADVISOR Function] for details of the index advisor results.
+Refer to xref:n1ql:n1ql-language-reference/advisor.adoc[ADVISOR Function] for more information on index advisor sessions.
 
 == Related Links
 

--- a/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
+++ b/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
@@ -45,6 +45,7 @@ a|
 * <<sys_my-user-info,system:my_user_info>>
 * <<sys-functions,system:functions>>
 * <<sys-functions-cache,system:functions_cache>>
+* <<sys-tasks-cache,system:tasks_cache>>
 
 | Security Catalogs
 a|
@@ -2094,6 +2095,120 @@ This query returns the following attributes:
 <15> [.out]`uses`: number (the number of uses of the function)
 
 Each query node keeps its own cache of recently-used user-defined functions, so you may see the same function listed for multiple nodes.
+
+[#sys-tasks-cache]
+== system:tasks_cache
+
+include::ROOT:partial$developer-preview.adoc[tag=admonition]
+
+This catalog maintains a list of recently-used index advisor sessions.
+To see the list of recently-used index advisor sessions, use:
+
+[source,n1ql]
+----
+SELECT * FROM system:tasks_cache;
+----
+
+This will result in a list similar to:
+
+[source,json]
+----
+[
+  {
+    "tasks_cache": {
+      "class": "advisor", // <1>
+      "delay": "1h0m0s", // <2>
+      "id": "8a086aae-3aec-5148-a1b0-a0f5e3635e7c", // <3>
+      "name": "8f3b67ec-8bee-47be-b8e1-972ccd004408", // <4>
+      "node": "10.143.192.101:8091", // <5>
+      "state": "scheduled", // <6>
+      "subClass": "analyze", // <7>
+      "submitTime": "2019-09-13 06:09:58.731749255 -0700 PDT m=+13405.291049586" // <8>
+    }
+  },
+  {
+    "tasks_cache": {
+      "class": "advisor",
+      "delay": "5m0s",
+      "id": "7bc1a91f-a509-5de1-adeb-4617a3be7398",
+      "name": "096c06d5-7969-4328-a876-0eb7958750a2",
+      "node": "10.143.192.101:8091",
+      "results": [ // <9>
+        {
+          "current_used_indexes": [
+            {
+              "index": "CREATE INDEX def_type ON `travel-sample`(`type`)",
+              "statements": [
+                {
+                  "run_count": 1,
+                  "statement": "SELECT h.name, a.airportname FROM `travel-sample` h JOIN `travel-sample` a ON h.city = a.city WHERE h.type = 'hotel' LIMIT 5;"
+                },
+                {
+                  "run_count": 1,
+                  "statement": "SELECT d.id, d.destinationairport, RATIO_TO_REPORT(d.distance) OVER ( PARTITION BY d.destinationairport ) AS `distance-ratio` FROM `travel-sample` AS d WHERE d.type='route' LIMIT 7;"
+                }
+              ]
+            },
+            ...
+          ],
+          "recommended_covering_indexes": [
+            {
+              "index": "CREATE INDEX adv_city_type_name ON `travel-sample`(`city`,`name`) WHERE `type` = 'hotel'",
+              "statements": [
+                {
+                  "run_count": 1,
+                  "statement": "SELECT h.name, a.airportname FROM `travel-sample` h JOIN `travel-sample` a ON h.city = a.city WHERE h.type = 'hotel' LIMIT 5;"
+                }
+              ]
+            },
+            {
+              "index": "CREATE INDEX adv_city_airportname ON `travel-sample`(`city`,`airportname`)",
+              "statements": [
+                {
+                  "run_count": 1,
+                  "statement": "SELECT h.name, a.airportname FROM `travel-sample` h JOIN `travel-sample` a ON h.city = a.city WHERE h.type = 'hotel' LIMIT 5;"
+                }
+              ]
+            }
+          ],
+          "recommended_indexes": [
+            {
+              "index": "CREATE INDEX adv_city_type ON `travel-sample`(`city`) WHERE `type` = 'hotel'",
+              "statements": [
+                {
+                  "run_count": 1,
+                  "statement": "SELECT h.name, a.airportname FROM `travel-sample` h JOIN `travel-sample` a ON h.city = a.city WHERE h.type = 'hotel' LIMIT 5;"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "startTime": "2019-09-17 06:17:34.765551322 -0700 PDT m=+12022.413144960", // <10>
+      "state": "completed",
+      "stopTime": "2019-09-17 06:17:34.811307672 -0700 PDT m=+12022.458901260", // <11>
+      "subClass": "analyze",
+      "submitTime": "2019-09-17 06:12:34.765135808 -0700 PDT m=+11722.412729419"
+    }
+  }
+]
+----
+
+This query returns the following attributes:
+
+<1>  [.out]`class`: string (the class of the session; in this case, `advisor`)
+<2>  [.out]`delay`: string (the scheduled duration of the session)
+<3>  [.out]`id`: string (the internal ID of the session)
+<4>  [.out]`name`: string (the name of the session)
+<5>  [.out]`node`: string (the node where the session was started)
+<6>  [.out]`state`: string (the state of the session -- `scheduled`, `cancelled`, `completed`)
+<7>  [.out]`subClass`: string (the subclass of the session; in this case, `analyze`)
+<8>  [.out]`submitTime`: string (the date and time when the function was called to start the session)
+<9>  [.out]`results`: array (completed sessions only: the index advisor results)
+<10> [.out]`startTime`: string (completed sessions only: the date and time when the session started)
+<11> [.out]`stopTime`: string (completed sessions only: the date and time when the session stopped)
+
+Refer to xref:n1ql:n1ql-language-reference/advisor.adoc#results[ADVISOR Function] for details of the index advisor results.
 
 == Related Links
 

--- a/modules/n1ql/pages/n1ql-language-reference/advise.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/advise.adoc
@@ -179,6 +179,7 @@ This field is only returned for recommended indexes, or for current indexes if t
 |string
 |===
 
+[[recommendation-rules]]
 === Recommendation Rules
 
 The index advisor recommends secondary indexes based on the query predicate, according to the following rules.

--- a/modules/n1ql/pages/n1ql-language-reference/advisor.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/advisor.adoc
@@ -8,13 +8,21 @@
 :update: {n1ql}/update.adoc
 :delete: {n1ql}/delete.adoc
 :merge: {n1ql}/merge.adoc
+:advise: {n1ql}/advise.adoc
+
+:monitor: xref:manage:monitor/monitoring-n1ql-query.adoc
+:sys-completed-req: {monitor}#sys-completed-req
+:sys-tasks-cache: {monitor}#sys-tasks-cache
+
+:index-advisor: xref:tools:query-workbench.adoc#index-advisor
+:completed-limit: xref:settings:query-settings.adoc#completed-limit
 
 [abstract]
 The `ADVISOR` function provides recommendations for GSI indexes to optimize query response time.
 There are two main scenarios for using this function.
-One is to invoke the index advisor for a given query or set of queries; the other is to start a session in which every query of interest is collected for a set time period, then invoke the index analyzer for that collection of queries after the session ends.
+One is to invoke the index advisor _immediately_ for a given query or set of queries; the other is to start a session in which every query of interest is collected for a set time period, then invoke the index analyzer _asynchronously_ for that collection of queries after the session ends.
 Within these two scenarios, this function has several different usages.
-The operation and output of the function depends on the function's single argument.
+The operation and output of each usage depends on the function's single argument.
 For clarity, each usage is listed separately on this page.
 
 include::ROOT:partial$developer-preview.adoc[tag=admonition]
@@ -30,11 +38,11 @@ The index advisor works with {select}[SELECT], {update}[UPDATE], {delete}[DELETE
 === Arguments
 
 string::
-A single N1QL query for which you want index advice.
+A string, or an expression which resolves to a string, containing a single N1QL query.
 
 === Return Value
 
-An index advisor results object with the following properties.
+Returns an index advisor results object with the following properties.
 
 [[results]]
 **Results**
@@ -45,9 +53,9 @@ An index advisor results object with the following properties.
 
 |**current_used_indexes** +
 __optional__
-|If the query uses an index, this is an array of Index objects, each giving information about one of the currently used primary or secondary indexes.
+|If the query engine can select any current primary or secondary indexes to use with an input query, this is an array of Index objects, each giving information about one of the current indexes.
 
-If the query does not currently use an index, this field does not appear.
+If the query engine cannot select a current index to use with an input query, this field does not appear.
 |< <<indexes,Indexes>> > array
 
 |**recommended_covering_indexes** +
@@ -68,7 +76,7 @@ If the index advisor cannot recommend any indexes, this field does not appear.
 [[indexes]]
 **Indexes**
 
-[options="header", cols="3a,11a,4a"]
+[options="header", cols="~a,~a,~a"]
 |===
 |Name|Description|Schema
 
@@ -166,11 +174,11 @@ The index advisor works with {select}[SELECT], {update}[UPDATE], {delete}[DELETE
 === Arguments
 
 array::
-An array of strings, each of which contains a N1QL query for which you want index advice.
+An array of strings, or an expression which resolves to an array of strings, each of which contains a N1QL query.
 
 === Return Value
 
-An <<results,index advisor results>> object.
+Returns an <<results,index advisor results>> object.
 
 === Examples
 
@@ -234,7 +242,7 @@ SELECT ADVISOR(["SELECT * FROM `travel-sample` WHERE type = 'hotel' AND city = '
 
 .Get index advice for recent completed requests
 ====
-This example uses a subquery to get an array of statements from the xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-req[system:completed_requests] catalog.
+This example uses a subquery to get an array of statements from the {sys-completed-req}[system:completed_requests] catalog.
 
 [source,n1ql]
 ----
@@ -365,16 +373,23 @@ Valid time units are `ns` (nanoseconds), `us` (microseconds), `ms` (milliseconds
 
 query-count;;
 [Optional] An integer specifying the maximum number of queries to be collected for analysis by the index advisor.
-If omitted, the default setting is the same as the service-level xref:settings:query-settings.adoc#completed-limit[completed-limit] setting.
+If omitted, the default setting is the same as the service-level {completed-limit}[completed-limit] setting.
 You can change the service-level `completed-limit` setting to change the default for this property.
 
 === Return Value
 
-An object with the following property:
+Returns an object with the following property:
 
-session::
-A string in UUID format, specifying the name of the index analyzer session.
+[options="header", cols="3a,11a,4a"]
+|===
+|Name|Description|Schema
+
+|**session** +
+__required__
+|The name of the index analyzer session.
 You will need to refer to this name to <<advisor-session-get,invoke the index analyzer>> for this session, or to <<advisor-session-stop,stop>>, <<advisor-session-abort,abort>>, or <<advisor-session-purge,purge>> this session.
+|string (UUID)
+|===
 
 === Example
 
@@ -407,6 +422,7 @@ SELECT ADVISOR({"action": "start", "response": "0s", "duration": "1h"}) AS Colle
 === Description
 
 When used with a `list_obj` object argument, the function can be used to list index advisor sessions.
+Each index advisor session is stored as a scheduled task in the {sys-tasks-cache}[system:tasks_cache] catalog.
 
 === Arguments
 
@@ -437,7 +453,7 @@ Returns an array of tasks cache objects, each of which has the following propert
 
 |**tasks_cache** +
 __required__
-|A nested object that gives information about a session.
+|A nested object that gives information about an index advisor session.
 |<<session,Session>>
 |===
 
@@ -515,7 +531,7 @@ If the session is still active, this field is not present.
 |< <<results,Results>> > array
 |===
 
-Returns an empty array if the tasks cache is empty.
+Returns an empty array if there are no index advisor sessions in the tasks cache.
 
 === Example
 
@@ -789,6 +805,6 @@ SELECT ADVISOR({"action": "purge", "session": "8c41a3c6-2252-437e-ab47-0b28f29f4
 
 == Related Links
 
-* The xref:n1ql-language-reference/advise.adoc[ADVISE] task
-* The xref:tools:query-workbench.adoc#index-advisor[Index Advisor] in the Query Workbench
-* The xref:manage:monitor/monitoring-n1ql-query.adoc#sys-tasks-cache[system:tasks_cache] catalog
+* The {advise}[ADVISE] task
+* The {index-advisor}[Index Advisor] in the Query Workbench
+* The {sys-tasks-cache}[system:tasks_cache] catalog

--- a/modules/n1ql/pages/n1ql-language-reference/advisor.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/advisor.adoc
@@ -611,7 +611,7 @@ session;;
 
 === Return Value
 
-Returns NULL.
+Returns an empty array.
 
 === Example
 
@@ -627,7 +627,7 @@ SELECT ADVISOR({"action": "stop", "session": "8c41a3c6-2252-437e-ab47-0b28f29f47
 ----
 [
   {
-    "Stop": null
+    "Stop": []
   }
 ]
 ----
@@ -654,7 +654,7 @@ session;;
 
 === Return Value
 
-Returns NULL.
+Returns an empty array.
 
 === Example
 
@@ -670,7 +670,7 @@ SELECT ADVISOR({"action": "abort", "session": "8c41a3c6-2252-437e-ab47-0b28f29f4
 ----
 [
   {
-    "Abort": null
+    "Abort": []
   }
 ]
 ----
@@ -785,7 +785,7 @@ session;;
 
 === Return Value
 
-Returns NULL.
+Returns an empty array.
 
 === Example
 
@@ -801,7 +801,7 @@ SELECT ADVISOR({"action": "purge", "session": "8c41a3c6-2252-437e-ab47-0b28f29f4
 ----
 [
   {
-    "Purge": null
+    "Purge": []
   }
 ]
 ----

--- a/modules/n1ql/pages/n1ql-language-reference/advisor.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/advisor.adoc
@@ -39,7 +39,7 @@ An index advisor results object with the following properties.
 [[results]]
 **Results**
 
-[options="header", cols="3a,11a,4a"]
+[options="header", cols="~a,~a,~a"]
 |===
 |Name|Description|Schema
 
@@ -68,7 +68,7 @@ If the index advisor cannot recommend any indexes, this field does not appear.
 [[indexes]]
 **Indexes**
 
-[options="header", cols="~a,~a,~a"]
+[options="header", cols="3a,11a,4a"]
 |===
 |Name|Description|Schema
 
@@ -86,7 +86,7 @@ __required__
 [[statements]]
 **Statements**
 
-[options="header", cols="~a,~a,~a"]
+[options="header", cols="3a,11a,4a"]
 |===
 |Name|Description|Schema
 
@@ -444,7 +444,7 @@ __required__
 [[session]]
 **Session**
 
-[options="header", cols="~a,~a,~a"]
+[options="header", cols="3a,11a,4a"]
 |===
 |Name|Description|Schema
 

--- a/modules/n1ql/pages/n1ql-language-reference/advisor.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/advisor.adoc
@@ -9,6 +9,7 @@
 :delete: {n1ql}/delete.adoc
 :merge: {n1ql}/merge.adoc
 :advise: {n1ql}/advise.adoc
+:rules: {n1ql}/advise.adoc#recommendation-rules
 
 :monitor: xref:manage:monitor/monitoring-n1ql-query.adoc
 :sys-completed-req: {monitor}#sys-completed-req
@@ -18,7 +19,7 @@
 :completed-limit: xref:settings:query-settings.adoc#completed-limit
 
 [abstract]
-The `ADVISOR` function provides recommendations for GSI indexes to optimize query response time.
+The `ADVISOR` function provides index recommendations to optimize query response time.
 There are two main scenarios for using this function.
 One is to invoke the index advisor _immediately_ for a given query or set of queries; the other is to start a session in which every query of interest is collected for a set time period, then invoke the index advisor _asynchronously_ for that collection of queries when the session ends.
 Within these two scenarios, this function has several different usages.
@@ -152,7 +153,7 @@ SELECT ADVISOR("SELECT * FROM `travel-sample` WHERE type = 'hotel' AND city = 'P
           "statements": [
             {
               "run_count": 1,
-              "statement": "advise SELECT * FROM `travel-sample` WHERE type = 'hotel' AND city = 'Paris'"
+              "statement": "SELECT * FROM `travel-sample` WHERE type = 'hotel' AND city = 'Paris'"
             }
           ]
         }
@@ -161,6 +162,10 @@ SELECT ADVISOR("SELECT * FROM `travel-sample` WHERE type = 'hotel' AND city = 'P
   }
 ]
 ----
+
+Only one statement occurs in these results, because the function was called with a single query input.
+In this case, the index advisor identifies two indexes which are currently used by the query, and recommends one secondary index.
+No covering indexes are recommended.
 ====
 
 [[advisor-array]]
@@ -237,6 +242,7 @@ SELECT ADVISOR(["SELECT * FROM `travel-sample` WHERE type = 'hotel' AND city = '
 ]
 ----
 
+In this case, the index advisor recommends an index which would be suitable for both of the input queries.
 (Results are truncated for brevity.)
 ====
 
@@ -288,7 +294,7 @@ SELECT ADVISOR((SELECT RAW statement FROM system:completed_requests)) AS Recent;
           "statements": [
             {
               "run_count": 1,
-              "statement": "advise SELECT h.name, a.airportname FROM `travel-sample` h JOIN `travel-sample` a ON h.city = a.city WHERE h.type = 'hotel' LIMIT 5;"
+              "statement": "SELECT h.name, a.airportname FROM `travel-sample` h JOIN `travel-sample` a ON h.city = a.city WHERE h.type = 'hotel' LIMIT 5;"
             },
             ...
           ]
@@ -298,7 +304,7 @@ SELECT ADVISOR((SELECT RAW statement FROM system:completed_requests)) AS Recent;
           "statements": [
             {
               "run_count": 1,
-              "statement": "advise SELECT h.name, a.airportname FROM `travel-sample` h JOIN `travel-sample` a ON h.city = a.city WHERE h.type = 'hotel' LIMIT 5;"
+              "statement": "SELECT h.name, a.airportname FROM `travel-sample` h JOIN `travel-sample` a ON h.city = a.city WHERE h.type = 'hotel' LIMIT 5;"
             },
             ...
           ]
@@ -333,6 +339,7 @@ SELECT ADVISOR((SELECT RAW statement FROM system:completed_requests)) AS Recent;
 ]
 ----
 
+In this case, the index advisor recommends several covering indexes and secondary indexes, each of which would be suitable for multiple recent queries.
 (Results are truncated for brevity.)
 ====
 
@@ -597,7 +604,7 @@ SELECT ADVISOR({"action": "list"}) AS List;
 
 When used with a `stop_obj` object argument, the function can be used to stop an index advisor session.
 In this case, the session is stopped, and the index advisor analyzes any queries that have been collected by this session so far.
-The session and any resulting index advice are retained in the _tasks cache_.
+The session and any resulting index advice are retained in the tasks cache.
 You can then <<advisor-session-get,get the results>> for this session to see the index advice.
 
 === Arguments
@@ -811,6 +818,6 @@ SELECT ADVISOR({"action": "purge", "session": "8c41a3c6-2252-437e-ab47-0b28f29f4
 
 == Related Links
 
-* The {advise}[ADVISE] task
+* The {advise}[ADVISE] task -- also describes the index advisor {rules}[recommendation rules]
 * The {index-advisor}[Index Advisor] in the Query Workbench
 * The {sys-tasks-cache}[system:tasks_cache] catalog

--- a/modules/n1ql/pages/n1ql-language-reference/advisor.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/advisor.adoc
@@ -1,0 +1,794 @@
+= ADVISOR Function
+:page-topic-type: concept
+:page-status: Developer Preview
+:imagesdir: ../../assets/images
+
+:n1ql: xref:n1ql-language-reference
+:select: {n1ql}/selectintro.adoc
+:update: {n1ql}/update.adoc
+:delete: {n1ql}/delete.adoc
+:merge: {n1ql}/merge.adoc
+
+[abstract]
+The `ADVISOR` function provides recommendations for GSI indexes to optimize query response time.
+There are two main scenarios for using this function.
+One is to invoke the index advisor for a given query or set of queries; the other is to start a session in which every query of interest is collected for a set time period, then invoke the index analyzer for that collection of queries after the session ends.
+Within these two scenarios, this function has several different usages.
+The operation and output of the function depends on the function's single argument.
+For clarity, each usage is listed separately on this page.
+
+include::ROOT:partial$developer-preview.adoc[tag=admonition]
+
+[[advisor-string]]
+== ADVISOR(`string`)
+
+=== Description
+
+When used with a string argument, the function invokes the index advisor for a single N1QL query.
+The index advisor works with {select}[SELECT], {update}[UPDATE], {delete}[DELETE], or {merge}[MERGE] queries.
+
+=== Arguments
+
+string::
+A single N1QL query for which you want index advice.
+
+=== Return Value
+
+An index advisor results object with the following properties.
+
+[[results]]
+**Results**
+
+[options="header", cols="3a,11a,4a"]
+|===
+|Name|Description|Schema
+
+|**current_used_indexes** +
+__optional__
+|If the query uses an index, this is an array of Index objects, each giving information about one of the currently used primary or secondary indexes.
+
+If the query does not currently use an index, this field does not appear.
+|< <<indexes,Indexes>> > array
+
+|**recommended_covering_indexes** +
+__optional__
+|If the index advisor recommends any indexes, this is an array of Index objects, each giving information about one of the recommended indexes.
+
+If the index advisor cannot recommend any covering indexes, this field does not appear.
+|< <<indexes,Indexes>> > array
+
+|**recommended_indexes** +
+__optional__
+|If the index advisor recommends any indexes, this is an array of Index objects, each giving information about one of the recommended indexes.
+
+If the index advisor cannot recommend any indexes, this field does not appear.
+|< <<indexes,Indexes>> > array
+|===
+
+[[indexes]]
+**Indexes**
+
+[options="header", cols="~a,~a,~a"]
+|===
+|Name|Description|Schema
+
+|**index** +
+__required__
+|The N1QL command used to define the index.
+|string
+
+|**statements** +
+__required__
+|An array of Statement objects, each giving information about one of the N1QL input queries associated with this index.
+|< <<statements,Statements>> > array
+|===
+
+[[statements]]
+**Statements**
+
+[options="header", cols="~a,~a,~a"]
+|===
+|Name|Description|Schema
+
+|**run_count** +
+__required__
+|When the function is used with a single N1QL input query, this is always 1.
+
+When the function is used with an array of queries, or a collection of queries from a session, this is the number of times that this N1QL input query occurs in the input array or session.
+|integer
+
+|**statement** +
+__required__
+|The N1QL input query.
+|string
+|===
+
+=== Example
+
+.Get index advice for a single query
+====
+[source,n1ql]
+----
+SELECT ADVISOR("SELECT * FROM `travel-sample` WHERE type = 'hotel' AND city = 'Paris'") AS Single;
+----
+
+.Result
+[source,json]
+----
+[
+  {
+    "Single": {
+      "current_used_indexes": [
+        {
+          "index": "CREATE INDEX def_type ON `travel-sample`(`type`)",
+          "statements": [
+            {
+              "run_count": 1,
+              "statement": "advise SELECT * FROM `travel-sample` WHERE type = 'hotel' AND city = 'Paris'"
+            }
+          ]
+        },
+        {
+          "index": "CREATE INDEX def_city ON `travel-sample`(`city`)",
+          "statements": [
+            {
+              "run_count": 1,
+              "statement": "advise SELECT * FROM `travel-sample` WHERE type = 'hotel' AND city = 'Paris'"
+            }
+          ]
+        }
+      ],
+      "recommended_indexes": [
+        {
+          "index": "CREATE INDEX adv_city_type ON `travel-sample`(`city`) WHERE `type` = 'hotel'",
+          "statements": [
+            {
+              "run_count": 1,
+              "statement": "advise SELECT * FROM `travel-sample` WHERE type = 'hotel' AND city = 'Paris'"
+            }
+          ]
+        }
+      ]
+    }
+  }
+]
+----
+====
+
+[[advisor-array]]
+== ADVISOR(`array`)
+
+=== Description
+
+When used with an array argument, the function invokes the index advisor for multiple N1QL queries.
+The index advisor works with {select}[SELECT], {update}[UPDATE], {delete}[DELETE], or {merge}[MERGE] queries.
+
+=== Arguments
+
+array::
+An array of strings, each of which contains a N1QL query for which you want index advice.
+
+=== Return Value
+
+An <<results,index advisor results>> object.
+
+=== Examples
+
+.Get index advice for multiple queries
+====
+[source,n1ql]
+----
+SELECT ADVISOR(["SELECT * FROM `travel-sample` WHERE type = 'hotel' AND city = 'Paris'", "SELECT * FROM `travel-sample` h JOIN `travel-sample` a ON a.city = h.city WHERE h.type = 'hotel' AND a.type = 'airport'"]) AS Multiple;
+----
+
+.Result
+[source,json]
+----
+[
+  {
+    "Multiple": {
+      "current_used_indexes": [
+        {
+          "index": "CREATE INDEX def_city ON `travel-sample`(`city`)",
+          "statements": [
+            {
+              "run_count": 1,
+              "statement": "SELECT * FROM `travel-sample` WHERE type = 'hotel' AND city = 'Paris'"
+            },
+            ...
+          ]
+        },
+        {
+          "index": "CREATE INDEX def_type ON `travel-sample`(`type`)",
+          "statements": [
+            {
+              "run_count": 1,
+              "statement": "SELECT * FROM `travel-sample` WHERE type = 'hotel' AND city = 'Paris'"
+            },
+            ...
+          ]
+        }
+      ],
+      "recommended_indexes": [
+        {
+          "index": "CREATE INDEX adv_city_type ON `travel-sample`(`city`) WHERE `type` = 'hotel'",
+          "statements": [
+            {
+              "run_count": 1,
+              "statement": "SELECT * FROM `travel-sample` WHERE type = 'hotel' AND city = 'Paris'"
+            },
+            {
+              "run_count": 1,
+              "statement": "SELECT * FROM `travel-sample` h JOIN `travel-sample` a ON a.city = h.city WHERE h.type = 'hotel' AND a.type = 'airport'"
+            }
+          ]
+        }
+      ]
+    }
+  }
+]
+----
+
+(Results are truncated for brevity.)
+====
+
+.Get index advice for recent completed requests
+====
+This example uses a subquery to get an array of statements from the xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-req[system:completed_requests] catalog.
+
+[source,n1ql]
+----
+SELECT ADVISOR((SELECT RAW statement FROM system:completed_requests)) AS Recent;
+----
+
+.Result
+[source,json]
+----
+[
+  {
+    "Recent": {
+      "current_used_indexes": [
+        {
+          "index": "CREATE INDEX def_type ON `travel-sample`(`type`)",
+          "statements": [
+            {
+              "run_count": 4,
+              "statement": "SELECT d.id, d.destinationairport, RATIO_TO_REPORT(d.distance) OVER (PARTITION BY d.destinationairport) AS `distance-ratio` FROM `travel-sample` AS d WHERE d.type='route' LIMIT 7;"
+            },
+            {
+              "run_count": 3,
+              "statement": "SELECT * FROM `travel-sample` r WHERE r.type = 'airport' LIMIT 3;"
+            },
+            ...
+          ]
+        },
+        {
+          "index": "CREATE INDEX def_city ON `travel-sample`(`city`)",
+          "statements": [
+            {
+              "run_count": 1,
+              "statement": "SELECT h.name, h.city, a.airportname FROM `travel-sample` h JOIN `travel-sample` a ON h.city = a.city WHERE h.type = 'hotel' AND a.type = 'airport' LIMIT 5;"
+            },
+            ...
+          ]
+        },
+        ...
+      ],
+      "recommended_covering_indexes": [
+        {
+          "index": "CREATE INDEX adv_city_airportname ON `travel-sample`(`city`,`airportname`)",
+          "statements": [
+            {
+              "run_count": 1,
+              "statement": "advise SELECT h.name, a.airportname FROM `travel-sample` h JOIN `travel-sample` a ON h.city = a.city WHERE h.type = 'hotel' LIMIT 5;"
+            },
+            ...
+          ]
+        },
+        {
+          "index": "CREATE INDEX adv_city_type_name ON `travel-sample`(`city`,`name`) WHERE `type` = 'hotel'",
+          "statements": [
+            {
+              "run_count": 1,
+              "statement": "advise SELECT h.name, a.airportname FROM `travel-sample` h JOIN `travel-sample` a ON h.city = a.city WHERE h.type = 'hotel' LIMIT 5;"
+            },
+            ...
+          ]
+        },
+        ...
+      ],
+      "recommended_indexes": [
+        {
+          "index": "CREATE INDEX adv_array_star_reviews_ratings_Cleanliness ON `travel-sample`(array_star((`reviews`)).`ratings`.`Cleanliness`)",
+          "statements": [
+            {
+              "run_count": 1,
+              "statement": "SELECT ARRAY_AGG(reviews[*].ratings.Cleanliness) AS Reviews FROM `travel-sample`;"
+            },
+            ...
+          ]
+        },
+        {
+          "index": "CREATE INDEX adv_city_type ON `travel-sample`(`city`) WHERE `type` = 'hotel'",
+          "statements": [
+            {
+              "run_count": 1,
+              "statement": "SELECT h.name, h.city, a.airportname FROM `travel-sample` h JOIN `travel-sample` a ON h.city = a.city WHERE h.type = 'hotel' AND a.type = 'airport' LIMIT 5;"
+            },
+            ...
+          ]
+        },
+        ...
+      ]
+    }
+  }
+]
+----
+
+(Results are truncated for brevity.)
+====
+
+[[advisor-session-start]]
+== ADVISOR(`start_session`)
+
+=== Description
+
+When used with a `start_session` object argument, the function can be used to start an index advisor session.
+As long as the session is running, any queries that meet the criteria you specify are collected for later analysis.
+
+By default, the session continues running for the duration you specify when you start the session.
+At the end of the duration, the session is retained in the _tasks cache_.
+You can then <<advisor-session-get,invoke the index advisor>> for any queries that have been collected as part of this session.
+
+=== Arguments
+
+start_session::
+An object with the following properties:
+
+action;;
+[Required] The string `start`.
+
+profile;;
+[Optional] A string specifying the user profile whose queries you want to collect.
+If omitted, all queries are collected.
+
+response;;
+[Optional] A string representing a duration.
+All completed queries lasting longer than this threshold are collected for analysis by the index advisor.
+Valid time units are `ns` (nanoseconds), `us` (microseconds), `ms` (milliseconds), `s` (seconds), `m` (minutes), or `h` (hours).
+If omitted, the default setting is `0s`.
+
+duration;;
+[Required] A string representing a duration.
+The index advisor session runs for the length of this duration.
+Valid time units are `ns` (nanoseconds), `us` (microseconds), `ms` (milliseconds), `s` (seconds), `m` (minutes), or `h` (hours).
+
+query-count;;
+[Optional] An integer specifying the maximum number of queries to be collected for analysis by the index advisor.
+If omitted, the default setting is the same as the service-level xref:settings:query-settings.adoc#completed-limit[completed-limit] setting.
+You can change the service-level `completed-limit` setting to change the default for this property.
+
+=== Return Value
+
+An object with the following property:
+
+session::
+A string in UUID format, specifying the name of the index analyzer session.
+You will need to refer to this name to <<advisor-session-get,invoke the index analyzer>> for this session, or to <<advisor-session-stop,stop>>, <<advisor-session-abort,abort>>, or <<advisor-session-purge,purge>> this session.
+
+=== Example
+
+.Start an index advisor session
+====
+The following example starts an index advisor session to run for one hour.
+All completed queries taking longer than 0 seconds will be collected.
+
+[source,n1ql]
+----
+SELECT ADVISOR({"action": "start", "response": "0s", "duration": "1h"}) AS Collect;
+----
+
+.Result
+[source,json]
+----
+[
+  {
+    "Collect": {
+      "session": "8c41a3c6-2252-437e-ab47-0b28f29f47fb"
+    }
+  }
+]
+----
+====
+
+[[advisor-session-list]]
+== ADVISOR(`list_session`)
+
+=== Description
+
+When used with a `list_session` object argument, the function can be used to list index advisor sessions.
+
+=== Arguments
+
+list_session::
+An object with the following properties:
+
+action;;
+[Required] The string `list`.
+
+status;;
+[Required] A string specifying the status of the index advisor sessions to list.
+This must be one of the following:
++
+* `completed` -- only list completed sessions
+* `active` -- only list active sessions
+* `all` -- list all sessions
+
+=== Return Value
+
+Returns an array of tasks cache objects, each of which has the following properties.
+
+[[tasks-cache]]
+**Tasks Cache**
+
+[options="header", cols="3a,11a,4a"]
+|===
+|Name|Description|Schema
+
+|**tasks_cache** +
+__required__
+|A nested object that gives information about a session.
+|<<session,Session>>
+|===
+
+[[session]]
+**Session**
+
+[options="header", cols="~a,~a,~a"]
+|===
+|Name|Description|Schema
+
+|**class** +
+__required__
+|The class of the session; in this case, `advisor`.
+|string
+
+|**delay** +
+__required__
+|The scheduled duration of the session.
+|string (duration)
+
+|**id** +
+__required__
+|The internal ID of the session.
+|string (UUID)
+
+|**name** +
+__required__
+|The name of the session.
+You will need to refer to this name to <<advisor-session-get,invoke the index analyzer>> for this session, or to <<advisor-session-stop,stop>>, <<advisor-session-abort,abort>>, or <<advisor-session-purge,purge>> this session.
+|string (UUID)
+
+|**node** +
+__required__
+|The node where the session was started.
+|string (address)
+
+|**state** +
+__required__
+|The state of the session:
+
+* `scheduled` -- the session is active.
+* `cancelled` -- the session was stopped.
+* `completed` -- the session is completed.
+|enum (cancelled, completed, scheduled)
+
+|**subClass** +
+__required__
+|The subclass of the session; in this case, `analyze`.
+|string
+
+|**submitTime** +
+__required__
+|The date and time when the function was called to start the session.
+|string (date-time)
+
+|**startTime** +
+__optional__
+|The date and time when the session started.
+
+If the session is still active, this field is not present.
+|string (date-time)
+
+|**stopTime** +
+__optional__
+|The date and time when the session stopped.
+
+If the session is still active, this field is not present.
+|string (date-time)
+
+|**results** +
+__optional__
+|An array containing a single <<results,index advisor results>> object.
+
+If the session is still active, this field is not present.
+|< <<results,Results>> > array
+|===
+
+Returns an empty array if the tasks cache is empty.
+
+=== Example
+
+.List index advisor sessions
+====
+[source,n1ql]
+----
+SELECT ADVISOR({"action": "list", "status": "all"}) AS List;
+----
+
+.Result
+[source,json]
+----
+[
+  {
+    "List": [
+      {
+        "tasks_cache": {
+          "class": "advisor",
+          "delay": "1h0m0s",
+          "id": "bcd9f8e4-b324-504c-a98b-ace90dba869f",
+          "name": "aa7f688a-bf29-438f-888f-eeaead87ca40",
+          "node": "10.143.192.101:8091",
+          "state": "scheduled",
+          "subClass": "analyze",
+          "submitTime": "2019-09-17 05:18:12.903122381 -0700 PDT m=+8460.550715992"
+        }
+      },
+      {
+        "tasks_cache": {
+          "class": "advisor",
+          "delay": "5m0s",
+          "id": "254abec5-5782-543e-9ee0-d07da146b94e",
+          "name": "ca2cfe56-01fa-4563-8eb0-a753af76d865",
+          "node": "10.143.192.101:8091",
+          "results": [
+            ...
+          ],
+          "startTime": "2019-09-17 05:03:31.821597725 -0700 PDT m=+7579.469191487",
+          "state": "completed",
+          "stopTime": "2019-09-17 05:03:31.963133954 -0700 PDT m=+7579.610727539",
+          "subClass": "analyze",
+          "submitTime": "2019-09-17 04:58:31.821230131 -0700 PDT m=+7279.468823737"
+        }
+      }
+    ]
+  }
+]
+----
+
+(Results are truncated for brevity.)
+====
+
+[[advisor-session-stop]]
+== ADVISOR(`stop_session`)
+
+=== Description
+
+When used with a `stop_session` object argument, the function can be used to stop an index advisor session.
+In this case, the session is stopped, but the session is retained in the tasks cache.
+You can then <<advisor-session-get,invoke the index advisor>> for any queries that have been collected as part of this session.
+
+=== Arguments
+
+stop_session::
+An object with the following properties:
+
+action;;
+[Required] The string `stop`.
+
+session;;
+[Required] A string specifying the name of a session.
+
+=== Return Value
+
+Returns NULL.
+
+=== Example
+
+.Stop an index advisor session
+====
+[source,n1ql]
+----
+SELECT ADVISOR({"action": "stop", "session": "8c41a3c6-2252-437e-ab47-0b28f29f47fb"}) AS Stop;
+----
+
+.Result
+[source,json]
+----
+[
+  {
+    "Stop": null
+  }
+]
+----
+====
+
+[[advisor-session-abort]]
+== ADVISOR(`abort_session`)
+
+=== Description
+
+When used with an `abort_session` object argument, the function can be used to abort an index advisor session.
+In this case, the session is stopped, and the session is removed from the tasks cache.
+
+=== Arguments
+
+abort_session::
+An object with the following properties:
+
+action;;
+[Required] The string `abort`.
+
+session;;
+[Required] A string specifying the name of a session.
+
+=== Return Value
+
+Returns NULL.
+
+=== Example
+
+.Abort an index advisor session
+====
+[source,n1ql]
+----
+SELECT ADVISOR({"action": "abort", "session": "8c41a3c6-2252-437e-ab47-0b28f29f47fb"}) AS Abort;
+----
+
+.Result
+[source,json]
+----
+[
+  {
+    "Abort": null
+  }
+]
+----
+====
+
+[[advisor-session-get]]
+== ADVISOR(`get_session`)
+
+=== Description
+
+When used with `get_session` object argument, the function can be used to get the results of a completed index advisor session.
+The index advisor is invoked for any collected {select}[SELECT], {update}[UPDATE], {delete}[DELETE], or {merge}[MERGE] queries.
+
+=== Arguments
+
+get_session::
+An object with the following properties:
+
+action;;
+[Required] The string `get`.
+
+session;;
+[Required] A string specifying the name of a session.
+
+=== Return Value
+
+Returns an array containing an array, which in turn contains an <<results,index advisor results>> object.
+
+Returns an empty array if the specified session collected no queries, or if the specified session does not exist.
+
+=== Example
+
+.Get index advice for an index advisor session
+====
+[source,n1ql]
+----
+SELECT ADVISOR({"action": "get", "session": "8c41a3c6-2252-437e-ab47-0b28f29f47fb"}) AS Get;
+----
+
+.Result
+[source,json]
+----
+[
+  {
+    "Get": [
+      [
+        {
+          "current_used_indexes": [
+            {
+              "index": "CREATE INDEX def_type ON `travel-sample`(`type`)",
+              "statements": [
+                {
+                  "run_count": 1,
+                  "statement": "SELECT h.name, a.airportname FROM `travel-sample` h JOIN `travel-sample` a ON h.city = a.city WHERE h.type = 'hotel' LIMIT 5;"
+                },
+                ...
+              ]
+            },
+            ...
+          ],
+          "recommended_covering_indexes": [
+            {
+              "index": "CREATE INDEX adv_city_type_name ON `travel-sample`(`city`,`name`) WHERE `type` = 'hotel'",
+              "statements": [
+                {
+                  "run_count": 1,
+                  "statement": "SELECT h.name, a.airportname FROM `travel-sample` h JOIN `travel-sample` a ON h.city = a.city WHERE h.type = 'hotel' LIMIT 5;"
+                }
+              ]
+            },
+            ...
+          ],
+          "recommended_indexes": [
+            {
+              "index": "CREATE INDEX adv_city_type ON `travel-sample`(`city`) WHERE `type` = 'hotel'",
+              "statements": [
+                {
+                  "run_count": 1,
+                  "statement": "SELECT h.name, a.airportname FROM `travel-sample` h JOIN `travel-sample` a ON h.city = a.city WHERE h.type = 'hotel' LIMIT 5;"
+                }
+              ]
+            },
+            ...
+          ]
+        }
+      ]
+    ]
+  }
+]
+----
+
+(Results are truncated for brevity.)
+====
+
+[[advisor-session-purge]]
+== ADVISOR(`purge_session`)
+
+=== Description
+
+When used with a `purge_session` object argument, the function can be used to purge the results of a completed index advisor session from the tasks cache.
+
+=== Arguments
+
+purge_session::
+An object with the following properties:
+
+action;;
+[Required] The string `purge`.
+
+session;;
+[Required] A string specifying the name of a session.
+
+=== Return Value
+
+Returns NULL.
+
+=== Example
+
+.Purge an index advisor session
+====
+[source,n1ql]
+----
+SELECT ADVISOR({"action": "purge", "session": "8c41a3c6-2252-437e-ab47-0b28f29f47fb"}) AS Purge;
+----
+
+.Result
+[source,json]
+----
+[
+  {
+    "Purge": null
+  }
+]
+----
+====
+
+== Related Links
+
+* The xref:n1ql-language-reference/advise.adoc[ADVISE] task
+* The xref:tools:query-workbench.adoc#index-advisor[Index Advisor] in the Query Workbench
+* The xref:manage:monitor/monitoring-n1ql-query.adoc#sys-tasks-cache[system:tasks_cache] catalog

--- a/modules/n1ql/pages/n1ql-language-reference/advisor.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/advisor.adoc
@@ -433,12 +433,16 @@ action;;
 [Required] The string `list`.
 
 status;;
-[Required] A string specifying the status of the index advisor sessions to list.
+[Optional] A string specifying the status of the index advisor sessions to list.
 This must be one of the following:
 +
+--
 * `completed` -- only list completed sessions
 * `active` -- only list active sessions
 * `all` -- list all sessions
+--
++
+If omitted, the default is `all`.
 
 === Return Value
 
@@ -535,11 +539,11 @@ Returns an empty array if there are no index advisor sessions in the tasks cache
 
 === Example
 
-.List index advisor sessions
+.List all index advisor sessions
 ====
 [source,n1ql]
 ----
-SELECT ADVISOR({"action": "list", "status": "all"}) AS List;
+SELECT ADVISOR({"action": "list"}) AS List;
 ----
 
 .Result

--- a/modules/n1ql/pages/n1ql-language-reference/advisor.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/advisor.adoc
@@ -124,7 +124,7 @@ SELECT ADVISOR("SELECT * FROM `travel-sample` WHERE type = 'hotel' AND city = 'P
           "statements": [
             {
               "run_count": 1,
-              "statement": "advise SELECT * FROM `travel-sample` WHERE type = 'hotel' AND city = 'Paris'"
+              "statement": "SELECT * FROM `travel-sample` WHERE type = 'hotel' AND city = 'Paris'"
             }
           ]
         },
@@ -133,7 +133,7 @@ SELECT ADVISOR("SELECT * FROM `travel-sample` WHERE type = 'hotel' AND city = 'P
           "statements": [
             {
               "run_count": 1,
-              "statement": "advise SELECT * FROM `travel-sample` WHERE type = 'hotel' AND city = 'Paris'"
+              "statement": "SELECT * FROM `travel-sample` WHERE type = 'hotel' AND city = 'Paris'"
             }
           ]
         }

--- a/modules/n1ql/pages/n1ql-language-reference/advisor.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/advisor.adoc
@@ -20,7 +20,7 @@
 [abstract]
 The `ADVISOR` function provides recommendations for GSI indexes to optimize query response time.
 There are two main scenarios for using this function.
-One is to invoke the index advisor _immediately_ for a given query or set of queries; the other is to start a session in which every query of interest is collected for a set time period, then invoke the index analyzer _asynchronously_ for that collection of queries after the session ends.
+One is to invoke the index advisor _immediately_ for a given query or set of queries; the other is to start a session in which every query of interest is collected for a set time period, then invoke the index advisor _asynchronously_ for that collection of queries when the session ends.
 Within these two scenarios, this function has several different usages.
 The operation and output of each usage depends on the function's single argument.
 For clarity, each usage is listed separately on this page.
@@ -345,8 +345,9 @@ When used with a `start_obj` object argument, the function can be used to start 
 As long as the session is running, any queries that meet the criteria you specify are collected for later analysis.
 
 By default, the session continues running for the duration you specify when you start the session.
-At the end of the duration, the session is retained in the _tasks cache_.
-You can then <<advisor-session-get,invoke the index advisor>> for any queries that have been collected as part of this session.
+At the end of the duration, the index advisor analyzes any queries that have been collected by this session.
+The session and any resulting index advice are retained in the _tasks cache_.
+You can then <<advisor-session-get,get the results>> for this session to see the index advice.
 
 === Arguments
 
@@ -386,8 +387,8 @@ Returns an object with the following property:
 
 |**session** +
 __required__
-|The name of the index analyzer session.
-You will need to refer to this name to <<advisor-session-get,invoke the index analyzer>> for this session, or to <<advisor-session-stop,stop>>, <<advisor-session-abort,abort>>, or <<advisor-session-purge,purge>> this session.
+|The name of the index advisor session.
+You will need to refer to this name to <<advisor-session-get,get the results>> for this session, or to <<advisor-session-stop,stop>>, <<advisor-session-abort,abort>>, or <<advisor-session-purge,purge>> this session.
 |string (UUID)
 |===
 
@@ -486,7 +487,7 @@ __required__
 |**name** +
 __required__
 |The name of the session.
-You will need to refer to this name to <<advisor-session-get,invoke the index analyzer>> for this session, or to <<advisor-session-stop,stop>>, <<advisor-session-abort,abort>>, or <<advisor-session-purge,purge>> this session.
+You will need to refer to this name to <<advisor-session-get,get the results>> for this session, or to <<advisor-session-stop,stop>>, <<advisor-session-abort,abort>>, or <<advisor-session-purge,purge>> this session.
 |string (UUID)
 
 |**node** +
@@ -595,8 +596,9 @@ SELECT ADVISOR({"action": "list"}) AS List;
 === Description
 
 When used with a `stop_obj` object argument, the function can be used to stop an index advisor session.
-In this case, the session is stopped, but the session is retained in the tasks cache.
-You can then <<advisor-session-get,invoke the index advisor>> for any queries that have been collected as part of this session.
+In this case, the session is stopped, and the index advisor analyzes any queries that have been collected by this session so far.
+The session and any resulting index advice are retained in the _tasks cache_.
+You can then <<advisor-session-get,get the results>> for this session to see the index advice.
 
 === Arguments
 

--- a/modules/n1ql/pages/n1ql-language-reference/advisor.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/advisor.adoc
@@ -329,11 +329,11 @@ SELECT ADVISOR((SELECT RAW statement FROM system:completed_requests)) AS Recent;
 ====
 
 [[advisor-session-start]]
-== ADVISOR(`start_session`)
+== ADVISOR(`start_obj`)
 
 === Description
 
-When used with a `start_session` object argument, the function can be used to start an index advisor session.
+When used with a `start_obj` object argument, the function can be used to start an index advisor session.
 As long as the session is running, any queries that meet the criteria you specify are collected for later analysis.
 
 By default, the session continues running for the duration you specify when you start the session.
@@ -342,7 +342,7 @@ You can then <<advisor-session-get,invoke the index advisor>> for any queries th
 
 === Arguments
 
-start_session::
+start_obj::
 An object with the following properties:
 
 action;;
@@ -402,15 +402,15 @@ SELECT ADVISOR({"action": "start", "response": "0s", "duration": "1h"}) AS Colle
 ====
 
 [[advisor-session-list]]
-== ADVISOR(`list_session`)
+== ADVISOR(`list_obj`)
 
 === Description
 
-When used with a `list_session` object argument, the function can be used to list index advisor sessions.
+When used with a `list_obj` object argument, the function can be used to list index advisor sessions.
 
 === Arguments
 
-list_session::
+list_obj::
 An object with the following properties:
 
 action;;
@@ -570,17 +570,17 @@ SELECT ADVISOR({"action": "list", "status": "all"}) AS List;
 ====
 
 [[advisor-session-stop]]
-== ADVISOR(`stop_session`)
+== ADVISOR(`stop_obj`)
 
 === Description
 
-When used with a `stop_session` object argument, the function can be used to stop an index advisor session.
+When used with a `stop_obj` object argument, the function can be used to stop an index advisor session.
 In this case, the session is stopped, but the session is retained in the tasks cache.
 You can then <<advisor-session-get,invoke the index advisor>> for any queries that have been collected as part of this session.
 
 === Arguments
 
-stop_session::
+stop_obj::
 An object with the following properties:
 
 action;;
@@ -614,16 +614,16 @@ SELECT ADVISOR({"action": "stop", "session": "8c41a3c6-2252-437e-ab47-0b28f29f47
 ====
 
 [[advisor-session-abort]]
-== ADVISOR(`abort_session`)
+== ADVISOR(`abort_obj`)
 
 === Description
 
-When used with an `abort_session` object argument, the function can be used to abort an index advisor session.
+When used with an `abort_obj` object argument, the function can be used to abort an index advisor session.
 In this case, the session is stopped, and the session is removed from the tasks cache.
 
 === Arguments
 
-abort_session::
+abort_obj::
 An object with the following properties:
 
 action;;
@@ -657,16 +657,16 @@ SELECT ADVISOR({"action": "abort", "session": "8c41a3c6-2252-437e-ab47-0b28f29f4
 ====
 
 [[advisor-session-get]]
-== ADVISOR(`get_session`)
+== ADVISOR(`get_obj`)
 
 === Description
 
-When used with `get_session` object argument, the function can be used to get the results of a completed index advisor session.
+When used with a `get_obj` object argument, the function can be used to get the results of a completed index advisor session.
 The index advisor is invoked for any collected {select}[SELECT], {update}[UPDATE], {delete}[DELETE], or {merge}[MERGE] queries.
 
 === Arguments
 
-get_session::
+get_obj::
 An object with the following properties:
 
 action;;
@@ -746,15 +746,15 @@ SELECT ADVISOR({"action": "get", "session": "8c41a3c6-2252-437e-ab47-0b28f29f47f
 ====
 
 [[advisor-session-purge]]
-== ADVISOR(`purge_session`)
+== ADVISOR(`purge_obj`)
 
 === Description
 
-When used with a `purge_session` object argument, the function can be used to purge the results of a completed index advisor session from the tasks cache.
+When used with a `purge_obj` object argument, the function can be used to purge the results of a completed index advisor session from the tasks cache.
 
 === Arguments
 
-purge_session::
+purge_obj::
 An object with the following properties:
 
 action;;


### PR DESCRIPTION
The following documentation is ready for review:

* [ADVISOR Function](https://simon-dew.github.io/docs-site/DOC-5716/server/6.5/n1ql/n1ql-language-reference/advisor.html)
* [Monitor Queries › system:tasks_cache](https://simon-dew.github.io/docs-site/DOC-5716/server/6.5/manage/monitor/monitoring-n1ql-query.html#sys-tasks-cache)

Documentation issue: [DOC-5731](https://issues.couchbase.com/browse/DOC-5731)