### PR TITLE
DOC-4953 Update cbbackupmgr matrix to 6.0

### DIFF
--- a/modules/backup-restore/pages/enterprise-backup-restore.adoc
+++ b/modules/backup-restore/pages/enterprise-backup-restore.adoc
@@ -64,15 +64,25 @@ Consult the following table to see which versions are compatible.
 .Enterprise Backup Restore Compatibility
 [hrows=2]
 |===
-.2+| Restore host cluster version / [.cmd]`cbbackupmgr` version: 5+| Can restore data backed up from Couchbase Server version:
+.2+| Restore host cluster version / [.cmd]`cbbackupmgr` version: 6+| Can restore data backed up from Couchbase Server version:
 
+h| 6.0
 h| 5.5
 h| 5.1
 h| 5.0
 h| 4.6
 h| 4.5
 
+| Couchbase Server 6.0
+| ✓
+| ✓
+| ✓
+| ✓
+|
+|
+
 | Couchbase Server 5.5
+|
 | ✓
 | ✓
 | ✓
@@ -81,12 +91,14 @@ h| 4.5
 
 | Couchbase Server 5.1
 |
+|
 | ✓
 | ✓
 |
 |
 
 | Couchbase Server 5.0
+|
 |
 |
 | ✓
@@ -97,10 +109,12 @@ h| 4.5
 |
 |
 |
+|
 | ✓
 | ✓
 
 | Couchbase Server 4.5
+|
 |
 |
 |


### PR DESCRIPTION
The following documentation is ready for review: [cbbackupmgr Tool 6.0 Version Compatibility
](https://eric-schneider.github.io/DOC-4953-6.0/server/6.0/backup-restore/enterprise-backup-restore.html#version-compatibility)

Documentation Issue: [DOC-4953](https://issues.couchbase.com/browse/DOC-4953)