### PR TITLE
DOC-4321: default index placement policy

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -1,6 +1,7 @@
 = CREATE INDEX
 :page-topic-type: concept
 :imagesdir: ../../assets/images
+:keywords: secondary, index, placement
 :enterprise: https://www.couchbase.com/products/editions[ENTERPRISE EDITION]
 :community: https://www.couchbase.com/products/editions[COMMUNITY EDITION]
 
@@ -154,12 +155,12 @@ nodes;;
 ====
 In Couchbase Server Community Edition, a single global secondary index can be placed on a single node that runs the indexing service.
 The `nodes` property allows you to specify the node that the index is placed on.
-If `nodes` is not specified, one of the nodes running the index service is randomly picked for the index.
+(((default index placement)))If `nodes` is not specified, one of the nodes running the indexing service is randomly picked for the index.
 ====
 +
 [NOTE,title='{enterprise}']
 ====
-In Couchbase Server Enterprise Edition, multiple nodes can be specified to distribute replicas of an index amongst multiple nodes, for example:
+In Couchbase Server Enterprise Edition, you can specify multiple nodes to distribute replicas of an index across nodes running the indexing service, for example:
 
 [source,n1ql]
 ----
@@ -170,7 +171,8 @@ WITH {"nodes":["node1:8091", "node2:8091", "node3:8091"]};
 
 If specifying both [.var]`nodes` and [.var]`num_replica`, the number of nodes in the array must be one greater than the specified number of replicas otherwise the index creation will fail.
 
-If [.var]`nodes` is not specified, then nodes running the index service are randomly selected to host the index, based on the number of replicas.
+(((default index placement)))If [.var]`nodes` is not specified, then the system chooses nodes on which to place the new index and any replicas, in order to achieve the best resource utilization across nodes running the indexing service.
+This is done by taking into account the current resource usage statistics of index nodes.
 ====
 +
 IMPORTANT: A node name passed to the `nodes` property must include the cluster administration port, by default 8091.

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -206,25 +206,21 @@ IMPORTANT: We recommend that you do not create (or drop) secondary indexes when 
 
 == Usage
 
-[discrete]
-===== Array Indexing
+=== Array Indexing
 
 Array indexing enables you to create global indexes on array elements and optimize the execution of queries involving array elements.
 For details, refer to xref:n1ql-language-reference/indexing-arrays.adoc[Array Indexing].
 
-[discrete]
-===== Index Partitioning
+=== Index Partitioning
 
 Index partitioning helps increase the query performance by dividing and spreading a large index of documents across multiple nodes, horizontally scaling out an index as needed.
 For details, refer to xref:n1ql-language-reference/index-partitioning.adoc[Index Partitioning].
 
-[discrete]
-===== Using the `meta().id` Function
+=== Using the `meta().id` Function
 
 For details, refer to xref:n1ql-language-reference/indexing-meta-info.adoc[Indexing Meta Info].
 
-[discrete]
-===== Using Indexes for Aggregates
+=== Using Indexes for Aggregates
 
 If there is an index on the expression of an aggregate, that index may be used to satisfy the query.
 For example, given the index `alt_idx` created using the following statement:


### PR DESCRIPTION
The following draft documentation is ready for review:

* [CREATE INDEX › Syntax › WITH Clause](https://simon-dew.github.io/docs-site/DOC-4321/server/6.0/n1ql/n1ql-language-reference/createindex.html#index-with) — `nodes` property updated

Documentation issue: [DOC-4321](https://issues.couchbase.com/browse/DOC-4321)