### PR TITLE
Fix example/incorrect math in to_meters() function

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/userfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/userfun.adoc
@@ -47,7 +47,7 @@ The following statement creates a function called `to_meters`, which converts fe
 
 [source,n1ql]
 ----
-CREATE FUNCTION to_meters() { args[0] / 0.3048 };
+CREATE FUNCTION to_meters() { args[0] * 0.3048 };
 ----
 
 The following query uses the `to_meters` function to express the elevation of the selected airports in meters above mean sea level (mamsl).
@@ -68,23 +68,23 @@ LIMIT 5;
 [
   {
     "airportname": "Calais Dunkerque",
-    "mamsl": 39
+    "mamsl": 4
   },
   {
     "airportname": "Peronne St Quentin",
-    "mamsl": 968
+    "mamsl": 90
   },
   {
     "airportname": "Les Loges",
-    "mamsl": 1404
+    "mamsl": 130
   },
   {
     "airportname": "Couterne",
-    "mamsl": 2356
+    "mamsl": 219
   },
   {
     "airportname": "Bray",
-    "mamsl": 1194
+    "mamsl": 111
   }
 ]
 ----


### PR DESCRIPTION
The math is wrong to convert from feet to meters we need to multiply not divide.  I will find the "highest" airport and prove it out

SELECT airportname, geo.alt feet FROM `travel-sample`
WHERE type = "airport" order by geo.alt DESC LIMIT 1;
=> "feet": 9078

Google: Telluride airport altitude
=> Elevation AMSL‎: ‎9,078 ft / 2,767 m	

Run the example
CREATE FUNCTION to_meters() { args[0] / 0.3048 };

SELECT airportname, geo.alt feet, round(to_meters(geo.alt)) meters FROM `travel-sample`
WHERE type = "airport" order by geo.alt DESC LIMIT 1;
=> "feet": 9078
=>  "meters": 29783   WRONG

**** correct the function ****

DROP FUNCTION to_meters;
CREATE FUNCTION to_meters() { args[0] * 0.3048 };

SELECT airportname, geo.alt feet, round(to_meters(geo.alt)) meters FROM `travel-sample`
WHERE type = "airport" order by geo.alt DESC LIMIT 1;
=>  "feet": 9078,
=> "meters": 2767   CORRECT