### PR TITLE
Eventing port name is wrong

### DIFF
--- a/modules/install/pages/install-ports.adoc
+++ b/modules/install/pages/install-ports.adoc
@@ -1,5 +1,5 @@
 = Couchbase Server Ports
-:fn-eventing-debug-port: pass:n[footnote:fn-eventing-debug-port[pass:n[The Eventing Service Debugger port (9140, `debugPort`) is an internal port and is not supported for external access outside of the cluster. You should only use this port in your development environments.\]]]
+:fn-eventing-debug-port: pass:n[footnote:fn-eventing-debug-port[pass:n[The Eventing Service Debugger port `eventing_debug_port` (9140) is an internal port and is not supported for external access outside of the cluster. You should only use this port in your development environments.\]]]
 :fn-analytics-encrypted-port: footnote:fn-analytics-encrypted-port[The Analytics Service encrypted port (18095) is not currently used, but is reserved for future use.]
 
 [abstract]
@@ -282,7 +282,7 @@ a| Search Service gRPC port used for xref:learn:services-and-indexes/services/se
 | No
 | No
 
-| `debugPort` footnote:fn-eventing-debug-port[]
+| `eventing_debug_port` footnote:fn-eventing-debug-port[]
 | 9140
 | Eventing Service Debugger
 | No
@@ -353,6 +353,8 @@ Refer to <<table-ports-detailed>> for details about default ports and whether or
 
 Changing the port mappings will require a reset and reconfiguration of any Couchbase Server node.
 
+WARNING: Changing port mappings should only be done at the time of initial node/cluster setup as the required reset and reconfiguration will also purge all data on the node. 
+
 .To Change Port Mapping
 . xref:install-intro.adoc[Install Couchbase Server].
 . xref:startup-shutdown.adoc[Stop the Couchbase Server service].
@@ -365,18 +367,18 @@ vi /opt/couchbase/etc/couchbase/static_config
 ----
 +
 If you're remapping the CAPI port (8092 / 18092) you'll need to edit the [.path]_/opt/couchbase/etc/couchdb/default.d/capi.ini_ file and replace 8092 with the new port number.
-. Add each custom port map entry on its own line, using the following format:
+. Add each custom port map entry on its own line, using the following format (enclosed in braces and terminated by a period):
 +
 [source,console,subs=+quotes]
 ----
-{[.var]_port-name_, [.var]_port-number_}
+{[.var]_port-name_, [.var]_port-number_}.
 ----
 +
 For example, to change the REST API port from 8091 to 9000, you would add the following line:
 +
 [source,console]
 ----
-{rest_port, 9000}
+{rest_port, 9000}.
 ----
 +
 Once you've added all of your custom port mappings, save the file and close your text editor.


### PR DESCRIPTION
#1 Note "debugPort" is wrong it will not work the correct name is "eventing_debug_port"

#2 The example is wrong it must be terminated by a period for example if we had the following in static_config

{eventing_debug_port, 9444}
{net_kernel_verbosity, 10}

The couchbase server WILL NOT start but if we add a period after the closing brace

{eventing_debug_port, 9444}.
{net_kernel_verbosity, 10}.

The couchbase server starts

#3 make the syntax clear e.g. add "(enclosed in braces and terminated by a period)"

#4 warn that this will flush all data and restart the server from scratch, e.g. "WARNING: Changing port mapping should be done on the initial node/cluster setup as the required reset and reconfiguration will also purge any data on the node. "