### PR TITLE
Doc updation

### DIFF
--- a/modules/rest-api/pages/rest-intro.adoc
+++ b/modules/rest-api/pages/rest-intro.adoc
@@ -30,7 +30,7 @@ On that note, you may find it convenient to read responses with a tool that spec
 Some responses may have an empty body, but indicate the response with standard HTTP codes.
 For more information, see RFC 4627 at www.json.org.
 
-HTTP Basic Access Authentication:: The Couchbase Server REST API, web console user interface, and command line utilities all use HTTP basic authentication.
+HTTP Basic Access Authentication:: The Couchbase Server REST API, web console user interface and command line utilities all use HTTP basic authentication.
 
 Versatile Server Nodes::
 All server nodes in a cluster share the same properties and can handle any requests made via the REST API.


### PR DESCRIPTION
Removed extra comma from "HTTP Basic Access Authentication:: The Couchbase Server REST API, web console user interface and command line utilities all use HTTP basic authentication. "