### PR TITLE
Updated to reflect Eventing errata

### DIFF
--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -25,6 +25,10 @@ Starting with version 6.5, `cbbackupmgr` will leverage Server compression and ba
 If the data is compressed by default, it will be backed up as compressed.
 If the data is not compressed, it will be compressed first and then backed up when value compression is opted. This improves the performance by reducing the size of the data set to back up for transmission on the pipe and for the backup itself.
 
+==== Eventing Service
+
+* The internal class `N1qlQuery()` has been removed and replaced with internal class `N1QL()`, and the latter is not syntactically backwards compatible with former.
+
 ==== Networking
 
 This release introduces the following networking changes:
@@ -138,24 +142,19 @@ This section highlights some of the known issues in this release.
 |===
 | Issue | Description
 
-| https://issues.couchbase.com/browse/MB-37042[MB-3704^]
+| https://issues.couchbase.com/browse/MB-37042[MB-37042^]
 | *Summary*: The CLI and REST tools for exporting and importing Eventing functions do not support cross compatible syntax when using only the command line, however the UI can import either syntax.
 
 | https://issues.couchbase.com/browse/MB-33111[MB-33111^]
-| *Summary*: N1QL DML statements cannot manipulate documents in the same bucket as the handler is listening for mutations on to avoid recursion. Work around use the exposed data service KV map.
+| *Summary*: N1QL DML statements cannot manipulate documents in the same bucket as the handler is listening for mutations on to avoid recursion. 
+
+*Workaround*: Use the exposed data service KV map.
 
 | https://issues.couchbase.com/browse/MB-32437[MB-32437^]
 | *Summary*: In a multi-bucket scenario approaching the new 30 bucket limit, the Eventing service supports only one function per bucket. An error will be thrown when deploying the second function on a given bucket. 
 
-| https://issues.couchbase.com/browse/MB-32244[MB-32244^]
-| *Summary*: When dealing with non-existent keys. The `get` operation will now return undefined if the key doesn’t exist and the `delete` operation will now be treated as a no-op if the key doesn’t exist. Prior to version 6.5 both operations ( `get` or `delete`) threw exceptions when applied against non-existent keys. Note, the "_language compatibility_" setting in the Function Settings dialog allows for backward compatibility to maintaining prior behavior.
-
 | https://issues.couchbase.com/browse/MB-31639[MB-31639^]
 | *Summary*: The `cbbackupmgr` utility fails to backup a cluster with Eventing service for a user with "Data Backup & Restore" role.
-
-| https://issues.couchbase.com/browse/DOC-5427[DOC-5427^]
-| *Summary*: The internal class `N1qlQuery()` has been removed, and replaced with internal class `N1QL()` and the latter is not syntactically backwards compatible with former.
-
 |===
 
 ==== Index Service and Views
@@ -178,6 +177,15 @@ This section highlights some of the known issues in this release.
 | *Summary*: The `cbupgrade` script fails to upgrade single node IPv6 clusters.
 |===
 
+==== Tools, Web Console (UI), and REST API
+
+[#table_knownissues_v650-tools-ui-rest-api,cols="25,66"]
+|===
+| Issue | Description
+
+| https://issues.couchbase.com/browse/MB-37768[MB-37768^]
+| *Summary*: On macOS (and OS-X) the `cbc` binary needs @rpath to be manually set on the `cbc` binary, this will allow proper execution of `cbc` (and related symlinked command line tools).
+|===
 
 [#fixed-issues-650]
 === Fixed Issues
@@ -226,6 +234,16 @@ This section highlights some of the issues fixed in this release.
 | *Summary*: Fixed an issue where requesting the hash statistic severely affects the response times of replicateTo requests.
 |===
 
+==== Eventing Service
+
+[#table_fixedissues_v650-eventing,cols="25,66"]
+|===
+| Issue | Description
+
+| https://issues.couchbase.com/browse/MB-32244[MB-32244^]
+| *Summary*: When dealing with non-existent keys, the `get` operation will now return undefined if the key doesn’t exist and the `delete` operation will now be treated as a no-op if the key doesn’t exist. Prior to version 6.5 both operations ( `get` or `delete`) threw exceptions when applied against non-existent keys. Note, the "_language compatibility_" setting in the Function Settings dialog allows for backward compatibility to maintaining prior behavior.
+|===
+
 ==== Index Service and Views
 
 [#table_fixedissues_v650-gsi-views,cols="25,66"]
@@ -255,16 +273,6 @@ This section highlights some of the issues fixed in this release.
 | *Summary*: The install experience on Mac OS has been improved and starting this release, a disk image installer is available for Mac OS. 
 |===
 
-//==== Query Service
-
-//[#table_fixedissues_v650-query,cols="25,66"]
-//|===
-//| Issue | Description
-
-//| https://issues.couchbase.com/browse/MB-xxxx[MB-^]
-//| *Summary*: 
-//|===
-
 ==== Search Service
 
 [#table_fixedissues_v650-search,cols="25,66"]
@@ -280,10 +288,6 @@ This section highlights some of the issues fixed in this release.
 [#table_fixedissues_v650-tools-ui-rest-api,cols="25,66"]
 |===
 | Issue | Description
-
-
-| https://issues.couchbase.com/browse/MB-37768[MB-37768^]
-| *Summary*: On macOS (and OS-X) the `cbc` binary needs @rpath to be manually set on the `cbc` binary, this will allow proper execution of `cbc` (and related symlinked command line tools).
 
 | https://issues.couchbase.com/browse/MB-35840[MB-35840^]
 | *Summary*: The View index build progress information was missing on the UI and has been fixed.

--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -138,11 +138,24 @@ This section highlights some of the known issues in this release.
 |===
 | Issue | Description
 
+| https://issues.couchbase.com/browse/MB-37042[MB-3704^]
+| *Summary*: The CLI and REST tools for exporting and importing Eventing functions do not support cross compatible syntax when using only the command line, however the UI can import either syntax.
+
+| https://issues.couchbase.com/browse/MB-33111[MB-33111^]
+| *Summary*: N1QL DML statements cannot manipulate documents in the same bucket as the handler is listening for mutations on to avoid recursion. Work around use the exposed data service KV map.
+
 | https://issues.couchbase.com/browse/MB-32437[MB-32437^]
-| *Summary*: In a multi-bucket scenario with 30 or more buckets, the Eventing service supports only one function per bucket. An error will be thrown when deploying the second function on a given bucket. 
+| *Summary*: In a multi-bucket scenario approaching the new 30 bucket limit, the Eventing service supports only one function per bucket. An error will be thrown when deploying the second function on a given bucket. 
+
+| https://issues.couchbase.com/browse/MB-32244[MB-32244^]
+| *Summary*: When dealing with non-existent keys. The `get` operation will now return undefined if the key doesn’t exist and the `delete` operation will now be treated as a no-op if the key doesn’t exist. Prior to version 6.5 both operations ( `get` or `delete`) threw exceptions when applied against non-existent keys. Note, the "_language compatibility_" setting in the Function Settings dialog allows for backward compatibility to maintaining prior behavior.
 
 | https://issues.couchbase.com/browse/MB-31639[MB-31639^]
 | *Summary*: The `cbbackupmgr` utility fails to backup a cluster with Eventing service for a user with "Data Backup & Restore" role.
+
+| https://issues.couchbase.com/browse/DOC-5427[DOC-5427^]
+| *Summary*: The internal class `N1qlQuery()` has been removed, and replaced with internal class `N1QL()` and the latter is not syntactically backwards compatible with former.
+
 |===
 
 ==== Index Service and Views
@@ -267,6 +280,10 @@ This section highlights some of the issues fixed in this release.
 [#table_fixedissues_v650-tools-ui-rest-api,cols="25,66"]
 |===
 | Issue | Description
+
+
+| https://issues.couchbase.com/browse/MB-37768[MB-37768^]
+| *Summary*: On macOS (and OS-X) the `cbc` binary needs @rpath to be manually set on the `cbc` binary, this will allow proper execution of `cbc` (and related symlinked command line tools).
 
 | https://issues.couchbase.com/browse/MB-35840[MB-35840^]
 | *Summary*: The View index build progress information was missing on the UI and has been fixed.


### PR DESCRIPTION
New MB-37042
The CLI and REST tools for exporting and importing Eventing functions do not support cross compatible syntax when using only the command line, however the UI can import either syntax.

New MB-33111
N1QL DML statements cannot manipulate documents in the same bucket as the handler is listening to (but KV can)

Update to MB-32437
we only support a max of 30 buckets
Use the term "approaching the new 30 bucket limit" rather than "with 30 or more buckets" as it is more realistic to the MB

New MB-32244
get/delete behavior change and "language compatibility" setting

New DOC-5427 (and DOC-6097)
Note DOC-5427 is more descriptive to use in the release notes for "Change from N1qlQuery() to N1QL()" note there is no MB filed for this particular change.

New MB-37768
As the documentation for Evening in 6.5 will rely on 'cbc' to demonstrate expiry (pending update) it is critical that the 'cbc' tool work out of the box after an EE install on all platforms.  The 'cbc' binary is missing @rpath to be manually set as follows:

cd /Applications/Couchbase\ Server.app/Contents/Resources/couchbase-core/bin
install_name_tool -add_rpath @executable_path/../lib cbc