### PR TITLE
fix four (4) links to the external install doc set

### DIFF
--- a/modules/eventing/pages/eventing-debugging-and-diagnosability.adoc
+++ b/modules/eventing/pages/eventing-debugging-and-diagnosability.adoc
@@ -85,8 +85,8 @@ Upon source map detection, a text confirmation flag gets displayed in the bottom
 
 The Eventing Service Debugger port, `eventing_debug_port` (9140), is an internal port and is one of the ports that is configured by the *ns_server*. Note this port is not supported for external access outside of the cluster and should only be used in development environments. To modify this port setting (Linux example):
 
-. xref:install-intro.adoc[Install Couchbase Server].
-. xref:startup-shutdown.adoc[Stop the Couchbase Server service].
+. xref:install:install-intro.adoc[Install Couchbase Server].
+. xref:install:startup-shutdown.adoc[Stop the Couchbase Server service].
 . Edit the */opt/couchbase/etc/couchbase/static_config* file to add the new eventing_debug_port and the new port-number information. For example, to change the Eventing debugging port from 9140 to 9444, you would add the following line (enclosed in braces and terminated by a period):
 +
 [source,console]
@@ -94,9 +94,11 @@ The Eventing Service Debugger port, `eventing_debug_port` (9140), is an internal
 {eventing_debug_port, 9444}.
 ----
 . If Couchbase Server was previously configured, you'll need to delete the */opt/couchbase/var/lib/couchbase/config/config.dat* file to remove the old configuration.
-. xref:startup-shutdown.adoc[Start Couchbase Server].
+. xref:install:startup-shutdown.adoc[Start Couchbase Server].
 
-For detailed information on the modifying *ns_server* port mappings, refer to xref:install-ports.adoc#map-custom-ports[Custom Port Mapping].
+For detailed information on the modifying *ns_server* port mappings, refer to xref:install:install-ports.adoc#map-custom-ports[Custom Port Mapping].
+
+
 
 WARNING: Changing port mappings should only be done at the time of initial node/cluster setup as the required reset and reconfiguration will also purge all data on the node. 
 


### PR DESCRIPTION
I left out the  intermediate :install:  in my xref so my links just stay on the same page one example fix follows.

BAD
. xref:startup-shutdown.adoc[Start Couchbase Server].
GOOD
. xref:install:startup-shutdown.adoc[Start Couchbase Server].