### PR TITLE
DOC-6168: Mad Hatter allows Index Advisor w/o DP Mode

### DIFF
--- a/modules/ROOT/partials/developer-preview.adoc
+++ b/modules/ROOT/partials/developer-preview.adoc
@@ -3,11 +3,9 @@
 // tag::admonition[]
 [CAUTION]
 --
-// tag::nolink[]
 This is a Developer Preview feature, intended for development purposes only.
 Do not use this feature in production.
 No Enterprise Support is provided for Developer Preview features.
-// end::nolink[]
 
 Refer to xref:developer-preview:preview-mode.adoc[Developer Preview Mode] for more information.
 --

--- a/modules/ROOT/partials/enterprise-preview.adoc
+++ b/modules/ROOT/partials/enterprise-preview.adoc
@@ -1,0 +1,13 @@
+== Beta Feature
+
+// tag::admonition[]
+[CAUTION]
+--
+This is a Developer Preview feature, intended for development purposes only.
+Do not use this feature in production.
+No Enterprise Support is provided for Developer Preview features.
+
+Note that this feature is available in Couchbase Server Enterprise Edition.
+You do not need to activate Developer Preview Mode to use this feature.
+--
+// end::admonition[]

--- a/modules/ROOT/partials/enterprise-preview.adoc
+++ b/modules/ROOT/partials/enterprise-preview.adoc
@@ -3,11 +3,13 @@
 // tag::admonition[]
 [CAUTION]
 --
-This is a Developer Preview feature, intended for development purposes only.
-Do not use this feature in production.
-No Enterprise Support is provided for Developer Preview features.
+This is a pre-release Beta feature.
+Beta features may have some rough edges and bugs, and may change significantly before the final GA release.
 
 Note that this feature is available in Couchbase Server Enterprise Edition.
 You do not need to activate Developer Preview Mode to use this feature.
+
+You can obtain support for this feature by participating in a forum or submitting a ticket.
+Refer to xref:introduction:contact-couchbase.adoc[Contact Couchbase] for more information.
 --
 // end::admonition[]

--- a/modules/developer-preview/pages/preview-mode.adoc
+++ b/modules/developer-preview/pages/preview-mode.adoc
@@ -67,7 +67,7 @@ SUCCESS: Cluster is in developer preview mode
 
 The Developer Preview mode in Couchbase Server 6.5 Beta unlocks the following features:
 
-* Collections - These are data containers that can be created within any bucket whose type is either _Couchbase_ or _Ephemeral_.
+* Collections -- These are data containers that can be created within any bucket whose type is either _Couchbase_ or _Ephemeral_.
 +
 This allows data-items optionally to be assigned to different collections according to content-type.
 +
@@ -79,6 +79,9 @@ For more information, see xref:developer-preview:collections/collections-overvie
 * Cost-based Optimizer
 
 * Index Advisor
++
+Note that the N1QL `ADVISE` statement, and the Index Advisor features in the Query Workbench, are provided as unsupported Developer Preview features within Couchbase Server Enterprise Edition.
+You do not need to activate Developer Preview Mode to use these two features.
 
 * N1QL JavaScript UDFs (Stored Procedures)
 

--- a/modules/developer-preview/pages/preview-mode.adoc
+++ b/modules/developer-preview/pages/preview-mode.adoc
@@ -78,7 +78,7 @@ For more information, see xref:developer-preview:collections/collections-overvie
 
 * Cost-based Optimizer
 
-* Index Advisor -- Note that the N1QL `ADVISE` statement, and the Index Advisor UI in the Query Workbench, are available in Couchbase Server Enterprise Edition.
+* Index Advisor -- Note that the N1QL `ADVISE` statement, and the Index Advisor UI in the Query Workbench, are available in Couchbase Server Enterprise Edition as Beta features.
 You do not need to activate Developer Preview Mode to use these two features.
 
 * N1QL JavaScript UDFs (Stored Procedures)

--- a/modules/developer-preview/pages/preview-mode.adoc
+++ b/modules/developer-preview/pages/preview-mode.adoc
@@ -78,9 +78,7 @@ For more information, see xref:developer-preview:collections/collections-overvie
 
 * Cost-based Optimizer
 
-* Index Advisor
-+
-Note that the N1QL `ADVISE` statement, and the Index Advisor features in the Query Workbench, are provided as unsupported Developer Preview features within Couchbase Server Enterprise Edition.
+* Index Advisor -- Note that the N1QL `ADVISE` statement, and the Index Advisor UI in the Query Workbench, are available in Couchbase Server Enterprise Edition.
 You do not need to activate Developer Preview Mode to use these two features.
 
 * N1QL JavaScript UDFs (Stored Procedures)

--- a/modules/n1ql/pages/n1ql-language-reference/advise.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/advise.adoc
@@ -1,6 +1,7 @@
 = ADVISE
 :page-topic-type: concept
 :page-status: Developer Preview
+:page-edition: Enterprise Edition
 :imagesdir: ../../assets/images
 
 :n1ql: xref:n1ql-language-reference
@@ -23,10 +24,7 @@
 [abstract]
 The ADVISE statement provides index recommendations to optimize query response time.
 
-[CAUTION]
-====
-include::ROOT:partial$developer-preview.adoc[tag=nolink]
-====
+include::ROOT:partial$enterprise-preview.adoc[tag=admonition]
 
 == Purpose
 

--- a/modules/n1ql/pages/n1ql-language-reference/advise.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/advise.adoc
@@ -1,6 +1,6 @@
 = ADVISE
 :page-topic-type: concept
-:page-status: Developer Preview
+:page-status: Beta
 :page-edition: Enterprise Edition
 :imagesdir: ../../assets/images
 

--- a/modules/n1ql/pages/n1ql-language-reference/advisor.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/advisor.adoc
@@ -818,6 +818,6 @@ SELECT ADVISOR({"action": "purge", "session": "8c41a3c6-2252-437e-ab47-0b28f29f4
 
 == Related Links
 
-* The {advise}[ADVISE] task -- also describes the index advisor {rules}[recommendation rules]
+* The {advise}[ADVISE] statement -- also describes the index advisor {rules}[recommendation rules]
 * The {index-advisor}[Index Advisor] in the Query Workbench
 * The {sys-tasks-cache}[system:tasks_cache] catalog

--- a/modules/tools/pages/query-workbench.adoc
+++ b/modules/tools/pages/query-workbench.adoc
@@ -338,7 +338,7 @@ image::query-workbench-result-plantext.png[,720]
 == Index Advisor
 
 [.labels]
-[.edition]##{enterprise}##[.status]##Developer Preview##
+[.edition]##{enterprise}##[.status]##Beta##
 
 include::ROOT:partial$enterprise-preview.adoc[tag=admonition]
 

--- a/modules/tools/pages/query-workbench.adoc
+++ b/modules/tools/pages/query-workbench.adoc
@@ -2,6 +2,18 @@
 :page-aliases: developer-guide:query-workbench-intro
 :imagesdir: ../assets/images
 
+:infer: xref:n1ql:n1ql-language-reference/infer.adoc
+:scan_consistency: xref:settings:query-settings.adoc#scan_consistency
+:limit: xref:n1ql:n1ql-language-reference/limit.adoc
+:update: xref:n1ql:n1ql-language-reference/update.adoc
+:delete: xref:n1ql:n1ql-language-reference/delete.adoc
+:explain: xref:n1ql:n1ql-language-reference/explain.adoc
+:select: xref:n1ql:n1ql-language-reference/selectintro.adoc
+:merge: xref:n1ql:n1ql-language-reference/merge.adoc
+:advise: xref:n1ql:n1ql-language-reference/advise.adoc
+:covering-indexes: xref:n1ql:n1ql-language-reference/covering-indexes.adoc
+:recommendation-rules: xref:n1ql:n1ql-language-reference/advise.adoc#recommendation-rules
+
 [abstract]
 The [.ui]*Query Workbench* provides a rich graphical user interface to perform query development.
 
@@ -11,7 +23,7 @@ Features of the Query Workbench include:
 
 * A single, integrated visual interface to perform query development and testing.
 * Easy viewing and editing of complex queries by providing features such as multi-line formatting, copy-and-paste, syntax coloring, auto completion of N1QL keywords and bucket and field names, and easy cursor movement.
-* View the structure of the documents in a bucket by using the N1QL xref:n1ql:n1ql-language-reference/infer.adoc[INFER] command.
+* View the structure of the documents in a bucket by using the N1QL {infer}[INFER] command.
 You no longer have to select the documents at random and guess the structure of the document.
 * Display query results in multiple formats: JSON, table, and tree.
 You can also save the query results to a file on disk.
@@ -44,7 +56,7 @@ The Query Editor provides the following additional features:
 * *Auto-completion* - When entering a keyword in the Query editor, if you press the kbd:[Tab] key or kbd:[Ctrl+Space], the tool offers a list of matching N1QL keywords and bucket names that are close to what you have typed so far.
 For names that have a space or a hyphen (-), the auto-complete option includes back quotes around the name.
 If you expand a bucket in the Data Bucket Analysis, the tool learns and includes the field names from the schema of the expanded bucket.
-* *Support for N1QL INFER statements* - In the Enterprise Edition, the tool supports the N1QL xref:n1ql:n1ql-language-reference/infer.adoc[INFER] statement.
+* *Support for N1QL INFER statements* - In the Enterprise Edition, the tool supports the N1QL {infer}[INFER] statement.
 
 == Run a Query
 
@@ -137,11 +149,11 @@ Select one of the following options:
 * request_plus
 * statement_plus
 
-For more information, see xref:settings:query-settings.adoc#scan_consistency[Settings and Parameters].
+For more information, see {scan_consistency}[Settings and Parameters].
 
 | Positional Parameters
 | For the prepared queries, this option allows you to specify values for $0, $1, and so on up to as many positional parameters as you have.
-Click the + button to add new positional parameters, and the - button to remove the parameters.
+Click the btn:[+] button to add new positional parameters, and the btn:[-] button to remove the parameters.
 The parameters are automatically labelled as "$0", "$1", and so on.
 
 | Named Parameters
@@ -168,7 +180,7 @@ These buckets do not support queries.
 You must first define an index before querying these buckets.
 
 With the Enterprise Edition, you can expand any bucket to view the schema for that bucket: field names, types, and if you hover the mouse pointer over a field name, you can see example values for that field.
-Bucket analysis is based on the N1QL xref:n1ql:n1ql-language-reference/infer.adoc[INFER] statement, which you can run manually to get more detailed results.
+Bucket analysis is based on the N1QL {infer}[INFER] statement, which you can run manually to get more detailed results.
 This command infers a schema for a bucket by examining a random sample of documents.
 Because the command is based on a random sample, the results may vary slightly from run to run.
 The default sample size is 1000 documents.
@@ -187,7 +199,7 @@ image::query-workbench-infer-sample.png[,720]
 == Viewing the Query Results
 
 When you execute a query, the results are displayed in the [.ui]*Query Results* area.
-Since large result sets can take a long time to display, we recommend using the xref:n1ql:n1ql-language-reference/limit.adoc[LIMIT] clause as part of your query when appropriate.
+Since large result sets can take a long time to display, we recommend using the {limit}[LIMIT] clause as part of your query when appropriate.
 
 When a query finishes, the query metrics for that query are displayed on the right side of the btn:[Execute] and btn:[Explain] buttons.
 
@@ -197,7 +209,7 @@ The values can be: success, failed, or HTTP codes.
 * Execution - Shows the query execution time.
 * Result Count - Shows the number of returned documents.
 * Mutation Count - Shows the number of documents deleted or changed by the query.
-This appears only for xref:n1ql:n1ql-language-reference/update.adoc[UPDATE] and xref:n1ql:n1ql-language-reference/delete.adoc[DELETE] queries instead of Result Count.
+This appears only for {update}[UPDATE] and {delete}[DELETE] queries instead of Result Count.
 * Result Size - Shows the size in bytes of the query result.
 
 The following figures display the result of the query `pass:c[SELECT * FROM `travel-sample` LIMIT 1;]` in different formats.
@@ -231,7 +243,7 @@ image::query-workbench-result-tree.png[,720]
 
 == Query Plans
 
-Each time a query is executed, an xref:n1ql:n1ql-language-reference/explain.adoc[EXPLAIN] command is automatically run in the background to retrieve the query plan for that query.
+Each time a query is executed, an {explain}[EXPLAIN] command is automatically run in the background to retrieve the query plan for that query.
 You may also generate the query plan by clicking btn:[Explain].
 
 To display the query plan, click the *Plan* link or the *Plan Text* link.
@@ -319,15 +331,18 @@ In general, the preference of scan is
 
 === Plan Text
 
-This simply shows the text output of the xref:n1ql:n1ql-language-reference/explain.adoc[EXPLAIN] command.
+This simply shows the text output of the {explain}[EXPLAIN] command.
 
 image::query-workbench-result-plantext.png[,720]
 
 == Index Advisor
 
-include::ROOT:partial$developer-preview.adoc[tag=admonition]
+[.labels]
+[.edition]##{enterprise}##[.status]##Developer Preview##
 
-When you execute a xref:n1ql:n1ql-language-reference/selectintro.adoc[SELECT] query, a xref:n1ql:n1ql-language-reference/merge.adoc[MERGE] query, an xref:n1ql:n1ql-language-reference/update.adoc[UPDATE] query, or a xref:n1ql:n1ql-language-reference/delete.adoc[DELETE] query, an xref:n1ql:n1ql-language-reference/advise.adoc[ADVISE] command is automatically run in the background to generate index advice for that query.
+include::ROOT:partial$enterprise-preview.adoc[tag=admonition]
+
+When you execute a {select}[SELECT] query, a {merge}[MERGE] query, an {update}[UPDATE] query, or a {delete}[DELETE] query, an {advise}[ADVISE] command is automatically run in the background to generate index advice for that query.
 You may also generate the index advice by clicking btn:[Advise].
 
 If index advice is available, an asterisk *{asterisk}* is displayed after the *Advice* link in the [.ui]*Query Results* area.
@@ -353,7 +368,7 @@ You can click btn:[Create & Build Indexes] to create and build these recommended
 This process may take a while.
 
 Covered Index Recommendations::
-If the Index Advisor can also recommend any xref:n1ql:n1ql-language-reference/covering-indexes.adoc[covering indexes] for this query, in addition to the secondary indexes, array indexes, functional indexes, or partial indexes, they are listed under this heading.
+If the Index Advisor can also recommend any {covering-indexes}[covering indexes] for this query, in addition to the secondary indexes, array indexes, functional indexes, or partial indexes, they are listed under this heading.
 +
 You can click btn:[Create & Build Covered Indexes] to create and build these recommended indexes.
 (The exact name of this button reflects the number of covering indexes that the Index Advisor recommends.)
@@ -369,4 +384,4 @@ If there is no index advice for this query, the results area may display the one
 
 * `Click 'Advise' to generate query index advice` -- the Index Advisor has not yet been run.
 
-Refer to xref:n1ql:n1ql-language-reference/advise.adoc#recommendation-rules[Recommendation Rules] for details of the rules that the index advisor uses to recommend an index.
+Refer to {recommendation-rules}[Recommendation Rules] for details of the rules that the index advisor uses to recommend an index.


### PR DESCRIPTION
The following documentation is ready for review.

* [ADVISE](https://simon-dew.github.io/docs-site/MB-37362/server/6.5/n1ql/n1ql-language-reference/advise.html) — improved explanation in Caution box
* [Query Workbench › Index Advisor](https://simon-dew.github.io/docs-site/MB-37362/server/6.5/tools/query-workbench.html#index-advisor) — ditto
* [Developer Preview Mode and Features › Developer Preview Features in This Release](https://simon-dew.github.io/docs-site/MB-37362/server/6.5/developer-preview/preview-mode.html#developer-preview-features-in-this-release)

Doc issue [MB-37362](https://issues.couchbase.com/browse/MB-37362)