### PR TITLE
DOC-6384: "No such prepared statement" — error code 4040 on upgrading

### DIFF
--- a/modules/install/pages/upgrade-strategy-for-features.adoc
+++ b/modules/install/pages/upgrade-strategy-for-features.adoc
@@ -15,7 +15,7 @@ The following table summarizes the new features in this release, and describes w
 | No
 | Existing Observe APIs for replicateTo and persistTo will continue to exist.
 
-The new APIs for synchronous durability require Server 6.5 and SDK 3.0. 
+The new APIs for synchronous durability require Server 6.5 and SDK 3.0.
 
 | Robust rebalance
 | Cluster
@@ -122,3 +122,28 @@ Mixed Mode in this context refers only to the nodes that are running the indicat
 So if **No** is marked in the Mixed Mode column for a given feature, then all of the cluster nodes that are running that service must be upgraded to Couchbase Server 6.5 in order to enable that feature.
 If **Yes**, then the feature can potentially be enabled even if some of the nodes that are running the indicated service are on older versions of Couchbase Server.
 
+[[prepared-statements]]
+[float]
+=== Prepared Statement Upgrades
+
+When performing an online upgrade from Couchbase Server 6.0.3 to Couchbase Server 6.5, active Couchbase Java SDK 2.x applications may give exception `4040: No such prepared statement`.
+
+Client-side workarounds for the Couchbase Java SDK 2.x:
+
+* Restart the application server after the server upgrade.
+This implicitly clears the client cache, leading it to prepare statements again.
+* Change the client code.
+If the client receives exception `4040`, clean the cache using `invalidateQueryCache()` and retry.
+(This only works for Java.)
+
+Server-side workarounds:
+
+. Upgrade the first node -- this can be a Data service node, or any other node.
+
+. Increase the prepared statement cache size.
+In the Query Workbench, go to menu:Settings[General > Query Settings > Advanced Query Settings] and set *Prepared Limit* to `66560`.
+
+. Make sure that `encoded_plan` will be honored.
+Also in menu:Settings[General > Query Settings > Advanced Query Settings], set *N1QL Feature Controller* to `8`.
+
+These settings persist, and will be used as other query service nodes are upgraded.

--- a/modules/install/pages/upgrade-strategy-for-features.adoc
+++ b/modules/install/pages/upgrade-strategy-for-features.adoc
@@ -6,7 +6,7 @@ The following table summarizes the new features in this release, and describes w
 .Couchbase Server 6.5 Feature Upgrade Matrix
 [cols="1,1,1,1,1,2"]
 |===
-| Feature | Upgrade Level | xref:upgrade-strategies.adoc[Upgrade Type] | xref:upgrade.adoc#supported-upgrade-paths[Upgrade Path] | Mixed Mode<<feature-mixed-mode,†>> | Dependencies
+| Feature | Upgrade Level | xref:upgrade-strategies.adoc[Upgrade Type] | xref:upgrade.adoc#supported-upgrade-paths[Upgrade Path] | <<feature-mixed-mode,Mixed Mode>> | Dependencies
 
 | Durability
 | Cluster
@@ -36,7 +36,7 @@ SDK 3.0 has to be used for the new APIs.
 | Node-to-node encryption
 | Cluster
 | Offline
-| First upgrade to 6.5 and then enable node-to-node encryption on every node using the API/CLI. Restart server for encryption to be effective
+| First upgrade to 6.5 and then enable node-to-node encryption on every node using the API/CLI. Restart server for encryption to be effective.
 | No
 | With node-to-node encryption (and data option), newer TLS ports will be opened between services. If your firewalls are locked down to just the bare minimum ports, you will have to update your firewall rules to include the newer ports. 
 
@@ -114,6 +114,11 @@ See xref:install-ports.adoc[Network and Firewall Requirements] for the list of p
 | The source cluster must be running version 6.5, the target cluster can be on an earlier version.
 |===
 
-[[feature-mixed-mode]]† _Mixed Mode in this context refers to only the nodes that are running the indicated service.
-So if 'No' is marked in the Mixed Mode column of a given feature, then all of the cluster nodes that are running that service must be upgraded to Couchbase Server 6.0 in order to enable that feature.
-If 'Yes', then the feature can potentially be enabled even if some of the nodes that are running the indicated service are on older versions of Couchbase Server_
+[[feature-mixed-mode]]
+[float]
+=== Mixed Mode
+
+Mixed Mode in this context refers only to the nodes that are running the indicated service.
+So if **No** is marked in the Mixed Mode column for a given feature, then all of the cluster nodes that are running that service must be upgraded to Couchbase Server 6.5 in order to enable that feature.
+If **Yes**, then the feature can potentially be enabled even if some of the nodes that are running the indicated service are on older versions of Couchbase Server.
+

--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -170,6 +170,11 @@ This section highlights some of the known issues in this release.
 
 | https://issues.couchbase.com/browse/MB-33522[MB-33522^]
 | *Summary*: The `cbupgrade` script fails to upgrade single node IPv6 clusters.
+
+| https://issues.couchbase.com/browse/MB-38046[MB-38046^]
+| *Summary*: When performing an online upgrade from Couchbase Server 6.0.3 to Couchbase Server 6.5, active Couchbase Java SDK 2.x applications may give exception `4040: No such prepared statement`.
+
+*Workaround:* Refer to xref:install:upgrade-strategy-for-features.adoc#prepared-statements[Prepared Statement Upgrades].
 |===
 
 ==== Tools, Web Console (UI), and REST API


### PR DESCRIPTION
The following documentation is ready for review:

* [Release Notes for Couchbase Server 6.5 › Release 6.5.0 › Known Issues › Install and Upgrade]( https://github.com/couchbase/docs-server/blob/fb851e115f894da17d1f971de1946ae788c979c9/modules/release-notes/pages/relnotes.adoc#install-and-upgrade)
* [Upgrading to Couchbase Server 6.5 › Prepared Statement Upgrades](https://github.com/couchbase/docs-server/blob/fb851e115f894da17d1f971de1946ae788c979c9/modules/install/pages/upgrade-strategy-for-features.adoc#prepared-statement-upgrades)

Doc issue: [DOC-6384](https://issues.couchbase.com/browse/DOC-6384)