### PR TITLE
DOC-5671: new stat available for knowing last scan time of an index

### DIFF
--- a/modules/rest-api/partials/index-stats/definitions.adoc
+++ b/modules/rest-api/partials/index-stats/definitions.adoc
@@ -38,6 +38,10 @@ ifdef::basebackend-html[]
 endif::[]
 
 
+* <<_node>>
+* <<_index>>
+
+
 [[_node]]
 === Node
 

--- a/modules/rest-api/partials/index-stats/definitions.adoc
+++ b/modules/rest-api/partials/index-stats/definitions.adoc
@@ -108,7 +108,11 @@ For an index partition, the value is listed as `0`. +
 __optional__|The number of items currently indexed. +
 **Example** : `2155`|integer
 |**last_known_scan_time** +
-__optional__|Time of the last scan request received for this index (Unix timestamp in nanoseconds).|integer
+__optional__|Time of the last scan request received for this index (Unix timestamp in nanoseconds).
+This may be useful for determining whether this index is currently unused.
+
+[NOTE]
+This statistic is persisted to disk every 15 minutes, so it is preserved when the indexer restarts.|integer
 |**num_docs_indexed** +
 __optional__|Number of documents indexed by the indexer since last startup.|integer
 |**num_docs_pending** +

--- a/modules/rest-api/partials/index-stats/paths.adoc
+++ b/modules/rest-api/partials/index-stats/paths.adoc
@@ -6,6 +6,10 @@
 [[_paths]]
 == Paths
 
+* <<_get_node_stats>>
+* <<_get_index_stats>>
+
+
 [[_get_node_stats]]
 === Get Statistics for an Index Node
 ....


### PR DESCRIPTION
The following documentation is ready for review:

* See [Files changed](https://github.com/couchbase/docs-server/pull/1007/files)

Docs issue: [DOC-5671](https://issues.couchbase.com/browse/DOC-5671)