### PR TITLE
DOC-5258: Analytics is no longer a "developer preview" option

### DIFF
--- a/modules/cli/pages/cbcollect-info-tool.adoc
+++ b/modules/cli/pages/cbcollect-info-tool.adoc
@@ -82,16 +82,16 @@ Generated at collection-time.
 | Contains information relating to the core [.api]`memcached` component, including DCP stream requests and slow operations.
 
 | `ns_server.analytics.log`
-| (Developer Preview.)
+| Troubleshooting log for the Analytics service.
 
 | `ns_server.analytics_debug.log`
-| (Developer Preview.)
+| Debug-level troubleshooting log for the Analytics service.
 
 | `ns_server.analytics_shutdown.log`
-| (Developer Preview.)
+| Shutdown log for the Analytics service.
 
 | `ns_server.analytics_trace.log`
-| (Developer Preview.)
+| Trace-level troubleshooting log for the Analytics service.
 
 | `ns_server.babysitter.log`
 | Troubleshooting log for the babysitter process which is responsible for spawning all Couchbase Server processes and respawning them where necessary.


### PR DESCRIPTION
The following draft documentation is ready for review:

* [cbcollect_info](https://github.com/couchbase/docs-server/pull/942/files#diff-608faff57311f02219a04fcb83c3502c)

Docs issue: [DOC-5258](https://issues.couchbase.com/browse/DOC-5258)