### PR TITLE
DOC-2548: Add specific percentages to Index Pause states

### DIFF
--- a/modules/learn/pages/services-and-indexes/indexes/storage-modes.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/storage-modes.adoc
@@ -18,8 +18,12 @@ A snapshot of the index is maintained on disk, to permit rapid recovery if node-
 To be consistently beneficial, memory-optimized index-storage requires that all nodes running the Index Service have a memory quota sufficient for the number and size of their resident indexes, and for the frequency with which the indexes will be updated and scanned.
 
 Memory-optimized index-storage may be less suitable for nodes where memory is constrained; since whenever the Index Service memory-quota is exceeded, indexes on the node can neither be updated nor scanned.
-In such circumstances, an error-notification is provided; and although the indexes remain in `ONLINE` state, traffic is routed away from the node.
+
+If indexer RAM usage goes above 75%, an xref:manage:manage-settings/configure-alerts.adoc[error-notification] is provided.
+If indexer RAM usage then goes above 95%, the indexer goes into the Paused mode on that node; and although the indexes remain in `ONLINE` state, traffic is routed away from the node.
+
 Before index-operations can resume, memory must be freed.
+When the indexer RAM usage drops below 80%, the indexer goes into Active mode again on that node.
 
 In cases where recovery requires an Index-Service node to be restarted, the node's resident memory-optimized indexes are rebuilt from the snapshots retained on disk.
 Following the node's restart, these indexes remain in the `BUILDING` state until all information has been read into memory: then, final updates are made with the indexes in `ONLINE` state.

--- a/modules/learn/pages/services-and-indexes/indexes/storage-modes.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/storage-modes.adoc
@@ -2,16 +2,15 @@
 :page-aliases: indexes:storage-modes,understanding-couchbase:services-and-indexes/indexes/storage-modes,architecture:index-storage
 
 [abstract]
-A Secondary Index can be saved in either of two ways: _standard_ or _memory-optimized_.
+A Secondary Index can be saved in either of two ways: _memory-optimized_ or _standard_.
 
 [#memopt-gsi2]
 == Memory-Optimized Index Storage
 
-[NOTE]
-.https://www.couchbase.com/products/editions[ENTERPRISE EDITION]
-====
+[.labels]
+[.edition]#{enterprise}#
+
 Memory-optimized index-storage is supported by the _Nitro_ storage engine, and is only available in Couchbase Server Enterprise Edition.
-====
 
 Memory-optimized index-storage allows high-speed maintenance and scanning; since the index is kept fully in memory at all times.
 A snapshot of the index is maintained on disk, to permit rapid recovery if node-failures are experienced.
@@ -46,16 +45,16 @@ Note that attempting to delete bucket-data _selectively_ during an out-of-memory
 _Standard_ is the default storage-setting for Secondary Indexes: the indexes are saved on disk; in a disk-optimized format that uses both memory and disk for index-update and scanning.
 The performance of standard index storage depends on overall I/O performance.
 
-[NOTE]
-.https://www.couchbase.com/products/editions[ENTERPRISE EDITION]
-====
+****
+[.edition]#{enterprise}#
+
 In Couchbase Server Enterprise Edition, standard index-storage is supported by the _Plasma_ storage engine.
 In this case, compaction is handled automatically.
-====
+****
 
-[NOTE]
-.https://www.couchbase.com/products/editions[COMMUNITY EDITION]
-====
+****
+[.edition]#{community}#
+
 In Couchbase Server Community Edition, standard index-storage is supported by the _ForestDB_ storage engine.
 In this case, each index saved with the _standard_ option has two write modes:
 
@@ -69,7 +68,7 @@ Note, however, that the index-fragmentation data-size is not significantly chang
 
 By default, Couchbase Server Community Edition uses Circular Write Mode for standard index storage.
 Append-only Write Mode is provided for backwards compatibility with previous versions.
-====
+****
 
 Other storage-settings are described in detail in xref:manage:manage-settings/configure-compact-settings.adoc[Configuring Auto-Compaction].
 

--- a/modules/learn/pages/services-and-indexes/indexes/storage-modes.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/storage-modes.adoc
@@ -18,11 +18,11 @@ To be consistently beneficial, memory-optimized index-storage requires that all 
 
 Memory-optimized index-storage may be less suitable for nodes where memory is constrained; since whenever the Index Service memory-quota is exceeded, indexes on the node can neither be updated nor scanned.
 
-If indexer RAM usage goes above 75%, an xref:manage:manage-settings/configure-alerts.adoc[error-notification] is provided.
-If indexer RAM usage then goes above 95%, the indexer goes into the Paused mode on that node; and although the indexes remain in `ONLINE` state, traffic is routed away from the node.
+If indexer RAM usage goes above 75% of the Index Service memory-quota, an xref:manage:manage-settings/configure-alerts.adoc[error-notification] is provided.
+If indexer RAM usage then goes above 95% of the Index Service memory-quota, the indexer goes into the Paused mode on that node; and although the indexes remain in `ONLINE` state, traffic is routed away from the node.
 
 Before index-operations can resume, memory must be freed.
-When the indexer RAM usage drops below 80%, the indexer goes into Active mode again on that node.
+When the indexer RAM usage drops below 80% of the Index Service memory-quota, the indexer goes into Active mode again on that node.
 
 In cases where recovery requires an Index-Service node to be restarted, the node's resident memory-optimized indexes are rebuilt from the snapshots retained on disk.
 Following the node's restart, these indexes remain in the `BUILDING` state until all information has been read into memory: then, final updates are made with the indexes in `ONLINE` state.


### PR DESCRIPTION
The following documentation is ready for review:

* [Storage Settings › Memory-Optimized Index Storage](https://simon-dew.github.io/docs-site/DOC-2548/server/6.0/learn/services-and-indexes/indexes/storage-modes.html#memopt-gsi2)

Docs issue: [DOC-2548](https://issues.couchbase.com/browse/DOC-2548)