### PR TITLE
Make "Collections" link to collections overview

### DIFF
--- a/modules/developer-preview/pages/preview-mode.adoc
+++ b/modules/developer-preview/pages/preview-mode.adoc
@@ -67,12 +67,9 @@ SUCCESS: Cluster is in developer preview mode
 
 The Developer Preview mode in Couchbase Server 6.5 unlocks the following features:
 
-* Collections -- These are data containers that can be created within any bucket whose type is either _Couchbase_ or _Ephemeral_.
+* xref:developer-preview:collections/collections-overview.adoc[Collections] -- These are data containers that can be created within any bucket whose type is either _Couchbase_ or _Ephemeral_.
 +
-This allows data-items optionally to be assigned to different collections according to content-type.
-+
-For the Developer Preview, collections can be managed by either the _REST API_ or the _CLI_.
-For more information, see xref:developer-preview:collections/collections-overview.adoc[Collections Overview].
+This allows data-items optionally to be assigned to different collections according to content-type. Once Developer Preview mode is enabled, collections can be managed by either the _REST API_ or the _CLI_.
 
 * High Data Density
 


### PR DESCRIPTION
It looks better if in each case the first word after the bullet point links to the actual content.