### PR TITLE
DOC-6178: Indexer DCP rollback

### DIFF
--- a/modules/learn/pages/services-and-indexes/indexes/index-replication.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/index-replication.adoc
@@ -4,7 +4,7 @@
 
 :index-service: xref:services-and-indexes/services/index-service.adoc
 :index-partitioning: xref:n1ql:n1ql-language-reference/index-partitioning.adoc
-:automatic-failover: xref:learn:clusters-and-availability/automatic-failover.adoc
+:failover: xref:learn:clusters-and-availability/failover.adoc
 :database-change-protocol: xref:learn:clusters-and-availability/intra-cluster-replication.adoc#database-change-protocol
 :index-storage-mode: xref:manage:manage-settings/general-settings.adoc#index-storage-mode
 :index-storage-settings-via-cli: xref:manage:manage-settings/general-settings.adoc#index-storage-settings-via-cli
@@ -109,9 +109,10 @@ For N1QL, the default consistency is `not_bounded`.
 [[index-snapshots]]
 == Index Snapshots
 
-A {database-change-protocol}[snapshot] of the index is maintained on disk, to permit rapid recovery if node-failures are experienced.
+One or more index {database-change-protocol}[snapshots] are maintained on disk, to permit rapid recovery if node-failures are experienced.
 In cases where recovery requires an Index-Service node to be restarted, the node’s indexes are rebuilt from the snapshots retained on disk.
 
+By default, two index snapshots are stored on disk.
 You can change index snapshot settings via the {index-storage-settings-via-cli}[CLI] or the {index-settings-via-rest}[REST API].
 
 [[index-rollback]]
@@ -121,23 +122,23 @@ The index service also maintains a {database-change-protocol}[DCP failover log].
 If necessary, the data service can request the index service to return to a specified rollback point and update its history.
 
 You can change index rollback settings via the {index-storage-settings-via-cli}[CLI] or the {index-settings-via-rest}[REST API].
-You can also change the number of committed rollback points for memory-optimized index storage via the {index-storage-mode}[UI].
 
 [[index-rollback-after-failover]]
-=== Index Rollback After Auto-Failover
+=== Index Rollback After Failover
 
-When a data node {automatic-failover}[fails over automatically], a replica data node is promoted to active.
+When a data node {failover}[fails over], a replica data node is promoted to active.
 If the index service has more recent data than the new active data node, the data node issues a rollback request to the index service.
 
-In Couchbase Server 6.5 and later, when the index service receives the rollback request, it first attempts to revert to a current index snapshot.
-If successful, the index service does not need to rebuild its indexes from scratch when the data node fails over automatically.
+In Couchbase Server 6.5 and later, when the index service receives the rollback request, it first attempts to revert to a stored index snapshot.
+If successful, the index service does not need to rebuild its indexes from scratch when the data node fails over.
 The index service can continue servicing query clients without interruption.
 
 If the index service cannot revert to a current index snapshot, it rebuilds all indexes from scratch.
 
 [NOTE]
 ====
-If <<index-consistency,scan consistency>> is set to `not_bounded` or `at_plus`, the index service may return stale data for a short time after reverting to a snapshot, until the index service is fully up-to-date with the new active data node.
+If <<index-consistency,scan consistency>> is set to `not_bounded`, the index service may return stale data for a short time after reverting to a snapshot, until the index service is fully up-to-date with the new active data node.
+
 If <<index-consistency,scan consistency>> is set to `request_plus`, the index service will not perform any scans until a consistent snapshot is created.
 In this case, stale results are not returned.
 ====

--- a/modules/learn/pages/services-and-indexes/indexes/index-replication.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/index-replication.adoc
@@ -66,7 +66,7 @@ With credentials that provide appropriate authorization, this default can be cha
 +
 [source,shell]
 ----
-$ curl -u <username>:<password> <host>:9102/settings -d "{\"indexer.settings.num_replica\": <num_replicas>}"
+curl -u <username>:<password> <host>:9102/settings -d "{\"indexer.settings.num_replica\": <num_replicas>}"
 ----
 +
 Note, however, that whenever explicit specification of replica-numbers is made within the `CREATE INDEX` statement, this explicit specification takes precedence over any established default.

--- a/modules/learn/pages/services-and-indexes/indexes/index-replication.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/index-replication.adoc
@@ -2,10 +2,20 @@
 :page-partial:
 :page-aliases: indexes:index-replication,indexes:performance-consistency,understanding-couchbase:services-and-indexes/indexes/index-replication
 
+:index-service: xref:services-and-indexes/services/index-service.adoc
+:index-partitioning: xref:n1ql:n1ql-language-reference/index-partitioning.adoc
+:automatic-failover: xref:learn:clusters-and-availability/automatic-failover.adoc
+:database-change-protocol: xref:learn:clusters-and-availability/intra-cluster-replication.adoc#database-change-protocol
+:index-storage-mode: xref:manage:manage-settings/general-settings.adoc#index-storage-mode
+:index-storage-settings-via-cli: xref:manage:manage-settings/general-settings.adoc#index-storage-settings-via-cli
+:index-settings-via-rest: xref:manage:manage-settings/general-settings.adoc#index-settings-via-rest
+:query: xref:n1ql:query.adoc
+
 [abstract]
 The _Index Service_ ensures availability and performance through _replication_ and _partitioning_.
 The _consistency_ of query-results can be controlled per query.
 
+[[index-replication]]
 == Index Replication
 
 Secondary indexes can be replicated across cluster-nodes.
@@ -15,7 +25,7 @@ This ensures:
 * _High Performance_: If original and replica copies are available, incoming queries are load-balanced across them.
 
 Index-replicas can be created with the N1QL `CREATE INDEX` statement.
-Note that whenever a given number of index-replicas is specified for creation, the number must be less than the number of cluster-nodes currently running the xref:services-and-indexes/services/index-service.adoc[Index Service].
+Note that whenever a given number of index-replicas is specified for creation, the number must be less than the number of cluster-nodes currently running the {index-service}[Index Service].
 If it is not, the index creation fails.
 Note also that if, following creation of the maximum number of copies, the number of nodes running the Index Service decreases, Couchbase Server progressively assigns replacement index-replicas to any and all Index-Service nodes subsequently be added to the cluster, until the required number of index-replicas again exists for each replicated index.
 
@@ -50,7 +60,7 @@ The default is `0`.
 If the default is changed to, say, `2`, creation of a single index is henceforth accompanied by the creation of two replicas, which are automatically distributed across the nodes of the cluster running the Index Service.
 No explicit specification within the `CREATE INDEX` statement is required.
 +
-With credentials that provide appropriate authorization, this default can be changed; by means of the `curl` command, as follows:
+With credentials that provide appropriate authorization, this default can be changed by means of the `curl` command, as follows:
 +
 ----
 curl -u <username>:<password> <host>:9102/settings -d "{\"indexer.settings.num_replica\": <num_replicas>}"
@@ -58,8 +68,9 @@ curl -u <username>:<password> <host>:9102/settings -d "{\"indexer.settings.num_r
 +
 Note, however, that whenever explicit specification of replica-numbers is made within the `CREATE INDEX` statement, this explicit specification takes precedence over any established default.
 
-For further information on using N1QL, see xref:java-sdk::n1ql-query.adoc[Querying with N1QL].
+For further information on using N1QL, refer to {query}[Query Fundamentals].
 
+[[index-partitioning]]
 == Index Partitioning
 
 _Index Partitioning_ increases query performance, by dividing and spreading a large index of documents across multiple nodes. This feature is available only in Couchbase Server Enterprise Edition.
@@ -74,8 +85,9 @@ The benefits include:
 
 * Provision of a low-latency range query, while allowing indexes to be scaled out as needed.
 
-For detailed information, see xref:n1ql:n1ql-language-reference/index-partitioning.adoc[Index Partitioning].
+For detailed information, refer to {index-partitioning}[Index Partitioning].
 
+[[index-consistency]]
 == Index Consistency
 
 Whereas Couchbase Server handles data-mutations with _full consistency_ — all mutations to a given key are applied to the same vBucket, and become immediately available — it maintains indexes with degrees of _eventual consistency_, determined by means of the following query consistency-options, specified per query:
@@ -90,3 +102,30 @@ If index-maintenance is running behind, the query waits for it to catch up.
 
 For N1QL, the default consistency is `not_bounded`.
 // end::scan_consistency[]
+
+[[index-snapshots]]
+== Index Snapshots
+
+A {database-change-protocol}[snapshot] of the index is maintained on disk, to permit rapid recovery if node-failures are experienced.
+In cases where recovery requires an Index-Service node to be restarted, the node’s indexes are rebuilt from the snapshots retained on disk.
+
+You can change the number of committed rollback points for memory-optimized index storage via the {index-storage-mode}[UI].
+You can change more index snapshot settings via the {index-storage-settings-via-cli}[CLI] or the {index-settings-via-rest}[REST API].
+
+[[index-rollback]]
+=== Index Rollback
+
+When a data node {automatic-failover}[fails over automatically], a replica data node is promoted to active.
+If the index service has more recent data than the new active data node, the data node issues a {database-change-protocol}[DCP rollback request] to the index service.
+
+In Couchbase Server 6.5 and later, when the index service receives the rollback request, it first attempts to roll back to a current index snapshot.
+If successful, the index service does not need to rebuild its indexes from scratch when the data node fails over automatically.
+The index service can continue servicing query clients without interruption.
+
+If the index service cannot roll back to a current index snapshot, it rebuilds all indexes from scratch.
+
+[NOTE]
+====
+If <<index-consistency,scan consistency>> is set to `not_bounded` or `at_plus`, the index service may return stale data for a short time after rolling back to a snapshot, until the index service is fully up-to-date with the new active data node.
+If <<index-consistency,scan consistency>> is set to `request_plus`, the index service will not perform any scans until a consistent snapshot is created.
+In this case, stale results are not returned.

--- a/modules/learn/pages/services-and-indexes/indexes/index-replication.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/index-replication.adoc
@@ -36,6 +36,7 @@ In the following example, an index with two replicas is created.
 The active index is on `node1`, and the replicas are on `node2` and `node3`:
 +
 [#nodes-example2]
+[source,n1ql]
 ----
 CREATE INDEX productName_index1 ON bucket_name(productName, ProductID)
     WHERE type="product" USING GSI
@@ -47,6 +48,7 @@ The replicas are automatically distributed across those nodes of the cluster tha
 +
 In the following example, an index is created with two replicas, with no destination-nodes specified:
 +
+[source,n1ql]
 ----
 CREATE INDEX productName_index1 ON bucket_name(productName, ProductID)
     WHERE type="product" USING GSI
@@ -62,6 +64,7 @@ No explicit specification within the `CREATE INDEX` statement is required.
 +
 With credentials that provide appropriate authorization, this default can be changed by means of the `curl` command, as follows:
 +
+[source,shell]
 ----
 curl -u <username>:<password> <host>:9102/settings -d "{\"indexer.settings.num_replica\": <num_replicas>}"
 ----

--- a/modules/learn/pages/services-and-indexes/indexes/index-replication.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/index-replication.adoc
@@ -112,23 +112,32 @@ For N1QL, the default consistency is `not_bounded`.
 A {database-change-protocol}[snapshot] of the index is maintained on disk, to permit rapid recovery if node-failures are experienced.
 In cases where recovery requires an Index-Service node to be restarted, the node’s indexes are rebuilt from the snapshots retained on disk.
 
-You can change the number of committed rollback points for memory-optimized index storage via the {index-storage-mode}[UI].
-You can change more index snapshot settings via the {index-storage-settings-via-cli}[CLI] or the {index-settings-via-rest}[REST API].
+You can change index snapshot settings via the {index-storage-settings-via-cli}[CLI] or the {index-settings-via-rest}[REST API].
 
 [[index-rollback]]
-=== Index Rollback
+== Index Rollback
+
+The index service also maintains a {database-change-protocol}[DCP failover log].
+If necessary, the data service can request the index service to return to a specified rollback point and update its history.
+
+You can change index rollback settings via the {index-storage-settings-via-cli}[CLI] or the {index-settings-via-rest}[REST API].
+You can also change the number of committed rollback points for memory-optimized index storage via the {index-storage-mode}[UI].
+
+[[index-rollback-after-failover]]
+=== Index Rollback After Auto-Failover
 
 When a data node {automatic-failover}[fails over automatically], a replica data node is promoted to active.
-If the index service has more recent data than the new active data node, the data node issues a {database-change-protocol}[DCP rollback request] to the index service.
+If the index service has more recent data than the new active data node, the data node issues a rollback request to the index service.
 
-In Couchbase Server 6.5 and later, when the index service receives the rollback request, it first attempts to roll back to a current index snapshot.
+In Couchbase Server 6.5 and later, when the index service receives the rollback request, it first attempts to revert to a current index snapshot.
 If successful, the index service does not need to rebuild its indexes from scratch when the data node fails over automatically.
 The index service can continue servicing query clients without interruption.
 
-If the index service cannot roll back to a current index snapshot, it rebuilds all indexes from scratch.
+If the index service cannot revert to a current index snapshot, it rebuilds all indexes from scratch.
 
 [NOTE]
 ====
-If <<index-consistency,scan consistency>> is set to `not_bounded` or `at_plus`, the index service may return stale data for a short time after rolling back to a snapshot, until the index service is fully up-to-date with the new active data node.
+If <<index-consistency,scan consistency>> is set to `not_bounded` or `at_plus`, the index service may return stale data for a short time after reverting to a snapshot, until the index service is fully up-to-date with the new active data node.
 If <<index-consistency,scan consistency>> is set to `request_plus`, the index service will not perform any scans until a consistent snapshot is created.
 In this case, stale results are not returned.
+====

--- a/modules/learn/pages/services-and-indexes/indexes/index-replication.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/index-replication.adoc
@@ -66,7 +66,7 @@ With credentials that provide appropriate authorization, this default can be cha
 +
 [source,shell]
 ----
-curl -u <username>:<password> <host>:9102/settings -d "{\"indexer.settings.num_replica\": <num_replicas>}"
+$ curl -u <username>:<password> <host>:9102/settings -d "{\"indexer.settings.num_replica\": <num_replicas>}"
 ----
 +
 Note, however, that whenever explicit specification of replica-numbers is made within the `CREATE INDEX` statement, this explicit specification takes precedence over any established default.

--- a/modules/learn/pages/services-and-indexes/indexes/storage-modes.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/storage-modes.adoc
@@ -19,7 +19,7 @@ To be consistently beneficial, memory-optimized index-storage requires that all 
 Memory-optimized index-storage may be less suitable for nodes where memory is constrained; since whenever the Index Service memory-quota is exceeded, indexes on the node can neither be updated nor scanned.
 
 If indexer RAM usage goes above 75% of the Index Service memory-quota, an xref:manage:manage-settings/configure-alerts.adoc[error-notification] is provided.
-If indexer RAM usage then goes above 95% of the Index Service memory-quota, the indexer goes into the Paused mode on that node; and although the indexes remain in `ONLINE` state, traffic is routed away from the node.
+If indexer RAM usage then goes above 95% of the Index Service memory-quota, the indexer goes into the Paused mode on that node; and although the indexes remain in `Active` state, traffic is routed away from the node.
 
 Before index-operations can resume, memory must be freed.
 When the indexer RAM usage drops below 80% of the Index Service memory-quota, the indexer goes into Active mode again on that node.
@@ -34,8 +34,8 @@ To resume indexing operations on a node where the Indexer has paused due to low 
 Note that attempting to delete bucket-data _selectively_ during an out-of-memory condition does not succeed in decreasing memory-usage; since without memory, such requested deletions cannot themselves be processed.
 
 In cases where recovery requires an Index-Service node to be restarted, the node's resident memory-optimized indexes are rebuilt from the snapshots retained on disk.
-Following the node's restart, these indexes remain in the `BUILDING` state until all information has been read into memory: then, final updates are made with the indexes in `ONLINE` state.
-Note that once a rebuilt index is thus available, queries with `consistency=request_plus` or `consistency=at_plus` fail, if the specified timestamp exceeds the last timestamp processed by given index.
+Following the node's restart, these indexes remain in the `Warmup` state until all information has been read into memory: then, final updates are made with the indexes in `Active` state.
+Note that once a rebuilt index is thus available, queries with `consistency=request_plus` or `consistency=at_plus` fail, if the specified timestamp exceeds the last timestamp processed by given index. footnote:[In fact, queries in this case wait for a consistent snapshot to be available and time out, rather than fail immediately.]
 However, queries with `consistency=unbounded` execute normally.
 For information on these settings, see xref:services-and-indexes/indexes/index-replication.adoc[Index Availability and Performance].
 

--- a/modules/learn/pages/services-and-indexes/indexes/storage-modes.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/storage-modes.adoc
@@ -24,12 +24,6 @@ If indexer RAM usage then goes above 95% of the Index Service memory-quota, the 
 Before index-operations can resume, memory must be freed.
 When the indexer RAM usage drops below 80% of the Index Service memory-quota, the indexer goes into Active mode again on that node.
 
-In cases where recovery requires an Index-Service node to be restarted, the node's resident memory-optimized indexes are rebuilt from the snapshots retained on disk.
-Following the node's restart, these indexes remain in the `BUILDING` state until all information has been read into memory: then, final updates are made with the indexes in `ONLINE` state.
-Note that once a rebuilt index is thus available, queries with `consistency=request_plus` or `consistency=at_plus` fail, if the specified timestamp exceeds the last timestamp processed by given index.
-However, queries with `consistency=unbounded` execute normally.
-For information on these settings, see xref:services-and-indexes/indexes/index-replication.adoc[Index Availability and Performance].
-
 To resume indexing operations on a node where the Indexer has paused due to low memory, consider taking one or more of the following actions:
 
 * Increase the index-memory quota, to give indexes additional memory for request-processing.
@@ -38,6 +32,12 @@ To resume indexing operations on a node where the Indexer has paused due to low 
 * Flush buckets that have indexes: flushing a bucket deletes all data in a bucket; and even if there are pending updates not yet processed, flushing causes all indexes to drop their own data.
 +
 Note that attempting to delete bucket-data _selectively_ during an out-of-memory condition does not succeed in decreasing memory-usage; since without memory, such requested deletions cannot themselves be processed.
+
+In cases where recovery requires an Index-Service node to be restarted, the node's resident memory-optimized indexes are rebuilt from the snapshots retained on disk.
+Following the node's restart, these indexes remain in the `BUILDING` state until all information has been read into memory: then, final updates are made with the indexes in `ONLINE` state.
+Note that once a rebuilt index is thus available, queries with `consistency=request_plus` or `consistency=at_plus` fail, if the specified timestamp exceeds the last timestamp processed by given index.
+However, queries with `consistency=unbounded` execute normally.
+For information on these settings, see xref:services-and-indexes/indexes/index-replication.adoc[Index Availability and Performance].
 
 [#standard-index-storage]
 == Standard Index Storage

--- a/modules/manage/pages/manage-settings/general-settings.adoc
+++ b/modules/manage/pages/manage-settings/general-settings.adoc
@@ -268,7 +268,7 @@ Name and memory settings are established with the xref:cli:cbcli/couchbase-cli-s
 
 [source,shell]
 ----
-$ /opt/couchbase/bin/couchbase-cli setting-cluster \
+/opt/couchbase/bin/couchbase-cli setting-cluster \
 --cluster 10.143.192.101:8091 \
 --username Administrator \
 --password password \
@@ -292,7 +292,7 @@ Note that settings for an individual server may be retrieved with the xref:cli:c
 
 [source,shell]
 ----
-$ /opt/couchbase/bin/couchbase-cli server-info \
+/opt/couchbase/bin/couchbase-cli server-info \
 -c 10.143.192.101 -u Administrator -p password | grep fts
 ----
 This returns the setting for `ftsMemoryQuota`:
@@ -308,7 +308,7 @@ Index storage can be configured with the xref:cli:cbcli/couchbase-cli-setting-in
 
 [source,shell]
 ----
-$ /opt/couchbase/bin/couchbase-cli setting-index \
+/opt/couchbase/bin/couchbase-cli setting-index \
 -c 10.143.192.101:8091 \
 -u Administrator \
 -p password \
@@ -336,7 +336,7 @@ Software update-notifications can be configured by means of the xref:cli:cbcli/c
 
 [source,shell]
 ----
-$ /opt/couchbase/bin/couchbase-cli setting-notification \
+/opt/couchbase/bin/couchbase-cli setting-notification \
 -c 10.143.192.101 -u Administrator -p password \
 --enable-notifications 1
 ----
@@ -355,7 +355,7 @@ Auto-failover can be configured with the xref:cli:cbcli/couchbase-cli-setting-au
 
 [source,shell]
 ----
-$ /opt/couchbase/bin/couchbase-cli setting-autofailover \
+/opt/couchbase/bin/couchbase-cli setting-autofailover \
 -c 10.143.192.101:8091 \
 -u Administrator \
 -p password \
@@ -384,7 +384,7 @@ To obtain the cluster's current rebalance settings by means of the CLI, use the 
 
 [source,shell]
 ----
-$ /opt/couchbase/bin/couchbase-cli setting-rebalance \
+/opt/couchbase/bin/couchbase-cli setting-rebalance \
 -c 10.143.192.101 \
 -u Administrator \
 -p password \
@@ -403,7 +403,7 @@ To modify the current rebalance settings, use the `--set` option; and specify ap
 
 [source,shell]
 ----
-$ /opt/couchbase/bin/couchbase-cli setting-rebalance \
+/opt/couchbase/bin/couchbase-cli setting-rebalance \
 -c 10.143.192.101 \
 -u Administrator \
 -p password \
@@ -427,7 +427,7 @@ To configure the number of XDCR processes for the node, use the xref:cli:cbcli/c
 
 [source,shell]
 ----
-$ /opt/couchbase/bin/couchbase-cli setting-xdcr \
+/opt/couchbase/bin/couchbase-cli setting-xdcr \
 -c 10.143.192.101 \
 -u Administrator \
 -p password \
@@ -453,7 +453,7 @@ To establish name and memory settings, use the `/pools/default` method.
 
 [source,shell]
 ----
-$ curl -v -X POST -u Administrator:password \
+curl -v -X POST -u Administrator:password \
 http://10.143.192.101:8091/pools/default \
 -d clusterName=10.143.192.101 \
 -d memoryQuota=256 \
@@ -470,7 +470,7 @@ The output can be filtered, by means of a tool such as `jq`:
 
 [source,shell]
 ----
-$ curl -s -u Administrator:password \
+curl -s -u Administrator:password \
 http://10.143.192.101:8091/pools/default | jq '.ftsMemoryQuota'
 ----
 
@@ -487,7 +487,7 @@ Software update-notifications can be configured by means of the `/setting/stats`
 
 [source,shell]
 ----
-$ curl -v -X POST -u Administrator:password \
+curl -v -X POST -u Administrator:password \
 http://10.143.192.101:8091/settings/stats \
 -d sendStats=true
 ----
@@ -502,7 +502,7 @@ To establish node availability settings, use the `/settings/autoFailover` method
 
 [source,shell]
 ----
-$ curl -v -X POST -u Administrator:password \
+curl -v -X POST -u Administrator:password \
 http://10.143.192.101:8091/settings/autoFailover \
 -d enabled=true \
 -d timeout=120 \
@@ -523,7 +523,7 @@ Additionally, the `/settings/autoReprovision` method can be used; to specify tha
 
 [source,shell]
 ----
-$ curl -v -X POST -u Administrator:password \
+curl -v -X POST -u Administrator:password \
 http://10.143.192.101:8091/settings/autoReprovision \
 -d enabled=true \
 -d maxNodes=1
@@ -538,7 +538,7 @@ To establish index settings, use the `/settings/indexes` method.
 
 [source,shell]
 ----
-$ curl -v -X POST -u Administrator:password \
+curl -v -X POST -u Administrator:password \
 http://10.143.192.101:8091/settings/indexes \
 -d indexerThreads=4 \
 -d logLevel=verbose \
@@ -565,7 +565,7 @@ To set the number of reader and writer threads for Couchbase Server, use the `PO
 
 [source,shell]
 ----
-$ curl -v -X POST -u Administrator:password \
+curl -v -X POST -u Administrator:password \
 http://10.143.192.101:8091/pools/default/settings/memcached/global \
 -d num_reader_threads=12 \
 -d num_writer_threads=8
@@ -589,7 +589,7 @@ To set the directory for temporary query data, and establish its size-limit, use
 
 [source,shell]
 ----
-$ curl -v -X POST -u Administrator:password \
+curl -v -X POST -u Administrator:password \
 http://10.143.192.101:8091/settings/querySettings \
 -d queryTmpSpaceDir=%2Fopt%2Fcouchbase%2Fvar%2Flib%2Fcouchbase%2Ftmp \
 -d queryTmpSpaceSize=5120
@@ -612,7 +612,7 @@ To specify particular URLs as allowed and disallowed, use the `/settings/querySe
 
 [source,shell]
 ----
-$ curl -v -X POST -u Administrator:password \
+curl -v -X POST -u Administrator:password \
 http://10.143.192.101:8091/settings/querySettings/curlWhitelist \
 -d '{"all_access":false,"allowed_urls":["https://company1.com"],"disallowed_urls":["https://company2.com"]}'
 ----
@@ -634,7 +634,7 @@ To obtain the cluster's current rebalance settings by means of the REST API, use
 
 [source,shell]
 ----
-$ curl -X GET -u Administrator:password \
+curl -X GET -u Administrator:password \
 http://10.143.192.101:8091/settings/retryRebalance
 ----
 
@@ -651,7 +651,7 @@ To change the rebalance settings, use the `POST` method with the same URI, speci
 
 [source,shell]
 ----
-$ curl -X POST -u Administrator:password \
+curl -X POST -u Administrator:password \
 http://10.143.192.101:8091/settings/retryRebalance \
 -d enabled=false \
 -d afterTimePeriod=100 \
@@ -675,7 +675,7 @@ Note that this example pipes the output to the https://stedolan.github.io/jq/[jq
 
 [source,shell]
 ----
-$ curl -X GET -u Administrator:password \
+curl -X GET -u Administrator:password \
 http://10.143.192.101:8091/settings/replications | jq '.'
 ----
 
@@ -710,7 +710,7 @@ To change this value, use the `POST` method with the same URI, specifying the re
 
 [source,shell]
 ----
-$ curl -X POST -u Administrator:password \
+curl -X POST -u Administrator:password \
 http://10.143.192.101:8091/settings/replications \
 -d goMaxProcs=5 | jq '.'
 ----

--- a/modules/manage/pages/manage-settings/general-settings.adoc
+++ b/modules/manage/pages/manage-settings/general-settings.adoc
@@ -226,7 +226,7 @@ The number can be increased on multi-core machines.
 The default is 0.
 
 * *Max Rollback Points*.
-The maximum number of committed rollback points.
+The maximum number of xref:learn:services-and-indexes/indexes/index-replication.adoc#index-rollback[committed rollback points].
 The default is 5.
 
 * *Indexer Log Level*.

--- a/modules/manage/pages/manage-settings/general-settings.adoc
+++ b/modules/manage/pages/manage-settings/general-settings.adoc
@@ -268,7 +268,7 @@ Name and memory settings are established with the xref:cli:cbcli/couchbase-cli-s
 
 [source,shell]
 ----
-/opt/couchbase/bin/couchbase-cli setting-cluster \
+$ /opt/couchbase/bin/couchbase-cli setting-cluster \
 --cluster 10.143.192.101:8091 \
 --username Administrator \
 --password password \
@@ -292,7 +292,7 @@ Note that settings for an individual server may be retrieved with the xref:cli:c
 
 [source,shell]
 ----
-/opt/couchbase/bin/couchbase-cli server-info \
+$ /opt/couchbase/bin/couchbase-cli server-info \
 -c 10.143.192.101 -u Administrator -p password | grep fts
 ----
 This returns the setting for `ftsMemoryQuota`:
@@ -308,7 +308,7 @@ Index storage can be configured with the xref:cli:cbcli/couchbase-cli-setting-in
 
 [source,shell]
 ----
-/opt/couchbase/bin/couchbase-cli setting-index \
+$ /opt/couchbase/bin/couchbase-cli setting-index \
 -c 10.143.192.101:8091 \
 -u Administrator \
 -p password \
@@ -336,7 +336,7 @@ Software update-notifications can be configured by means of the xref:cli:cbcli/c
 
 [source,shell]
 ----
-/opt/couchbase/bin/couchbase-cli setting-notification \
+$ /opt/couchbase/bin/couchbase-cli setting-notification \
 -c 10.143.192.101 -u Administrator -p password \
 --enable-notifications 1
 ----
@@ -355,7 +355,7 @@ Auto-failover can be configured with the xref:cli:cbcli/couchbase-cli-setting-au
 
 [source,shell]
 ----
-/opt/couchbase/bin/couchbase-cli setting-autofailover \
+$ /opt/couchbase/bin/couchbase-cli setting-autofailover \
 -c 10.143.192.101:8091 \
 -u Administrator \
 -p password \
@@ -384,7 +384,7 @@ To obtain the cluster's current rebalance settings by means of the CLI, use the 
 
 [source,shell]
 ----
-/opt/couchbase/bin/couchbase-cli setting-rebalance \
+$ /opt/couchbase/bin/couchbase-cli setting-rebalance \
 -c 10.143.192.101 \
 -u Administrator \
 -p password \
@@ -403,7 +403,7 @@ To modify the current rebalance settings, use the `--set` option; and specify ap
 
 [source,shell]
 ----
-/opt/couchbase/bin/couchbase-cli setting-rebalance \
+$ /opt/couchbase/bin/couchbase-cli setting-rebalance \
 -c 10.143.192.101 \
 -u Administrator \
 -p password \
@@ -427,7 +427,7 @@ To configure the number of XDCR processes for the node, use the xref:cli:cbcli/c
 
 [source,shell]
 ----
-/opt/couchbase/bin/couchbase-cli setting-xdcr \
+$ /opt/couchbase/bin/couchbase-cli setting-xdcr \
 -c 10.143.192.101 \
 -u Administrator \
 -p password \
@@ -453,7 +453,7 @@ To establish name and memory settings, use the `/pools/default` method.
 
 [source,shell]
 ----
-curl -v -X POST -u Administrator:password \
+$ curl -v -X POST -u Administrator:password \
 http://10.143.192.101:8091/pools/default \
 -d clusterName=10.143.192.101 \
 -d memoryQuota=256 \
@@ -470,7 +470,7 @@ The output can be filtered, by means of a tool such as `jq`:
 
 [source,shell]
 ----
-curl -s -u Administrator:password \
+$ curl -s -u Administrator:password \
 http://10.143.192.101:8091/pools/default | jq '.ftsMemoryQuota'
 ----
 
@@ -487,7 +487,7 @@ Software update-notifications can be configured by means of the `/setting/stats`
 
 [source,shell]
 ----
-curl -v -X POST -u Administrator:password \
+$ curl -v -X POST -u Administrator:password \
 http://10.143.192.101:8091/settings/stats \
 -d sendStats=true
 ----
@@ -502,7 +502,7 @@ To establish node availability settings, use the `/settings/autoFailover` method
 
 [source,shell]
 ----
-curl -v -X POST -u Administrator:password \
+$ curl -v -X POST -u Administrator:password \
 http://10.143.192.101:8091/settings/autoFailover \
 -d enabled=true \
 -d timeout=120 \
@@ -523,7 +523,7 @@ Additionally, the `/settings/autoReprovision` method can be used; to specify tha
 
 [source,shell]
 ----
-curl -v -X POST -u Administrator:password \
+$ curl -v -X POST -u Administrator:password \
 http://10.143.192.101:8091/settings/autoReprovision \
 -d enabled=true \
 -d maxNodes=1
@@ -538,7 +538,7 @@ To establish index settings, use the `/settings/indexes` method.
 
 [source,shell]
 ----
-curl -v -X POST -u Administrator:password \
+$ curl -v -X POST -u Administrator:password \
 http://10.143.192.101:8091/settings/indexes \
 -d indexerThreads=4 \
 -d logLevel=verbose \
@@ -565,7 +565,7 @@ To set the number of reader and writer threads for Couchbase Server, use the `PO
 
 [source,shell]
 ----
-curl -v -X POST -u Administrator:password \
+$ curl -v -X POST -u Administrator:password \
 http://10.143.192.101:8091/pools/default/settings/memcached/global \
 -d num_reader_threads=12 \
 -d num_writer_threads=8
@@ -589,7 +589,7 @@ To set the directory for temporary query data, and establish its size-limit, use
 
 [source,shell]
 ----
-curl -v -X POST -u Administrator:password \
+$ curl -v -X POST -u Administrator:password \
 http://10.143.192.101:8091/settings/querySettings \
 -d queryTmpSpaceDir=%2Fopt%2Fcouchbase%2Fvar%2Flib%2Fcouchbase%2Ftmp \
 -d queryTmpSpaceSize=5120
@@ -612,7 +612,7 @@ To specify particular URLs as allowed and disallowed, use the `/settings/querySe
 
 [source,shell]
 ----
-curl -v -X POST -u Administrator:password \
+$ curl -v -X POST -u Administrator:password \
 http://10.143.192.101:8091/settings/querySettings/curlWhitelist \
 -d '{"all_access":false,"allowed_urls":["https://company1.com"],"disallowed_urls":["https://company2.com"]}'
 ----
@@ -634,7 +634,7 @@ To obtain the cluster's current rebalance settings by means of the REST API, use
 
 [source,shell]
 ----
-curl -X GET -u Administrator:password \
+$ curl -X GET -u Administrator:password \
 http://10.143.192.101:8091/settings/retryRebalance
 ----
 
@@ -651,7 +651,7 @@ To change the rebalance settings, use the `POST` method with the same URI, speci
 
 [source,shell]
 ----
-curl -X POST -u Administrator:password \
+$ curl -X POST -u Administrator:password \
 http://10.143.192.101:8091/settings/retryRebalance \
 -d enabled=false \
 -d afterTimePeriod=100 \
@@ -675,7 +675,7 @@ Note that this example pipes the output to the https://stedolan.github.io/jq/[jq
 
 [source,shell]
 ----
-curl -X GET -u Administrator:password \
+$ curl -X GET -u Administrator:password \
 http://10.143.192.101:8091/settings/replications | jq '.'
 ----
 
@@ -710,7 +710,7 @@ To change this value, use the `POST` method with the same URI, specifying the re
 
 [source,shell]
 ----
-curl -X POST -u Administrator:password \
+$ curl -X POST -u Administrator:password \
 http://10.143.192.101:8091/settings/replications \
 -d goMaxProcs=5 | jq '.'
 ----

--- a/modules/manage/pages/manage-settings/general-settings.adoc
+++ b/modules/manage/pages/manage-settings/general-settings.adoc
@@ -69,7 +69,7 @@ It appears as follows:
 image::manage-settings/current-version.png[,540,align=left]
 
 The *Enable Software Update Notifications* checkbox is checked by default.
-If the checkbox is checked, Couchbase Web Console provides adjacent notifications whenever a new version of Couchbase Server is available; if the checkbox is unchecked, notifications are not provided
+If the checkbox is checked, Couchbase Web Console provides adjacent notifications whenever a new version of Couchbase Server is available; if the checkbox is unchecked, notifications are not provided.
 
 If the checkbox is checked, Couchbase Web Console communicates with Couchbase Server to ascertain the following information, which is then transmitted to Couchbase:
 
@@ -266,6 +266,7 @@ Additionally, for information on URL whitelisting via the N1QL `CURL()` function
 
 Name and memory settings are established with the xref:cli:cbcli/couchbase-cli-setting-cluster.adoc[setting-cluster] command.
 
+[source,shell]
 ----
 /opt/couchbase/bin/couchbase-cli setting-cluster \
 --cluster 10.143.192.101:8091 \
@@ -289,6 +290,7 @@ SUCCESS: Cluster settings modified
 
 Note that settings for an individual server may be retrieved with the xref:cli:cbcli/couchbase-cli-server-info.adoc[server-info] command, the output for which can be filtered, as appropriate, by `grep`:
 
+[source,shell]
 ----
 /opt/couchbase/bin/couchbase-cli server-info \
 -c 10.143.192.101 -u Administrator -p password | grep fts
@@ -304,6 +306,7 @@ This returns the setting for `ftsMemoryQuota`:
 
 Index storage can be configured with the xref:cli:cbcli/couchbase-cli-setting-index.adoc[setting-index] command.
 
+[source,shell]
 ----
 /opt/couchbase/bin/couchbase-cli setting-index \
 -c 10.143.192.101:8091 \
@@ -331,6 +334,7 @@ SUCCESS: Indexer settings modified
 
 Software update-notifications can be configured by means of the xref:cli:cbcli/couchbase-cli-setting-notification.adoc[setting-notification] command.
 
+[source,shell]
 ----
 /opt/couchbase/bin/couchbase-cli setting-notification \
 -c 10.143.192.101 -u Administrator -p password \
@@ -349,6 +353,7 @@ SUCCESS: Notification settings updated
 
 Auto-failover can be configured with the xref:cli:cbcli/couchbase-cli-setting-autofailover.adoc[setting-autofailover] command.
 
+[source,shell]
 ----
 /opt/couchbase/bin/couchbase-cli setting-autofailover \
 -c 10.143.192.101:8091 \
@@ -377,6 +382,7 @@ For a detailed description of auto-failover settings, policy, and constraints, s
 
 To obtain the cluster's current rebalance settings by means of the CLI, use the xref:cli:cbcli/couchbase-cli-setting-rebalance.adoc[setting-rebalance] command, with the `--get` option:
 
+[source,shell]
 ----
 /opt/couchbase/bin/couchbase-cli setting-rebalance \
 -c 10.143.192.101 \
@@ -395,6 +401,7 @@ Maximum number of retries: 2
 
 To modify the current rebalance settings, use the `--set` option; and specify appropriate values for the `--max-attempts` and `--wait-for` flags:
 
+[source,shell]
 ----
 /opt/couchbase/bin/couchbase-cli setting-rebalance \
 -c 10.143.192.101 \
@@ -418,6 +425,7 @@ For more information, see the reference page xref:rest-api:rest-configure-rebala
 
 To configure the number of XDCR processes for the node, use the xref:cli:cbcli/couchbase-cli-setting-xdcr.adoc[setting-xdcr] command, with the `--max-processes` option:
 
+[source,shell]
 ----
 /opt/couchbase/bin/couchbase-cli setting-xdcr \
 -c 10.143.192.101 \
@@ -443,6 +451,7 @@ These are described below.
 
 To establish name and memory settings, use the `/pools/default` method.
 
+[source,shell]
 ----
 curl -v -X POST -u Administrator:password \
 http://10.143.192.101:8091/pools/default \
@@ -459,6 +468,7 @@ This establishes the cluster's IP address as its name, and assigns memory-quotas
 Note that when used with GET, `/pools/default` returns configuration-settings.
 The output can be filtered, by means of a tool such as `jq`:
 
+[source,shell]
 ----
 curl -s -u Administrator:password \
 http://10.143.192.101:8091/pools/default | jq '.ftsMemoryQuota'
@@ -475,6 +485,7 @@ If successful, this returns the value of the key `ftsMemoryQuota`:
 
 Software update-notifications can be configured by means of the `/setting/stats` command.
 
+[source,shell]
 ----
 curl -v -X POST -u Administrator:password \
 http://10.143.192.101:8091/settings/stats \
@@ -489,6 +500,7 @@ To prevent the sending of notifications, set the value of `sendStats` to `false`
 
 To establish node availability settings, use the `/settings/autoFailover` method.
 
+[source,shell]
 ----
 curl -v -X POST -u Administrator:password \
 http://10.143.192.101:8091/settings/autoFailover \
@@ -509,6 +521,7 @@ For more information on these options, see the descriptions provided above, for 
 
 Additionally, the `/settings/autoReprovision` method can be used; to specify that if a node containing _active_ Ephemeral buckets becomes unavailable, its replicas on the specified number of other nodes are promoted to active status as appropriate, to avoid data-loss.
 
+[source,shell]
 ----
 curl -v -X POST -u Administrator:password \
 http://10.143.192.101:8091/settings/autoReprovision \
@@ -523,6 +536,7 @@ This enables auto-reprovisioning, specifying 1 as the maximum number of nodes.
 
 To establish index settings, use the `/settings/indexes` method.
 
+[source,shell]
 ----
 curl -v -X POST -u Administrator:password \
 http://10.143.192.101:8091/settings/indexes \
@@ -539,6 +553,7 @@ For detailed information on these and other settings, see the REST reference pag
 
 If successful, the call returns a JSON object, which provides values for all current index settings:
 
+[source,json]
 ----
 {"storageMode":"memory_optimized","indexerThreads":4,"memorySnapshotInterval":150,"stableSnapshotInterval":40000,"maxRollbackPoints":10,"logLevel":"verbose"}
 ----
@@ -548,6 +563,7 @@ If successful, the call returns a JSON object, which provides values for all cur
 
 To set the number of reader and writer threads for Couchbase Server, use the `POST /pools/default/settings/memcached/global` http method and endpoint, as follows:
 
+[source,shell]
 ----
 curl -v -X POST -u Administrator:password \
 http://10.143.192.101:8091/pools/default/settings/memcached/global \
@@ -558,6 +574,7 @@ http://10.143.192.101:8091/pools/default/settings/memcached/global \
 This sets the number of _reader_ threads to `12`, and the number of _writer_ threads to `8`.
 If successful, the call returns an object whose values confirm the settings that have been made:
 
+[source,json]
 ----
 {"num_reader_threads":12,"num_writer_threads":8}
 ----
@@ -570,6 +587,7 @@ Also see the REST API reference page, xref:rest-api:rest-reader-writer-thread-co
 
 To set the directory for temporary query data, and establish its size-limit, use the `/settings/querySettings` method.
 
+[source,shell]
 ----
 curl -v -X POST -u Administrator:password \
 http://10.143.192.101:8091/settings/querySettings \
@@ -583,6 +601,7 @@ This specifies that the directory for temporary query data should be `/opt/couch
 
 If successful, this call returns a JSON document featuring all the current query-related settings, including access-control:
 
+[source,json]
 ----
 {"queryTmpSpaceDir":"/opt/couchbase/var/lib/couchbase/tmp","queryTmpSpaceSize":5120,"queryCurlWhitelist":{"all_access":false}}
 ----
@@ -591,6 +610,7 @@ The document's values indicate that the specified values for directory and size 
 
 To specify particular URLs as allowed and disallowed, use the `/settings/querySettings/curlWhitelist` method:
 
+[source,shell]
 ----
 curl -v -X POST -u Administrator:password \
 http://10.143.192.101:8091/settings/querySettings/curlWhitelist \
@@ -602,6 +622,7 @@ The document's values indicate that `https://company1.com` is allowed, and `http
 
 If successful, the call returns a JSON document that confirms the modified settings:
 
+[source,json]
 ----
 {"all_access":false,"allowed_urls":["https://company1.com"],"disallowed_urls":["https://company2.com"]}
 ----
@@ -611,6 +632,7 @@ If successful, the call returns a JSON document that confirms the modified setti
 
 To obtain the cluster's current rebalance settings by means of the REST API, use the `GET /settings/retryRebalance` http method and URI, as follows:
 
+[source,shell]
 ----
 curl -X GET -u Administrator:password \
 http://10.143.192.101:8091/settings/retryRebalance
@@ -618,6 +640,7 @@ http://10.143.192.101:8091/settings/retryRebalance
 
 If successful, the command returns the following object:
 
+[source,json]
 ----
 {"enabled":true,"afterTimePeriod":200,"maxAttempts":3}
 ----
@@ -626,6 +649,7 @@ This output shows that rebalance retry is enabled, with `200` seconds required t
 
 To change the rebalance settings, use the `POST` method with the same URI, specifying appropriate values:
 
+[source,shell]
 ----
 curl -X POST -u Administrator:password \
 http://10.143.192.101:8091/settings/retryRebalance \
@@ -636,6 +660,7 @@ http://10.143.192.101:8091/settings/retryRebalance \
 
 If successful, the command returns the following object:
 
+[source,json]
 ----
 {"enabled":false,"afterTimePeriod":100,"maxAttempts":2}
 ----
@@ -648,6 +673,7 @@ This verifies that rebalance retry has been disabled, the required period betwee
 To determine how many XDCR processes are configured per node, use the `GET /settings/replications` http method and URI, as follows.
 Note that this example pipes the output to the https://stedolan.github.io/jq/[jq] program, to facilitate readability.
 
+[source,shell]
 ----
 curl -X GET -u Administrator:password \
 http://10.143.192.101:8091/settings/replications | jq '.'
@@ -655,6 +681,7 @@ http://10.143.192.101:8091/settings/replications | jq '.'
 
 If successful, the command returns the following object:
 
+[source,json]
 ----
 {
   "checkpointInterval": 600,
@@ -681,6 +708,7 @@ If successful, the command returns the following object:
 The configured number of threads is the value to `goMaxProcs`; which is currently `4.`
 To change this value, use the `POST` method with the same URI, specifying the required number of processes as the value to the `--goMaxProcs` option:
 
+[source,shell]
 ----
 curl -X POST -u Administrator:password \
 http://10.143.192.101:8091/settings/replications \
@@ -689,6 +717,7 @@ http://10.143.192.101:8091/settings/replications \
 
 If successful, this returns the following object:
 
+[source,json]
 ----
 {
   "checkpointInterval": 600,

--- a/modules/manage/pages/manage-settings/general-settings.adoc
+++ b/modules/manage/pages/manage-settings/general-settings.adoc
@@ -7,7 +7,7 @@ _General_ settings allow configuration of _cluster name_, _memory quotas_, _stor
 [#configuring-general-settings-examples-on-this-page]
 == Examples on This Page
 
-Full and Cluster Administrators can configure general settings by means of xref:manage:manage-settings/general-settings.adoc#configure-general-settings-with-the-ui[Couchbase Web Console], the xref:manage:manage-settings/general-settings.adoc#configure-general-settings-with-the-cli[CLI], or the xref:manage:manage-settings/general-settings.adoc#configure-general-settings-with-the-rest-api[REST API].
+Full and Cluster Administrators can configure general settings by means of <<configure-general-settings-with-the-ui,Couchbase Web Console>>, the <<configure-general-settings-with-the-cli,CLI>>, or the <<configure-general-settings-with-the-rest-api,REST API>>.
 
 [#configure-general-settings-with-the-ui]
 == Configure General Settings with the UI
@@ -258,8 +258,8 @@ Alternatively, cancel recently entered values, and thereby reset to previous val
 
 To configure _name and memory_, _index storage_, and _auto-failover_ via CLI, use the appropriate CLI command; as described below.
 Note that no CLI support is provided for configuring _query settings_.
-As an alternative, see xref:manage:manage-settings/general-settings.adoc#configure-general-settings-with-the-rest-api[Configure General Settings with the REST API], below.
-Additionally, for information on URL whitelisting via the N1QL `CURL()` function, see xref:n1ql:n1ql-language-reference/curl.adoc[CURL Function].
+As an alternative, see <<configure-general-settings-with-the-rest-api,Configure General Settings with the REST API>>, below.
+Additionally, for information on URL access lists via the N1QL `CURL()` function, see xref:n1ql:n1ql-language-reference/curl.adoc[CURL Function].
 
 [#name-and-memory-settings-via-cli]
 === Name and Memory Settings via CLI
@@ -517,7 +517,7 @@ This enables auto-failover, with a timeout of 120 seconds, and a maximum failove
 It also specifies, by means of `canAbortRebalance`, that if a node becomes unresponsive during a rebalance, that node can be failed over automatically, and the rebalance thereby aborted.
 Additionally, failover is enabled in the event of suboptimal disk responsiveness, with a time-period of 120 seconds specified.
 
-For more information on these options, see the descriptions provided above, for the xref:manage:manage-settings/general-settings.adoc#node-availability[UI].
+For more information on these options, see the descriptions provided above, for the <<node-availability,UI>>.
 
 Additionally, the `/settings/autoReprovision` method can be used; to specify that if a node containing _active_ Ephemeral buckets becomes unavailable, its replicas on the specified number of other nodes are promoted to active status as appropriate, to avoid data-loss.
 

--- a/modules/manage/pages/manage-settings/general-settings.adoc
+++ b/modules/manage/pages/manage-settings/general-settings.adoc
@@ -226,7 +226,7 @@ The number can be increased on multi-core machines.
 The default is 0.
 
 * *Max Rollback Points*.
-The maximum number of xref:learn:services-and-indexes/indexes/index-replication.adoc#index-rollback[committed rollback points].
+The maximum number of xref:learn:services-and-indexes/indexes/index-replication.adoc#index-snapshots[committed rollback points].
 The default is 5.
 
 * *Indexer Log Level*.

--- a/modules/manage/pages/manage-settings/general-settings.adoc
+++ b/modules/manage/pages/manage-settings/general-settings.adoc
@@ -225,10 +225,6 @@ The number of dedicated threads used by the Index Service.
 The number can be increased on multi-core machines.
 The default is 0.
 
-* *Max Rollback Points*.
-The maximum number of xref:learn:services-and-indexes/indexes/index-replication.adoc#index-snapshots[committed rollback points].
-The default is 5.
-
 * *Indexer Log Level*.
 Adjust the logging level.
 The options are: `Silent`, `Fatal`, `Error`, `Warn`, `Info`, `Verbose`, `Timing`, `Debug`, and `Trace`.


### PR DESCRIPTION
The following documentation is ready for review:

* [Availability and Performance](https://simon-dew.github.io/docs-site/DOC-6178/server/6.5/learn/services-and-indexes/indexes/index-replication.html) — added **Index Snapshots** and **Index Replication**
* [General Settings](https://simon-dew.github.io/docs-site/DOC-6178/server/6.5/manage/manage-settings/general-settings.html) — updated links, added code highlighting
* [Storage Settings](https://docs.couchbase.com/server/6.5/learn/services-and-indexes/indexes/storage-modes.html) — rearranged description of MOIS snaphots

Docs issue: [DOC-6178](https://issues.couchbase.com/browse/DOC-6178)