### PR TITLE
DOC-5321: setting query timeout from rest is in nanoseconds

### DIFF
--- a/modules/n1ql/partials/n1ql-rest-api/admin/definitions.adoc
+++ b/modules/n1ql/partials/n1ql-rest-api/admin/definitions.adoc
@@ -616,26 +616,16 @@ The number of service threads for the query. +
 **Example** : `8`|integer (int32)
 |**timeout** +
 __optional__|[[timeout-srv]]
-Maximum time to spend on the request before timing out.
+Maximum time to spend on the request before timing out (ns).
 
 The default value means no timeout is applied and the request runs for however long it takes.
 
 There is also a xref:settings:query-settings.adoc#timeout_req[request-level] `timeout` parameter.
 The minimum of that and the service-level `timeout` setting is applied.
 
-Its format includes an amount and a mandatory unit, e.g. `10ms` (10 milliseconds) or `0.5s` (half a second).
-Valid units are:{blank}
-
-`ns` (nanoseconds) +
-`us` (microseconds) +
-`ms` (milliseconds) +
-`s` (seconds) +
-`m` (minutes) +
-`h` (hours) +
-
 Specify `0` or a negative integer to disable. +
-**Default** : `"0s"` +
-**Example** : `"30m"`|string (duration)
+**Default** : `0` +
+**Example** : `500000000`|integer (int64)
 |===
 
 [[_logging_parameters]]


### PR DESCRIPTION
The following documentation is ready for review:

* [Admin REST API › Definitions › Settings](https://simon-dew.github.io/docs-site/DOC-5321/server/6.5/n1ql/n1ql-rest-api/admin.html#timeout-srv)
* [Settings and Parameters › Service-Level Query Settings](https://simon-dew.github.io/docs-site/DOC-5321/server/6.5/settings/query-settings.html#timeout-srv)

Docs issue: [DOC-5321](https://issues.couchbase.com/browse/DOC-5321)