### PR TITLE
Adding an example to show N1QL queries against custom FTS index(es)

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
@@ -325,7 +325,7 @@ WHERE t1.type = "airline" AND SEARCH(t1.country, "United States");
 ...
 ----
 
-If the FTS index that is being queried here, has it's default mapping disabled and has a custom type mapping defined ("airline" in the above example), the query would need to explicitly specify the "type".
+If the FTS index being queried has it's default mapping disabled and has a custom type mapping defined ("airline" in the above example), the query would need to explicitly specify the "type".
 Here's more on how you could define custom type mappings within the FTS index xref:fts:fts-creating-indexes.adoc[Specifying Type Mappings].
 Note that for N1QL queries, an FTS index with only 1 type mapping will be searchable.
 ====

--- a/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
@@ -300,6 +300,36 @@ This query returns 10 results, and the results are ordered, as specified by the 
 As an alternative, you could limit the number of results and order them using the N1QL xref:n1ql-language-reference/limit.adoc[LIMIT] and xref:n1ql-language-reference/orderby.adoc[ORDER BY] clauses.
 ====
 
+.Search against an FTS index that carries a custom type mapping
+====
+[source,n1ql]
+----
+SELECT META(t1).id
+FROM `travel-sample` AS t1
+WHERE t1.type = "airline" AND SEARCH(t1.country, "United States");
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "id": "airline_2577"
+  },
+  {
+    "id": "airline_2395"
+  },
+  {
+    "id": "airline_2657"
+  },
+...
+----
+
+If the FTS index that is being queried here, has it's default mapping disabled and has a custom type mapping defined ("airline" in the above example), the query would need to explicitly specify the "type".
+Here's more on how you could define custom type mappings within the FTS index xref:fts:fts-creating-indexes.adoc[Specifying Type Mappings].
+Note that for N1QL queries, an FTS index with only 1 type mapping will be searchable.
+====
+
 [[search_meta,SEARCH_META()]]
 == SEARCH_META([`identifier`])
 


### PR DESCRIPTION
Custom FTS index => FTS index with a custom type mapping