### PR TITLE
DOC-6237: Standalone FTS and N1QL FTS behavior difference

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
@@ -92,6 +92,13 @@ For more details, refer to xref:fts:fts-query-types.adoc[Query Types].
 | object
 | A complete full text search request, including sort and pagination options, and so on.
 For more details, refer to xref:fts:fts-sorting.adoc[Sorting Query Results].
+
+[NOTE]
+====
+When specifying a complete full text search request with the N1QL SEARCH() function, if the value of the `size` parameter is greater than the xref:xref:fts:fts-response-object-schema.adoc#request[maximum number of full text search results], the query ignores the `size` parameter and returns all matching results.
+
+This is different to the behavior of a complete full text search request in the Search service, where the query returns an error if the value of the `size` parameter is greater than the maximum number of full text search results.
+====
 |===
 +
 The _query_ argument may be replaced by a N1QL query parameter, as long as the query parameter resolves to a string or an object.
@@ -214,6 +221,7 @@ WHERE SEARCH(t1, "country:\"United States\"");
     "id": "landmark_3385"
   },
 ...
+]
 ----
 
 The results are unordered, so they may be returned in a different order each time.
@@ -246,6 +254,7 @@ WHERE SEARCH(t1, {
     "name": "New Road Guest House (B&B)"
   },
 ...
+]
 ----
 
 The results are unordered, so they may be returned in a different order each time.
@@ -268,7 +277,7 @@ WHERE SEARCH(t1, {
      "field": "reviews.content",
      "analyzer": "standard"
    },
-   "size" : 10,
+   "size" : 5,
    "sort": [
       {
        "by" : "field",
@@ -294,13 +303,14 @@ WHERE SEARCH(t1, {
     "name": "Thornehill Broome Beach Campground"
   },
 ...
+]
 ----
 
 This query returns 5 results, and the results are ordered, as specified by the search options.
 As an alternative, you could limit the number of results and order them using the N1QL xref:n1ql-language-reference/limit.adoc[LIMIT] and xref:n1ql-language-reference/orderby.adoc[ORDER BY] clauses.
 ====
 
-.Search against an FTS index that carries a custom type mapping
+.Search against a full text search index that carries a custom type mapping
 ====
 [source,n1ql]
 ----
@@ -326,9 +336,10 @@ WHERE t1.type = "airline" AND SEARCH(t1.country, "United States");
 ]
 ----
 
-If the FTS index being queried has it's default mapping disabled and has a custom type mapping defined ("airline" in the above example), the query would need to explicitly specify the "type".
-Here's more on how you could define custom type mappings within the FTS index xref:fts:fts-creating-indexes.adoc[Specifying Type Mappings].
-Note that for N1QL queries, an FTS index with only 1 type mapping will be searchable.
+If the full text search index being queried has its default mapping disabled and has a custom type mapping defined ("airline" in the above example), the query needs to specify the type explicitly.
+
+For more information on defining custom type mappings within the full text search index, refer to xref:fts:fts-creating-indexes.adoc#specifying-type-mappings[Specifying Type Mappings].
+Note that for N1QL queries, only full text search indexes with one type mapping are searchable.
 ====
 
 [[search_meta,SEARCH_META()]]

--- a/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
@@ -92,6 +92,13 @@ For more details, refer to xref:fts:fts-query-types.adoc[Query Types].
 | object
 | A complete full text search request, including sort and pagination options, and so on.
 For more details, refer to xref:fts:fts-sorting.adoc[Sorting Query Results].
+
+[NOTE]
+====
+When specifying a complete full text search request with the N1QL SEARCH() function, if the value of the `size` parameter is greater than the xref:xref:fts:fts-response-object-schema.adoc#request[maximum number of full text search results], the query ignores the `size` parameter and returns all matching results.
+
+This is different to the behavior of a complete full text search request in the Search service, where the query returns an error if the value of the `size` parameter is greater than the maximum number of full text search results.
+====
 |===
 +
 The _query_ argument may be replaced by a N1QL query parameter, as long as the query parameter resolves to a string or an object.

--- a/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
@@ -296,7 +296,7 @@ WHERE SEARCH(t1, {
 ...
 ----
 
-This query returns 10 results, and the results are ordered, as specified by the search options.
+This query returns 5 results, and the results are ordered, as specified by the search options.
 As an alternative, you could limit the number of results and order them using the N1QL xref:n1ql-language-reference/limit.adoc[LIMIT] and xref:n1ql-language-reference/orderby.adoc[ORDER BY] clauses.
 ====
 

--- a/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
@@ -92,13 +92,6 @@ For more details, refer to xref:fts:fts-query-types.adoc[Query Types].
 | object
 | A complete full text search request, including sort and pagination options, and so on.
 For more details, refer to xref:fts:fts-sorting.adoc[Sorting Query Results].
-
-[NOTE]
-====
-When specifying a complete full text search request with the N1QL SEARCH() function, if the value of the `size` parameter is greater than the xref:xref:fts:fts-response-object-schema.adoc#request[maximum number of full text search results], the query ignores the `size` parameter and returns all matching results.
-
-This is different to the behavior of a complete full text search request in the Search service, where the query returns an error if the value of the `size` parameter is greater than the maximum number of full text search results.
-====
 |===
 +
 The _query_ argument may be replaced by a N1QL query parameter, as long as the query parameter resolves to a string or an object.
@@ -330,6 +323,7 @@ WHERE t1.type = "airline" AND SEARCH(t1.country, "United States");
     "id": "airline_2657"
   },
 ...
+]
 ----
 
 If the FTS index being queried has it's default mapping disabled and has a custom type mapping defined ("airline" in the above example), the query would need to explicitly specify the "type".


### PR DESCRIPTION
The following documentation is ready for review:

* [Search Functions › SEARCH() › Arguments](https://github.com/couchbase/docs-server/blob/3c588b7aa3ec78a7a72cd7268261eb373d0af6b5/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc#arguments) — added note to **query** argument

(And other minor formatting / wording changes)

Docs issue: [DOC-6237](https://issues.couchbase.com/browse/DOC-6237)