### PR TITLE
DOC-3818: explain the need for "IS NOT MISSING" for index selection

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/groupby-aggregate-performance.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/groupby-aggregate-performance.adoc
@@ -1,9 +1,10 @@
 = Group By and Aggregate Performance
+:page-edition: enterprise edition
+:page-status: Couchbase Server 5.5
+:imagesdir: ../../assets/images
 
 [abstract]
 N1QL Pushdowns optimize the performance of N1QL queries by supporting GROUP BY and Aggregate expressions.
-
-_(Introduced in Couchbase Server 5.5 - Enterprise Edition)_
 
 [#Overview]
 == Overview
@@ -35,13 +36,14 @@ This reduction step of performing the GROUP BY and Aggregation on the indexer re
 For example, let's compare the previous vs.
 current performance of using GROUP BY and examine the EXPLAIN plan of the following query that is defined in the Couchbase `travel-sample` index:
 
+[source,n1ql]
 ----
 CREATE INDEX `def_type` ON `travel-sample`(`type`)
 ----
 
 Consider the query:
 
-[#codeblocktst]
+[source,n1ql]
 ----
 SELECT type, COUNT(type)
 FROM `travel-sample`
@@ -63,6 +65,7 @@ As the data and query complexity grows, the performance benefit (both latency an
 
 For example, consider the query:
 
+[source,n1ql]
 ----
 SELECT type, COUNT(type)
 FROM `travel-sample`
@@ -71,8 +74,9 @@ GROUP BY type;
 ----
 
 The text explain plan shows the accelerated aggregation details.
-For details, see the <<section_bpf_wjf_ycb,Query Plan Fields>> section.
+For details, see <<section_bpf_wjf_ycb>>.
 
+[source,json]
 ----
 ...
         "index_group_aggs": {
@@ -119,15 +123,17 @@ image::n1ql-language-reference/GBAP_pre55execution.png[,700]
 
 == Examples for Indexer GROUP BY and Aggregation
 
-*Example A:* Let’s Consider a composite index to explore some scenarios:
+Let’s consider a composite index to explore some scenarios:
 
+.Example A
+[source,n1ql]
 ----
 CREATE INDEX idx_a ON `travel-sample` (geo.alt, geo.lat, geo.lon, id) WHERE type = "airport"
 ----
 
 Let’s consider sample queries that can benefit from this optimization and the queries that cannot.
 
-*Positive Case examples of queries that use indexing grouping and aggregation:*
+Positive Case examples of queries that use indexing grouping and aggregation::
 
 * `pass:c[SELECT COUNT(*) FROM `travel-sample` WHERE geo.alt > 10 AND type="airport";]`
 * `pass:c[SELECT COUNT(geo.alt) FROM `travel-sample` WHERE geo.alt BETWEEN 10 AND 30 AND type = "airport";]`
@@ -136,22 +142,35 @@ Let’s consider sample queries that can benefit from this optimization and the 
 * `pass:c[SELECT lat_count, SUM(id) FROM `travel-sample` WHERE geo.alt > 100 AND type = "airport" GROUP BY geo.alt LETTING lat_count = COUNT(geo.lat) HAVING lat_count > 1;]`
 * `pass:c[SELECT AVG(DISTINCT geo.lat) FROM `travel-sample` WHERE geo.alt > 100 AND type = "airport" GROUP BY geo.alt;]`
 
-*Negative Case examples:*
+Negative Case examples::
 
 * `pass:c[SELECT COUNT(*) FROM `travel-sample` WHERE geo.lat > 20 AND type = "airport";]`
- ** This query has no predicate on the leading key `geo.alt`.
++
++
+This query has no predicate on the leading key `geo.alt`.
 The index `idx_a` cannot be used.
+
 * `pass:c[SELECT COUNT(*) FROM `travel-sample`;]`
- ** This query has no predicate at all.
++
++
+This query has no predicate at all.
+
 * `pass:c[SELECT COUNT(v1) FROM `travel-sample` LET v1 = ROUND(geo.lat) WHERE geo.lat > 10 AND type = "airport";]`
- ** The aggregate depends on `LET` variable.
++
++
+The aggregate depends on `LET` variable.
+
 * `pass:c[SELECT ARRAY_AGG(geo.alt) FROM `travel-sample` WHERE geo.alt > 10 AND type = "airport";]`
- ** `ARRAY_AGG` is not supported.
++
++
+`ARRAY_AGG` is not supported.
 
-*Positive query examples with GROUP BY on leading index keys*
+=== Positive query examples with GROUP BY on leading index keys
 
-*Example B:* Consider the following index:
+Consider the following index:
 
+.Example B
+[source,n1ql]
 ----
 CREATE INDEX idx_b ON `travel-sample`(geo.alt, geo.lat, geo.lon, id)
 ----
@@ -159,6 +178,7 @@ CREATE INDEX idx_b ON `travel-sample`(geo.alt, geo.lat, geo.lon, id)
 In the following query, the GROUP BY keys `(geo.alt, geo.lat)` are the leading keys of the index, so the index is naturally ordered and grouped by the order of the index key definition.
 Therefore, the query below is suitable for indexer to handle grouping and aggregation.
 
+[source,n1ql]
 ----
 SELECT geo.alt, geo.lat, SUM(geo.lon), AVG(id), COUNT(DISTINCT geo.lon)
 FROM `travel-sample`
@@ -172,10 +192,12 @@ Here's the executed query plan showing that index scan handled grouping and aggr
 
 image::n1ql-language-reference/GBAP_ExB_Plan.png[,70%]
 
-*Positive query examples with GROUP BY on non-leading index keys*
+=== Positive query examples with GROUP BY on non-leading index keys
 
-*Example C:* Consider the following index and query:
+Consider the following index and query:
 
+.Example C
+[source,n1ql]
 ----
 CREATE INDEX idx_c ON `travel-sample`(geo.alt, geo.lat, geo.lon, id)
  WHERE type = "airport"
@@ -194,10 +216,12 @@ In this scenario (when the grouping is on non-leading keys), any query with aggr
 
 image::n1ql-language-reference/GBAP_ExC_Plan.png[,50%]
 
-*Positive query examples on array indexes with GROUP BY on leading index keys*
+=== Positive query examples on array indexes with GROUP BY on leading index keys
 
-*Example D:* Consider the following index and query:
+Consider the following index and query:
 
+.Example D
+[source,n1ql]
 ----
 CREATE INDEX idx_d ON `travel-sample` (geo.lat, geo.lon, DISTINCT public_likes, id) WHERE type = "hotel"
 
@@ -217,8 +241,10 @@ It’s important to note the array index key is created with a `DISTINCT` modifi
 
 image::n1ql-language-reference/GBAP_ExD_Plan.png[,70%]
 
-*Example D2:* On the other hand, if there’s a predicate missing on `geo.lon`--which is prior to the array key--while using the same `idx_d` index as above, then the grouping is done by the old method:
+On the other hand, if there’s a predicate missing on `geo.lon` -- which is prior to the array key -- while using the same `idx_d` index as above, then the grouping is done by the old method:
 
+.Example D2
+[source,n1ql]
 ----
 SELECT geo.lat, geo.lon, SUM(id), AVG(id)
 FROM `travel-sample`
@@ -231,8 +257,10 @@ HAVING SUM(id) > 100;
 
 image::n1ql-language-reference/GBAP_ExD2_Plan.png[]
 
-*Example E:* Consider the index and query:
+Consider the index and query:
 
+.Example E
+[source,n1ql]
 ----
 CREATE INDEX idx_e ON `travel-sample` (ALL public_likes, geo.lat, geo.lon, id) WHERE type = "hotel"
 
@@ -275,79 +303,28 @@ When the requirements are unmet, the query will fetch the relevant data and then
 No application changes are necessary.
 The query plan generated reflects this decision.
 
-GROUP BY Scenarios:::
-1.
-<<docs-internal-guid-44fa3035-b9c8-1706-a73e-b0f1c03d91da,GROUP BY on leading keys>>
-+
-2.
-<<docs-internal-guid-b944b625-b4b7-85b3-0987-2afeb4f88289,GROUP BY on non-leading keys>>
-+
-3.
-<<docs-internal-guid-3e3d5b1a-b5b6-ef35-da76-906170103e59,GROUP BY keys in different CREATE INDEX order>>
-+
-4.
-<<docs-internal-guid-9640b8bb-b679-d376-cf13-9a0dd1211391,GROUP BY on expression>>
-+
-5.
-<<docs-internal-guid-29f284c7-ba1c-b38b-97a7-1a2d9a3d998b,Heterogeneous data types for GROUP BY key>>
-+
-6.
-<<docs-internal-guid-e3f2aba4-ba21-bda0-6921-b83d1b3a30fa,GROUP BY META().id Primary Index>>
-+
-7.
-<<docs-internal-guid-67306400-ba24-c55f-4713-86943530e62c,LIMIT with GROUP BY on leading keys>>
-+
-8.
-<<docs-internal-guid-82a268f5-ba2b-e5a4-7785-827a5d72d1d1,OFFSET with GROUP BY on leading keys>>
+GROUP BY Scenarios::
 
-Aggregate Scenarios:::
-9.
-<<docs-internal-guid-62fed86e-ba30-23d8-b1eb-ec7749f8b015,Aggregate without GROUP BY>>
-+
-10.
-<<docs-internal-guid-af7d26f3-ba4e-e380-4deb-14da7f213d50,Expression in aggregate function>>
-+
-11.
-<<docs-internal-guid-c2a14520-ba57-2a9f-b0b1-4688448cadcb,SUM, COUNT, MIN, MAX, or AVG Aggregate function>>
-+
-12.
-<<docs-internal-guid-a09e0778-ba63-b476-8b94-010a6fa15ca8,DISTINCT aggregates>>
-+
-13.
-<<docs-internal-guid-9773d2db-ba85-f585-ea05-595abd843c10,HAVING with an aggregate function inside>>
-+
-14.
-<<docs-internal-guid-19518afc-ba8a-3f81-650a-f64236d62a51,LETTING with an aggregate function inside>>
+. <<group-by-on-leading-keys>>
+. <<group-by-on-non-leading-keys>>
+. <<group-by-keys-in-different-order>>
+. <<group-by-on-expression>>
+. <<heterogeneous-data-types>>
+. <<group-by-meta-id>>
+. <<limit-with-group-by>>
+. <<offset-with-group-by>>
 
-// <dl>
-// <dlentry>
-// <dt>Aggregate on Array Index Scenarios:</dt>
-// <dd>15.
-// <xref
-// href="#groupby-aggregate-performance/docs-internal-guid-f14f9e5d-ba8d-b654-70f2-27f204564ae0"
-// format="dita">Aggregate on non-array index field</xref></dd>
-// <dd>16.
-// <xref
-// href="#groupby-aggregate-performance/docs-internal-guid-6b830f6f-babe-926c-480c-d3ddd586babc"
-// format="dita">Aggregate on array index field</xref></dd>
-// <dd>17.
-// <xref
-// href="#groupby-aggregate-performance/docs-internal-guid-c6e690e3-bada-1180-5846-bd30e534ac57"
-// format="dita">DISTINCT Aggregate on non-array index
-// field</xref></dd>
-// <dd>18.
-// <xref
-// href="#groupby-aggregate-performance/docs-internal-guid-3d16d747-baee-8dc9-5248-bcf386260db4"
-// format="dita">DISTINCT Aggregate on array index field</xref></dd>
-// <dd>19.
-// <xref
-// href="#groupby-aggregate-performance/docs-internal-guid-6af647a9-baf9-d11a-f512-01f0fdc2c587"
-// format="dita">Array of arrays</xref></dd>
-// </dlentry>
-// </dl>
+Aggregate Scenarios::
 
-*1.
-GROUP BY on leading keys*
+. <<aggregate-without-group-by>>
+. <<expression-in-aggregate-function>>
+. <<sum-count-min-max-avg>>
+. <<distinct-aggregates>>
+. <<having-with-aggregate-function>>
+. <<letting-with-aggregate-function>>
+
+[[group-by-on-leading-keys]]
+=== GROUP BY on leading keys
 
 One of the common cases is to have both predicates and GROUP BY on leading keys of the index.
 First create the index so that the query is covered by the index.
@@ -356,23 +333,34 @@ You can then think about the order of the keys.
 The query requires a predicate on leading keys to consider an index.
 The simplest predicate is `IS NOT MISSING`.
 
+[source,n1ql]
 ----
 CREATE INDEX idx_expr ON Keyspace_ref (a, b, c);
 
-SELECT a, b, Aggregate_Function(c)  /* MIN(c), MAX(c), COUNT(c), or SUM(c) */
+SELECT a, b, Aggregate_Function(c)  -- <1>
 FROM Keyspace_ref
-WHERE a IS NOT MISSING              /* 1st index field must be in a WHERE clause */
+WHERE a IS NOT MISSING -- <2>
 GROUP BY a, b;
 ----
 
-*Example 1:* List the cities with the landmarks with the highest latitude.
+<1> Where `Aggregate_Function(c)` is `MIN(c)`, `MAX(c)`, `COUNT(c)`, or `SUM(c)`
+<2> 1st index field must be in a WHERE clause
 
+[[ex1]]
+.List the cities with the landmarks with the highest latitude
+====
 Use the `MAX()` aggregate to find the highest landmark latitude in each state, group the results by `country` and `state`, and then sort in reverse order by the highest latitudes per `state`.
 
+.Index
+[source,n1ql]
 ----
 CREATE INDEX idx1 ON `travel-sample`(country, state, geo.lat)
 WHERE type="landmark";
+----
 
+.Query
+[source,n1ql]
+----
 SELECT country, state, MAX(ROUND(geo.lat)) AS Max_Latitude
 FROM `travel-sample`
 WHERE country IS NOT MISSING
@@ -384,8 +372,8 @@ ORDER BY Max_Latitude DESC;
 In this query, we need to give the predicate `country IS NOT MISSING` (or any WHERE clause) to ensure this index is selected for the query.
 Without a matching predicate, the query will use the primary index.
 
-Results:
-
+.Results
+[source,json]
 ----
 [
   {
@@ -406,8 +394,8 @@ Results:
 ...
 ----
 
-The Example 1 EXPLAIN Plan shows that `GROUP BY` is executed by the indexer and is detailed in the <<table_bw2_nrf_ycb,GROUP BY Query Plan table>>:
-
+.Explain Plan
+[source,json]
 ----
 {
   "plan": {
@@ -469,8 +457,12 @@ The Example 1 EXPLAIN Plan shows that `GROUP BY` is executed by the indexer and 
 ...
 ----
 
-*2.
-GROUP BY on non-leading keys*
+The EXPLAIN Plan shows that `GROUP BY` is executed by the indexer.
+This is detailed in <<table_bw2_nrf_ycb>>.
+====
+
+[[group-by-on-non-leading-keys]]
+=== GROUP BY on non-leading keys
 
 When using GROUP BY on a non-leading key:
 
@@ -479,14 +471,15 @@ When using GROUP BY on a non-leading key:
 The N1QL indexer will do 2nd level of aggregation and compute the final result.
 * The N1QL indexer can pushdown only if the leading key has a predicate.
 
-To use Aggregate Pushdown, use the following syntax of the index and query statements:
+To use Aggregate Pushdown, use the following syntax for the index and query statements:
 
+[source,n1ql]
 ----
 CREATE INDEX idx_expr ON Keyspace_ref (a, b, c);
 ----
 
-*Syntax A:*
-
+.Syntax A
+[source,n1ql]
 ----
 SELECT Aggregate_Function(a), b, Aggregate_Function(c)
 FROM Keyspace_ref
@@ -494,8 +487,8 @@ WHERE a IS NOT MISSING
 GROUP BY b;
 ----
 
-*Syntax B:*
-
+.Syntax B
+[source,n1ql]
 ----
 SELECT Aggregate_Function(a), Aggregate_Function(b), c
 FROM Keyspace_ref
@@ -503,14 +496,21 @@ WHERE a IS NOT MISSING
 GROUP BY c;
 ----
 
-*Example 2 (A):* List the states with their total number of landmarks and the lowest latitude of any landmark.
-
+[[ex2-a]]
+.List the states with their total number of landmarks and the lowest latitude of any landmark
+====
 Use the `COUNT()` operator to find the total number of landmarks and use the `MIN()` operator to find the lowest landmark latitude in each state, group the results by `state`, and then sort in order by the lowest latitudes per `state`.
 
+.Index
+[source,n1ql]
 ----
 CREATE INDEX idx2 ON `travel-sample`(country, state, ROUND(geo.lat))
 WHERE type="landmark";
+----
 
+.Query
+[source,n1ql]
+----
 SELECT COUNT(country) AS Total_landmarks, state, MIN(ROUND(geo.lat)) AS Min_Latitude
 FROM `travel-sample`
 WHERE country IN ["France", "United States", "United Kingdom"]
@@ -519,10 +519,8 @@ GROUP BY state
 ORDER BY Min_Latitude;
 ----
 
-Explain Plan:
-
-image::n1ql-language-reference/GBAP_Ex2A_EP.png[]
-
+.Explain Plan
+[source,json]
 ----
 {
   "plan": {
@@ -581,15 +579,15 @@ image::n1ql-language-reference/GBAP_Ex2A_EP.png[]
                   "keypos": 1
                 }
               ],
-              "partial": true
+              "partial": true -- <1>
             },
 ...
 ----
 
-NOTE: The `"partial": true` line means it was pre-aggregated.
+image::n1ql-language-reference/GBAP_Ex2A_EP.png[]
 
-Results:
-
+.Results
+[source,json]
 ----
 [
   {
@@ -609,12 +607,18 @@ Results:
   },
 ...
 ----
+====
 
-*Example 2 (B):* List the number of landmarks by latitude and the state it's in.
+<1> The `"partial": true` line means it was pre-aggregated.
 
+[[ex2-b]]
+.List the number of landmarks by latitude and the state it's in
+====
 Use `COUNT(country)` for the total number of landmarks at each latitude.
 At a particular latitude, the `state` will be the same; but an aggregate function on it is needed, so `MIN()` or `MAX()` is used to return the original value.
 
+.Query
+[source,n1ql]
 ----
 SELECT COUNT(country) Num_Landmarks, MIN(state) State_Name, ROUND(geo.lat) Latitude
 FROM `travel-sample`
@@ -624,8 +628,8 @@ GROUP BY ROUND(geo.lat)
 ORDER BY ROUND(geo.lat);
 ----
 
-Results:
-
+.Results
+[source,json]
 ----
 [
   {
@@ -645,12 +649,14 @@ Results:
   },
 ...
 ----
+====
 
-*3.
-GROUP BY keys in different CREATE INDEX order*
+[[group-by-keys-in-different-order]]
+=== GROUP BY keys in different CREATE INDEX order
 
 When using GROUP BY on keys in a different order than they appear in the CREATE INDEX statement, use the following syntax:
 
+[source,n1ql]
 ----
 CREATE INDEX idx_expr ON Keyspace_ref(a, b, c);
 
@@ -660,14 +666,23 @@ WHERE a IS NOT MISSING
 GROUP BY b, a;
 ----
 
-*Example 3:* Like Example 1 with the GROUP BY fields swapped, list the landmarks with the lowest longitude.
+[[ex3]]
+.List the landmarks with the lowest longitude
+====
+Like <<ex1>> with the GROUP BY fields swapped.
 
 Use the `MIN()` operator to find the lowest landmark longitude in each city, group the results by `activity` and `city`, and then sort in reverse order by the lowest longitudes per `activity`.
 
+.Index
+[source,n1ql]
 ----
 CREATE INDEX idx3 ON `travel-sample`(activity, city, geo.lon)
 WHERE type="landmark";
+----
 
+.Query
+[source,n1ql]
+----
 SELECT activity, city, MIN(ROUND(geo.lon)) AS Max_Longitude
 FROM `travel-sample`
 WHERE country IS NOT MISSING
@@ -676,8 +691,8 @@ GROUP BY activity, city
 ORDER BY Min_Longitude;
 ----
 
-Results:
-
+.Results
+[source,json]
 ----
 [
   {
@@ -702,16 +717,17 @@ Results:
   },
 ...
 ----
+====
 
-*4.
-GROUP BY on expression*
+[[group-by-on-expression]]
+=== GROUP BY on expression
 
 When grouping on an expression or operation, the indexer will return pre-aggregated results whenever the GROUP BY and leading index keys are not an exact match.
 
-To use Aggregate Pushdown and avoid pre-aggregated results, use one of the two following syntaxes of the index and query statements:
+To use Aggregate Pushdown and avoid pre-aggregated results, use one of the two following syntaxes for the index and query statements:
 
-*Syntax A: Field with an expression* (GROUP BY and Index keys match)
-
+.Syntax A: Field with an expression -- GROUP BY and Index keys match
+[source,n1ql]
 ----
 CREATE INDEX idx_expr ON Keyspace_ref(a+b, b, c);
 
@@ -721,8 +737,8 @@ WHERE a IS NOT MISSING
 GROUP BY a+b;
 ----
 
-*Syntax B: Operation on a field* (GROUP BY and Index keys match)
-
+.Syntax B: Operation on a field -- GROUP BY and Index keys match
+[source,n1ql]
 ----
 CREATE INDEX idx_operation ON Keyspace_ref (LOWER(a), b, c);
 
@@ -734,8 +750,8 @@ GROUP BY LOWER(a);
 
 For comparison, the below index and query combination will yield pre-aggregated results.
 
-*Pre-aggregated Syntax:* The GROUP BY and Index keys don't match.
-
+.Pre-aggregated Syntax -- the GROUP BY and Index keys don't match
+[source,n1ql]
 ----
 CREATE INDEX idx_operation ON Keyspace_ref (a, b, c);
 
@@ -745,16 +761,23 @@ WHERE a IS NOT MISSING
 GROUP BY UPPER(a);
 ----
 
-*Example 4 (A):* A field with an expression.
-
+[[ex4-a]]
+.A field with an expression
+====
 Let's say the distance of a flight feels like "nothing" when it's direct, but feels like the true distance when there is one layover.
 Then we can list and group by flight distances by calculating the distance multiplied by the stops it makes.
 
+.Index
+[source,n1ql]
 ----
 CREATE INDEX idx4_expr
 ON `travel-sample`(ROUND(distance*stops), ROUND(distance), sourceairport)
 WHERE type="route";
+----
 
+.Query
+[source,n1ql]
+----
 SELECT ROUND(distance*stops) AS Distance_Feels_Like,
        MAX(ROUND(distance)) AS Distance_True,
        COUNT(sourceairport) Number_of_Airports
@@ -764,10 +787,8 @@ AND type = "route"
 GROUP BY ROUND(distance*stops);
 ----
 
-Query Plan:
-
-image::n1ql-language-reference/GBAP_Ex4A_VP.png[,50%]
-
+.Explain Plan
+[source,json]
 ----
 ...
         "index_group_aggs": {
@@ -809,8 +830,10 @@ image::n1ql-language-reference/GBAP_Ex4A_VP.png[,50%]
 ...
 ----
 
-Results:
+image::n1ql-language-reference/GBAP_Ex4A_VP.png[,50%]
 
+.Results
+[source,json]
 ----
 [
   {
@@ -830,17 +853,25 @@ Results:
   },
 ...
 ----
+====
 
-*Example 4 (B): An operation on a field.*
-
+[[ex4-b]]
+.An operation on a field
+====
 Let's say the distance of a flight feels like "nothing" when it's direct, but feels like the true distance when there is one layover.
 Then we can list and group by the uppercase of the airport codes and listing the flight distances by calculating the distance multiplied by the stops it makes along with the total distance.
 
+.Index
+[source,n1ql]
 ----
 CREATE INDEX idx4_oper
 ON `travel-sample`(sourceairport, ROUND(distance*stops), distance)
 WHERE type="route";
+----
 
+.Query
+[source,n1ql]
+----
 SELECT UPPER(sourceairport) AS Airport_Code,
        MIN(ROUND(distance*stops)) AS Distance_Feels_Like,
        SUM(ROUND(distance)) AS Total_Distance
@@ -850,8 +881,8 @@ AND type = "route"
 GROUP BY UPPER(sourceairport);
 ----
 
-Results:
-
+.Results
+[source,json]
 ----
 [
   {
@@ -871,29 +902,30 @@ Results:
   },
 ...
 ----
+====
 
-*5.
-Heterogeneous data types for GROUP BY key*
+[[heterogeneous-data-types]]
+=== Heterogeneous data types for GROUP BY key
 
 When a field has a mix of data types for the GROUP BY key:
 
 * `NULLS` and `MISSING` are two separate groups.
 
-*Example 5*:
-
+[[ex5]]
+.Heterogeneous data types
+====
 To see a separate grouping of `MISSING` and `NULL`, we need to `GROUP BY` a field we know exists in one document but not in another document while both documents have another field in common.
-For example, create 3 such documents:
 
+.Create Documents
+[source,n1ql]
 ----
 INSERT INTO `travel-sample` VALUES("01",{"type":1, "email":"abc","xx":3});
-
 INSERT INTO `travel-sample` VALUES("01",{"type":1, "email":"abc","xx":null});
-
 INSERT INTO `travel-sample` VALUES("02",{"type":1, "email":"abcd"});
 ----
 
-Then run the following query:
-
+.Query
+[source,n1ql]
 ----
 SELECT type, xx, MIN(email) AS Min_Email
 FROM `travel-sample`
@@ -901,8 +933,8 @@ WHERE type IS NOT NULL
 GROUP BY type, xx;
 ----
 
-Results:
-
+.Results
+[source,json]
 ----
 [
   {
@@ -917,7 +949,7 @@ Results:
   },
   {
     "Min_Email": "abcd",
-    "type": 1              <-- is a separate result since field "xx" is MISSING
+    "type": 1 // <1>
   },
   {
     "Min_Email": null,
@@ -925,14 +957,18 @@ Results:
   },
 ...
 ----
+====
 
-*6.
-GROUP BY META().ID Primary Index*
+<1> This is a separate result since field `xx` is MISSING
+
+[[group-by-meta-id]]
+=== GROUP BY META().ID Primary Index
 
 If there is no filter, then pushdown is supported for an expression on the Document ID `META().id` in the `GROUP BY` clause.
 
-To use Aggregate Pushdown, use the following example of the index and query statement:
+To use Aggregate Pushdown, use the following syntax for the index and query statement:
 
+[source,n1ql]
 ----
 CREATE PRIMARY INDEX idx_expr ON named_keyspace_ref;
 
@@ -943,18 +979,25 @@ GROUP BY SUBSTR(META().id, 0, 10);
 
 NOTE: If there is a filter on the Document ID, then the primary index can be used as a secondary scan.
 
-*Example 6:* List the number of countries that are in each decile of the `META().id` field.
-
+[[ex6]]
+.List the number of countries that are in each decile of the `META().id` field
+====
+.Index
+[source,n1ql]
 ----
 CREATE PRIMARY INDEX idx6 ON `travel-sample`;
+----
 
+.Query
+[source,n1ql]
+----
 SELECT COUNT(1) AS Cnt, SUBSTR(META().id,0,9) AS Meta_Group
 FROM `travel-sample`
 GROUP BY SUBSTR(META().id,0,9);
 ----
 
-Results:
-
+.Results
+[source,json]
 ----
 [
   {
@@ -971,12 +1014,14 @@ Results:
   },
 ...
 ----
+====
 
-*7.
-LIMIT with GROUP BY on leading keys*
+[[limit-with-group-by]]
+=== LIMIT with GROUP BY on leading keys
 
 To use Aggregate Pushdown when there is a LIMIT clause and a GROUP BY clause on one or more leading keys, use the following example of the index and query statement:
 
+[source,n1ql]
 ----
 CREATE INDEX idx_expr ON named_keyspace_ref (k0, k1);
 
@@ -987,12 +1032,19 @@ GROUP BY k0
 LIMIT n;
 ----
 
-*Example 7:* LIMIT with GROUP BY on the leading key.
-
+[[ex7]]
+.LIMIT with GROUP BY on the leading key
+====
+.Index
+[source,n1ql]
 ----
 CREATE INDEX idx7 ON `travel-sample` (city, name)
 WHERE type = "landmark";
+----
 
+.Query
+[source,n1ql]
+----
 SELECT city AS City, COUNT(DISTINCT name) AS Landmark_Count
 FROM `travel-sample`
 WHERE city IS NOT MISSING
@@ -1001,8 +1053,8 @@ GROUP BY city
 LIMIT 4;
 ----
 
-Explain Plan:
-
+.Explain Plan
+[source,json]
 ----
 {
   "plan": {
@@ -1059,15 +1111,13 @@ Explain Plan:
               ]
             },
             "keyspace": "travel-sample",
-            "limit": "4",
+            "limit": "4", // <1>
             "namespace": "default",
 ...
 ----
 
-NOTE: The `limit` is pushed to the indexer because the GROUP BY key matched with the leading index key.
-
-Results:
-
+.Results
+[source,json]
 ----
 [
   {
@@ -1088,12 +1138,16 @@ Results:
   }
 ]
 ----
+====
 
-*8.
-OFFSET with GROUP BY on leading keys*
+<1> The `limit` is pushed to the indexer because the GROUP BY key matched with the leading index key.
+
+[[offset-with-group-by]]
+=== OFFSET with GROUP BY on leading keys
 
 To use Aggregate Pushdown when there is an OFFSET clause and a GROUP BY clause on one or more leading keys, use the following example of the index and query statement.
 
+[source,n1ql]
 ----
 CREATE INDEX idx_expr ON named_keyspace_ref (k0, k1);
 
@@ -1104,12 +1158,19 @@ GROUP BY k0
 OFFSET n;
 ----
 
-*Example 8:* OFFSET with GROUP BY on a leading key.
-
+[[ex8]]
+.OFFSET with GROUP BY on a leading key
+====
+.Index
+[source,n1ql]
 ----
 CREATE INDEX idx8 ON `travel-sample` (city, name)
 WHERE type = "landmark";
+----
 
+.Query
+[source,n1ql]
+----
 SELECT city AS City, COUNT(DISTINCT name) AS Landmark_Count
 FROM `travel-sample`
 WHERE city IS NOT MISSING
@@ -1118,8 +1179,8 @@ GROUP BY city
 OFFSET 4;
 ----
 
-Explain Plan:
-
+.Explain Plan
+[source,json]
 ----
 {
   "plan": {
@@ -1177,15 +1238,13 @@ Explain Plan:
             },
             "keyspace": "travel-sample",
             "namespace": "default",
-            "offset": "4",
+            "offset": "4", // <1>
             "spans": [
 ...
 ----
 
-NOTE: The `offset` is pushed to the indexer because the GROUP BY key matched with the leading index key.
-
-Results:
-
+.Results
+[source,json]
 ----
 [
   {
@@ -1206,51 +1265,78 @@ Results:
   },
 ...
 ----
+====
 
-*9.
-Aggregate without GROUP BY key*
+<1> The `offset` is pushed to the indexer because the GROUP BY key matched with the leading index key.
+
+[[aggregate-without-group-by]]
+=== Aggregate without GROUP BY key
 
 This is a case of aggregation over a range without groups.
 If the index can be used for computing the aggregate, the indexer will return a single aggregate value.
-To use Aggregate Pushdown, use the following syntax of index and queries:
+To use Aggregate Pushdown, use the following syntax for index and queries:
 
+[source,n1ql]
 ----
 CREATE INDEX idx_expr ON named_keyspace_ref (a, b, c);
-
-Q1: SELECT Aggregate_Function(c)
-    FROM named_keyspace_ref
-    WHERE a IS NOT MISSING;
-
-Q2: SELECT SUM(a)
-    FROM named_keyspace_ref
-    WHERE a IS NOT MISSING;
-
-Q3: SELECT SUM(a), COUNT(a), MIN(a)
-    FROM named_keyspace_ref
-    WHERE a IS NOT MISSING;
-
-Q4: SELECT SUM(a), COUNT(b), MIN(c)
-    FROM named_keyspace_ref
-    WHERE a IS NOT MISSING;
 ----
 
-*Example 9 (Q1):* Multiple Aggregate without GROUP BY key.
+.Q1
+[source,n1ql]
+----
+SELECT Aggregate_Function(c)
+FROM named_keyspace_ref
+WHERE a IS NOT MISSING;
+----
 
+.Q2
+[source,n1ql]
+----
+SELECT SUM(a)
+FROM named_keyspace_ref
+WHERE a IS NOT MISSING;
+----
+
+.Q3
+[source,n1ql]
+----
+SELECT SUM(a), COUNT(a), MIN(a)
+FROM named_keyspace_ref
+WHERE a IS NOT MISSING;
+----
+
+.Q4
+[source,n1ql]
+----
+SELECT SUM(a), COUNT(b), MIN(c)
+FROM named_keyspace_ref
+WHERE a IS NOT MISSING;
+----
+
+[[ex9-q1]]
+.Multiple Aggregate without GROUP BY key -- Q1
+====
+.Index
+[source,n1ql]
 ----
 CREATE INDEX idx9
 ON `travel-sample`(ROUND(distance), stops, sourceairport)
 WHERE type = "airport";
-
-Q1: SELECT SUM(ROUND(distance)) AS Total_Distance,
-           SUM(stops) AS Total_Stops,
-           COUNT(sourceairport) AS Total_Airports
-    FROM `travel-sample`
-    WHERE distance IS NOT MISSING
-    AND type = "airport";
 ----
 
-Results:
+.Query
+[source,n1ql]
+----
+SELECT SUM(ROUND(distance)) AS Total_Distance,
+       SUM(stops) AS Total_Stops,
+       COUNT(sourceairport) AS Total_Airports
+FROM `travel-sample`
+WHERE distance IS NOT MISSING
+AND type = "airport";
+----
 
+.Results
+[source,json]
 ----
 [
   {
@@ -1260,16 +1346,20 @@ Results:
   }
 ]
 ----
+====
 
-*Example 9 (Q2):* Aggregate without GROUP BY key.
-
+[[ex9-q2]]
+.Aggregate without GROUP BY key -- Q2
+====
+.Query
+[source,n1ql]
 ----
-Q2: SELECT SUM(ROUND(distance)) AS Total_Distance
-    FROM `travel-sample`;
+SELECT SUM(ROUND(distance)) AS Total_Distance
+FROM `travel-sample`;
 ----
 
-Results:
-
+.Results
+[source,json]
 ----
 [
   {
@@ -1277,19 +1367,23 @@ Results:
   }
 ]
 ----
+====
 
-*Example 9 (Q3):* Multiple Aggregate without GROUP BY key.
-
+[[ex9-q3]]
+.Multiple Aggregate without GROUP BY key -- Q3
+====
+.Query
+[source,n1ql]
 ----
-Q3: SELECT SUM(ROUND(distance)) AS Total_Distance,
-           COUNT(ROUND(distance)) AS Count_of_Distance,
-           MIN(ROUND(distance)) AS Min_of_Distance
-    FROM `travel-sample`
-    WHERE distance IS NOT MISSING;
+SELECT SUM(ROUND(distance)) AS Total_Distance,
+       COUNT(ROUND(distance)) AS Count_of_Distance,
+       MIN(ROUND(distance)) AS Min_of_Distance
+FROM `travel-sample`
+WHERE distance IS NOT MISSING;
 ----
 
-Results:
-
+.Results
+[source,json]
 ----
 [
   {
@@ -1299,19 +1393,23 @@ Results:
   }
 ]
 ----
+====
 
-*Example 9 (Q4):* Multiple Aggregate without GROUP BY key.
-
+[[ex9-q4]]
+.Multiple Aggregate without GROUP BY key -- Q4
+====
+.Query
+[source,n1ql]
 ----
-Q4: SELECT SUM(ROUND(distance)) AS Total_Distance,
-           COUNT(stops) AS Count_of_Stops,
-           MIN(sourceairport) AS Min_of_Airport
-    FROM `travel-sample`
-    WHERE distance IS NOT MISSING;
+SELECT SUM(ROUND(distance)) AS Total_Distance,
+       COUNT(stops) AS Count_of_Stops,
+       MIN(sourceairport) AS Min_of_Airport
+FROM `travel-sample`
+WHERE distance IS NOT MISSING;
 ----
 
-Results:
-
+.Results
+[source,json]
 ----
 [
   {
@@ -1321,13 +1419,15 @@ Results:
   }
 ]
 ----
+====
 
-*10.
-Expression in Aggregate function*
+[[expression-in-aggregate-function]]
+=== Expression in Aggregate function
 
 Aggregations with scalar expressions can be speeded up even if the index key does not have the matching expression on the key.
-To use Aggregate Pushdown, use the following syntax of the index and query statement:
+To use Aggregate Pushdown, use the following syntax for the index and query statement:
 
+[source,n1ql]
 ----
 CREATE INDEX idx_expr ON named_keyspace_ref (a,b,c);
 
@@ -1337,14 +1437,21 @@ WHERE a IS NOT MISSING
 GROUP BY a,b;
 ----
 
-*Example 10:* List the landmarks with the highest latitude.
-
+[[ex10]]
+.List the landmarks with the highest latitude
+====
 Use the `MAX()` operator to find the highest landmark latitude in each state, group the results by `country` and `state`, and then sort in reverse order by the highest latitudes.
 
+.Index
+[source,n1ql]
 ----
 CREATE INDEX idx10 ON `travel-sample`(country, state, ABS(ROUND(geo.lat)))
 WHERE type="landmark";
+----
 
+.Query
+[source,n1ql]
+----
 SELECT country, state, SUM(ABS(ROUND(geo.lat))) AS SumAbs_Latitude
 FROM `travel-sample`
 WHERE country IS NOT MISSING
@@ -1353,10 +1460,8 @@ GROUP BY country, state
 ORDER BY SumAbs_Latitude DESC;
 ----
 
-The Example 10 Explain Plan shows that Aggregates are executed by the indexer and is detailed in the <<docs-internal-guid-facfdbc0-bb3d-b00f-2ec0-6bee4921dabc,Aggregate Query Plan table>>:
-
-image::n1ql-language-reference/GBAP_Ex10_VP.png[,70%]
-
+.Explain Plan
+[source,json]
 ----
 {
   "plan": {
@@ -1415,8 +1520,13 @@ image::n1ql-language-reference/GBAP_Ex10_VP.png[,70%]
 ...
 ----
 
-Results:
+The Explain Plan shows that Aggregates are executed by the indexer.
+This is detailed in <<docs-internal-guid-facfdbc0-bb3d-b00f-2ec0-6bee4921dabc>>.
 
+image::n1ql-language-reference/GBAP_Ex10_VP.png[,70%]
+
+.Results
+[source,json]
 ----
 [
   {
@@ -1436,14 +1546,16 @@ Results:
   },
 ...
 ----
+====
 
-*11.
-SUM, COUNT, MIN, MAX, or AVG Aggregate functions*
+[[sum-count-min-max-avg]]
+=== SUM, COUNT, MIN, MAX, or AVG Aggregate functions
 
 Currently, the only aggregate functions that are supported are SUM(), COUNT(), MIN(), MAX(), and AVG() with or without the DISTINCT modifier.
 
-To use Aggregate Pushdown, use the below syntax of the index and query statement:
+To use Aggregate Pushdown, use the below syntax for the index and query statement:
 
+[source,n1ql]
 ----
 CREATE INDEX idx_expr ON named_keyspace_ref (a,b,c,d);
 
@@ -1454,12 +1566,18 @@ WHERE a IS NOT MISSING
 GROUP BY a;
 ----
 
-*Example 11:*
-
+.Aggregate functions
+====
+.Index
+[source,n1ql]
 ----
 CREATE INDEX idx11 ON `travel-sample`(ROUND(geo.lat), geo.alt, city, ROUND(geo.lon))
        WHERE type = "airport";
+----
 
+.Query
+[source,n1ql]
+----
 SELECT MIN(ROUND(geo.lat)) AS Min_Lat,
        SUM(geo.alt) AS Sum_Alt,
        COUNT(city) AS Count_City,
@@ -1471,8 +1589,8 @@ GROUP BY (ROUND(geo.lat))
 ORDER BY (ROUND(geo.lat)) DESC;
 ----
 
-Results:
-
+.Results
+[source,json]
 ----
 [
   {
@@ -1495,9 +1613,10 @@ Results:
   },
 ...
 ----
+====
 
-*12.
-DISTINCT aggregates*
+[[distinct-aggregates]]
+=== DISTINCT aggregates
 
 There are four cases when DISTINCT aggregates can use this feature:
 
@@ -1508,14 +1627,17 @@ There are four cases when DISTINCT aggregates can use this feature:
 
 To use Aggregate Pushdown, use one of the following syntaxes of the index and query statements:
 
-*Case #1:* If the DISTINCT aggregate is on the leading GROUP BY key(s).
+==== Case 1
 
+If the DISTINCT aggregate is on the leading GROUP BY key(s).
+
+[source,n1ql]
 ----
 CREATE INDEX idx_expr ON named_keyspace_ref (a, b, c);
 ----
 
-Syntax A:::
-+
+.Syntax A
+[source,n1ql]
 ----
 SELECT SUM(DISTINCT a)
 FROM named_keyspace_ref
@@ -1523,8 +1645,8 @@ WHERE a IS NOT MISSING
 GROUP BY a;
 ----
 
-Syntax B:::
-+
+.Syntax B
+[source,n1ql]
 ----
 SELECT COUNT(DISTINCT a), SUM(DISTINCT b)
 FROM named_keyspace_ref
@@ -1532,12 +1654,19 @@ WHERE a IS NOT MISSING
 GROUP BY a, b;
 ----
 
-*Example 12-1 (A):* A DISTINCT aggregate on the leading GROUP BY key(s).
-
+[[ex12-1-a]]
+.DISTINCT aggregate -- Case 1, Syntax A
+====
+.Index
+[source,n1ql]
 ----
 CREATE INDEX idx12_1 ON `travel-sample`(ROUND(geo.lat), ROUND(geo.lon), country)
 WHERE type = "airport";
+----
 
+.Query
+[source,n1ql]
+----
 SELECT SUM(DISTINCT ROUND(geo.lat)) AS Sum_Lat
 FROM `travel-sample`
 WHERE geo.lat IS NOT MISSING
@@ -1545,8 +1674,8 @@ AND type = "airport"
 GROUP BY ROUND(geo.lat);
 ----
 
-Results:
-
+.Results
+[source,json]
 ----
 [
   {
@@ -1560,9 +1689,13 @@ Results:
   },
 ...
 ----
+====
 
-*Example 12-1 (B):* A DISTINCT aggregate on the leading GROUP BY key(s).
-
+[[ex12-1-b]]
+.DISTINCT aggregate -- Case 1, Syntax B
+====
+.Query
+[source,n1ql]
 ----
 SELECT COUNT(DISTINCT ROUND(geo.lat)) AS Count_Lat,
        SUM(DISTINCT ROUND(geo.lon)) AS Sum_Lon
@@ -1572,8 +1705,8 @@ AND type = "airport"
 GROUP BY ROUND(geo.lat), ROUND(geo.lon);
 ----
 
-Results:
-
+.Results
+[source,json]
 ----
 [
   {
@@ -1590,15 +1723,19 @@ Results:
   },
 ...
 ----
+====
 
-*Case #2:* If the DISTINCT aggregate is on the leading GROUP BY key(s) + 1 (the next key)
+==== Case 2
 
+If the DISTINCT aggregate is on the leading GROUP BY key(s) + 1 (the next key).
+
+[source,n1ql]
 ----
 CREATE INDEX idx_expr ON named_keyspace_ref (a, b, c);
 ----
 
-Syntax A:::
-+
+.Syntax A
+[source,n1ql]
 ----
 SELECT SUM(DISTINCT b)
 FROM named_keyspace_ref
@@ -1606,8 +1743,8 @@ WHERE a IS NOT MISSING
 GROUP BY a;
 ----
 
-Syntax B:::
-+
+.Syntax B
+[source,n1ql]
 ----
 SELECT COUNT(DISTINCT c)
 FROM named_keyspace_ref
@@ -1615,12 +1752,19 @@ WHERE a IS NOT MISSING
 GROUP BY a, b;
 ----
 
-*Example 12-2 (A):* A DISTINCT aggregate  on the leading GROUP BY key(s) + 1 (the next key).
-
+[[ex12-2-a]]
+.DISTINCT aggregate -- Case 2, Syntax A
+====
+.Index
+[source,n1ql]
 ----
 CREATE INDEX idx12_2 ON `travel-sample`(country, ROUND(geo.lat), ROUND(geo.lon))
 WHERE type = "airport";
+----
 
+.Query
+[source,n1ql]
+----
 SELECT COUNT(DISTINCT country) AS Count_Country,
        SUM(DISTINCT ROUND(geo.lat)) AS Sum_Lat
 FROM `travel-sample`
@@ -1629,8 +1773,8 @@ AND type = "airport"
 GROUP BY country;
 ----
 
-Results:
-
+.Results
+[source,json]
 ----
 [
   {
@@ -1647,9 +1791,13 @@ Results:
   }
 ]
 ----
+====
 
-*Example 12-2 (B):* A DISTINCT aggregate on the leading GROUP BY key(s) + 1 (the next key)
-
+[[ex12-2-b]]
+.DISTINCT aggregate -- Case 2, Syntax B
+====
+.Query
+[source,n1ql]
 ----
 SELECT COUNT(DISTINCT country) AS Count_Country,
        SUM(DISTINCT ROUND(geo.lat)) AS Sum_Lat,
@@ -1660,8 +1808,8 @@ AND type = "airport"
 GROUP BY country, ROUND(geo.lat);
 ----
 
-Results:
-
+.Results
+[source,json]
 ----
 [
   {
@@ -1681,9 +1829,13 @@ Results:
   }
 ]
 ----
+====
 
-*Case #3:* If the DISTINCT aggregate is on a constant expression (GROUP BY can be on any key)
+==== Case 3
 
+If the DISTINCT aggregate is on a constant expression -- GROUP BY can be on any key.
+
+[source,n1ql]
 ----
 CREATE INDEX idx_expr ON named_keyspace_ref (a, b, c);
 
@@ -1695,12 +1847,19 @@ GROUP BY b;
 
 NOTE: The results will be pre-aggregated if the `GROUP BY` key is non-leading, as in this case and example.
 
-*Example 12-3:* A DISTINCT aggregate on a constant expression (GROUP BY can be on any key)
-
+[[ex12-3]]
+.DISTINCT aggregate -- Case 3
+====
+.Index
+[source,n1ql]
 ----
 CREATE INDEX idx12_3 ON `travel-sample`(country, geo.lat, geo.lon)
 WHERE type = "airport";
+----
 
+.Query
+[source,n1ql]
+----
 SELECT MIN(country) AS Min_Country,
        COUNT(DISTINCT 1) AS Constant_Value,
        MIN(ROUND(geo.lon)) AS Min_Logitude
@@ -1710,8 +1869,8 @@ AND type = "airport"
 GROUP BY geo.lat;
 ----
 
-Results:
-
+.Results
+[source,json]
 ----
 [
   {
@@ -1731,38 +1890,67 @@ Results:
   },
 ...
 ----
+====
 
-*Case #4:* If the DISTINCT aggregate is on the first key only or in a constant expression, and there is no GROUP BY clause
+==== Case 4
 
+If the DISTINCT aggregate is on the first key only or in a constant expression, and there is no GROUP BY clause.
+
+[source,n1ql]
 ----
 CREATE INDEX idx_expr ON named_keyspace_ref (a, b, c);
-
-Q1: SELECT SUM(DISTINCT a)
-    FROM named_keyspace_ref;               /* ok */
-
-Q2: SELECT COUNT(DISTINCT 1)
-    FROM named_keyspace_ref;               /* ok */
-
-Q3: SELECT SUM(DISTINCT c)
-    FROM named_keyspace_ref;                /* not ok */
 ----
+
+.Q1
+[source,n1ql]
+----
+SELECT SUM(DISTINCT a)
+FROM named_keyspace_ref; -- <1>
+----
+
+.Q2
+[source,n1ql]
+----
+SELECT COUNT(DISTINCT 1)
+FROM named_keyspace_ref; -- <2>
+----
+
+.Q3
+[source,n1ql]
+----
+SELECT SUM(DISTINCT c)
+FROM named_keyspace_ref; -- <3>
+----
+
+<1> OK
+<2> OK
+<3> Not OK
 
 All other cases of DISTINCT pushdown will return an error.
 
-*Example 12-4:* A DISTINCT aggregate on the first key only or in a constant expression, and there is no GROUP BY clause.
+[[ex12-4-q1]]
+.DISTINCT aggregate -- Case 4, Q1
+====
+A DISTINCT aggregate on the first key only or in a constant expression, where there is no GROUP BY clause.
 
+.Index
+[source,n1ql]
 ----
 CREATE INDEX idx12_4 ON `travel-sample`(geo.alt, geo.lat, geo.lon)
 WHERE type = "airport";
-
-Q1: SELECT SUM(DISTINCT ROUND(geo.alt)) AS Sum_Alt
-    FROM `travel-sample`
-    WHERE geo.alt IS NOT MISSING
-    AND type = "airport";
 ----
 
-Results:
+.Query
+[source,n1ql]
+----
+SELECT SUM(DISTINCT ROUND(geo.alt)) AS Sum_Alt
+FROM `travel-sample`
+WHERE geo.alt IS NOT MISSING
+AND type = "airport";
+----
 
+.Results
+[source,json]
 ----
 [
   {
@@ -1770,17 +1958,23 @@ Results:
   }
 ]
 ----
+====
 
-Another query with index `idx12_4:`
+[[ex12-4-q2]]
+.DISTINCT aggregate -- Case 4, Q2
+====
+Another query with index `idx12_4`.
 
+.Query
+[source,n1ql]
 ----
-Q2: SELECT COUNT(DISTINCT 1) AS Const_expr
-    FROM `travel-sample`
-    WHERE type = "airport";
+SELECT COUNT(DISTINCT 1) AS Const_expr
+FROM `travel-sample`
+WHERE type = "airport";
 ----
 
-Results:
-
+.Results
+[source,json]
 ----
 [
   {
@@ -1788,18 +1982,24 @@ Results:
   }
 ]
 ----
+====
 
-Another query with index `idx12_4` but will not pushdown the aggregate to the indexer:
+[[ex12-4-q3]]
+.DISTINCT aggregate -- Case 4, Q3
+====
+Another query with index `idx12_4`, which will not push down the aggregate to the indexer.
 
+.Query
+[source,n1ql]
 ----
-Q3: SELECT SUM(DISTINCT ROUND(geo.lon)) AS Sum_Lon
-    FROM `travel-sample`
-    WHERE geo.alt IS NOT MISSING
-    AND type = "airport";
+SELECT SUM(DISTINCT ROUND(geo.lon)) AS Sum_Lon
+FROM `travel-sample`
+WHERE geo.alt IS NOT MISSING
+AND type = "airport";
 ----
 
-Results:
-
+.Results
+[source,json]
 ----
 [
   {
@@ -1807,12 +2007,14 @@ Results:
   }
 ]
 ----
+====
 
-*13.
-HAVING with an aggregate function inside*
+[[having-with-aggregate-function]]
+=== HAVING with an aggregate function inside
 
 To use Aggregate Pushdown when a HAVING clause has an aggregate function inside, use the following syntax of index and query statement:
 
+[source,n1ql]
 ----
 CREATE INDEX idx_expr ON named_keyspace_ref (k0, k1);
 
@@ -1823,14 +2025,21 @@ GROUP BY k0
 HAVING Aggregate_Function(k1);
 ----
 
-*Example 13:* HAVING with an aggregate function inside.
-
+[[ex13]]
+.HAVING with an aggregate function inside
+====
 List the cities that have more than 180 landmarks.
 
+.Index
+[source,n1ql]
 ----
 CREATE INDEX idx13 ON `travel-sample` (city, name)
 WHERE type = "landmark";
+----
 
+.Query
+[source,n1ql]
+----
 SELECT city AS City, COUNT(DISTINCT name) AS Landmark_Count
 FROM `travel-sample`
 WHERE city IS NOT MISSING
@@ -1839,8 +2048,8 @@ GROUP BY city
 HAVING COUNT(DISTINCT name) > 180;
 ----
 
-Results:
-
+.Results
+[source,json]
 ----
 [
   {
@@ -1861,12 +2070,14 @@ Results:
   }
 ]
 ----
+====
 
-*14.
-LETTING with an aggregate function inside*
+[[letting-with-aggregate-function]]
+=== LETTING with an aggregate function inside
 
 To use Aggregate Pushdown when a LETTING clause has an aggregate function inside, use the following syntax of the index and query statement.
 
+[source,n1ql]
 ----
 CREATE INDEX idx_expr ON named_keyspace_ref (k0, k1);
 
@@ -1878,14 +2089,21 @@ LETTING var_expr = Aggregate_Function(k1)
 HAVING var_expr;
 ----
 
-*Example 14:* LETTING with an aggregate function inside.
-
+[[ex14]]
+.LETTING with an aggregate function inside
+====
 List cities that have more than half of all landmarks.
 
+.Index
+[source,n1ql]
 ----
 CREATE INDEX idx14 ON `travel-sample` (city, name)
 WHERE type = "landmark";
+----
 
+.Query
+[source,n1ql]
+----
 SELECT city AS City, COUNT(DISTINCT name) AS Landmark_Count
 FROM `travel-sample`
 WHERE city IS NOT MISSING
@@ -1895,8 +2113,8 @@ LETTING MinimumThingsToSee = COUNT(DISTINCT name)
 HAVING MinimumThingsToSee > 180;
 ----
 
-Results:
-
+.Results
+[source,json]
 ----
 [
   {
@@ -1917,6 +2135,7 @@ Results:
   }
 ]
 ----
+====
 
 == Limitations
 
@@ -1929,8 +2148,7 @@ The following are currently not supported and not pushed to the indexer:
 * `OFFSET` pushdown with `GROUP BY` on non-leading keys.
 * A subquery in a `GROUP BY` or Aggregate pushdown.
 
-*Aggregate Comparison*
-
+.Aggregate Comparison
 [cols="^3,^2,^2,^2,^2"]
 |===
 | Item | Aggregate on Non-Array Index Field | Aggregate on Array Index Field | DISTINCT Aggregate on Non-Array Index Field | DISTINCT Aggregate on Array Index Field
@@ -1965,6 +2183,7 @@ The following are currently not supported and not pushed to the indexer:
 
 Consider the example:
 
+[source,n1ql]
 ----
 EXPLAIN SELECT type, COUNT(type)
 FROM `travel-sample`
@@ -1978,7 +2197,7 @@ In the query plan:
 * `pass:c[plan.`~children`[0].index_group_aggs]` shows the aggregation and groupings done by the indexer.
 * `index_group_aggs` object has details on the aggregate, index key position, expression dependency, and group expressions handled by the indexer.
 This object is present in the plan only when the indexer handles the grouping and aggregation.
-+
+
 [cols="2,5,5"]
 |===
 | Item Name | Description | Explain Text in This Example
@@ -2051,7 +2270,8 @@ Key Position to use the Index expr or the query expr.
 
 (because it matches the 1st key in the index expression)
 |===
-+
+
+[source,json]
 ----
 {
   "plan": {
@@ -2065,7 +2285,7 @@ Key Position to use the Index expr or the query expr.
           "cover (count(1))"
         ],
         "index": "idx_name",
-        "index_group_aggs": {
+        "index_group_aggs": { // <1>
           "aggregates": [
             {
               "aggregate": "COUNT",
@@ -2138,13 +2358,12 @@ Key Position to use the Index expr or the query expr.
 }
 ----
 
-NOTE: When the `index_group_aggs` section is present, it means that the query is using Index Aggregations.
+<1> When the `index_group_aggs` section is present, it means that the query is using Index Aggregations.
 
-GROUP BY Query Plan
-
+.GROUP BY Query Plan
 [#table_bw2_nrf_ycb,cols="2,5,5"]
 |===
-| Item Name | Description | EXPLAIN Text in <<docs-internal-guid-44fa3035-b9c8-1706-a73e-b0f1c03d91da,Example #1 (GROUP BY)>>
+| Item Name | Description | EXPLAIN Text in <<ex1>> (GROUP BY)
 
 | `aggregates`
 | Array of Aggregate objects, and each object represents one aggregate function.
@@ -2216,11 +2435,10 @@ Key Position to use the Index expr or the query expr.
 
 The Query Plan sections of an Aggregate pushdown are slightly different than those used in a GROUP BY.
 
-*Aggregate Query Plan*
-
-[cols="2,5,5"]
+.Aggregate Query Plan
+[#docs-internal-guid-facfdbc0-bb3d-b00f-2ec0-6bee4921dabc,cols="2,5,5"]
 |===
-| Item Name | Description | EXPLAIN Text in <<docs-internal-guid-be60f70b-ba52-b179-cd13-728a00e7c632,Example #10 (Aggregate)>>
+| Item Name | Description | EXPLAIN Text in <<ex10>> (Aggregate)
 
 | `aggregates`
 | Array of Aggregate objects, and each object represents one aggregate function.

--- a/modules/n1ql/pages/n1ql-language-reference/groupby-aggregate-performance.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/groupby-aggregate-performance.adoc
@@ -1,6 +1,5 @@
 = Group By and Aggregate Performance
 :page-edition: enterprise edition
-:page-status: Couchbase Server 5.5
 :imagesdir: ../../assets/images
 
 [abstract]

--- a/modules/n1ql/pages/n1ql-language-reference/groupby.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/groupby.adoc
@@ -12,8 +12,7 @@ This `GROUP BY` clause follows the `WHERE` clause and precedes the optional `LET
 
 == Syntax
 
-image::n1ql-language-reference/group-by-clause.png[]
-
+[subs="normal"]
 ----
 GROUP BY expr [, expr2 ]*
   [ LETTING alias = expr [, alias2 = expr2 ]* ]
@@ -21,6 +20,8 @@ GROUP BY expr [, expr2 ]*
 |
 LETTING alias = expr [, alias2 = expr2 ]*
 ----
+
+image::n1ql-language-reference/group-by-clause.png[]
 
 == Arguments
 
@@ -51,8 +52,9 @@ This is usually only necessary in queries which do not otherwise have a WHERE cl
 
 == Examples
 
-*Example 1: Group the unique landmarks by city and list the top 4 cities with the most landmarks in descending order.*
-
+.Group the unique landmarks by city and list the top 4 cities with the most landmarks in descending order
+====
+[source,n1ql]
 ----
 SELECT city City, COUNT(DISTINCT name) LandmarkCount
 FROM `travel-sample`
@@ -62,8 +64,8 @@ ORDER BY LandmarkCount DESC
 LIMIT 4;
 ----
 
-Results:
-
+.Results
+[source,json]
 ----
 [
   {
@@ -84,9 +86,11 @@ Results:
   }
 ]
 ----
+====
 
-*Example 2: Use LETTING to find cities that have a minimum number of things to see.*
-
+.Use LETTING to find cities that have a minimum number of things to see
+====
+[source,n1ql]
 ----
 SELECT city City, COUNT(DISTINCT name) LandmarkCount
 FROM `travel-sample`
@@ -96,8 +100,8 @@ LETTING MinimumThingsToSee = 400
 HAVING COUNT(DISTINCT name) > MinimumThingsToSee;
 ----
 
-Results:
-
+.Results
+[source,json]
 ----
 [
   {
@@ -110,9 +114,11 @@ Results:
   }
 ]
 ----
+====
 
-*Example 3: Use HAVING to specify cities that have more than 180 landmarks.*
-
+.Use HAVING to specify cities that have more than 180 landmarks
+====
+[source,n1ql]
 ----
 SELECT city City, COUNT(DISTINCT name) LandmarkCount
 FROM `travel-sample`
@@ -121,8 +127,8 @@ GROUP BY city
 HAVING COUNT(DISTINCT name) > 180;
 ----
 
-Results:
-
+.Results
+[source,json]
 ----
 [
   {
@@ -143,11 +149,13 @@ Results:
   }
 ]
 ----
+====
 
 NOTE: The above `HAVING` clause must use the xref:n1ql-language-reference/aggregatefun.adoc[aggregate function] `COUNT` instead of its alias `LandmarkCount`.
 
-*Example 4: Use HAVING to specify landmarks that begin with an "S" or higher.*
-
+.Use HAVING to specify landmarks that begin with an "S" or higher
+====
+[source,n1ql]
 ----
 SELECT city City, COUNT(DISTINCT name) LandmarkCount
 FROM `travel-sample`
@@ -156,8 +164,8 @@ GROUP BY city
 HAVING city > "S";
 ----
 
-138 Results in 150ms:
-
+.138 Results in 150ms
+[source,json]
 ----
 [
   {
@@ -178,9 +186,11 @@ HAVING city > "S";
   },
 ...
 ----
+====
 
-*Example 4b: Using WHERE yields the same results as HAVING, however, WHERE is faster.*
-
+.Using WHERE yields the same results as HAVING, however, WHERE is faster
+====
+[source,n1ql]
 ----
 SELECT city City, COUNT(DISTINCT name) LandmarkCount
 FROM `travel-sample`
@@ -189,8 +199,8 @@ AND city > "S"
 GROUP BY city
 ----
 
-138 Results in 94ms:
-
+.138 Results in 94ms
+[source,json]
 ----
 [
   {
@@ -211,6 +221,7 @@ GROUP BY city
   },
 ...
 ----
+====
 
 NOTE: The `WHERE` clause is faster because `WHERE` gets processed _before_ any `GROUP BY` and doesn't have access to aggregated values.
 `HAVING` gets processed _after_ `GROUP BY` and is used to constrain the resultset to only those with aggregated values.

--- a/modules/n1ql/pages/n1ql-language-reference/groupby.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/groupby.adoc
@@ -42,6 +42,13 @@ cond;; String or expression representing the clause of aggregate values.
 
 `GROUP BY` works only on a group key or xref:n1ql-language-reference/aggregatefun.adoc[aggregate function].
 
+If a query selects a field which is MISSING in some documents, the optimizer will not be able to choose a secondary index
+which uses that field as a leading key.
+
+To enable the optimizer to choose the required index, you must use a WHERE clause of some kind to filter out any documents in which the required field is MISSING.
+The minimum filter you can use to do this is `IS NOT MISSING`.
+This is usually only necessary in queries which do not otherwise have a WHERE clause; for example, some GROUP BY and aggregate queries.
+
 == Examples
 
 *Example 1: Group the unique landmarks by city and list the top 4 cities with the most landmarks in descending order.*
@@ -207,3 +214,5 @@ GROUP BY city
 
 NOTE: The `WHERE` clause is faster because `WHERE` gets processed _before_ any `GROUP BY` and doesn't have access to aggregated values.
 `HAVING` gets processed _after_ `GROUP BY` and is used to constrain the resultset to only those with aggregated values.
+
+For further examples, refer to xref:n1ql:n1ql-language-reference/groupby-aggregate-performance.adoc[Group By and Aggregate Performance].

--- a/modules/n1ql/pages/n1ql-language-reference/selectintro.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/selectintro.adoc
@@ -641,3 +641,96 @@ ORDER BY t.country, t.tz;
 ]
 ----
 ====
+
+[[index-selection]]
+=== Index Selection
+
+The optimizer attempts to select an appropriate secondary index for a query based on the filters in the WHERE clause.
+If it cannot select a secondary query, the query service falls back on the the primary index for the keyspace.
+
+Secondary indexes do not index a document if the leading index key is MISSING in the document.
+This means that when a query selects a field which is MISSING in some documents, the optimizer will not be able to choose a secondary index
+which uses that field as a leading key.
+
+To enable the optimizer to choose the required index, you must use a WHERE clause of some kind to filter out any documents in which the required field is MISSING.
+The minimum filter you can use to do this is `IS NOT MISSING`.
+This is usually only necessary in queries which do not otherwise have a WHERE clause; for example, some GROUP BY and aggregate queries.
+
+.Field with MISSING values -- cannot choose the secondary index
+====
+This example uses the `def_faa` index that comes pre-installed and is defined by following statement.
+
+.Index
+[source,n1ql]
+----
+CREATE INDEX `def_faa` ON `travel-sample`(`faa`);
+----
+
+.Query
+[source,n1ql]
+----
+EXPLAIN SELECT faa FROM `travel-sample`; -- <1>
+----
+
+.Result
+[source,json]
+----
+[
+  {
+    "plan": {
+      "#operator": "Sequence",
+      "~children": [
+        {
+          "#operator": "PrimaryScan3",
+          "cardinality": 31591,
+          "cost": 142984.663,
+          "index": "def_primary", // <2>
+          "index_projection": {
+            "primary_key": true
+          },
+          "keyspace": "travel-sample",
+          "namespace": "default",
+          "using": "gsi"
+        },
+...
+----
+====
+
+<1> The query selects the `faa` field, which is MISSING for any documents which are not airports.
+<2> Therefore the optimizer falls back on the `def_primary` index.
+
+.Filter out MISSING values -- correct secondary index is chosen
+====
+[source,n1ql]
+----
+EXPLAIN SELECT faa FROM `travel-sample` WHERE faa IS NOT MISSING; -- <1>
+----
+
+[source,json]
+----
+[
+  {
+    "plan": {
+      "#operator": "Sequence",
+      "~children": [
+        {
+          "#operator": "IndexScan3",
+          "covers": [
+            "cover ((`travel-sample`.`faa`))",
+            "cover ((meta(`travel-sample`).`id`))"
+          ],
+          "index": "def_faa", // <2>
+          "index_id": "5dbeaaf6ff7c4635",
+          "index_projection": {
+            "entry_keys": [
+              0
+            ]
+          },
+...
+----
+====
+
+<1> The WHERE clause filters out documents where `faa` is not MISSING.
+<2> The optimizer correctly chooses the `def_faa` index.
+
+For further examples, refer to xref:n1ql:n1ql-language-reference/groupby-aggregate-performance.adoc[Group By and Aggregate Performance].


### PR DESCRIPTION
The following draft documentation is ready for review:

* [SELECT Overview › Data Processing Capabilities › Index Selection](https://simon-dew.github.io/docs-site/DOC-3818/server/6.0/n1ql/n1ql-language-reference/selectintro.html#index-selection)
* [GROUP BY clause › Limitations](https://simon-dew.github.io/docs-site/DOC-3818/server/6.0/n1ql/n1ql-language-reference/groupby.html#limitations)

I have also updated markup and formatting for [Group By and Aggregate Performance](https://simon-dew.github.io/docs-site/DOC-3818/server/6.0/n1ql/n1ql-language-reference/groupby-aggregate-performance.html) — the content has not changed.

Documentation issue: [DOC-3818](https://issues.couchbase.com/browse/DOC-3818)