### PR TITLE
DOC-4953 Update cbbackupmgr matrix to 6.5

### DIFF
--- a/modules/backup-restore/pages/enterprise-backup-restore.adoc
+++ b/modules/backup-restore/pages/enterprise-backup-restore.adoc
@@ -64,15 +64,25 @@ Consult the following table to see which versions are compatible.
 .Enterprise Backup Restore Compatibility
 [hrows=2]
 |===
-.2+| Restore host cluster version / [.cmd]`cbbackupmgr` version: 5+| Can restore data backed up from Couchbase Server version:
+.2+| Restore host cluster version / [.cmd]`cbbackupmgr` version: 6+| Can restore data backed up from Couchbase Server version:
 
+h| 6.0
 h| 5.5
 h| 5.1
 h| 5.0
 h| 4.6
 h| 4.5
 
+| Couchbase Server 6.0
+| ✓
+| ✓
+| ✓
+| ✓
+|
+|
+
 | Couchbase Server 5.5
+|
 | ✓
 | ✓
 | ✓
@@ -81,12 +91,14 @@ h| 4.5
 
 | Couchbase Server 5.1
 |
+|
 | ✓
 | ✓
 |
 |
 
 | Couchbase Server 5.0
+|
 |
 |
 | ✓
@@ -97,10 +109,12 @@ h| 4.5
 |
 |
 |
+|
 | ✓
 | ✓
 
 | Couchbase Server 4.5
+|
 |
 |
 |

--- a/modules/backup-restore/pages/enterprise-backup-restore.adoc
+++ b/modules/backup-restore/pages/enterprise-backup-restore.adoc
@@ -64,8 +64,9 @@ Consult the following table to see which versions are compatible.
 .Enterprise Backup Restore Compatibility
 [hrows=2]
 |===
-.2+| Restore host cluster version / [.cmd]`cbbackupmgr` version: 6+| Can restore data backed up from Couchbase Server version:
+.2+| Restore host cluster version / [.cmd]`cbbackupmgr` version: 7+| Can restore data backed up from Couchbase Server version:
 
+h| 6.5
 h| 6.0
 h| 5.5
 h| 5.1
@@ -73,7 +74,17 @@ h| 5.0
 h| 4.6
 h| 4.5
 
+| Couchbase Server 6.5
+| ✓
+| *
+| *
+| *
+| *
+|
+|
+
 | Couchbase Server 6.0
+|
 | ✓
 | ✓
 | ✓
@@ -83,6 +94,7 @@ h| 4.5
 
 | Couchbase Server 5.5
 |
+|
 | ✓
 | ✓
 | ✓
@@ -90,6 +102,7 @@ h| 4.5
 |
 
 | Couchbase Server 5.1
+|
 |
 |
 | ✓
@@ -101,11 +114,13 @@ h| 4.5
 |
 |
 |
+|
 | ✓
 | ✓
 |
 
 | Couchbase Server 4.6
+|
 |
 |
 |
@@ -119,5 +134,8 @@ h| 4.5
 |
 |
 |
+|
 | ✓
 |===
+
+*Support for restoring older backups with Couchbase Server 6.5 will be added in a future software update.

--- a/modules/backup-restore/pages/enterprise-backup-restore.adoc
+++ b/modules/backup-restore/pages/enterprise-backup-restore.adoc
@@ -76,10 +76,10 @@ h| 4.5
 
 | Couchbase Server 6.5
 | ✓
-| *
-| *
-| *
-| *
+| ✓
+| ✓
+| ✓
+| ✓
 |
 |
 
@@ -137,5 +137,3 @@ h| 4.5
 |
 | ✓
 |===
-
-*Support for restoring older backups with Couchbase Server 6.5 will be added in a future software update.


### PR DESCRIPTION
The following documentation is ready for review: [cbbackupmgr Tool 6.5 Version Compatibility
](https://eric-schneider.github.io/DOC-4953-6.5/server/6.5/backup-restore/enterprise-backup-restore.html#version-compatibility)

Documentation Issue: [DOC-4953](https://issues.couchbase.com/browse/DOC-4953)