### PR TITLE
DOC-5675: No (obvious) mention of `--` handling

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/index.adoc
@@ -51,16 +51,16 @@ N1QL supports block comments and line comments.
 ==== Block Comments
 
 A block comment starts with `/{asterisk}` and ends with `{asterisk}/`.
-The query engine ignores the start and end markers `/{asterisk} {asterisk}/` and any text between them.
+The query engine ignores the start and end markers `/{asterisk} {asterisk}/`, and any text between them.
 
 ----
 /*  [ [text] | [newline] ]+  */
 ----
 
-A block comment may start on a new line, or may start on a line after other N1QL statements.
+A block comment may start on a new line, or in the middle of a line after other N1QL statements.
 A block comment may contain line breaks.
 
-There may also be further N1QL statements on the same line after the end of the block comment -- the query engine does not ignore these.
+There may also be further N1QL statements on the same line after the end of a block comment -- the query engine does _not_ ignore these.
 
 ==== Line Comments
 
@@ -74,7 +74,7 @@ The query engine ignores the two hyphens, and any text following them up to the 
 -- [text]
 ----
 
-A line comment may start on a new line, or at the end of a line after any other N1QL statements.
+A line comment may start on a new line, or in the middle of a line after any other N1QL statements.
 A line comment may not contain line breaks.
 
 [#nested-path-exp]

--- a/modules/n1ql/pages/n1ql-language-reference/index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/index.adoc
@@ -70,6 +70,7 @@ There may also be further N1QL statements on the same line after the end of a bl
 -- [text]
 ----
 
+You can use line comments in Couchbase Server 6.5 and later.
 A line comment starts with two hyphens `--`.
 The query engine ignores the two hyphens, and any text following them up to the end of the line.
 

--- a/modules/n1ql/pages/n1ql-language-reference/index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/index.adoc
@@ -9,11 +9,17 @@ It also provides reference information about the basic elements in N1QL which ca
 
 The N1QL language structure is composed of statements, expressions, and comments.
 
-Statements:: N1QL statements are categorized into the following groups:
+=== Statements
+
+N1QL statements are categorized into the following groups:
 * *Data Definition Language* (DDL) statements to xref:n1ql-language-reference/createindex.adoc[create indexes], modify indexes, and xref:n1ql-language-reference/dropindex.adoc[drop indexes].
 * *Data Manipulation Language* (DML) statements to xref:n1ql-language-reference/selectintro.adoc[select], xref:n1ql-language-reference/insert.adoc[insert], xref:n1ql-language-reference/update.adoc[update], xref:n1ql-language-reference/delete.adoc[delete], and xref:n1ql-language-reference/upsert.adoc[upsert] data into JSON documents.
 
-[[N1QL_Expressions]]Expressions:: The following are the different types of N1QL expressions:
+[[N1QL_Expressions]]
+=== Expressions
+
+The following are the different types of N1QL expressions:
+
 * xref:n1ql-language-reference/aggregatefun.adoc[aggregate]
 * xref:n1ql-language-reference/arithmetic.adoc[arithmetic]
 * xref:n1ql-language-reference/collectionops.adoc[collection]
@@ -28,9 +34,11 @@ Statements:: N1QL statements are categorized into the following groups:
 * xref:n1ql-language-reference/stringfun.adoc[string]
 * xref:n1ql-language-reference/subqueries.adoc[subquery]
 
-Comments::
+=== Comments
+
 N1QL supports block comments with the following syntax:
-+
+
+
 ----
 /*  [ [text] | [newline] ]+  */
 ----

--- a/modules/n1ql/pages/n1ql-language-reference/index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/index.adoc
@@ -50,12 +50,12 @@ N1QL supports block comments and line comments.
 
 ==== Block Comments
 
-A block comment starts with `/{asterisk}` and ends with `{asterisk}/`.
-The query engine ignores the start and end markers `/{asterisk} {asterisk}/`, and any text between them.
-
 ----
 /*  [ [text] | [newline] ]+  */
 ----
+
+A block comment starts with `/{asterisk}` and ends with `{asterisk}/`.
+The query engine ignores the start and end markers `/{asterisk}&nbsp;{asterisk}/`, and any text between them.
 
 A block comment may start on a new line, or in the middle of a line after other N1QL statements.
 A block comment may contain line breaks.
@@ -67,14 +67,14 @@ There may also be further N1QL statements on the same line after the end of a bl
 [.labels]
 [.status]#Couchbase Server 6.5#
 
-A line comment starts with two hyphens `--`.
-The query engine ignores the two hyphens, and any text following them up to the end of the line.
-
 ----
 -- [text]
 ----
 
-A line comment may start on a new line, or in the middle of a line after any other N1QL statements.
+A line comment starts with two hyphens `--`.
+The query engine ignores the two hyphens, and any text following them up to the end of the line.
+
+A line comment may start on a new line, or in the middle of a line after other N1QL statements.
 A line comment may not contain line breaks.
 
 [#nested-path-exp]

--- a/modules/n1ql/pages/n1ql-language-reference/index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/index.adoc
@@ -36,12 +36,36 @@ The following are the different types of N1QL expressions:
 
 === Comments
 
-N1QL supports block comments with the following syntax:
+N1QL supports block comments and line comments.
 
+==== Block Comments
+
+A block comment starts with `/{asterisk}` and ends with `{asterisk}/`.
+The query engine ignores the start and end markers `/{asterisk} {asterisk}/` and any text between them.
 
 ----
 /*  [ [text] | [newline] ]+  */
 ----
+
+A block comment may start on a new line, or may start on a line after other N1QL statements.
+A block comment may contain line breaks.
+
+There may also be further N1QL statements on the same line after the end of the block comment -- the query engine does not ignore these.
+
+==== Line Comments
+
+[.labels]
+[.status]#Couchbase Server 6.5#
+
+A line comment starts with two hyphens `--`.
+The query engine ignores the two hyphens, and any text following them up to the end of the line.
+
+----
+-- [text]
+----
+
+A line comment may start on a new line, or at the end of a line after any other N1QL statements.
+A line comment may not contain line breaks.
 
 [#nested-path-exp]
 == Nested Path Expressions

--- a/modules/n1ql/pages/n1ql-language-reference/index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/index.adoc
@@ -64,7 +64,6 @@ There may also be further N1QL statements on the same line after the end of a bl
 
 ==== Line Comments
 
-[.labels]
 [.status]#Couchbase Server 6.5#
 
 ----

--- a/modules/n1ql/pages/n1ql-language-reference/index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/index.adoc
@@ -1,6 +1,15 @@
 = N1QL Language Reference
 :page-topic-type: concept
 
+:createindex: xref:n1ql-language-reference/createindex.adoc
+:alterindex:  xref:n1ql-language-reference/alterindex.adoc
+:dropindex: xref:n1ql-language-reference/dropindex.adoc
+:selectintro: xref:n1ql-language-reference/selectintro.adoc
+:insert: xref:n1ql-language-reference/insert.adoc
+:update: xref:n1ql-language-reference/update.adoc
+:delete: xref:n1ql-language-reference/delete.adoc
+:upsert: xref:n1ql-language-reference/upsert.adoc
+
 [abstract]
 The N1QL reference guide describes the N1QL language structure, syntax, and shows how to run N1QL queries from a command line.
 It also provides reference information about the basic elements in N1QL which can be combined to build N1QL statements.
@@ -12,8 +21,9 @@ The N1QL language structure is composed of statements, expressions, and comments
 === Statements
 
 N1QL statements are categorized into the following groups:
-* *Data Definition Language* (DDL) statements to xref:n1ql-language-reference/createindex.adoc[create indexes], modify indexes, and xref:n1ql-language-reference/dropindex.adoc[drop indexes].
-* *Data Manipulation Language* (DML) statements to xref:n1ql-language-reference/selectintro.adoc[select], xref:n1ql-language-reference/insert.adoc[insert], xref:n1ql-language-reference/update.adoc[update], xref:n1ql-language-reference/delete.adoc[delete], and xref:n1ql-language-reference/upsert.adoc[upsert] data into JSON documents.
+
+* *Data Definition Language* (DDL) statements to {createindex}[create indexes], {alterindex}[modify indexes], and {dropindex}[drop indexes].
+* *Data Manipulation Language* (DML) statements to {selectintro}[select], {insert}[insert], {update}[update], {delete}[delete], and {upsert}[upsert] data into JSON documents.
 
 [[N1QL_Expressions]]
 === Expressions


### PR DESCRIPTION
The following draft documentation is ready for review:

* [N1QL Language Reference › N1QL Language Structure › Comments](https://simon-dew.github.io/docs-site/DOC-5675/server/6.5/n1ql/n1ql-language-reference/index.html#comments)

Documentation issue: [DOC-5675](https://issues.couchbase.com/browse/DOC-5675)