### PR TITLE
Updating Doc

### DIFF
--- a/modules/data-modeling/pages/intro-data-modeling.adoc
+++ b/modules/data-modeling/pages/intro-data-modeling.adoc
@@ -3,7 +3,7 @@
 
 [abstract]
 Couchbase Server is a multi-model database that natively manipulates data in key-value form or in JSON documents.
-Unlike relational databases which require strict predefined schema with tables and columns, Couchbase Server requires no predefined schema.
+Unlike relational databases which require strict predefined schema with tables and columns, Couchbase Server doesn't require a predefined schema.
 
 With Couchbase Server, applications can define their schema at the application layer and freely evolve their schema with no added administrative action.
 Schema changes do not require scheduling downtime nor do they trigger long running, offline updates to existing data.


### PR DESCRIPTION
Line 6 - Reframed the sentence - "Unlike relational databases which require strict predefined schema with tables and columns, Couchbase Server requires no predefined schema." to 
"Unlike relational databases which require strict predefined schema with tables and columns, Couchbase Server doesn't require a predefined schema."
as "does not require" sounds better than "requires no".