### PR TITLE
DOC-5290: Statements missing properties

### DIFF
--- a/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
+++ b/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
@@ -1035,6 +1035,15 @@ This catalog provides data about the known prepared statements and their state i
 For each prepared statement, this catalog provides information such as name, statement, query plan, last use time, number of uses, and so on.
 
 For field names and meanings, refer to xref:n1ql:n1ql-rest-api/admin.adoc#_statements[Statements].
+The `system:prepareds` catalog returns all the properties that the N1QL Admin REST API returns.
+In addition, the `system:prepareds` catalog also returns the following property.
+
+[options="header", cols=".^3a,.^11a,.^4a"]
+|===
+|Name|Description|Schema
+|**node** +
+__required__|The node on which the prepared statement is stored.|string
+|===
 
 [[sys-prepared-get]]
 === Get Prepared Statements

--- a/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
+++ b/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
@@ -1035,7 +1035,7 @@ This catalog provides data about the known prepared statements and their state i
 For each prepared statement, this catalog provides information such as name, statement, query plan, last use time, number of uses, and so on.
 
 For field names and meanings, refer to xref:n1ql:n1ql-rest-api/admin.adoc#_statements[Statements].
-The `system:prepareds` catalog returns all the properties that the N1QL Admin REST API returns.
+The `system:prepareds` catalog returns all the properties that the N1QL Admin REST API would return for a specific prepared statement.
 In addition, the `system:prepareds` catalog also returns the following property.
 
 [options="header", cols=".^3a,.^11a,.^4a"]

--- a/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
+++ b/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
@@ -172,12 +172,12 @@ When profiling is enabled, a query response includes the profile attribute.
 The attribute details are as follows:
 
 .Attribute Details
-[cols="3,11,8"]
+[cols="14,8"]
 |===
-2+| Attribute | Example
+| Attribute | Example
 
-2+a|
-`phaseTimes` - Cumulative execution times for various phases involved in the query execution, such as authorize, indexscan, fetch, parse, plan, run, etc.
+a|
+`phaseTimes` -- Cumulative execution times for various phases involved in the query execution, such as authorize, indexscan, fetch, parse, plan, run, etc.
 
 [NOTE]
 ====
@@ -199,8 +199,8 @@ a|
 }
 ----
 
-2+a|
-`phaseCounts` - Count of documents processed at selective phases involved in the query execution, such as authorize, indexscan, fetch, parse, plan, run, etc.
+a|
+`phaseCounts` -- Count of documents processed at selective phases involved in the query execution, such as authorize, indexscan, fetch, parse, plan, run, etc.
 
 [NOTE]
 ====
@@ -217,7 +217,8 @@ a|
 }
 ----
 
-2+| `phaseOperators` - Indicates the number of each kind of query operators involved in different phases of the query processing.
+a|
+`phaseOperators` -- Indicates the number of each kind of query operators involved in different phases of the query processing.
 For instance, this example, one non covering index path was taken, which involves 1 indexScan and 1 fetch operator.
 
 A join would have probably involved 2 fetches (1 per keyspace)
@@ -235,10 +236,41 @@ a|
 }
 ----
 
-2+| `executionTimings` - The execution details such as kernel and service execution times, number of documents processed at each query operator in each phase, and number of phase switches, for various phases involved in the query execution.
+a|
+`executionTimings` -- The execution details such as kernel and service execution times, number of documents processed at each query operator in each phase, and number of phase switches, for various phases involved in the query execution.
 
 The following statistics are collected for each operator:
-.7+a|
+
+`#operator`::
+Name of the operator.
+
+`#stats`::
+These values will be dynamic, depending on the documents processed by various phases up to this moment in time.
++
+A new query on `system:active_requests` will return different values.
+
+`#itemsIn`;;
+Number of input documents to the operator.
+
+`#itemsOut`;;
+Number of output documents after the operator processing.
+
+`#phaseSwitches`;;
+Number of switches between executing, waiting for services, or waiting for the `goroutine` scheduler.
+
+`execTime`;;
+Time spent executing the operator code inside N1QL query engine.
+
+`kernTime`;;
+Time spent waiting to be scheduled for CPU time.
+
+`servTime`;;
+Time spent waiting for another service, such as index or data.
++
+* For index scan, it is time spent waiting for GSI/indexer.
+* For fetch, it is time spent waiting on the KV store.
+
+a|
 [source,json]
 ----
 "executionTimings": {
@@ -269,32 +301,6 @@ The following statistics are collected for each operator:
   }, …]
 ----
 
-| `#operator`
-| Name of the operator.
-
-| `#stats`
-| These values will be dynamic, depending on the documents processed by various phases up to this moment in time.
-
-A new query on `system:active_requests` will return different values.
-
-| `#itemsIn`
-| Number of input documents to the operator.
-
-| `#itemsOut`
-| Number of output documents after the operator processing.
-
-| `#phaseSwitches`
-| Number of switches between executing, waiting for services, or waiting for the `goroutine` scheduler.
-
-`execTime` - Time spent executing the operator code inside N1QL query engine.
-
-`kernTime` - Time spent waiting to be scheduled for CPU time.
-
-`servTime` - Time spent waiting for another service, such as index or data.
-
-2+a|
-* For index scan, it is time spent waiting for GSI/indexer
-* For fetch, it is time spent waiting on the KV store
 |===
 
 These statistics (`kernTime`, `servTime`, and `execTime`) can be very helpful in troubleshooting query performance issues, such as:

--- a/modules/n1ql/partials/n1ql-rest-api/admin/definitions.adoc
+++ b/modules/n1ql/partials/n1ql-rest-api/admin/definitions.adoc
@@ -33,9 +33,26 @@ ifdef::basebackend-html[]
   td.tableblock{
     vertical-align: top !important;
   }
+
+  /* Hide content of tags section */
+  div.sect2 > h3#tags,
+  div.sect2 > h3#tags ~ *{
+    display: none;
 </style>
 ++++
 endif::[]
+
+
+**{toc-title}**
+
+* <<_clusters>>
+* <<_nodes>>
+* <<_requests>>
+* <<_statements>>
+* <<_vitals>>
+* <<_statistics>>
+* <<_metrics>>
+* <<_settings>>
 
 
 [[_clusters]]
@@ -139,34 +156,56 @@ __optional__|Username with whose privileges the query is run.|string
 |Name|Description|Schema
 |**avgElapsedTime** +
 __optional__|The mean time taken from when the request to execute the prepared statement was acknowledged by the service, to when the request was completed.
-It includes the time taken by the service to schedule the request.|string (duration)
+It includes the time taken by the service to schedule the request.
+
+This property is only returned when the prepared statement has been executed.
+It is only returned when retrieving a specific prepared statement, not when retrieving all prepared statements.|string (duration)
 |**avgServiceTime** +
-__optional__|The mean amount of calendar time taken to complete the execution of the prepared statement.|string (duration)
+__optional__|The mean amount of calendar time taken to complete the execution of the prepared statement.
+
+This property is only returned when the prepared statement has been executed.
+It is only returned when retrieving a specific prepared statement, not when retrieving all prepared statements.|string (duration)
 |**encoded_plan** +
-__optional__|The full prepared statement in encoded format.|string
+__required__|The full prepared statement in encoded format.|string
 |**featureControls** +
-__optional__||integer
+__optional__|This property is provided for technical support only.
+It is only returned when retrieving a specific prepared statement, not when retrieving all prepared statements.|integer
 |**indexApiVersion** +
-__optional__||integer
+__optional__|This property is provided for technical support only.
+It is only returned when retrieving a specific prepared statement, not when retrieving all prepared statements.|integer
 |**lastUse** +
-__optional__|Date and time of last use.|string (date-time)
+__optional__|Date and time of last use.
+
+This property is only returned when the prepared statement has been executed.|string (date-time)
 |**maxElapsedTime** +
 __optional__|The maximum time taken from when the request to execute the prepared statement was acknowledged by the service, to when the request was completed.
-It includes the time taken by the service to schedule the request.|string (duration)
+It includes the time taken by the service to schedule the request.
+
+This property is only returned when the prepared statement has been executed.
+It is only returned when retrieving a specific prepared statement, not when retrieving all prepared statements.|string (duration)
 |**maxServiceTime** +
-__optional__|The maximum amount of calendar time taken to complete the execution of the prepared statement.|string (duration)
+__optional__|The maximum amount of calendar time taken to complete the execution of the prepared statement.
+
+This property is only returned when the prepared statement has been executed.
+It is only returned when retrieving a specific prepared statement, not when retrieving all prepared statements.|string (duration)
 |**minElapsedTime** +
 __optional__|The minimum time taken from when the request to execute the prepared statement was acknowledged by the service, to when the request was completed.
-It includes the time taken by the service to schedule the request.|string (duration)
+It includes the time taken by the service to schedule the request.
+
+This property is only returned when the prepared statement has been executed.
+It is only returned when retrieving a specific prepared statement, not when retrieving all prepared statements.|string (duration)
 |**minServiceTime** +
-__optional__|The minimum amount of calendar time taken to complete the execution of the prepared statement.|string (duration)
+__optional__|The minimum amount of calendar time taken to complete the execution of the prepared statement.
+
+This property is only returned when the prepared statement has been executed.
+It is only returned when retrieving a specific prepared statement, not when retrieving all prepared statements.|string (duration)
 |**name** +
-__optional__|The name of the prepared statement.
+__required__|The name of the prepared statement.
 This may be a UUID that was assigned automatically, or a name that was user-specified when the statement was created.|string
 |**statement** +
-__optional__|The text of the N1QL query.|string
+__required__|The text of the N1QL query.|string
 |**uses** +
-__optional__|The count of times the prepared statement has been executed.|integer
+__required__|The count of times the prepared statement has been executed.|integer
 |===
 
 

--- a/modules/n1ql/partials/n1ql-rest-api/admin/overview.adoc
+++ b/modules/n1ql/partials/n1ql-rest-api/admin/overview.adoc
@@ -30,8 +30,8 @@ __Version__ : 6.5
 
 * configuration : Operations for cluster and node configuration.
 * prepared : Operations for prepared statements.
-* active : Operations for active statements.
-* completed : Operations for completed statements.
+* active : Operations for active requests.
+* completed : Operations for completed requests.
 * statistics : Operations for query statistics.
 * settings : Operations for query settings.
 * default : Other operations.

--- a/modules/n1ql/partials/n1ql-rest-api/admin/overview.adoc
+++ b/modules/n1ql/partials/n1ql-rest-api/admin/overview.adoc
@@ -4,6 +4,7 @@
 // This file is created automatically by Swagger2Markup.
 // DO NOT EDIT!
 
+
 // tag::body[]
 
 
@@ -23,6 +24,17 @@ where [.var]`node` is the host name or IP address of a computer running the N1QL
 === Version information
 [%hardbreaks]
 __Version__ : 6.5
+
+
+=== Tags
+
+* configuration : Operations for cluster and node configuration.
+* prepared : Operations for prepared statements.
+* active : Operations for active statements.
+* completed : Operations for completed statements.
+* statistics : Operations for query statistics.
+* settings : Operations for query settings.
+* default : Other operations.
 
 
 === Consumes

--- a/modules/n1ql/partials/n1ql-rest-api/admin/paths.adoc
+++ b/modules/n1ql/partials/n1ql-rest-api/admin/paths.adoc
@@ -375,7 +375,7 @@ Returns all prepared index statements.
 
 [[_active_resource]]
 === Active
-Operations for active statements.
+Operations for active requests.
 
 
 * <<_get_active_requests>>
@@ -542,7 +542,7 @@ Returns all active index requests.
 
 [[_completed_resource]]
 === Completed
-Operations for completed statements.
+Operations for completed requests.
 
 
 * <<_get_completed_requests>>

--- a/modules/n1ql/partials/n1ql-rest-api/admin/paths.adoc
+++ b/modules/n1ql/partials/n1ql-rest-api/admin/paths.adoc
@@ -4,25 +4,43 @@
 
 
 [[_paths]]
-== Paths
+== Resources
 
-// Dummy attributes for path parameters
+**{toc-title}**
 
-:name: \{name}
-:cluster: \{cluster}
-:node: \{node}
-:request: \{request}
-:stat: \{stat}
+* <<_configuration_resource>>
+* <<_prepared_resource>>
+* <<_active_resource>>
+* <<_completed_resource>>
+* <<_statistics_resource>>
+* <<_settings_resource>>
+* <<_default_resource>>
 
 
-[[_admin_clusters_get]]
-=== GET /admin/clusters
+[[_configuration_resource]]
+=== Configuration
+Operations for cluster and node configuration.
 
-==== Description
+
+* <<_get_clusters>>
+* <<_get_cluster>>
+* <<_get_nodes>>
+* <<_get_node>>
+* <<_get_config>>
+
+
+[[_get_clusters]]
+==== Read All Clusters
+....
+GET /admin/clusters
+....
+
+
+===== Description
 Returns information about all clusters.
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -31,7 +49,7 @@ Returns information about all clusters.
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -40,14 +58,18 @@ Returns information about all clusters.
 |===
 
 
-[[_admin_clusters_cluster_get]]
-=== GET /admin/clusters/{cluster}
+[[_get_cluster]]
+==== Read a Cluster
+....
+GET /admin/clusters/{cluster}
+....
 
-==== Description
+
+===== Description
 Returns information about the specified cluster.
 
 
-==== Parameters
+===== Parameters
 
 [options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
@@ -57,7 +79,7 @@ __required__|The name of a cluster.|string
 |===
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -66,7 +88,7 @@ __required__|The name of a cluster.|string
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -75,14 +97,18 @@ __required__|The name of a cluster.|string
 |===
 
 
-[[_admin_clusters_cluster_nodes_get]]
-=== GET /admin/clusters/{cluster}/nodes
+[[_get_nodes]]
+==== Read All Nodes
+....
+GET /admin/clusters/{cluster}/nodes
+....
 
-==== Description
+
+===== Description
 Returns information about all nodes in the specified cluster.
 
 
-==== Parameters
+===== Parameters
 
 [options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
@@ -92,7 +118,7 @@ __required__|The name of a cluster.|string
 |===
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -101,7 +127,7 @@ __required__|The name of a cluster.|string
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -110,14 +136,18 @@ __required__|The name of a cluster.|string
 |===
 
 
-[[_admin_clusters_cluster_nodes_node_get]]
-=== GET /admin/clusters/{cluster}/nodes/{node}
+[[_get_node]]
+==== Read a Node
+....
+GET /admin/clusters/{cluster}/nodes/{node}
+....
 
-==== Description
+
+===== Description
 Returns information about the specified node in the specified cluster.
 
 
-==== Parameters
+===== Parameters
 
 [options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
@@ -129,7 +159,7 @@ __required__|The name of a node.|string
 |===
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -138,7 +168,7 @@ __required__|The name of a node.|string
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -147,14 +177,18 @@ __required__|The name of a node.|string
 |===
 
 
-[[_admin_config_get]]
-=== GET /admin/config
+[[_get_config]]
+==== Read Configuration
+....
+GET /admin/config
+....
 
-==== Description
+
+===== Description
 Returns the configuration of the query service on the cluster.
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -163,7 +197,7 @@ Returns the configuration of the query service on the cluster.
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -172,10 +206,25 @@ Returns the configuration of the query service on the cluster.
 |===
 
 
-[[_admin_prepareds_get]]
-=== GET /admin/prepareds
+[[_prepared_resource]]
+=== Prepared
+Operations for prepared statements.
 
-==== Description
+
+* <<_get_prepareds>>
+* <<_get_prepared>>
+* <<_delete_prepared>>
+* <<_get_prepared_indexes>>
+
+
+[[_get_prepareds]]
+==== Retrieve All Prepared Statements
+....
+GET /admin/prepareds
+....
+
+
+===== Description
 Returns all prepared statements.
 [NOTE]
 ====
@@ -183,7 +232,7 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-prepared-get[Get Pre
 ====
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -192,7 +241,7 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-prepared-get[Get Pre
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -202,9 +251,13 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-prepared-get[Get Pre
 
 
 [[_get_prepared]]
-=== GET /admin/prepareds/{name}
+==== Retrieve a Prepared Statement
+....
+GET /admin/prepareds/{name}
+....
 
-==== Description
+
+===== Description
 Returns the specified prepared statement.
 [NOTE]
 ====
@@ -212,7 +265,7 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-prepared-get[Get Pre
 ====
 
 
-==== Parameters
+===== Parameters
 
 [options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
@@ -223,7 +276,7 @@ This may be a UUID that was assigned automatically, or a name that was user-spec
 |===
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -232,7 +285,7 @@ This may be a UUID that was assigned automatically, or a name that was user-spec
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -242,9 +295,13 @@ This may be a UUID that was assigned automatically, or a name that was user-spec
 
 
 [[_delete_prepared]]
-=== DELETE /admin/prepareds/{name}
+==== Delete a Prepared Statement
+....
+DELETE /admin/prepareds/{name}
+....
 
-==== Description
+
+===== Description
 Deletes the specified prepared statement.
 [NOTE]
 ====
@@ -252,7 +309,7 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-prepared-delete[Dele
 ====
 
 
-==== Parameters
+===== Parameters
 
 [options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
@@ -263,7 +320,7 @@ This may be a UUID that was assigned automatically, or a name that was user-spec
 |===
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -273,7 +330,7 @@ This may be a UUID that was assigned automatically, or a name that was user-spec
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -282,10 +339,59 @@ This may be a UUID that was assigned automatically, or a name that was user-spec
 |===
 
 
-[[_admin_active_requests_get]]
-=== GET /admin/active_requests
+[[_get_prepared_indexes]]
+==== Retrieve Prepared Index Statements
+....
+GET /admin/indexes/prepareds
+....
 
-==== Description
+
+===== Description
+Returns all prepared index statements.
+[TIP]
+====
+* Use <<_get_prepared>> to get information about a prepared index statement.
+* Use <<_delete_prepared>> to delete a prepared index statement.
+====
+
+
+===== Responses
+
+[options="header", cols=".^2a,.^14a,.^4a"]
+|===
+|HTTP Code|Description|Schema
+|**200**|An array of strings, each of which is the name of a prepared index statement.|< string > array
+|===
+
+
+===== Security
+
+[options="header", cols=".^3a,.^4a"]
+|===
+|Type|Name
+|**basic**|**<<_default,Default>>**
+|===
+
+
+[[_active_resource]]
+=== Active
+Operations for active statements.
+
+
+* <<_get_active_requests>>
+* <<_get_active_request>>
+* <<_delete_active_request>>
+* <<_get_active_indexes>>
+
+
+[[_get_active_requests]]
+==== Retrieve All Active Requests
+....
+GET /admin/active_requests
+....
+
+
+===== Description
 Returns all active query requests.
 [NOTE]
 ====
@@ -293,7 +399,7 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-active-get[Get Activ
 ====
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -302,7 +408,7 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-active-get[Get Activ
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -312,9 +418,13 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-active-get[Get Activ
 
 
 [[_get_active_request]]
-=== GET /admin/active_requests/{request}
+==== Retrieve an Active Request
+....
+GET /admin/active_requests/{request}
+....
 
-==== Description
+
+===== Description
 Returns the specified active query request.
 [NOTE]
 ====
@@ -322,7 +432,7 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-active-get[Get Activ
 ====
 
 
-==== Parameters
+===== Parameters
 
 [options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
@@ -333,7 +443,7 @@ This is the `requestID` that was assigned automatically when the statement was c
 |===
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -342,7 +452,7 @@ This is the `requestID` that was assigned automatically when the statement was c
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -352,9 +462,13 @@ This is the `requestID` that was assigned automatically when the statement was c
 
 
 [[_delete_active_request]]
-=== DELETE /admin/active_requests/{request}
+==== Delete an Active Request
+....
+DELETE /admin/active_requests/{request}
+....
 
-==== Description
+
+===== Description
 Terminates the specified active query request.
 [NOTE]
 ====
@@ -362,7 +476,7 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-active-delete[Termin
 ====
 
 
-==== Parameters
+===== Parameters
 
 [options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
@@ -373,7 +487,7 @@ This is the `requestID` that was assigned automatically when the statement was c
 |===
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -383,7 +497,7 @@ This is the `requestID` that was assigned automatically when the statement was c
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -392,10 +506,59 @@ This is the `requestID` that was assigned automatically when the statement was c
 |===
 
 
-[[_admin_completed_requests_get]]
-=== GET /admin/completed_requests
+[[_get_active_indexes]]
+==== Retrieve Active Index Requests
+....
+GET /admin/indexes/active_requests
+....
 
-==== Description
+
+===== Description
+Returns all active index requests.
+[TIP]
+====
+* Use <<_get_active_request>> to get information about an active index request.
+* Use <<_delete_active_request>> to terminate an active index request.
+====
+
+
+===== Responses
+
+[options="header", cols=".^2a,.^14a,.^4a"]
+|===
+|HTTP Code|Description|Schema
+|**200**|An array of strings, each of which is the requestID of an active index request.|< string > array
+|===
+
+
+===== Security
+
+[options="header", cols=".^3a,.^4a"]
+|===
+|Type|Name
+|**basic**|**<<_default,Default>>**
+|===
+
+
+[[_completed_resource]]
+=== Completed
+Operations for completed statements.
+
+
+* <<_get_completed_requests>>
+* <<_get_completed_request>>
+* <<_delete_completed_request>>
+* <<_get_completed_indexes>>
+
+
+[[_get_completed_requests]]
+==== Retrieve All Completed Requests
+....
+GET /admin/completed_requests
+....
+
+
+===== Description
 Returns all completed requests.
 [NOTE]
 ====
@@ -403,7 +566,7 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-get[Get Co
 ====
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -412,7 +575,7 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-get[Get Co
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -422,9 +585,13 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-get[Get Co
 
 
 [[_get_completed_request]]
-=== GET /admin/completed_requests/{request}
+==== Retrieve a Completed Request
+....
+GET /admin/completed_requests/{request}
+....
 
-==== Description
+
+===== Description
 Returns the specified completed request.
 [NOTE]
 ====
@@ -432,7 +599,7 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-get[Get Co
 ====
 
 
-==== Parameters
+===== Parameters
 
 [options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
@@ -443,7 +610,7 @@ This is the `requestID` that was assigned automatically when the statement was c
 |===
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -452,7 +619,7 @@ This is the `requestID` that was assigned automatically when the statement was c
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -462,9 +629,13 @@ This is the `requestID` that was assigned automatically when the statement was c
 
 
 [[_delete_completed_request]]
-=== DELETE /admin/completed_requests/{request}
+==== Delete a Completed Request
+....
+DELETE /admin/completed_requests/{request}
+....
 
-==== Description
+
+===== Description
 Purges the specified completed request.
 [NOTE]
 ====
@@ -472,7 +643,7 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-delete[Pur
 ====
 
 
-==== Parameters
+===== Parameters
 
 [options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
@@ -483,7 +654,7 @@ This is the `requestID` that was assigned automatically when the statement was c
 |===
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -493,7 +664,7 @@ This is the `requestID` that was assigned automatically when the statement was c
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -502,70 +673,14 @@ This is the `requestID` that was assigned automatically when the statement was c
 |===
 
 
-[[_admin_indexes_prepareds_get]]
-=== GET /admin/indexes/prepareds
-
-==== Description
-Returns all prepared index statements.
-[TIP]
-====
-* Use <<_get_prepared>> to get information about a prepared index statement.
-* Use <<_delete_prepared>> to delete a prepared index statement.
-====
+[[_get_completed_indexes]]
+==== Retrieve Completed Index Requests
+....
+GET /admin/indexes/completed_requests
+....
 
 
-==== Responses
-
-[options="header", cols=".^2a,.^14a,.^4a"]
-|===
-|HTTP Code|Description|Schema
-|**200**|An array of strings, each of which is the name of a prepared index statement.|< string > array
-|===
-
-
-==== Security
-
-[options="header", cols=".^3a,.^4a"]
-|===
-|Type|Name
-|**basic**|**<<_default,Default>>**
-|===
-
-
-[[_admin_indexes_active_requests_get]]
-=== GET /admin/indexes/active_requests
-
-==== Description
-Returns all active index requests.
-[TIP]
-====
-* Use <<_get_active_request>> to get information about an active index request.
-* Use <<_delete_active_request>> to terminate an active index request.
-====
-
-
-==== Responses
-
-[options="header", cols=".^2a,.^14a,.^4a"]
-|===
-|HTTP Code|Description|Schema
-|**200**|An array of strings, each of which is the requestID of an active index request.|< string > array
-|===
-
-
-==== Security
-
-[options="header", cols=".^3a,.^4a"]
-|===
-|Type|Name
-|**basic**|**<<_default,Default>>**
-|===
-
-
-[[_admin_indexes_completed_requests_get]]
-=== GET /admin/indexes/completed_requests
-
-==== Description
+===== Description
 Returns all completed index requests.
 [TIP]
 ====
@@ -574,7 +689,7 @@ Returns all completed index requests.
 ====
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -583,7 +698,7 @@ Returns all completed index requests.
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -592,47 +707,25 @@ Returns all completed index requests.
 |===
 
 
-[[_get_ping]]
-=== GET /admin/ping
-
-==== Description
-Returns a minimal response, indicating that the service is running and reachable.
+[[_statistics_resource]]
+=== Statistics
+Operations for query statistics.
 
 
-==== Responses
-
-[options="header", cols=".^2a,.^14a,.^4a"]
-|===
-|HTTP Code|Description|Schema
-|**200**|An empty object.|object
-|===
+* <<_get_vitals>>
+* <<_get_stats>>
+* <<_get_stat>>
+* <<_get_debug_vars>>
 
 
-==== Security
-
-[options="header", cols=".^3a,.^4a"]
-|===
-|Type|Name
-|**basic**|**<<_none,None>>**
-|===
+[[_get_vitals]]
+==== Retrieve Vitals
+....
+GET /admin/vitals
+....
 
 
-==== Example HTTP response
-
-====
-
-.Response 200
-[source,json]
-----
-{}
-----
-====
-
-
-[[_admin_vitals_get]]
-=== GET /admin/vitals
-
-==== Description
+===== Description
 Returns data about the running state and health of the query engine.
 This information can be very useful to assess the current workload and performance characteristics of a query engine, and hence load-balance the requests being sent to various query engines.
 [NOTE]
@@ -641,7 +734,7 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#vitals[Get System Vitals
 ====
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -650,7 +743,7 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#vitals[Get System Vitals
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -660,13 +753,17 @@ Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#vitals[Get System Vitals
 
 
 [[_get_stats]]
-=== GET /admin/stats
+==== Retrieve All Statistics
+....
+GET /admin/stats
+....
 
-==== Description
+
+===== Description
 Returns all statistics.
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -677,7 +774,7 @@ Each statistic has a different set of metrics.|<<_statistics,Statistics>>
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -686,14 +783,18 @@ Each statistic has a different set of metrics.|<<_statistics,Statistics>>
 |===
 
 
-[[_admin_stats_stat_get]]
-=== GET /admin/stats/{stat}
+[[_get_stat]]
+==== Retrieve a Statistic
+....
+GET /admin/stats/{stat}
+....
 
-==== Description
+
+===== Description
 Returns the specified statistic.
 
 
-==== Parameters
+===== Parameters
 
 [options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
@@ -705,7 +806,7 @@ You cannot specify a metric.|enum (active_requests, at_plus, audit_actions, audi
 |===
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -715,7 +816,7 @@ Each statistic has a different set of metrics.|<<_metrics,Metrics>>
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -725,13 +826,17 @@ Each statistic has a different set of metrics.|<<_metrics,Metrics>>
 
 
 [[_get_debug_vars]]
-=== GET /debug/vars
+==== Get Debug Variables
+....
+GET /debug/vars
+....
 
-==== Description
+
+===== Description
 Currently unused.
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -740,12 +845,12 @@ Currently unused.
 |===
 
 
-==== Produces
+===== Produces
 
 * `text/html`
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -754,7 +859,7 @@ Currently unused.
 |===
 
 
-==== Example HTTP response
+===== Example HTTP response
 
 ====
 
@@ -766,10 +871,23 @@ Currently unused.
 ====
 
 
-[[_admin_settings_get]]
-=== GET /admin/settings
+[[_settings_resource]]
+=== Settings
+Operations for query settings.
 
-==== Description
+
+* <<_get_settings>>
+* <<_post_settings>>
+
+
+[[_get_settings]]
+==== Retrieve Service-Level Query Settings
+....
+GET /admin/settings
+....
+
+
+===== Description
 Returns service-level query settings.
 [NOTE]
 ====
@@ -777,7 +895,7 @@ Refer to xref:settings:query-settings.adoc[Query Settings] for more information 
 ====
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -786,7 +904,7 @@ Refer to xref:settings:query-settings.adoc[Query Settings] for more information 
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -795,10 +913,14 @@ Refer to xref:settings:query-settings.adoc[Query Settings] for more information 
 |===
 
 
-[[_admin_settings_post]]
-=== POST /admin/settings
+[[_post_settings]]
+==== Update Service-Level Query Settings
+....
+POST /admin/settings
+....
 
-==== Description
+
+===== Description
 Updates service-level query settings.
 [NOTE]
 ====
@@ -806,7 +928,7 @@ Refer to xref:settings:query-settings.adoc[Query Settings] for more information 
 ====
 
 
-==== Parameters
+===== Parameters
 
 [options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
@@ -816,7 +938,7 @@ __optional__|An object specifying service-level query settings.|<<_settings,Sett
 |===
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -825,13 +947,62 @@ __optional__|An object specifying service-level query settings.|<<_settings,Sett
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
 |Type|Name
 |**basic**|**<<_default,Default>>**
 |===
+
+
+[[_default_resource]]
+=== Default
+Other operations.
+
+
+* <<_get_ping>>
+
+
+[[_get_ping]]
+==== Ping
+....
+GET /admin/ping
+....
+
+
+===== Description
+Returns a minimal response, indicating that the service is running and reachable.
+
+
+===== Responses
+
+[options="header", cols=".^2a,.^14a,.^4a"]
+|===
+|HTTP Code|Description|Schema
+|**200**|An empty object.|object
+|===
+
+
+===== Security
+
+[options="header", cols=".^3a,.^4a"]
+|===
+|Type|Name
+|**basic**|**<<_none,None>>**
+|===
+
+
+===== Example HTTP response
+
+====
+
+.Response 200
+[source,json]
+----
+{}
+----
+====
 
 
 

--- a/modules/n1ql/partials/n1ql-rest-api/functions/definitions.adoc
+++ b/modules/n1ql/partials/n1ql-rest-api/functions/definitions.adoc
@@ -33,9 +33,21 @@ ifdef::basebackend-html[]
   td.tableblock{
     vertical-align: top !important;
   }
+
+  /* Hide content of tags section */
+  div.sect2 > h3#tags,
+  div.sect2 > h3#tags ~ *{
+    display: none;
+  }
 </style>
 ++++
 endif::[]
+
+
+**{toc-title}**
+
+* <<_libraries>>
+* <<_functions>>
 
 
 [[_libraries]]

--- a/modules/n1ql/partials/n1ql-rest-api/functions/overview.adoc
+++ b/modules/n1ql/partials/n1ql-rest-api/functions/overview.adoc
@@ -25,6 +25,13 @@ where [.var]`node` is the host name or IP address of a computer running the N1QL
 __Version__ : 1.0
 
 
+=== Tags
+
+* collection : Operations for all libraries and functions.
+* libraries : Operations for individual libraries.
+* functions : Operations for individual functions.
+
+
 === Consumes
 
 * `application/json`

--- a/modules/n1ql/partials/n1ql-rest-api/functions/paths.adoc
+++ b/modules/n1ql/partials/n1ql-rest-api/functions/paths.adoc
@@ -4,22 +4,40 @@
 
 
 [[_paths]]
-== Paths
+== Resources
+
+**{toc-title}**
+
+* <<_collection_resource>>
+* <<_libraries_resource>>
+* <<_functions_resource>>
+
+
+[[_collection_resource]]
+=== Collection
+Operations for all libraries and functions.
+
+
+* <<_post_collection>>
+* <<_get_collection>>
+* <<_put_collection>>
+* <<_delete_collection>>
+
 
 [[_post_collection]]
-=== Create or Update a Collection of Libraries
+==== Create or Update a Collection of Libraries
 ....
 POST /functions/v1/libraries
 ....
 
 
-==== Description
+===== Description
 Creates the specified libraries and their associated functions.
 If any specified library exists, the functions specified in the body for that library are appended to the existing library.
 If any specified function exists within an existing library, the existing function is overwritten.
 
 
-==== Parameters
+===== Parameters
 
 [options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
@@ -29,7 +47,7 @@ __required__|An array of objects, each of which gives information about one libr
 |===
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -40,7 +58,7 @@ The body of the request may be incorrect.|No Content
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -49,7 +67,7 @@ The body of the request may be incorrect.|No Content
 |===
 
 
-==== Example HTTP request
+===== Example HTTP request
 
 ====
 The example below creates or updates two libraries, `math` and `science`.
@@ -82,17 +100,17 @@ $ curl -X POST \
 
 
 [[_get_collection]]
-=== Read All Libraries
+==== Read All Libraries
 ....
 GET /functions/v1/libraries
 ....
 
 
-==== Description
+===== Description
 Returns all libraries and functions.
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -101,7 +119,7 @@ Returns all libraries and functions.
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -110,7 +128,7 @@ Returns all libraries and functions.
 |===
 
 
-==== Example HTTP request
+===== Example HTTP request
 
 ====
 The example below fetches all defined libraries.
@@ -125,7 +143,7 @@ $ curl -X GET \
 ====
 
 
-==== Example HTTP response
+===== Example HTTP response
 
 ====
 
@@ -156,18 +174,18 @@ $ curl -X GET \
 
 
 [[_put_collection]]
-=== Replace All Libraries
+==== Replace All Libraries
 ....
 PUT /functions/v1/libraries
 ....
 
 
-==== Description
+===== Description
 This has exactly the same effect as <<_delete_collection,deleting all libraries>> followed by <<_post_collection,creating a collection of libraries>>.
 That is, all existing libraries in the system are deleted, and the libraries specified in the body of this call are created, resulting in the system having exclusively the libraries specified by this call.
 
 
-==== Parameters
+===== Parameters
 
 [options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
@@ -177,7 +195,7 @@ __required__|An array of objects, each of which gives information about one libr
 |===
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -188,7 +206,7 @@ The body of the request may be incorrect.|No Content
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -197,7 +215,7 @@ The body of the request may be incorrect.|No Content
 |===
 
 
-==== Example HTTP request
+===== Example HTTP request
 
 ====
 The example below removes all libraries in the system and creates two libraries, `math` and `science`.
@@ -230,17 +248,17 @@ $ curl -X PUT \
 
 
 [[_delete_collection]]
-=== Delete All Libraries
+==== Delete All Libraries
 ....
 DELETE /functions/v1/libraries
 ....
 
 
-==== Description
+===== Description
 Deletes all libraries entirely.
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -249,7 +267,7 @@ Deletes all libraries entirely.
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -258,7 +276,7 @@ Deletes all libraries entirely.
 |===
 
 
-==== Example HTTP request
+===== Example HTTP request
 
 
 ====
@@ -274,20 +292,31 @@ $ curl -X DELETE \
 ====
 
 
+[[_libraries_resource]]
+=== Libraries
+Operations for individual libraries.
+
+
+* <<_post_library>>
+* <<_get_library>>
+* <<_put_library>>
+* <<_delete_library>>
+
+
 [[_post_library]]
-=== Create or Update a Library
+==== Create or Update a Library
 ....
 POST /functions/v1/libraries/{library}
 ....
 
 
-==== Description
+===== Description
 Creates the specified library and its associated functions.
 If the specified library exists, the functions specified are added to the existing library.
 If a specified function exists within the existing library, the existing function is overwritten.
 
 
-==== Parameters
+===== Parameters
 
 [options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
@@ -304,7 +333,7 @@ The `name` property in the library object must match the library name specified 
 |===
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -317,7 +346,7 @@ The body of the request may be incorrect.|No Content
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -326,7 +355,7 @@ The body of the request may be incorrect.|No Content
 |===
 
 
-==== Example HTTP request
+===== Example HTTP request
 
 ====
 The example below creates or updates a library called `math`.
@@ -356,17 +385,17 @@ $ curl -X POST \
 
 
 [[_get_library]]
-=== Read a Library
+==== Read a Library
 ....
 GET /functions/v1/libraries/{library}
 ....
 
 
-==== Description
+===== Description
 Returns a library with all its functions.
 
 
-==== Parameters
+===== Parameters
 
 [options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
@@ -376,7 +405,7 @@ __required__|The name of a library.|string
 |===
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -387,7 +416,7 @@ The library name in the path may be incorrect.|No Content
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -396,7 +425,7 @@ The library name in the path may be incorrect.|No Content
 |===
 
 
-==== Example HTTP request
+===== Example HTTP request
 
 ====
 The example below gets all functions in the library `math`.
@@ -411,7 +440,7 @@ $ curl -X GET \
 ====
 
 
-==== Example HTTP response
+===== Example HTTP response
 
 ====
 
@@ -435,18 +464,18 @@ $ curl -X GET \
 
 
 [[_put_library]]
-=== Replace a Library
+==== Replace a Library
 ....
 PUT /functions/v1/libraries/{library}
 ....
 
 
-==== Description
+===== Description
 This has exactly the same effect as <<_delete_library,deleting a library>> followed by <<_post_library,creating a library>>.
 That is, if the library exists, it is deleted entirely and replaced with the contents of the library specified in the body of this call, resulting in the library having only functions specified by this call exclusively.
 
 
-==== Parameters
+===== Parameters
 
 [options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
@@ -463,7 +492,7 @@ The `name` property in the library object must match the library name specified 
 |===
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -476,7 +505,7 @@ The body of the request may be incorrect.|No Content
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -485,7 +514,7 @@ The body of the request may be incorrect.|No Content
 |===
 
 
-==== Example HTTP request
+===== Example HTTP request
 
 ====
 The example below replaces the `math` library with a new copy, dropping any old `math` library.
@@ -515,17 +544,17 @@ $ curl -X PUT \
 
 
 [[_delete_library]]
-=== Delete a Library
+==== Delete a Library
 ....
 DELETE /functions/v1/libraries/{library}
 ....
 
 
-==== Description
+===== Description
 Deletes the specified library entirely.
 
 
-==== Parameters
+===== Parameters
 
 [options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
@@ -535,7 +564,7 @@ __required__|The name of a library.|string
 |===
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -546,7 +575,7 @@ The library name in the path may be incorrect.|No Content
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -555,7 +584,7 @@ The library name in the path may be incorrect.|No Content
 |===
 
 
-==== Example HTTP request
+===== Example HTTP request
 
 ====
 The example below deletes the `math` library entirely.
@@ -570,14 +599,25 @@ $ curl -X DELETE \
 ====
 
 
+[[_functions_resource]]
+=== Functions
+Operations for individual functions.
+
+
+* <<_post_function>>
+* <<_get_function>>
+* <<_put_function>>
+* <<_delete_function>>
+
+
 [[_post_function]]
-=== Create or Update a Function
+==== Create or Update a Function
 ....
 POST /functions/v1/libraries/{library}/functions/{function}
 ....
 
 
-==== Description
+===== Description
 Creates the specified function in the specified library.
 If the specified library does not exist, the library is created.
 If the function already exists in the specified library, the existing function is overwritten.
@@ -589,7 +629,7 @@ If they do not match, you may get an evaluation error when you attempt to execut
 ====
 
 
-==== Parameters
+===== Parameters
 
 [options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
@@ -608,7 +648,7 @@ The `name` property in the function object must match the function name specifie
 |===
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -621,7 +661,7 @@ The body of the request may be incorrect.|No Content
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -630,7 +670,7 @@ The body of the request may be incorrect.|No Content
 |===
 
 
-==== Example HTTP request
+===== Example HTTP request
 
 ====
 The example below creates or updates a function called `sub` in the library called `math`.
@@ -653,17 +693,17 @@ $ curl -X POST \
 
 
 [[_get_function]]
-=== Read a Function
+==== Read a Function
 ....
 GET /functions/v1/libraries/{library}/functions/{function}
 ....
 
 
-==== Description
+===== Description
 Returns the specified function from the specified library.
 
 
-==== Parameters
+===== Parameters
 
 [options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
@@ -675,7 +715,7 @@ __required__|The name of a function.|string
 |===
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -686,7 +726,7 @@ The library name or function name in the path may be incorrect.|No Content
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -695,7 +735,7 @@ The library name or function name in the path may be incorrect.|No Content
 |===
 
 
-==== Example HTTP request
+===== Example HTTP request
 
 ====
 The example below gets the function `f2c` from the library `science`.
@@ -710,7 +750,7 @@ $ curl -X GET \
 ====
 
 
-==== Example HTTP response
+===== Example HTTP response
 
 ====
 
@@ -727,17 +767,17 @@ $ curl -X GET \
 
 
 [[_put_function]]
-=== Replace a Function
+==== Replace a Function
 ....
 PUT /functions/v1/libraries/{library}/functions/{function}
 ....
 
 
-==== Description
+===== Description
 This has exactly the same effect as <<_post_function,creating or updating a function>>, and is included for completeness.
 
 
-==== Parameters
+===== Parameters
 
 [options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
@@ -756,7 +796,7 @@ The `name` property in the function object must match the function name specifie
 |===
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -769,7 +809,7 @@ The body of the request may be incorrect.|No Content
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -778,7 +818,7 @@ The body of the request may be incorrect.|No Content
 |===
 
 
-==== Example HTTP request
+===== Example HTTP request
 
 ====
 The example below creates or replaces a function called `sub` in the library called `math`.
@@ -800,17 +840,17 @@ $ curl -X PUT \
 
 
 [[_delete_function]]
-=== Delete a Function
+==== Delete a Function
 ....
 DELETE /functions/v1/libraries/{library}/functions/{function}
 ....
 
 
-==== Description
+===== Description
 Deletes the specified function in the specified library.
 
 
-==== Parameters
+===== Parameters
 
 [options="header", cols=".^2a,.^3a,.^9a,.^4a"]
 |===
@@ -822,7 +862,7 @@ __required__|The name of a function.|string
 |===
 
 
-==== Responses
+===== Responses
 
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
@@ -833,7 +873,7 @@ The library name or function name in the path may be incorrect.|No Content
 |===
 
 
-==== Security
+===== Security
 
 [options="header", cols=".^3a,.^4a"]
 |===
@@ -842,7 +882,7 @@ The library name or function name in the path may be incorrect.|No Content
 |===
 
 
-==== Example HTTP request
+===== Example HTTP request
 
 ====
 The example below deletes the function `sub` in the `math` library.

--- a/modules/rest-api/partials/index-stats/definitions.adoc
+++ b/modules/rest-api/partials/index-stats/definitions.adoc
@@ -38,6 +38,8 @@ ifdef::basebackend-html[]
 endif::[]
 
 
+**{toc-title}**
+
 * <<_node>>
 * <<_index>>
 

--- a/modules/rest-api/partials/index-stats/paths.adoc
+++ b/modules/rest-api/partials/index-stats/paths.adoc
@@ -6,6 +6,8 @@
 [[_paths]]
 == Paths
 
+**{toc-title}**
+
 * <<_get_node_stats>>
 * <<_get_index_stats>>
 


### PR DESCRIPTION
The following draft documentation is ready for review:

* [Monitor Queries › system:prepareds](https://simon-dew.github.io/docs-site/DOC-5290/server/6.5/manage/monitor/monitoring-n1ql-query.html#sys-prepared) — `nodes` property
* [Admin REST API › Definitions › Statements](https://simon-dew.github.io/docs-site/DOC-5290/server/6.5/n1ql/n1ql-rest-api/admin.html#_statements) — explain when each property is returned

Plus other minor improvements to both pages.

Docs issue: [DOC-5290](https://issues.couchbase.com/browse/DOC-5290)