### PR TITLE
DOC-5670: Stale=ok scans are now allowed during indexer warmup

### DIFF
--- a/modules/learn/pages/clusters-and-availability/recovery.adoc
+++ b/modules/learn/pages/clusters-and-availability/recovery.adoc
@@ -89,6 +89,6 @@ However, in cases where the node’s memory-footprint is extremely large, and da
 In Couchbase Server 6.5 and later, it is possible to request a xref:learn:services-and-indexes/indexes/index-scans.adoc[scan] from each index as soon as it has warmed up -- you do not have to wait for the recovery to be complete.
 This can reduce the downtime during recovery.
 
-Only scans where `stale=ok`, or scans for which a consistent snapshot is available, are allowed during recovery.
+Only scans where consistency is `not_bounded`, or scans for which a consistent snapshot is available, are allowed during recovery.
 In other cases, an error is returned so that replicas can be tried.
 ====

--- a/modules/learn/pages/clusters-and-availability/recovery.adoc
+++ b/modules/learn/pages/clusters-and-availability/recovery.adoc
@@ -83,3 +83,12 @@ This indicates that one or more of the following conditions exist:
 In many cases, Delta recovery is faster than Full recovery; since a significant quantity of usable data already resides on the node, and therefore does not require network-transfer: only updates made since the node’s last-recorded mutation need to be accessed from other nodes in the cluster.
 
 However, in cases where the node’s memory-footprint is extremely large, and data exceeds bucket memory-quotas, the memory-management overhead potentially entailed by Delta recovery might imply Full recovery’s taking less time overall.
+
+[NOTE]
+====
+In Couchbase Server 6.5 and later, it is possible to request a xref:learn:services-and-indexes/indexes/index-scans.adoc[scan] from each index as soon as it has warmed up -- you do not have to wait for the recovery to be complete.
+This can reduce the downtime during recovery.
+
+Only scans where `stale=ok`, or scans for which a consistent snapshot is available, are allowed during recovery.
+In other cases, an error is returned so that replicas can be tried.
+====


### PR DESCRIPTION
Added note to Recovery page. See [Files changed](https://github.com/couchbase/docs-server/pull/1002/files).

Docs issue: [DOC-5670](https://issues.couchbase.com/browse/DOC-5670)