### PR TITLE
DOC-5871: Add field "keyspace_alias" to the output of Advise stmt

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/advise.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/advise.adoc
@@ -210,32 +210,32 @@ Example: `UNNEST schedule AS x WHERE x.day = 1`
 |An {array-index}[array index], where the leading index key is an array expression indexing all elements in the unnested array.
 
 |[start=2]
-. Equality
-|The query has a predicate with an {comparisonops}[equality] expression.
+. Equality / NULL / MISSING
+|The query has a predicate with an {comparisonops}[equality], {comparisonops}[IS NULL], or {comparisonops}[IS MISSING] expression.
 
 Example: `WHERE id = 10`
-|A {secondary-index}[secondary index], where the index key is the field referenced by the predicate expression.
+|A {secondary-index}[secondary index], where one index key is the field referenced by the predicate expression.
 
 |[start=3]
 . IN predicates
 |The query has a predicate with an {collection-op-in}[IN] expression.
 
 Example: `WHERE id IN [10, 20]`
-|A {secondary-index}[secondary index], where the index key is the field referenced by the predicate expression.
+|A {secondary-index}[secondary index], where one index key is the field referenced by the predicate expression.
 
 |[start=4]
 . Not less than / between / not greater than
 |The query has a predicate with a {comparisonops}[+<=+], {comparisonops}[BETWEEN], or {comparisonops}[+>=+] expression.
 
 Example: `WHERE id >= 10`
-|A {secondary-index}[secondary index], where the index key is the field referenced by the predicate expression.
+|A {secondary-index}[secondary index], where one index key is the field referenced by the predicate expression.
 
 |[start=5]
 . Less than / between / greater than
 |The query has a predicate with a {comparisonops}[<], {comparisonops}[BETWEEN], or {comparisonops}[>] expression.
 
 Example: `WHERE id BETWEEN 10 AND 25`
-|A {secondary-index}[secondary index], where the index key is the field referenced by the predicate expression.
+|A {secondary-index}[secondary index], where one index key is the field referenced by the predicate expression.
 
 |[start=6]
 . Array predicate
@@ -246,7 +246,7 @@ Example: `WHERE ANY v IN schedule SATISFIES v.utc > "19:00" END`
 
 |[start=7]
 . Derived join filter as leading key
-|The query has a {join}[join], which is filtered using an ON clause on the left-hand side keyspace.
+|The query has a {join}[join] using an ON clause which filters on the left-hand side keyspace.
 
 Example: `FROM {backtick}travel-sample{backtick} r JOIN {backtick}travel-sample{backtick} a ON r.airlineid = META(a).id`
 |A {secondary-index}[secondary index], where the leading index key is the field from the left-hand side keyspace in the ON clause.
@@ -256,7 +256,7 @@ Example: `FROM {backtick}travel-sample{backtick} r JOIN {backtick}travel-sample{
 |The query has a predicate with {comparisonops}[IS NOT NULL], {comparisonops}[IS NOT MISSING], or {comparisonops}[IS NOT VALUED].
 
 Example: `WHERE id IS NOT NULL`
-|A {secondary-index}[secondary index], where the index key is the field referenced by the predicate expression.
+|A {secondary-index}[secondary index], where one index key is the field referenced by the predicate expression.
 
 |[start=9]
 . Functional predicates
@@ -266,6 +266,13 @@ Example: `WHERE LOWER(name) = "john"`
 |A {functional-index}[functional index], where the index key contains the function referenced by the predicate expression.
 
 |[start=10]
+. Non-static join predicate
+|The query has a {join}[join] using an ON clause in which neither the left-hand side source object nor the right-hand side source object is static.
+
+Example: `FROM {backtick}travel-sample{backtick} r JOIN {backtick}travel-sample{backtick} a ON r.airlineid = a.id`
+|A {secondary-index}[secondary index], where one index key is the field from the right-hand side keyspace in the ON clause.
+
+|[start=11]
 . Flavor for partial index
 |The query includes filters on a particular {schema-output}[flavor] of document.
 

--- a/modules/n1ql/pages/n1ql-language-reference/advise.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/advise.adoc
@@ -182,7 +182,7 @@ If the index is not identical to the recommended index, or if it is not an optim
 |string
 
 |**recommending_rule** +
-__required__
+__optional__
 |The rules used to generate the recommendation.
 
 This field is only returned for recommended indexes, or for current indexes if they are identical to the recommended index.

--- a/modules/n1ql/pages/n1ql-language-reference/advise.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/advise.adoc
@@ -166,6 +166,13 @@ __required__
 |The N1QL command used to define the index.
 |string
 
+|**keyspace_alias** +
+__required__
+|The keyspace to which the index belongs.
+If the query specifies an alias for this keyspace, the alias is appended to the keyspace name, joined by an underscore.
+This may help to distinguish the indexes for either side of a JOIN operation.
+|string
+
 |**index_status** +
 __optional__
 |Information on the status of the index, stating whether the index is identical to the recommended index, or whether the index is an optimal covering index.

--- a/modules/n1ql/pages/n1ql-language-reference/advise.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/advise.adoc
@@ -302,14 +302,16 @@ ADVISE SELECT * FROM `travel-sample` a WHERE a.type = 'hotel' AND a.country = 'F
         {
           "current_indexes": [
             {
-              "index_statement": "CREATE INDEX def_type ON `travel-sample`(`type`)"
+              "index_statement": "CREATE INDEX def_type ON `travel-sample`(`type`)",
+              "keyspace_alias": "travel-sample_a"
             }
           ],
           "recommended_indexes": {
             "indexes": [
               {
                 "index_statement": "CREATE INDEX adv_country_type ON `travel-sample`(`country`) WHERE `type` = 'hotel'",
-                "recommending_rule": "Index keys follow order of predicate types: 2. equality, 10. flavor for partial index."
+                "keyspace_alias": "travel-sample_a",
+                "recommending_rule": "Index keys follow order of predicate types: 2. equality/null/missing, 11. flavor for partial index."
               }
             ]
           }
@@ -341,19 +343,22 @@ ADVISE SELECT airportname FROM `travel-sample` WHERE type = 'airport' AND geo.al
         {
           "current_indexes": [
             {
-              "index_statement": "CREATE INDEX def_type ON `travel-sample`(`type`)"
+              "index_statement": "CREATE INDEX def_type ON `travel-sample`(`type`)",
+              "keyspace_alias": "travel-sample"
             }
           ],
           "recommended_indexes": {
             "covering_indexes": [
               {
-                "index_statement": "CREATE INDEX adv_geo_alt_type_airportname ON `travel-sample`(`geo`.`alt`,`airportname`) WHERE `type` = 'airport'"
+                "index_statement": "CREATE INDEX adv_geo_alt_type_airportname ON `travel-sample`(`geo`.`alt`,`airportname`) WHERE `type` = 'airport'",
+                "keyspace_alias": "travel-sample"
               }
             ],
             "indexes": [
               {
                 "index_statement": "CREATE INDEX adv_geo_alt_type ON `travel-sample`(`geo`.`alt`) WHERE `type` = 'airport'",
-                "recommending_rule": "Index keys follow order of predicate types: 5. less than/between/greater than, 10. flavor for partial index."
+                "keyspace_alias": "travel-sample",
+                "recommending_rule": "Index keys follow order of predicate types: 1. Common leading key for disjunction (5. less than/between/greater than), 11. flavor for partial index."
               }
             ]
           }
@@ -387,7 +392,8 @@ ADVISE SELECT * FROM `travel-sample` WHERE type LIKE 'air%'or type LIKE 'rou%';
             {
               "index_statement": "CREATE INDEX def_type ON `travel-sample`(`type`)",
               "index_status": "SAME TO THE INDEX WE CAN RECOMMEND",
-              "recommending_rule": "Index keys follow order of predicate types: 4. not less than/between/not greater than."
+              "keyspace_alias": "travel-sample",
+              "recommending_rule": "Index keys follow order of predicate types: 1. Common leading key for disjunction (4. not less than/between/not greater than)."
             }
           ],
           "recommended_indexes": "No index recommendation at this time."
@@ -420,7 +426,8 @@ ADVISE SELECT type FROM `travel-sample` WHERE type LIKE 'air%'or type LIKE 'rou%
           "current_indexes": [
             {
               "index_statement": "CREATE INDEX def_type ON `travel-sample`(`type`)",
-              "index_status": "THIS IS AN OPTIMAL COVERING INDEX."
+              "index_status": "THIS IS AN OPTIMAL COVERING INDEX.",
+              "keyspace_alias": "travel-sample"
             }
           ],
           "recommended_indexes": "No index recommendation at this time."
@@ -452,7 +459,8 @@ ADVISE SELECT * FROM `travel-sample` LIMIT 5;
         {
           "current_indexes": [
             {
-              "index_statement": "CREATE PRIMARY INDEX def_primary ON `travel-sample`"
+              "index_statement": "CREATE PRIMARY INDEX def_primary ON `travel-sample`",
+              "keyspace_alias": "travel-sample"
             }
           ],
           "recommended_indexes": "No index recommendation at this time."

--- a/modules/n1ql/pages/n1ql-language-reference/advise.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/advise.adoc
@@ -269,7 +269,7 @@ Example: `WHERE LOWER(name) = "john"`
 . Non-static join predicate
 |The query has a {join}[join] using an ON clause in which neither the left-hand side source object nor the right-hand side source object is static.
 
-Example: `FROM {backtick}travel-sample{backtick} r JOIN {backtick}travel-sample{backtick} a ON r.airlineid = a.id`
+Example: `FROM {backtick}travel-sample{backtick} r JOIN {backtick}travel-sample{backtick} a ON r.airline = a.iata`
 |A {secondary-index}[secondary index], where one index key is the field from the right-hand side keyspace in the ON clause.
 
 |[start=11]

--- a/modules/n1ql/partials/n1ql-language-reference/advice-workbench.adoc
+++ b/modules/n1ql/partials/n1ql-language-reference/advice-workbench.adoc
@@ -1,2 +1,2 @@
-If you run the ADVISE statement in the Query Workbench, you must use the *Table*, *JSON*, or *Tree* link to see the result.
-You cannot use the *Advice* link in the Query Workbench to see the result of the ADVISE statement.
+If you run the ADVISE statement in the Query Workbench, you can use the *Table*, *JSON*, or *Tree* link to see the result, just like any other query.
+You can also use the *Advice* link in the Query Workbench to see the result of the ADVISE statement in graphical format.

--- a/modules/tools/pages/query-workbench.adoc
+++ b/modules/tools/pages/query-workbench.adoc
@@ -331,7 +331,7 @@ When you execute a xref:n1ql:n1ql-language-reference/selectintro.adoc[SELECT] qu
 You may also generate the index advice by clicking btn:[Advise].
 
 If index advice is available, an asterisk *{asterisk}* is displayed after the *Advice* link in the [.ui]*Query Results* area.
-To display the index advice, click the *Advice* link.
+To display the index advice in graphical format, click the *Advice* link.
 
 include::n1ql:partial$n1ql-language-reference/advice-workbench.adoc[]
 


### PR DESCRIPTION
The following draft documentation is ready for review.

* [ADVISE › Return Value](https://simon-dew.github.io/docs-site/DOC-5871/server/6.5/n1ql/n1ql-language-reference/advise.html#return-value) — scroll down to the **Indexes** table
* [ADVISE › Return Value › Recommendation Rules](https://simon-dew.github.io/docs-site/DOC-5871/server/6.5/n1ql/n1ql-language-reference/advise.html#recommendation-rules)
* [ADVISE › Examples](https://simon-dew.github.io/docs-site/DOC-5871/server/6.5/n1ql/n1ql-language-reference/advise.html#examples)

Docs issue: [DOC-5871](https://issues.couchbase.com/browse/DOC-5871)