### PR TITLE
DOC-5691: Update index replica documentation

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -66,6 +66,8 @@ Valid GSI index names can contain any of the following characters: `A-Z` `a-z` `
 The minimum length of an index name is 1 character and there is no maximum length set for an index name.
 When querying, if the index name contains a `&num;` or `&lowbar;` character, you must enclose the index name within backticks.
 
+IMPORTANT: We recommend that you do not create (or drop) secondary indexes when any node with a secondary index role is down, as this may result in duplicate index names.
+
 [[keyspace-ref,keyspace-ref]]
 === Keyspace Reference
 

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -177,15 +177,17 @@ An object with the following properties:
 nodes;;
 [Optional] An array of strings, each of which represents a node name.
 +
-[NOTE,title='{community}']
-====
+****
+[.edition]#{community}#
+
 In Couchbase Server Community Edition, a single global secondary index can be placed on a single node that runs the indexing service.
 The `nodes` property allows you to specify the node that the index is placed on.
 (((default index placement)))If `nodes` is not specified, one of the nodes running the indexing service is randomly picked for the index.
-====
+****
 +
-[NOTE,title='{enterprise}']
-====
+****
+[.edition]#{enterprise}#
+
 In Couchbase Server Enterprise Edition, you can specify multiple nodes to distribute replicas of an index across nodes running the indexing service, for example:
 
 [source,n1ql]
@@ -199,7 +201,7 @@ If specifying both [.var]`nodes` and [.var]`num_replica`, the number of nodes in
 
 (((default index placement)))If [.var]`nodes` is not specified, then the system chooses nodes on which to place the new index and any replicas, in order to achieve the best resource utilization across nodes running the indexing service.
 This is done by taking into account the current resource usage statistics of index nodes.
-====
+****
 +
 IMPORTANT: A node name passed to the `nodes` property must include the cluster administration port, by default 8091.
 For example `WITH {"nodes": ["192.0.2.0:8091"]}` instead of `WITH {"nodes": ["192.0.2.0"]}`.
@@ -218,17 +220,18 @@ When set to `false`, the `CREATE INDEX` operation queues the task for building t
 
 num_replica;;
 +
-[title='{enterprise}']
-NOTE: This property is only available in Couchbase Server Enterprise Edition.
-+
+****
+[.edition]#{enterprise}#
+
+This property is only available in Couchbase Server Enterprise Edition.
+
 [Optional] Integer that specifies the number of xref:learn:services-and-indexes/indexes/index-replication.adoc#index-replication[replicas] of the index to create.
-+
+
 The indexer will automatically distribute these replicas amongst index nodes in the cluster for load-balancing and high availability purposes.
 The indexer will attempt to distribute the replicas based on the server groups in use in the cluster where possible.
-+
+
 If the value of this property is not less than the number of index nodes in the cluster, then the index creation will fail.
-+
-IMPORTANT: We recommend that you do not create (or drop) secondary indexes when any node with a secondary index role is down as this may result in duplicate index names.
+****
 
 == Usage
 
@@ -274,6 +277,13 @@ image::n1ql-language-reference/create-index-replica-id.png["The Indexes screen s
 If you select `view by server node` from the drop-down menu, you can see the server node where each index and index replica is placed.
 
 You can also use the xref:rest-api:get-status-indexes.adoc[Index service REST API] to find the ID of an index replica and see which node it is placed on.
+
+[NOTE]
+====
+By default, index replicas are used to serve index scans.
+The system automatically load-balances an index scan across the index and all its replicas.
+Adding index replicas enables you to scale scan throughput, in addition to providing high availability.
+====
 
 == Examples
 


### PR DESCRIPTION
The following documentation is ready for review:

* [CREATE INDEX › Usage › Index Replicas](https://simon-dew.github.io/docs-site/DOC-5691/server/6.5/n1ql/n1ql-language-reference/createindex.html#index-replicas)

Docs issue: [DOC-5691](https://issues.couchbase.com/browse/DOC-5691)