### PR TITLE
Correct language ref link to 'FROM clause'

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/hints.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/hints.adoc
@@ -6,7 +6,7 @@ The `USE` clause enables you to specify that the query should use particular key
 
 == Purpose
 
-The `USE` clause is used within the xref:n1ql-language-reference/join.adoc[FROM] clause.
+The `USE` clause is used within the xref:n1ql-language-reference/from.adoc[FROM] clause.
 It enables you to provide a hint to the query service, specifying that the query should use particular keys, or a particular index.
 
 == Prerequisites


### PR DESCRIPTION
Still incorrect in the mad-hatter branch, so this will need cherry-picking over.