### PR TITLE
DOC-4321: default index placement policy

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -24,7 +24,7 @@ This status field and other index metadata can be queried using `system:indexes`
 [IMPORTANT]
 ====
 Indexes cannot be built concurrently on a given bucket unless the `defer_build` option of the CREATE INDEX statement is used in combination with BUILD INDEX statement.
-The following error is reported if a second index creation operation is kicked off before the completion of the ongoing index creation.
+The following error is reported if a second index build operation is kicked off before the completion of the ongoing index build.
 
 [source,json]
 ----
@@ -36,6 +36,12 @@ You can create multiple identical secondary indexes on a bucket and place them o
 In Couchbase Server Enterprise Edition, the recommended way to do this is using the `num_replicas` option.
 In Couchbase Server Community Edition, you need to create multiple identical indexes and place them using the `nodes` option.
 Refer to <<index-with,WITH Clause>> below for more details.
+
+[NOTE]
+====
+You cannot run multiple `CREATE INDEX` statements in parallel, even when you specify that the indexes should be created on different nodes.
+This is to avoid the possibility of duplicate index names.
+====
 
 [discrete]
 ===== RBAC Privileges

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -1,6 +1,7 @@
 = CREATE INDEX
 :page-topic-type: concept
 :imagesdir: ../../assets/images
+:keywords: secondary, index, placement
 :enterprise: https://www.couchbase.com/products/editions[ENTERPRISE EDITION]
 :community: https://www.couchbase.com/products/editions[COMMUNITY EDITION]
 
@@ -156,12 +157,12 @@ nodes;;
 ====
 In Couchbase Server Community Edition, a single global secondary index can be placed on a single node that runs the indexing service.
 The `nodes` property allows you to specify the node that the index is placed on.
-If `nodes` is not specified, one of the nodes running the index service is randomly picked for the index.
+(((default index placement)))If `nodes` is not specified, one of the nodes running the indexing service is randomly picked for the index.
 ====
 +
 [NOTE,title='{enterprise}']
 ====
-In Couchbase Server Enterprise Edition, multiple nodes can be specified to distribute replicas of an index amongst multiple nodes, for example:
+In Couchbase Server Enterprise Edition, you can specify multiple nodes to distribute replicas of an index across nodes running the indexing service, for example:
 
 [source,n1ql]
 ----
@@ -172,7 +173,8 @@ WITH {"nodes":["node1:8091", "node2:8091", "node3:8091"]};
 
 If specifying both [.var]`nodes` and [.var]`num_replica`, the number of nodes in the array must be one greater than the specified number of replicas otherwise the index creation will fail.
 
-If [.var]`nodes` is not specified, then nodes running the index service are randomly selected to host the index, based on the number of replicas.
+(((default index placement)))If [.var]`nodes` is not specified, then the system chooses nodes on which to place the new index and any replicas, in order to achieve the best resource utilization across nodes running the indexing service.
+This is done by taking into account the current resource usage statistics of index nodes.
 ====
 +
 IMPORTANT: A node name passed to the `nodes` property must include the cluster administration port, by default 8091.


### PR DESCRIPTION
Porting changes from #884 forward to Mad Hatter.

* include note that you can't create multiple indexes in parallel
* clarify that error code 5000 refers to BUILD not CREATE