### PR TITLE
DOC-5821: ADVISE statement check for DP mode removed

### DIFF
--- a/modules/ROOT/partials/developer-preview.adoc
+++ b/modules/ROOT/partials/developer-preview.adoc
@@ -3,9 +3,11 @@
 // tag::admonition[]
 [CAUTION]
 --
+// tag::nolink[]
 This is a Developer Preview feature, intended for development purposes only.
 Do not use this feature in production.
 No Enterprise Support is provided for Developer Preview features.
+// end::nolink[]
 
 Refer to xref:developer-preview:preview-mode.adoc[Developer Preview Mode] for more information.
 --

--- a/modules/n1ql/pages/n1ql-language-reference/advise.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/advise.adoc
@@ -23,7 +23,10 @@
 [abstract]
 The ADVISE statement provides index recommendations to optimize query response time.
 
-include::ROOT:partial$developer-preview.adoc[tag=admonition]
+[CAUTION]
+====
+include::ROOT:partial$developer-preview.adoc[tag=nolink]
+====
 
 == Purpose
 


### PR DESCRIPTION
Draft documentation ready for review:

* [ADVISE](https://simon-dew.github.io/docs-site/DOC-5821/server/6.5/n1ql/n1ql-language-reference/advise.html)

Documentation issue: [DOC-5821](https://issues.couchbase.com/browse/DOC-5821)