### PR TITLE
DOC-5816: REGEX should be REGEXP

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/patternmatchingfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/patternmatchingfun.adoc
@@ -30,7 +30,7 @@ Returns TRUE if the string value contains any sequence that matches the regular 
 ----
 SELECT name
 FROM `travel-sample`
-WHERE type = "landmark" AND REGEX_CONTAINS(name, "In+.*")
+WHERE type = "landmark" AND REGEXP_CONTAINS(name, "In+.*")
 LIMIT 5;
 ----
 
@@ -77,7 +77,7 @@ Returns TRUE if the string value exactly matches the regular expression pattern.
 ----
 SELECT name
 FROM `travel-sample`
-WHERE type = "landmark" and REGEX_LIKE(name, "In+.*")
+WHERE type = "landmark" and REGEXP_LIKE(name, "In+.*")
 LIMIT 5;
 ----
 
@@ -126,7 +126,7 @@ The following query finds positions of first occurrence of vowels in each word o
 
 [source,N1QL]
 ----
-SELECT name, ARRAY REGEX_POSITION(x, "[aeiou]") FOR x IN TOKENS(name) END
+SELECT name, ARRAY REGEXP_POSITION(x, "[aeiou]") FOR x IN TOKENS(name) END
 FROM `travel-sample`
 WHERE type = "hotel"
 LIMIT 2;
@@ -156,7 +156,7 @@ LIMIT 2;
 ----
 ====
 
-[#section_regex_relace]
+[#section_regex_replace]
 == REGEXP_REPLACE(`expression`, `pattern`, `repl` [, `n`])
 
 === Arguments
@@ -181,9 +181,9 @@ If _n_ is not provided, all matching occurrences are replaced.
 ====
 [source,N1QL]
 ----
-SELECT REGEX_REPLACE("N1QL is Sql(infact, sql++) for NoSql", "[sS][qQ][lL]", "SQL"),
-       REGEX_REPLACE("Winning innings Inn", "[Ii]n+", "Hotel", 6),
-       REGEX_REPLACE("Winning innings Inn", "[IiNn]+g", upper("inning"), 2);
+SELECT REGEXP_REPLACE("N1QL is Sql(infact, sql++) for NoSql", "[sS][qQ][lL]", "SQL"),
+       REGEXP_REPLACE("Winning innings Inn", "[Ii]n+", "Hotel", 6),
+       REGEXP_REPLACE("Winning innings Inn", "[IiNn]+g", upper("inning"), 2);
 ----
 
 .Results
@@ -205,7 +205,7 @@ In this example, the query retrieves first 4 documents and replaces the pattern 
 
 [source,N1QL]
 ----
-SELECT name, REGEX_REPLACE(name, "n+", "NNNN") as new_name
+SELECT name, REGEXP_REPLACE(name, "n+", "NNNN") as new_name
 FROM `travel-sample`
 LIMIT 4;
 ----

--- a/modules/n1ql/pages/n1ql-language-reference/patternmatchingfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/patternmatchingfun.adoc
@@ -13,6 +13,8 @@ From Couchbase Server 5.0, The Go Programming Language version 1.8 is supported.
 [#section_regex_contains]
 == REGEXP_CONTAINS(`expression`, `pattern`)
 
+This function has an alias <<aliases,REGEX_CONTAINS()>>.
+
 === Arguments
 
 expression:: String, or any N1QL expression that evaluates to a string.
@@ -60,6 +62,8 @@ LIMIT 5;
 [#section_regex_like]
 == REGEXP_LIKE(`expression`, `pattern`)
 
+This function has an alias <<aliases,REGEX_LIKE()>>.
+
 === Arguments
 
 expression:: String, or any N1QL expression that evaluates to a string.
@@ -106,6 +110,8 @@ LIMIT 5;
 
 [#section_regex_position]
 == REGEXP_POSITION(`expression`, `pattern`)
+
+This function has an alias <<aliases,REGEX_POSITION()>>.
 
 === Arguments
 
@@ -158,6 +164,8 @@ LIMIT 2;
 
 [#section_regex_replace]
 == REGEXP_REPLACE(`expression`, `pattern`, `repl` [, `n`])
+
+This function has an alias <<aliases,REGEX_REPLACE()>>.
 
 === Arguments
 
@@ -233,3 +241,13 @@ LIMIT 4;
 ]
 ----
 ====
+
+[[aliases]]
+== Aliases
+
+Each pattern-matching function has an alias whose name begins with `REGEX_`.
+
+* `REGEX_CONTAINS()` is an alias for <<section_regex_contains,REGEXP_CONTAINS()>>.
+* `REGEX_LIKE()` is an alias for <<section_regex_like,REGEXP_LIKE()>>.
+* `REGEX_POSITION()` is an alias for <<section_regex_position,REGEXP_POSITION()>>.
+* `REGEX_REPLACE()` is an alias for <<section_regex_replace,REGEXP_REPLACE()>>.


### PR DESCRIPTION
The following draft documentation is aready for review:

* [Pattern-matching functions](https://github.com/couchbase/docs-server/blob/4db4f8192491b3b719671d5cf7016ee71c5491d7/modules/n1ql/pages/n1ql-language-reference/patternmatchingfun.adoc)

Documentation issue: [DOC-5816](https://issues.couchbase.com/browse/DOC-5816)