### PR TITLE
DOC-6156: curl calls documentation: wrong port

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/curl.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/curl.adoc
@@ -230,7 +230,7 @@ From a CBQ prompt, you can send a CURL() command to allow or disallow specific U
 
 [source,shell]
 ----
-$ curl -X POST -u Administrator:password \ -d '{"all_access": true, "allowed_urls" : ["company1.com", "couchbase.com"], "disallowed_urls" : ["company2.com"] }' http://localhost:9000/settings/querySettings/curlWhitelist
+$ curl -X POST -u Administrator:password \ -d '{"all_access": true, "allowed_urls" : ["company1.com", "couchbase.com"], "disallowed_urls" : ["company2.com"] }' http://localhost:8091/settings/querySettings/curlWhitelist
 ----
 
 The access list file command structure is described in the following table.
@@ -696,7 +696,7 @@ $ curl -X POST -u Administrator:password \
 "all_access": true,
 "allowed_urls" : ["company1.com", "couchbase.com"],
 "disallowed_urls" : ["company2.com"]
-}' http://localhost:9000/settings/querySettings/curlWhitelist
+}' http://localhost:8091/settings/querySettings/curlWhitelist
 ----
 ====
 
@@ -709,7 +709,7 @@ $ curl -X POST -u Administrator:password \
 $ curl -X POST -u Administrator:password \
 -d '{
 "all_access": true
-}' http://localhost:9000/settings/querySettings/curlWhitelist
+}' http://localhost:8091/settings/querySettings/curlWhitelist
 ----
 ====
 
@@ -724,7 +724,7 @@ $ curl -X POST -u Administrator:password \
 "all_access": false,
 "allowed_urls" : [],
 "disallowed_urls" : []
-}' http://localhost:9000/settings/querySettings/curlWhitelist
+}' http://localhost:8091/settings/querySettings/curlWhitelist
 ----
 ====
 
@@ -737,7 +737,7 @@ $ curl -X POST -u Administrator:password \
 $ curl -X POST -u Administrator:password \
 -d '{
 "all_access": false
-}' http://localhost:9000/settings/querySettings/curlWhitelist
+}' http://localhost:8091/settings/querySettings/curlWhitelist
 ----
 ====
 
@@ -752,7 +752,7 @@ $ curl -X POST -u Administrator:password \
 "all_access": false,
 "allowed_urls" : ["https://maps.googleapis.com/maps/api/geocode/json"],
 "disallowed_urls" : []
-}' http://localhost:9000/settings/querySettings/curlWhitelist
+}' http://localhost:8091/settings/querySettings/curlWhitelist
 ----
 ====
 
@@ -767,7 +767,7 @@ $ curl -X POST -u Administrator:password \
 "all_access": false,
 "disallowed_urls" : ["https://maps.googleapis.com/maps/api/geocode/json"],
 "allowed_urls" : []
-}' http://localhost:9000/settings/querySettings/curlWhitelist
+}' http://localhost:8091/settings/querySettings/curlWhitelist
 ----
 ====
 
@@ -782,7 +782,7 @@ $ curl -X POST -u Administrator:password \
 "all_access": false,
 "disallowed_urls" : ["https://maps.googleapis.com/maps/api/geocode/json"],
 "allowed_urls" : ["http://127.0.0.1:9499/query/service"]
-}' http://localhost:9000/settings/querySettings/curlWhitelist
+}' http://localhost:8091/settings/querySettings/curlWhitelist
 ----
 ====
 
@@ -797,7 +797,7 @@ $ curl -X POST -u Administrator:password \
 "all_access": false,
 "disallowed_urls" : ["https://maps.googleapis.com/maps/api/geocode/json"],
 "allowed_urls" : ["https://maps.googleapis.com/maps/api/geocode/json"]
-}' http://localhost:9000/settings/querySettings/curlWhitelist
+}' http://localhost:8091/settings/querySettings/curlWhitelist
 ----
 ====
 


### PR DESCRIPTION
The following documentation is ready for review:

* [CURL Function](https://github.com/couchbase/docs-server/pull/975/files#diff-f0cbd2edf768fd233287410643f035f0) — change port 9000 to 8091 in examples

Docs issue: [DOC-6165](https://issues.couchbase.com/browse/DOC-6156)