### PR TITLE
DOC-6225: Data Access Using N1QL redirect

### DIFF
--- a/modules/n1ql/pages/query.adoc
+++ b/modules/n1ql/pages/query.adoc
@@ -1,6 +1,6 @@
 = Query: Fundamentals
 :page-topic-type: concept
-:page-aliases: n1ql:n1ql-intro/data-access-using-n1ql
+:page-aliases: n1ql:index,n1ql:n1ql-intro/data-access-using-n1ql
 
 [abstract]
 The Query Service supports the querying of data by means of the N1QL query language.

--- a/modules/n1ql/pages/query.adoc
+++ b/modules/n1ql/pages/query.adoc
@@ -1,5 +1,6 @@
 = Query: Fundamentals
 :page-topic-type: concept
+:page-aliases: n1ql:n1ql-intro/data-access-using-n1ql
 
 [abstract]
 The Query Service supports the querying of data by means of the N1QL query language.


### PR DESCRIPTION
In release/6.5, Data access using N1QL will redirect to the new Query: Fundamentals page.

Also redirected the former top-level N1QL index to the new Query: Fundamentals page.

Docs issue [DOC-6225](https://issues.couchbase.com/browse/DOC-6225)