### PR TITLE
Clarify customer feedback, correct macOS path

### DIFF
--- a/modules/eventing/pages/eventing-debugging-and-diagnosability.adoc
+++ b/modules/eventing/pages/eventing-debugging-and-diagnosability.adoc
@@ -44,14 +44,16 @@ As a result, the next event-instance gets trapped and is forwarded to the Debugg
 In the below screen, you can notice the message: "Waiting for mutation."
 +
 image::debug_2.png[,400]
++
+NOTE: During a debugging session this window must remain active. When you are presented a debug URL you must copy then paste it into a new browser window (described below). If you are using the UI to create the mutation, you must use a different browser window to create the mutation. 
 
-. Upon a data mutation, the debug URL in the Debugging pop-up gets populated and the *Copy* button is enabled.
+. Upon a data mutation, the debug URL in the Debugging pop-up gets populated and the *Copy* button is enabled.  
 +
 image::debug_3.png[,400]
 
 . Click *Copy* in the pop-up. 
 
-. Paste the URL from the Debugging pop-up that you copied to your Google Chrome browser's address bar.  
+. Paste the URL from the Debugging pop-up that you copied into a new window (or tab) in your Google Chrome browser's address bar.  
 +
 image::debug_4.png[,100%]
 
@@ -137,7 +139,7 @@ NOTE: The *cbcollect_info* tool does not collect the Application log files.
 (Assumes default installation location)
 
 | Mac OS X
-| /Users/<user>/Library/Application Support/Couchbase/var/lib/ couchbase/data/@eventing
+| /Users/<user>/Library/Application\ Support/Couchbase/var/lib/ couchbase/data/@eventing
 |===
 
 


### PR DESCRIPTION
1. Clarify customer feedback that the debug window must remain active 
   https://forums.couchbase.com/t/problem-with-debug-option-ui/24730
   We want to avoid further forum questions ahead of time.

2. Escape the space in the macOS path for correct cut-n-paste behavior