### PR TITLE
Add working directions to change the debug port

### DIFF
--- a/modules/eventing/pages/eventing-debugging-and-diagnosability.adoc
+++ b/modules/eventing/pages/eventing-debugging-and-diagnosability.adoc
@@ -83,17 +83,22 @@ Upon source map detection, a text confirmation flag gets displayed in the bottom
 [#modifydebugport]
 === Modifying the Debug Port
 
-By default, the *ns_server* configures the Eventing Debug on port *9140*. Using the *static_config* file you can modify the default Eventing Debug port.
+The Eventing Service Debugger port, `eventing_debug_port` (9140), is an internal port and is one of the ports that is configured by the *ns_server*. Note this port is not supported for external access outside of the cluster and should only be used in development environments. To modify this port setting (Linux example):
 
-To modify the debug port:
+. xref:install-intro.adoc[Install Couchbase Server].
+. xref:startup-shutdown.adoc[Stop the Couchbase Server service].
+. Edit the */opt/couchbase/etc/couchbase/static_config* file to add the new eventing_debug_port and the new port-number information. For example, to change the Eventing debugging port from 9140 to 9444, you would add the following line (enclosed in braces and terminated by a period):
++
+[source,console]
+----
+{eventing_debug_port, 9444}.
+----
+. If Couchbase Server was previously configured, you'll need to delete the */opt/couchbase/var/lib/couchbase/config/config.dat* file to remove the old configuration.
+. xref:startup-shutdown.adoc[Start Couchbase Server].
 
-        . Stop Couchbase server.
-        . Navigate to the */opt/couchbase/etc/couchbase/static_config* file. This is the location where Couchbase Server picks up the configuration parameters.
-        . Edit the *static_config file* to add the new eventing_debug_port and the new port-number information.
-        . (Optional step) To remove any old configuration file, delete the */opt/couchbase/var/lib/couchbase/config/config.dat* file.
-        . Start Couchbase server.
+For detailed information on the modifying *ns_server* port mappings, refer to xref:install-ports.adoc#map-custom-ports[Custom Port Mapping].
 
-*Note*: If no port numbers are not specified, default ports are used. To override some or all default ports, append the user-defined ports to the *static_config file* file.
+WARNING: Changing port mappings should only be done at the time of initial node/cluster setup as the required reset and reconfiguration will also purge all data on the node. 
 
 [#logging-functions]
 == Logging Functions


### PR DESCRIPTION
1. Add working directions to change the debug port

2. Also follows https://github.com/couchbase/docs-server/pull/1085 

3. Also reference https://docs.couchbase.com/server/6.5/install/install-ports.html#map-custom-ports (which is fixed in above pull)