### PR TITLE
Remove MB-33111 this is an improvement not a bug.

### DIFF
--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -145,11 +145,6 @@ This section highlights some of the known issues in this release.
 | https://issues.couchbase.com/browse/MB-37042[MB-37042^]
 | *Summary*: The CLI and REST tools for exporting and importing Eventing functions do not support cross compatible syntax when using only the command line, however the UI can import either syntax.
 
-| https://issues.couchbase.com/browse/MB-33111[MB-33111^]
-| *Summary*: N1QL DML statements cannot manipulate documents in the same bucket as the handler is listening for mutations on to avoid recursion. 
-
-*Workaround*: Use the exposed data service KV map.
-
 | https://issues.couchbase.com/browse/MB-32437[MB-32437^]
 | *Summary*: In a multi-bucket scenario approaching the new 30 bucket limit, the Eventing service supports only one function per bucket. An error will be thrown when deploying the second function on a given bucket. 
 


### PR DESCRIPTION
It belongs in the release notes, as it documents that N1QL has differnt behavior than the exposed KV map.

I just updated https://github.com/jon-strabala/docs-server/blob/release/6.5/modules/eventing/pages/eventing-language-constructs.adoc to include MB-33111 because this is not a bug rather an improvement as such it should be removed form the release notes.