### PR TITLE
DOC-5987: prepared statements calls USING syntax does not work

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/execute.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/execute.adoc
@@ -29,7 +29,7 @@ TIP: If the name of the prepared statement contains hyphens, wrap the entire nam
 
 === USING Clause
 
-_(Introduced in Couchbase Server 6.5)_
+[.status]#Couchbase Server 6.5#
 
 [Optional] The USING clause enables you to specify parameter values to use in the prepared statement.
 
@@ -75,7 +75,7 @@ Once the resources are available again, execution proceeds without any further i
 [[parameters]]
 == Parameters
 
-_(Introduced in Couchbase Server 6.5)_
+[.status]#Couchbase Server 6.5#
 
 A prepared statement may contain parameters.
 These are replaced by a supplied value when the statement is executed.

--- a/modules/n1ql/pages/n1ql-language-reference/execute.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/execute.adoc
@@ -103,10 +103,15 @@ USING ["paris", "france"];
 ----
 ====
 
-[NOTE]
-You can also specify named parameters and positional parameters using the N1QL REST API (`/query/service` endpoint) or the `cbq` command line tool.
+[IMPORTANT]
+====
+Alternatively, you can specify named parameters and positional parameters using the N1QL REST API (`/query/service` endpoint) or the `cbq` command line tool.
 Named parameters can be specified as request-level parameters, and positional parameters can be specified using the `args` parameter.
 Refer to xref:settings:query-settings.adoc[Query Settings] for more information.
+
+If you specify parameters with the N1QL REST API or the `cbq` command line tool, you cannot also specify parameters with the USING clause at the same time.
+When you do this, the query service returns error `5003`: "cannot have both USING clause and request parameters".
+====
 
 [[examples]]
 == Examples

--- a/modules/n1ql/pages/n1ql-language-reference/execute.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/execute.adoc
@@ -105,11 +105,11 @@ USING ["paris", "france"];
 
 [IMPORTANT]
 ====
-Alternatively, you can specify named parameters and positional parameters using the N1QL REST API (`/query/service` endpoint) or the `cbq` command line tool.
+Alternatively, you can specify named parameters and positional parameters using the N1QL REST API (`/query/service` endpoint), the `cbq` command line tool, or a software development kit (SDK).
 Named parameters can be specified as request-level parameters, and positional parameters can be specified using the `args` parameter.
 Refer to xref:settings:query-settings.adoc[Query Settings] for more information.
 
-If you specify parameters with the N1QL REST API or the `cbq` command line tool, you cannot also specify parameters with the USING clause at the same time.
+When you specify parameters with the USING clause, you cannot also specify parameters at the same time using the N1QL REST API, the `cbq` command line tool, or an SDK.
 When you do this, the query service returns error `5003`: "cannot have both USING clause and request parameters".
 ====
 

--- a/modules/n1ql/pages/n1ql-language-reference/n1ql-error-codes.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/n1ql-error-codes.adoc
@@ -470,6 +470,10 @@ These codes are related to the execution.
 | `execution.internal_error`
 | Internal error during execution.
 
+| `5003`
+| `Execution parameter error`
+| Cannot have both USING clause and request parameters.
+
 | `5010`
 | `execution.evaluation_error`
 | Evaluation error.


### PR DESCRIPTION
The following draft documentation is ready for review:

* [EXECUTE › Parameters](https://github.com/couchbase/docs-server/blob/bf6217277388220bcfb33bb71463a7964fbcb43d/modules/n1ql/pages/n1ql-language-reference/execute.adoc#parameters)
* [N1QL Error Codes › 5xxx Codes (exec)](https://github.com/couchbase/docs-server/blob/bf6217277388220bcfb33bb71463a7964fbcb43d/modules/n1ql/pages/n1ql-language-reference/n1ql-error-codes.adoc#5xxx-codes-exec)

Docs issue: [DOC-5987](https://issues.couchbase.com/browse/DOC-5987)