### PR TITLE
DOC-4287: REST API docs should cover eventing and analytics services

### DIFF
--- a/modules/install/pages/init-setup.adoc
+++ b/modules/install/pages/init-setup.adoc
@@ -324,7 +324,7 @@ Define the services:
 ----
 curl -u [admin-name]:[password] -v
   -X POST http://[localhost]:8091/node/controller/setupServices
-  -d services=[kv | index | n1ql | fts]
+  -d services=[kv | index | n1ql | fts | cbas | eventing]
 ----
 
 Initialize the node:

--- a/modules/install/pages/init-setup.adoc
+++ b/modules/install/pages/init-setup.adoc
@@ -352,7 +352,11 @@ Set the Index RAM quota (to be applied across the entire cluster):
 ----
 curl -u username=[admin-name]&password=[password]
   -X POST http://[localhost]:8091/pools/default
-  -d memoryQuota=[value] -d indexMemoryQuota=[value]
+  -d memoryQuota=[value]
+  -d indexMemoryQuota=[value]
+  -d ftsMemoryQuota=[value]
+  -d cbasMemoryQuota=[value]
+  -d eventingMemoryQuota=[value]
 ----
 
 === Examples

--- a/modules/rest-api/pages/rest-cluster-joinnode.adoc
+++ b/modules/rest-api/pages/rest-cluster-joinnode.adoc
@@ -22,10 +22,10 @@ Curl request syntax:
 
 ----
 curl -u [admin]:[password] -d clusterMemberHostIp=[ip-address] \
-	-d clusterMemberPort=[port] \
-	-d user=[admin] -d password=[password]
-	-d services=[data | index | n1ql]
-	http://[localhost]:8091/node/controller/doJoinCluster
+  -d clusterMemberPort=[port] \
+  -d user=[admin] -d password=[password]
+  -d services=[kv | index | n1ql | fts | cbas | eventing]
+  http://[localhost]:8091/node/controller/doJoinCluster
 ----
 
 == Description

--- a/modules/rest-api/pages/rest-endpoints-all.adoc
+++ b/modules/rest-api/pages/rest-endpoints-all.adoc
@@ -95,7 +95,15 @@ The server node is specified with the `otpNode=[node_name]` parameter.
 
 | POST
 | [.path]_/node/controller/setupServices_
-| Sets the services -- `kv` (data), `index` (index), `n1ql` (query), `fts` (search), `cbas` (analytics), `eventing`(eventing).
+a| Sets the services:
+
+`kv` (data) +
+`index` (index) +
+`n1ql` (query) +
+`fts` (search) +
+`cbas` (analytics) +
+`eventing` (eventing)
+
 Used also by the provisioning wizard.
 
 | POST

--- a/modules/rest-api/pages/rest-endpoints-all.adoc
+++ b/modules/rest-api/pages/rest-endpoints-all.adoc
@@ -95,7 +95,7 @@ The server node is specified with the `otpNode=[node_name]` parameter.
 
 | POST
 | [.path]_/node/controller/setupServices_
-| Sets the services (data, query, index, fts).
+| Sets the services -- `kv` (data), `index` (index), `n1ql` (query), `fts` (search), `cbas` (analytics), `eventing`(eventing).
 Used also by the provisioning wizard.
 
 | POST

--- a/modules/rest-api/pages/rest-node-provisioning.adoc
+++ b/modules/rest-api/pages/rest-node-provisioning.adoc
@@ -21,7 +21,7 @@ curl -u Administrator:password -v -X POST http://[localhost]:8091/node/controlle
 
 // Setup Services
 curl -u Administrator:password -v -X POST http://[localhost]:8091/node/controller/setupServices
-  -d services=[kv | index | n1ql | fts]
+  -d services=[kv | index | n1ql | fts | cbas | eventing]
 
 // Setup Administrator username and password
 curl -u Administrator:password -v -X POST http://[localhost]:8091/settings/web

--- a/modules/rest-api/pages/rest-node-services.adoc
+++ b/modules/rest-api/pages/rest-node-services.adoc
@@ -12,7 +12,7 @@ Adding a node syntax:
 curl -u [admin]:[password]
   [localhost]:8091/controller/addNode
   -d "hostname=[IPaddress]&user=[admin]&password=[password]"
-  -d "services=[data | index | n1ql | fts | cbas | eventing]"
+  -d "services=[kv | index | n1ql | fts | cbas | eventing]"
 ----
 
 Joining a node to a cluster:
@@ -28,20 +28,22 @@ curl -u [admin]:[password] -d clusterMemberHostIp=[ip-address]
 == Description
 
 This command is used to add a node to a cluster and specify the service.
-If a service is not specified, the default (data) will be added.
+If a service is not specified, the data service (kv) will be added by default.
 
 [caption=Attention]
 IMPORTANT: Couchbase Server services can only be enabled via the REST API when adding a server to an existing cluster.
-To initialized cluster (with the first node) with any Couchbase Server service other than the data service (default), use the Couchbase Web Console.
+To initialize a cluster (with the first node) with any Couchbase Server service other than the default data service (kv), use the Couchbase Web Console.
 
-When enabling the FTS service, ensure that you set the [.param]`ftsMemoryQuota` parameter as follows:
+When enabling services, ensure that you set the appropriate memory quota parameters as follows:
 
 ----
 curl -X POST -u Administrator:password \
   http://127.0.0.1:8091/pools/default \
   -d 'memoryQuota=256' \
   -d 'indexMemoryQuota=256' \
-  -d 'ftsMemoryQuota=512'
+  -d 'ftsMemoryQuota=512' \
+  -d 'cbasMemoryQuota=1048' \
+  -d 'eventingMemoryQuota=512'
 ----
 
 == HTTP method and URI

--- a/modules/rest-api/pages/rest-node-services.adoc
+++ b/modules/rest-api/pages/rest-node-services.adoc
@@ -22,7 +22,7 @@ curl -u [admin]:[password] -d clusterMemberHostIp=[ip-address]
   -d clusterMemberPort=[port]
   -d user=[admin] -d password=[password]
   http://[localhost]:8091/node/controller/doJoinCluster
-  -d "services=[data | index | n1ql | fts | cbas | eventing]"
+  -d "services=[kv | index | n1ql | fts | cbas | eventing]"
 ----
 
 == Description


### PR DESCRIPTION
The following documentation is ready for review:

* [REST API endpoint list](https://simon-dew.github.io/docs-site/DOC-4287/server/6.0/rest-api/rest-endpoints-all.html) — `/node/controller/setupServices`
* [Creating a new cluster](https://simon-dew.github.io/docs-site/DOC-4287/server/6.0/rest-api/rest-node-provisioning.html) — `/node/controller/setupServices`
* [Joining Nodes into Clusters](https://simon-dew.github.io/docs-site/DOC-4287/server/6.0/rest-api/rest-cluster-joinnode.html) — `/node/controller/doJoinCluster`
* [Enabling Couchbase Server Services](https://simon-dew.github.io/docs-site/DOC-4287/server/6.0/rest-api/rest-node-services.html) — correct services, add all memory quota options
* [Initializing the Cluster › Initializing the Cluster Using the REST API](https://simon-dew.github.io/docs-site/DOC-4287/server/6.0/install/init-setup.html#initialize-cluster-rest)

Docs issue [DOC-4287](https://issues.couchbase.com/browse/DOC-4287)