### PR TITLE
DOC-4757: Explicitly state that Analytics upgrade from 5.x to 6.x is not supported

### DIFF
--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -706,6 +706,8 @@ CONNECT LINK (dataverse_name.)? Local (, (dataverse_name.)? Local)*
 Analytics data from Developer Preview releases cannot be upgraded.
 
 If you plan to use the production release of Couchbase Analytics in version 6.0, you must perform a fresh installation of Couchbase Server 6.0 on any existing Analytics nodes that are running a previous version; otherwise, the Analytics Service will not function properly.
+
+When upgrading from Couchbase Server 5.5 to Couchbase Server 6.0 or later, any existing Analytics datasets must be removed and recreated, and data must be ingested again from the Data Service.
 ====
 
 [#deprecation-600]

--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -707,7 +707,7 @@ Analytics data from Developer Preview releases cannot be upgraded.
 
 If you plan to use the production release of Couchbase Analytics in version 6.0, you must perform a fresh installation of Couchbase Server 6.0 on any existing Analytics nodes that are running a previous version; otherwise, the Analytics Service will not function properly.
 
-When upgrading from Couchbase Server 5.5 to Couchbase Server 6.0 or later, any existing Analytics datasets must be removed before the upgrade and recreated afterward, and data must be ingested again from the Data Service.
+When upgrading from Couchbase Server 5.5 to Couchbase Server 6.0 or later, any existing Analytics datasets must be removed before the upgrade and recreated afterwards, and data must be ingested again from the Data Service.
 ====
 
 [#deprecation-600]

--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -707,7 +707,7 @@ Analytics data from Developer Preview releases cannot be upgraded.
 
 If you plan to use the production release of Couchbase Analytics in version 6.0, you must perform a fresh installation of Couchbase Server 6.0 on any existing Analytics nodes that are running a previous version; otherwise, the Analytics Service will not function properly.
 
-When upgrading from Couchbase Server 5.5 to Couchbase Server 6.0 or later, any existing Analytics datasets must be removed and recreated, and data must be ingested again from the Data Service.
+When upgrading from Couchbase Server 5.5 to Couchbase Server 6.0 or later, any existing Analytics datasets must be removed before the upgrade and recreated afterward, and data must be ingested again from the Data Service.
 ====
 
 [#deprecation-600]


### PR DESCRIPTION
- Add warning that datasets must be recreated

Documentation issue: [DOC-4757](https://issues.couchbase.com/browse/DOC-4757)