### PR TITLE
DOC-6115: CBQ shell redirect output overwritten

### DIFF
--- a/modules/n1ql/pages/n1ql-intro/cbq.adoc
+++ b/modules/n1ql/pages/n1ql-intro/cbq.adoc
@@ -1,47 +1,90 @@
 = Running N1QL Queries from a Command Line
+:tabs:
 :page-topic-type: concept
 
 [abstract]
 [.cmd]`cbq` is the command line shell that you can use to issue N1QL queries on Couchbase Server.
 
-To run [.cmd]`cbq`:
+To run [.cmd]`cbq` on the local host:
 
 . Log in to a Couchbase Server node that has the query service enabled.
 . Open a command window.
 . Change to the Couchbase tools directory.
 +
+[{tabs}]
+====
+Linux::
++
+--
+[source,console]
 ----
-# On Linux systems:
 $ cd /opt/couchbase/bin
 ----
+--
+
+macOS::
 +
+--
+[source,console]
 ----
-# On OS X systems:
 $ cd /Applications/Couchbase\ Server.app/Contents/Resources/couchbase-core/bin
 ----
+--
+
+Microsoft Windows::
++
+--
+[source,console]
+----
+> cd C:\Program Files\Couchbase\Server\bin
+----
+--
+====
 
 . Run the following command to connect to the local query node and start the interactive query shell:
++
+[{tabs}]
+====
+Linux / macOS::
++
+--
+[source,console]
+----
+$ ./cbq
+----
+--
 
- $ ./cbq
+Microsoft Windows::
++
+--
+[source,console]
+----
+> cbq
+----
+--
+====
 +
 [NOTE]
 ====
 Run the following command to connect to the cluster, the IP address can be any node in the cluster as cbq will automatically discover the query nodes:
 
+[source,console]
 ----
 ./cbq -engine=http://123.45.67.89:8091
 ----
 ====
 
 . At the [.cmd]`cbq` prompt, enter a N1QL query and end the query with a semicolon.
-Press return to execute the query.
+Press kbd:[Return] to execute the query.
 For example:
 +
+[source,console]
 ----
 cbq> create primary index on `beer-sample`;
 ----
 +
 .Result
+[source,json]
 ----
 {
     "requestID": "fd4086fa-9ed0-465d-9a99-422c5d8e9506",
@@ -58,11 +101,13 @@ cbq> create primary index on `beer-sample`;
 }
 ----
 +
+[source,console]
 ----
 cbq> select * from `beer-sample` limit 1;
 ----
 +
 .Results
+[source,json]
 ----
 {
     "requestID": "b9f6490d-91c6-4a18-b0b9-a2345cb58b88",
@@ -98,20 +143,23 @@ cbq> select * from `beer-sample` limit 1;
 
 == Accessing a Secure Bucket
 
-If your bucket has a password, you need to pass the bucket name and bucket password like so:
+If your bucket has a password, you can pass the bucket name and bucket password like so:
 
+[source,console]
 ----
 ./cbq -engine="http://<bucketname>:<bucketpassword>@123.45.67.89:8091/"
 ----
 
 For the 'beer-sample' bucket, if you add a password to it of _w1fg2Uhj89_ (as by default it has none), the command to start [.cmd]`cbq` would look like this:
 
+[source,console]
 ----
 ./cbq -engine="http://beer-sample:w1fg2Uhj89@123.45.67.89:8091/"
 ----
 
 If you want to access all of the buckets in the same cbq session, you would pass in the Administrator username and password instead of the bucket level.
 
+[source,console]
 ----
 ./cbq -engine="http://Administrator:password@123.45.67.89:8091/"
 ----
@@ -120,7 +168,7 @@ NOTE: These commands execute successfully only if you have loaded sample bucket 
 
 == Exiting [.cmd]`cbq`
 
-Type [.in]`Ctrl-D` to exit [.cmd]`cbq`.
+Type kbd:[Ctrl+D] to exit [.cmd]`cbq`.
 
 == Keyboard Shortcuts for cbq
 
@@ -132,68 +180,68 @@ These shortcuts are similar to those used in the Emacs text editor.
 |===
 | Keystroke | Action
 
-| Ctrl-A, Home
+| kbd:[Ctrl+A], kbd:[Home]
 | Move cursor to beginning of line
 
-| Ctrl-E, End
+| kbd:[Ctrl+E], kbd:[End]
 | Move cursor to end of line
 
-| Ctrl-B, Left
+| kbd:[Ctrl+B], kbd:[Left]
 | Move cursor one character left
 
-| Ctrl-F, Right
+| kbd:[Ctrl+F], kbd:[Right]
 | Move cursor one character right
 
-| Ctrl-Left
+| kbd:[Ctrl+Left]
 | Move cursor to previous word
 
-| Ctrl-Right
+| kbd:[Ctrl+Right]
 | Move cursor to next word
 
-| Ctrl-D, Del
+| kbd:[Ctrl+D], kbd:[Del]
 | (if line is not empty) Delete character under cursor
 
-| Ctrl-D
+| kbd:[Ctrl+D]
 | (if line is empty) End of File - usually quits application
 
-| Ctrl-C
+| kbd:[Ctrl+C]
 | Reset input (create new empty prompt)
 
-| Ctrl-L
+| kbd:[Ctrl+L]
 | Clear screen (line is unmodified)
 
-| Ctrl-T
+| kbd:[Ctrl+T]
 | Transpose previous character with current character
 
-| Ctrl-H, BackSpace
+| kbd:[Ctrl+H], kbd:[BackSpace]
 | Delete character before cursor
 
-| Ctrl-W
+| kbd:[Ctrl+W]
 | Delete word leading up to cursor
 
-| Ctrl-K
+| kbd:[Ctrl+K]
 | Delete from cursor to end of line
 
-| Ctrl-U
+| kbd:[Ctrl+U]
 | Delete from start of line to cursor
 
-| Ctrl-P, Up
+| kbd:[Ctrl+P], kbd:[Up]
 | Previous match from history
 
-| Ctrl-N, Down
+| kbd:[Ctrl+N], kbd:[Down]
 | Next match from history
 
-| Ctrl-R
-| Reverse Search history (Ctrl-S forward, Ctrl-G cancel)
+| kbd:[Ctrl+R]
+| Reverse Search history (kbd:[Ctrl+S] forward, kbd:[Ctrl+G] cancel)
 
-| Ctrl-Y
-| Paste from Yank buffer (Alt-Y to paste next yank instead)
+| kbd:[Ctrl+Y]
+| Paste from Yank buffer (kbd:[Alt+Y] to paste next yank instead)
 
-| Tab
+| kbd:[Tab]
 | Next completion
 
-| Shift-Tab
-| (after Tab) Previous completion
+| kbd:[Shift+Tab]
+| (after kbd:[Tab]) Previous completion
 |===
 
 Source: [.cite]_\https://github.com/peterh/liner_

--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -411,6 +411,9 @@ $ ./cbq --file="sample.txt"
 a|
 Specifies an output file where the commands and their results are to be written.
 
+If the file doesn't exist, it is created.
+If the file already exists, it is overwritten.
+
 Shell command: <<cbq-redirect,\REDIRECT>>
 
 .Examples
@@ -763,6 +766,10 @@ a| [[cbq-redirect]]
 Redirects the output of all the commands to the specified file until the cbq shell receives the [.cmd]`\REDIRECT OFF` command.
 By default, the file is created in the directory that you were in when you started the cbq shell.
 You can specify a different location using relative paths.
+
+If the file doesn't exist, it is created.
+If the file already exists, it is overwritten.
+In Couchbase Server 6.0.4, you can append redirected output to an existing file using <<file-append-mode>>.
 
 .Example
 [source,console]
@@ -1524,7 +1531,10 @@ cbq> \REDIRECT OFF;
 ----
 
 All the commands specified after `\REDIRECT` and before `\REDIRECT OFF` are saved into the specified output file.
-If the file doesn't exist then it is created.
+
+If the file doesn't exist, it is created.
+If the file already exists, it is overwritten.
+In Couchbase Server 6.0.4, you can append redirected output to an existing file using <<file-append-mode>>.
 
 .Example
 [source,console]
@@ -1539,6 +1549,36 @@ cbq> \REDIRECT OFF;
 You can specify multiple `\REDIRECT` commands.
 When you do so, the output file changes to the specified files and switches back to [.out]`stdout` only when you specify `\REDIRECT OFF`.
 
+[[file-append-mode]]
+=== File Append Mode
+
+[.labels]
+[.status]#Couchbase Server 6.0.4#
+
+In Couchbase Server 6.0.4, you can use _file append mode_ to specify that cbq should append redirected output to the end of an existing file, rather than overwriting it.
+
+To use file append mode, include a plus sign `+` at the start of the output path or filename.
+
+.Example
+[source,console]
+----
+cbq> \REDIRECT +temp_output.txt;
+cbq> SELECT * from `beer-sample` LIMIT 1;
+cbq> \REDIRECT OFF;
+----
+
+Every time you start appending to the output file, a timestamp is added to the end of the output file, followed by any redirected commands and results.
+
+----
+-- <2020-03-06T03:37:28.484-08:00> : opened in append mode
+
+SELECT * from `beer-sample` LIMIT 1
+...
+----
+
+Note that file append mode is only available with the `\REDIRECT` command within a shell session.
+It is not available for the `-o` or `--output` command line option.
+When you use the `-o` or `--output` command line option, the specified output file is always overwritten.
 
 [#cbq-server-shell-info]
 == Server and Shell Information

--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -48,8 +48,8 @@ Connected to : http://localhost:8091/. Type Ctrl-D to exit.
 === Support for Multi-line Queries
 
 The cbq shell supports multi-line queries by default, enabling you to enter a query over multiple lines.
-When entering a query, you can hit kbd:[Enter] without specifying a semi-colon (;) at the end of the line to move the cursor to the next line.
-The prompt ">" indicates that the shell is in multi-line mode.
+When entering a query, you can hit kbd:[Enter] without specifying a semi-colon (`;`) at the end of the line to move the cursor to the next line.
+The prompt `>` indicates that the shell is in multi-line mode.
 For example:
 
 [source,console]
@@ -59,12 +59,12 @@ cbq> select *
 > LIMIT 1;
 ----
 
-When you're done, use a semi-colon ";" to indicate the end of the query, and then press kbd:[Enter] to execute the query.
+When you're done, use a semi-colon `;` to indicate the end of the query, and then press kbd:[Enter] to execute the query.
 
 === Handling Comments
 
-You can add comments in your query by preceding the comment with a '&#35;' or '--'.
-The cbq shell interprets a line that starts with '&#35;' or '--' as a comment, logs the line into history, and returns a new prompt.
+You can add comments in your query by preceding the comment with a `&num;` or `--`.
+The cbq shell interprets a line that starts with `&num;` or `--` as a comment, logs the line into history, and returns a new prompt.
 No other action is taken.
 
 [source,console]
@@ -77,7 +77,7 @@ cbq> select *
 ----
 
 However, if a comment exists within a statement, it is considered as part of the N1QL command.
-If the cbq shell encounters a block comment (enclosed between /* \... */) within a statement, it sends the block comment to the query service.
+If the cbq shell encounters a block comment (enclosed between `/{asterisk}` \... `{asterisk}/`) within a statement, it sends the block comment to the query service.
 
 [source,console]
 ----
@@ -363,7 +363,7 @@ $ ./cbq --help
 a|
 Provides a single command mode to execute a query from the command line.
 
-You can also use multiple "-s" options on the command line.
+You can also use multiple `-s` options on the command line.
 If one of the commands is incorrect, an error is displayed for that command and cbq continues to execute the remaining commands.
 
 .Examples
@@ -676,7 +676,7 @@ cbq>
 where [.var]`args` can be parameters, aliases, or any input.
 a| [[cbq-echo]]
 If the input is a parameter, this command echoes (displays) the value of the parameter.
-The parameter must be prefixed according to it's type.
+The parameter must be prefixed according to its type.
 See <<table_ltk_c5s_5v>> for details.
 
 If the input is not a parameter, the command echoes the statement as is.
@@ -740,9 +740,9 @@ cbq> \COPYRIGHT;
 | [.var]`input-file`
 a| [[cbq-source]]
 Reads and executes the commands from a file.
-Multiple commands in the input file must be separated by "; [.var]``<newline>``"
+Multiple commands in the input file must be separated by `;` [.var]`<newline>`.
 
-For example, sample.txt contains the following commands:
+For example, [.path]_sample.txt_ contains the following commands:
 
 ----
 select * from `travel-sample` limit 1;
@@ -908,7 +908,7 @@ You can pass a single user name credential to the cbq shell on startup using the
 ----
 
 The shell then prompts you for a password.
-You can also provide a single password credential using the -p option.
+You can also provide a single password credential using the `-p` option.
 You cannot use this option by itself.
 It must be used with the `-u` option to specify the user name that the password is associated with.
 
@@ -948,7 +948,7 @@ To set the credentials for different users on startup, use one of the following 
 ----
 
 The [.var]`list-of-creds` can take either one or multiple credentials.
-The credentials consist of an identity and a password separated by a colon ":".
+The credentials consist of an identity and a password separated by a colon `:`.
 To specify multiple credentials, append all the user names and passwords to the same credentials array.
 For example:
 
@@ -1100,7 +1100,7 @@ The cbq shell uses the prefix to differentiate between the different types of pa
 
 NOTE: Positional parameters are set using the [.param]`-args` query parameter.
 
-You can use the cbq shell to set all the REST API settings by specifying the settings as query parameters prefixed by '-'.
+You can use the cbq shell to set all the REST API settings by specifying the settings as query parameters prefixed by `-`.
 As a best practice, we recommend that you save the initial set of basic parameters and their default values using the [.cmd]`\PUSH` command (with no arguments).
 
 .Examples
@@ -1215,14 +1215,14 @@ The following table lists the available predefined session variables.
 | Specifies the file name to store the command history.
 By default the file is saved in the user's home directory.
 
-Default:[.path]__.cbq_history__
+Default: [.path]__.cbq_history__
 |===
 
 === Handling Named Parameters
 
 Use the \SET command to define named parameters.
-For each named parameter, prefix the variable name with '-$'.
-The following example creates named parameters 'r' and 'date' with values 9.5 and "1-1-2016" respectively.
+For each named parameter, prefix the variable name with `-$`.
+The following example creates named parameters `r` and `date` with values 9.5 and "1-1-2016" respectively.
 
 ----
 \SET -$r 9.5;
@@ -1406,7 +1406,7 @@ This parameter specifies the time to wait before returning an error when executi
 --timeout=value
 ----
 
-Timeout can be specified in the following units: "ns" for nanoseconds, "μs" for microseconds, "ms" for milliseconds, "s" for seconds, "m" for minutes, and "h" for hours.
+Timeout can be specified in the following units: `ns` for nanoseconds, `μs` for microseconds, `ms` for milliseconds, `s` for seconds, `m` for minutes, and `h` for hours.
 Examples of valid values include "0.5s", "10ms", or "1m".
 
 You can also the SET shell command to set this parameter.

--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -1,7 +1,7 @@
 = cbq: The Command Line Shell for N1QL
 
 [abstract]
-[.cmd]`cbq` is a comprehensive new command line shell for N1QL.
+[.cmd]`cbq` is a comprehensive command line shell for N1QL.
 It is a powerful, developer friendly tool that enables you to query and update data from Couchbase Server.
 The cbq shell enables you to perform all the operations that are supported by the Query REST API and more, such as additional scripting functionality.
 
@@ -16,22 +16,28 @@ When starting the cbq shell you can provide a set of command line options.
 If no options are present then it assumes default values for expected options.
 
 NOTE: The cbq shell commands are case insensitive.
-However, the command line option are case sensitive.
+However, the command line options are case sensitive.
 
 For the complete list of command line options and shell commands, see tables <<table_a3h_rhz_dw>> and <<table_htk_hgc_fw>>.
 
 The cbq shell enables you to manipulate parameters based on the REST API.
 See <<cbq-parameter-manipulation>> for details.
 
-*Executing a Single Command*
+== Running the cbq Shell
+
+To run the cbq shell, refer to xref:n1ql:n1ql-intro/cbq.adoc[Running N1QL Queries from a Command Line].
+
+=== Executing a Single Command
 
 You can use the [.param]`--script` option to execute a single N1QL query and exit the shell:
 
+[source,console]
 ----
-./cbq --script="select \* from \`travel-sample\` LIMIT 1"
+$ ./cbq --script="select \* from \`travel-sample\` LIMIT 1"
 ----
 
 .Results
+[source,console]
 ----
 Connected to : http://localhost:8091/. Type Ctrl-D to exit.
 {
@@ -39,27 +45,29 @@ Connected to : http://localhost:8091/. Type Ctrl-D to exit.
 }
 ----
 
-*Support for Multi-line Queries*
+=== Support for Multi-line Queries
 
 The cbq shell supports multi-line queries by default, enabling you to enter a query over multiple lines.
-When entering a query, you can hit Enter without specifying a semi-colon (;) at the end of the line to move the cursor to the next line.
+When entering a query, you can hit kbd:[Enter] without specifying a semi-colon (;) at the end of the line to move the cursor to the next line.
 The prompt ">" indicates that the shell is in multi-line mode.
 For example:
 
+[source,console]
 ----
 cbq> select *
 > from `travel-sample`
 > LIMIT 1;
 ----
 
-When you're done, use a semi-colon ";" to indicate the end of the query, and then Enter key to execute the query.
+When you're done, use a semi-colon ";" to indicate the end of the query, and then press kbd:[Enter] to execute the query.
 
-*Handling Comments*
+=== Handling Comments
 
 You can add comments in your query by preceding the comment with a '&#35;' or '--'.
 The cbq shell interprets a line that starts with '&#35;' or '--' as a comment, logs the line into history, and returns a new prompt.
 No other action is taken.
 
+[source,console]
 ----
 cbq> select *
  > #This is the first comment
@@ -71,22 +79,24 @@ cbq> select *
 However, if a comment exists within a statement, it is considered as part of the N1QL command.
 If the cbq shell encounters a block comment (enclosed between /* \... */) within a statement, it sends the block comment to the query service.
 
+[source,console]
 ----
 cbq> select * from `travel-sample` /* This statement includes a block comment */ LIMIT 1;
 ----
 
-*File Based Operations*
+=== File Based Operations
 
 The cbq shell can execute N1QL and shell commands contained in files using file-based commands and options.
 See <<cbq-file-based-ops>> for more information.
 
-*History*
+=== History
 
 The [.cmd]`cbq` shell stores the history for every session.
 All the commands executed in a session are stored in history.
 By default, history is stored in [.path]_~/.cbq_history_.
 You can change the name of the file using the SET command to set the predefined parameter [.var]`HISTFILE`.
 
+[source,console]
 ----
 \SET HISTFILE filename;
 ----
@@ -95,31 +105,36 @@ By default, all the commands are stored in the specified file.
 You can scroll through history and retrieve the commands from history using the scrolling arrow keys.
 Once the query is on the command prompt, you can edit it before executing the updated query.
 
-*Exit Status*
+=== Exit Status
 
 The cbq shell returns the exit status 0 for successful exit with no errors and 1 if an error was encountered before exiting.
 
-*Exit On Error*
+=== Exit On Error
 
 When you specify the argument `--exit-on-error`, the cbq shell checks the result returned after executing the query for any error and exits when the first error is encountered.
 
-*Help*
+=== Help
 
 Help displays the help information for the shell commands and for the general usage of cbq.
 Use the help option when bringing up the shell to display the information for all available options:
 
- $ ./cbq -h
- $ ./cbq --help
+[source,console]
+----
+$ ./cbq -h
+$ ./cbq --help
+----
 
 Use the [.cmd]`\HELP` shell command during a session to display information for specific shell commands.
 If you specify one or more commands, the shell displays the usage information for the specified commands.
 
+[source,console]
 ----
 cbq> \HELP command-name;
 ----
 
 If you do not specify a command, the cbq shell lists all the commands for which syntax help is available.
 
+[source,console]
 ----
 cbq> \HELP;
 ----
@@ -146,17 +161,20 @@ The cbq shell supports both IPV4 and IPV6 addresses.
 
 Shell command: <<cbq-connect,\CONNECT>>
 
-*Examples*
+.Examples
+[source,console]
+----
+$ ./cbq -e couchbase://localhost
 
- $ ./cbq -e couchbase://localhost
+$ ./cbq --engine http://localhost:8091
 
- $ ./cbq --engine http://localhost:8091
+$ ./cbq -e http://localhost:8091
 
- $ ./cbq -e http://localhost:8091
-
- $ ./cbq -e http://[fd63:6f75:6368:1075:816:3c1d:789b:bc4]:8091
+$ ./cbq -e http://[fd63:6f75:6368:1075:816:3c1d:789b:bc4]:8091
+----
 
 .Result
+[source,console]
 ----
 Connected to : http://localhost:8091/. Type Ctrl-D or \QUIT to exit.
 Path to history file for the shell : /Users/myuser1/.cbq_history
@@ -172,10 +190,11 @@ a|
 The cbq shell does not connect to any query service.
 You must explicitly connect to a query service using the [.cmd]`\CONNECT` shell command.
 
-*Examples*
-
- $ ./cbq --no-engine
-
+.Examples
+[source,console]
+----
+$ ./cbq --no-engine
+----
 | `-q`
 
 `--quiet`
@@ -184,13 +203,16 @@ You must explicitly connect to a query service using the [.cmd]`\CONNECT` shell 
 a|
 Enables or disables the startup connection message for the cbq shell.
 
-*Examples*
-
- $ ./cbq -q -e http://localhost:8091
+.Examples
+[source,console]
+----
+$ ./cbq -q -e http://localhost:8091
+----
 
 .Result
+[source,console]
 ----
- cbq>
+cbq>
 ----
 
 | `-b`
@@ -202,7 +224,10 @@ a|
 This option is available only with Analytics service.
 When invoked with the batch option, cbq sends the queries to server only when you hit EOF or \ to indicate the end of the batch input.
 
- $ ./cbq --batch
+[source,console]
+----
+$ ./cbq --batch
+----
 
 You can also set the batch mode in the interactive session using the following commands:
 
@@ -219,10 +244,11 @@ You can also set the batch mode in the interactive session using the following c
 a|
 Sets the query timeout parameter.
 
-*Examples*
-
- $ ./cbq -e http://localhost:8091 --timeout="1s"
-
+.Examples
+[source,console]
+----
+$ ./cbq -e http://localhost:8091 --timeout="1s"
+----
 | `-u`
 
 `--user`
@@ -236,11 +262,12 @@ This option requires administration credentials and you cannot switch the creden
 
 Couchbase recommends using the `-u` and `-p` option if your password contains special characters such as #, $, %, &, (,), or '.
 
-*Examples*
-
- $ ./cbq -e http://localhost:8091 -u=Administrator
-                     Enter Password:
-
+.Examples
+[source,console]
+----
+$ ./cbq -e http://localhost:8091 -u=Administrator
+                    Enter Password:
+----
 | `-p`
 
 `--password`
@@ -255,10 +282,11 @@ This option requires administration credentials and you cannot switch the creden
 
 Couchbase recommends using the `-u` and `-p` option if your password contains special characters such as #, $, %, &, (,), or '.
 
-*Examples*
-
- $ ./cbq -e http://localhost:8091 -u=Administrator -p=password
-
+.Examples
+[source,console]
+----
+$ ./cbq -e http://localhost:8091 -u=Administrator -p=password
+----
 | `-c`
 
 `--credentials`
@@ -272,10 +300,11 @@ Shell command: <<cbq-set,\SET>> `-creds`
 
 REST API: `-creds` parameter
 
-*Examples*
-
- $ ./cbq -e http://localhost:8091 -c=beer-sample:password,Administrator:password
-
+.Examples
+[source,console]
+----
+$ ./cbq -e http://localhost:8091 -c=beer-sample:password,Administrator:password
+----
 | `-v`
 
 `--version`
@@ -285,17 +314,21 @@ a|
 Provides the version of the cbq shell.
 To display the query engine version of Couchbase Server (this is not the same as the version of Couchbase Server itself), use one of the following N1QL queries:
 
+[source,n1ql]
 ----
 select version();
 ----
 
+[source,n1ql]
 ----
 select min_version();
 ----
 
-*Examples*
-
- $ ./cbq --version
+.Examples
+[source,console]
+----
+$ ./cbq --version
+----
 
 .Result
 ----
@@ -315,10 +348,11 @@ Provides help for the command line options.
 
 Shell command: <<cbq-help,\HELP>>
 
-*Examples*
-
- $ ./cbq --help
-
+.Examples
+[source,console]
+----
+$ ./cbq --help
+----
 | `-s`
 
 `-script`
@@ -330,8 +364,7 @@ Provides a single command mode to execute a query from the command line.
 You can also use multiple "-s" options on the command line.
 If one of the commands is incorrect, an error is displayed for that command and cbq continues to execute the remaining commands.
 
-*Examples*
-
+.Examples
 [source,console]
 ----
 $ ./cbq -s="select * from \`travel-sample\` limit 1"
@@ -364,8 +397,10 @@ Provides an input file which contains all the commands to be run.
 
 Shell command: <<cbq-source,\SOURCE>>
 
- $ ./cbq --file="sample.txt"
-
+[source,console]
+----
+$ ./cbq --file="sample.txt"
+----
 | `-o`
 
 `--output`
@@ -376,20 +411,22 @@ Specifies an output file where the commands and their results are to be written.
 
 Shell command: <<cbq-redirect,\REDIRECT>>
 
-*Examples*
-
- $ ./cbq -o="results.txt" -s="select * from `travel-sample` limit 1"
-
+.Examples
+[source,console]
+----
+$ ./cbq -o="results.txt" -s="select * from `travel-sample` limit 1"
+----
 | `--exit-on-error`
 | None
 | false
 a|
 Specifies that the cbq shell must exit when it encounters the first error.
 
-*Examples*
-
- $ ./cbq --exit-on-error -f="sample.txt"
-
+.Examples
+[source,console]
+----
+$ ./cbq --exit-on-error -f="sample.txt"
+----
 | `--no-ssl-verify` or
 
 `-skip-verify`
@@ -401,10 +438,12 @@ Specifies that cbq shell can skip the verification of certificates.
 The default ports are 18091 and 18093.
 You need not specify the port when connecting to the cluster.
 
-*Examples*
-
- $ ./cbq --no-ssl-verify -f="sample.txt"
- $ ./cbq -skip-verify https://127.0.0.1:18091
+.Examples
+[source,console]
+----
+$ ./cbq --no-ssl-verify -f="sample.txt"
+$ ./cbq -skip-verify https://127.0.0.1:18091
+----
 |===
 
 .cbq Shell Commands
@@ -426,12 +465,13 @@ The cbq shell supports both IPV4 and IPV6 addresses.
 
 Command Line Option: `-e` or `--engine`
 
-*Examples*
-
+.Examples
+[source,console]
 ----
 cbq> \CONNECT http://localhost:8093;
 ----
 
+[source,console]
 ----
 cbq> \CONNECT http://[fd63:6f75:6368:1075:816:3c1d:789b:bc4]:8091
 ----
@@ -441,8 +481,8 @@ cbq> \CONNECT http://[fd63:6f75:6368:1075:816:3c1d:789b:bc4]:8091
 a|
 Disconnects the cbq shell from the query service or cluster endpoint.
 
-*Example*
-
+.Example
+[source,console]
 ----
 cbq> \DISCONNECT;
 
@@ -457,12 +497,13 @@ cbq> \DISCONNECT;
 a|
 Exits cbq shell.
 
-*Examples*
-
+.Examples
+[source,console]
 ----
 cbq> \EXIT;
 ----
 
+[source,console]
 ----
 cbq> \QUIT;
 ----
@@ -483,12 +524,13 @@ Variables can be of the following types:
 
 When the [.cmd]`\SET` command is used without any arguments, it displays the values for all the parameters of the current session.
 
-*Examples*
-
+.Examples
+[source,console]
 ----
 cbq> \SET -args [5, "12-14-1987"];
 ----
 
+[source,console]
 ----
 cbq> \SET -args [6,7];
 ----
@@ -502,17 +544,19 @@ When the [.cmd]`\PUSH` command is used without any arguments, it copies the top 
 
 While each variable stack grows by 1, the previous values are preserved.
 
-*Examples*
-
+.Examples
+[source,console]
 ----
 cbq> \PUSH -args  [8];
 ----
 
+[source,console]
 ----
 cbq> \PUSH;
 ----
 
 .Resulting variable stack
+[source,console]
 ----
 cbq> \SET;
  Query Parameters :
@@ -527,12 +571,13 @@ cbq>
 a|
 Deletes or resets the entire stack for the specified parameter.
 
-*Examples*
-
+.Examples
+[source,console]
 ----
 cbq> \UNSET -args;
 ----
 
+[source,console]
 ----
 cbq> \SET;
  Query Parameters :
@@ -547,12 +592,12 @@ Pops the top most value from the specified parameter's stack.
 
 When the [.cmd]`\POP` command is used without any arguments, it pops the top most value of every variable's stack.
 
-*Examples*
-
+.Examples
 ----
 \POP -args;
 ----
 
+[source,console]
 ----
 cbq> \SET;
  Query Parameters :
@@ -568,12 +613,13 @@ You can then execute the alias using `\\alias-name;`.
 
 When the [.cmd]`\ALIAS` command is used without any arguments, it lists all the available aliases.
 
-*Examples*
-
+.Examples
+[source,console]
 ----
 cbq> \ALIAS travel-limit1 select * from `travel-sample` limit 1;
 ----
 
+[source,console]
 ----
 cbq> \ALIAS;
 serverversion  select version()
@@ -581,6 +627,7 @@ travel-limit1  select * from `travel-sample` limit 1
 cbq>
 ----
 
+[source,console]
 ----
 cbq> \\serverversion;
 {
@@ -608,12 +655,13 @@ cbq> \\serverversion;
 a|
 Deletes the specified alias.
 
-*Examples*
-
+.Examples
+[source,console]
 ----
 cbq> \UNALIAS travel-limit1;
 ----
 
+[source,console]
 ----
 cbq> \ALIAS;
 serverversion  select version()
@@ -633,12 +681,13 @@ If the input is not a parameter, the command echoes the statement as is.
 
 If the input is an alias, the command displays the value of an alias command.
 
-*Examples*
-
+.Examples
+[source,console]
 ----
 cbq> \ECHO -$r;
 ----
 
+[source,console]
 ----
 cbq> \ECHO \\serverversion;
 select version()
@@ -649,8 +698,8 @@ select version()
 a|
 Displays the version of the client shell.
 
-*Example*
-
+.Example
+[source,console]
 ----
 cbq> \VERSION;
  SHELL VERSION  : 1.5
@@ -662,8 +711,8 @@ a|
 Displays the help information for the specified command.
 When used without any arguments, it lists all the commands supported by the cbq shell.
 
-*Example*
-
+.Example
+[source,console]
 ----
 cbq> \HELP ECHO;
 \ECHO args ...
@@ -679,8 +728,8 @@ Example :
 a|
 Displays the copyright, attributions, and distribution terms.
 
-*Example*
-
+.Example
+[source,console]
 ----
 cbq> \COPYRIGHT;
 ----
@@ -700,8 +749,8 @@ select * from `travel-sample` limit 1;
 EOF
 ----
 
-*Example*
-
+.Example
+[source,console]
 ----
 cbq> \SOURCE sample.txt;
 ----
@@ -713,8 +762,8 @@ Redirects the output of all the commands to the specified file until the cbq she
 By default, the file is created in the [.path]_/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin_ directory.
 You can specify a different location using relative paths.
 
-*Example*
-
+.Example
+[source,console]
 ----
 cbq> \REDIRECT temp_out.txt;
 cbq> select * from `travel-sample` limit 1;
@@ -726,8 +775,8 @@ cbq>
 a|
 Redirects the output of subsequent commands from a custom file to standard output (os.stdout).
 
-*Example*
-
+.Example
+[source,console]
 ----
 cbq> \REDIRECT OFF;
 ----
@@ -748,12 +797,13 @@ There are two ways to establish a connection:
 
 * Using a shell command:
 +
+[source,console]
 ----
 cbq> \CONNECT url;
 ----
 
 The [.var]`url` is made up of two components: the URL and a port number.
-The URL can be any valid IP address or URL.
+The URL can be the IP address or URL of any node in the cluster, as cbq will automatically discover the query nodes.
 The URL is optional and if it is not specified, the default URL `+http://localhost:8091+` is used.
 An error is thrown if the URL is invalid.
 
@@ -770,8 +820,9 @@ You can close the connection with an existing node or cluster without exiting th
 If the shell is not connected to any endpoint, an error with a message that the shell is not connected to any instance is thrown.
 
 .Examples
+[source,console]
 ----
-./cbq -e=http://localhost:8091;
+$ ./cbq -e=http://localhost:8091;
 Connected to : http://localhost:8091/. Type Ctrl-D to exit.
 
 cbq> \DISCONNECT;
@@ -783,27 +834,31 @@ Connected to : http://127.0.0.1:8091 . Type Ctrl-D / \exit / \quit to exit.
 cbq> \EXIT;
 Exiting the shell.
 
-$./cbq -e=http://127.0.0.1:8091;
+$ ./cbq -e=http://127.0.0.1:8091;
 Connected to : http://127.0.0.1:8091/. Type Ctrl-D to exit.
 cbq>
 ----
 
-*Bringing Up an Unconnected Instance*
+=== Bringing Up an Unconnected Instance
 
 You can bring up the shell without connecting to any query service or cluster endpoint by using the [.opt]`-ne` or [.opt]`--no-engine` option.
 After starting cbq without any service, you can connect to a specific endpoint using the [.cmd]`CONNECT` command.
 
 .Example
- $ ./cbq -ne
- cbq> \CONNECT http://127.0.0.1:8091;
- Connected to : http://127.0.0.1:8091 . Type Ctrl-D / \exit / \quit to exit.
+[source,console]
+----
+$ ./cbq -ne
+cbq> \CONNECT http://127.0.0.1:8091;
+Connected to : http://127.0.0.1:8091 . Type Ctrl-D / \exit / \quit to exit.
+----
 
-*Exiting the cbq Shell*
+=== Exiting the cbq Shell
 
-You can exit the cbq shell using one of the following commands:
+You can exit the cbq shell by pressing kbd:[Ctrl+D] or by using one of the following commands:
 
 ----
-\EXIT; | \QUIT; | Ctrl-D
+\EXIT;
+\QUIT;
 ----
 
 When you run the exit command, the cbq shell first saves the history, closes existing connections, saves the current session in a session file, resets all environment variables, and then closes the shell liner interface.
@@ -902,7 +957,7 @@ For example:
 For information on passing a single user name credential to the cbq shell, see <<cbq-single-cred>>.
 
 [#pass-cred-shell-cmd]
-*Passing Credentials Using the SET Shell Command*
+=== Passing Credentials Using the SET Shell Command
 
 You can provide the credential types using the SET command.
 
@@ -919,12 +974,13 @@ To do so, set the [.param]`-creds` query parameter for the session using the fol
 ----
 
 [#pass-cred-rest-api]
-*Passing Credentials Using Query REST API*
+=== Passing Credentials Using Query REST API
 
 You can use query REST API to pass credentials from clients.
 
 For SASL buckets, you can pass the credentials as:
 
+[source,json]
 ----
 [  {
      "user":"travel-sample",
@@ -934,6 +990,7 @@ For SASL buckets, you can pass the credentials as:
 
 If you are using the Administrator credentials:
 
+[source,json]
 ----
 [  {
         "user":"Administrator",
@@ -943,6 +1000,7 @@ If you are using the Administrator credentials:
 
 For multiple SASL protected buckets, you can pass an array of authentication credentials:
 
+[source,json]
 ----
 [  {
         "user":"beer-sample",
@@ -954,11 +1012,12 @@ For multiple SASL protected buckets, you can pass an array of authentication cre
    }  ]
 ----
 
-*Displaying the Credentials*
+=== Displaying the Credentials
 
 You can display the credentials for the current session using the <<cbq-echo,ECHO>> shell command.
 This command displays only the user names (and not the passwords).
 
+[source,console]
 ----
 cbq> \ECHO -creds;
 
@@ -967,6 +1026,7 @@ Administrator:*
 
 You can also display a full list of variables using the SET command specified without any arguments.
 
+[source,console]
 ----
 cbq> \SET;
 Query Parameters ::
@@ -991,7 +1051,7 @@ The cbq shell categorizes parameters into the following types:
 * Session or Pre-defined Parameters
 * User-defined Parameters
 
-*Parameter Configuration*
+=== Parameter Configuration
 
 When using parameters, you can set a stack of values for each parameter.
 You can either push a new value onto the stack using the PUSH command, or set the current value for a parameter using the SET command.
@@ -1004,7 +1064,7 @@ To unset the values from a parameter's stack, you can use the UNSET command to r
 However, if you want to delete a single value from the settings, use the POP command.
 When you use the POP command with no arguments, it pops the one value from the top of each parameter's stack.
 
-*Setting Variable Values*
+=== Setting Variable Values
 
 Each variable has a separate stack associated with it and the [.var]`prefix` [.var]`name` argument helps distinguish between the stacks.
 
@@ -1042,6 +1102,7 @@ You can use the cbq shell to set all the REST API settings by specifying the set
 As a best practice, we recommend that you save the initial set of basic parameters and their default values using the [.cmd]`\PUSH` command (with no arguments).
 
 .Examples
+[source,console]
 ----
 cbq> \SET -$airport "SJC";
 cbq> \PUSH -args ["LAX", 6];
@@ -1125,6 +1186,7 @@ Parameter name : histfile Value  [".cbq_history"]
 
 To display all the parameters defined in a session, use the SET command with no arguments.
 
+[source,console]
 ----
 cbq> \SET;
 Query Parameters ::
@@ -1154,7 +1216,7 @@ By default the file is saved in the user's home directory.
 Default:[.path]__.cbq_history__
 |===
 
-*Handling Named Parameters*
+=== Handling Named Parameters
 
 Use the \SET command to define named parameters.
 For each named parameter, prefix the variable name with '-$'.
@@ -1165,7 +1227,7 @@ The following example creates named parameters 'r' and 'date' with values 9.5 an
 \SET -$date "1-1-2016";
 ----
 
-*Handling Positional Parameters*
+=== Handling Positional Parameters
 
 Use the SET shell command with the [.param]`-args` query parameter to define positional parameters:
 
@@ -1180,23 +1242,26 @@ For example,
 \SET -args [ 9.5, "1-1-2016"];
 ----
 
-*Resetting Variable Values*
+=== Resetting Variable Values
 
 You can reset the value of a variable by either popping it or deleting it altogether.
 To pop the top of a parameter's stack use:
 
+[source,console]
 ----
 cbq>\POP <prefix><name>;
 ----
 
 To pop the top of every parameter's stack once, use the POP command without any arguments:
 
+[source,console]
 ----
 cbq>\POP;
 ----
 
 To pop all the values of a parameter's stack and then delete the parameter, use:
 
+[source,console]
 ----
 cbq> \UNSET <prefix><name>;
 ----
@@ -1213,9 +1278,10 @@ If not, the shell considers the parameters as generic statements and displays th
 \ECHO input ... ;
 ----
 
-where [.var]`input` can be a parameter with prefix ([.var]`<prefix><parameter-name>`), an alias (\\[.var]`command-alias`), a N1QL statement, or a string.
+where [.var]`input` can be a parameter with prefix ([.var]`<prefix><parameter-name>`), an alias ([.var]`\\command-alias`), a N1QL statement, or a string.
 
 .Examples
+[source,console]
 ----
 cbq> \ECHO hello;
 hello
@@ -1239,6 +1305,7 @@ Run the following command to define an alias:
 ----
 
 .Example
+[source,console]
 ----
 cbq> \ALIAS travel-alias1 SELECT * from `travel-sample` LIMIT 1;
 ----
@@ -1246,6 +1313,7 @@ cbq> \ALIAS travel-alias1 SELECT * from `travel-sample` LIMIT 1;
 To run the command alias, use `\\command-alias`.
 
 .Example
+[source,console]
 ----
 cbq> \\travel-alias1;
 
@@ -1279,6 +1347,7 @@ To list all the existing aliases, use:
 ----
 
 .Example
+[source,console]
 ----
 cbq> \ALIAS;
 serverversion  select version()
@@ -1291,6 +1360,7 @@ You can delete a defined alias using the \UNLIAS command.
 \UNALIAS alias-name ... ;
 ----
 
+[source,console]
 ----
 cbq> \UNALIAS serverversion travel-alias1;
 
@@ -1322,9 +1392,9 @@ EXECUTE name-of-prepared-stmt;
 
 == Canceling a Query
 
-You can cancel a running query by using the Ctrl+C keys.
+You can cancel a running query by using the kbd:[Ctrl+C] keys.
 
-*Connection Timeout Parameter*
+=== Connection Timeout Parameter
 
 You can use the timeout parameter to limit the running time of a query.
 This parameter specifies the time to wait before returning an error when executing a query.
@@ -1383,6 +1453,7 @@ SELECT abv from `beer-sample` LIMIT 3;
 To execute the commands contained in [.path]_sample.txt_ using the -f option, run `$./cbq -f=sample.txt`
 
 .Results
+[source,console]
 ----
 Connected to : http://localhost:8091/. Type Ctrl-D to exit.
 CREATE PRIMARY INDEX on `beer-sample` USING GSI;
@@ -1409,6 +1480,7 @@ $
 To execute the commands contained in [.path]_sample.txt_ using the shell command, run `cbq> \SOURCE sample.txt;`
 
 .Results
+[source,console]
 ----
 CREATE PRIMARY INDEX on `beer-sample` USING GSI;
 { ...
@@ -1431,7 +1503,7 @@ Help Information for all Shell Commands
 cbq>
 ----
 
-*Redirecting Results to a File*
+=== Redirecting Results to a File
 
 You can redirect all the output for a session or part of a session to a specified file by using the following option:
 
@@ -1442,6 +1514,7 @@ You can redirect all the output for a session or part of a session to a specifie
 
 To redirect a specific set of commands during a session, you must specify the commands between REDIRECT and REDIRECT OFF as shown:
 
+[source,console]
 ----
 cbq> \REDIRECT filename;
 command-1; command-2;, ..., command-n;
@@ -1452,6 +1525,7 @@ All the commands specified after `\REDIRECT` and before `\REDIRECT OFF` are save
 If the file doesn't exist then it is created.
 
 .Example
+[source,console]
 ----
 cbq> \REDIRECT temp_output.txt;
 > CREATE PRIMARY INDEX on `beer-sample` USING GSI;
@@ -1468,29 +1542,34 @@ When you do so, the output file changes to the specified files and switches back
 
 The cbq shell provides commands that convey information about the shell or cluster endpoints.
 
-Version::
+=== Version
+
 You can find the version of the client (shell) by using either the command line option to display the current version of the shell and exit, or as a shell command to print the version of the shell during the shell session.
-+
+
 .Example Using the Command-line Option
+[source,console]
 ----
-./cbq -v
+$ ./cbq -v
 SHELL VERSION : 1.0
 
 $ ./cbq --version
 SHELL VERSION : 1.0
 ----
-+
+
 .Example Using the Shell Command
+[source,console]
 ----
 cbq> \VERSION;
 SHELL VERSION : 1.0
 ----
-+
+
 To display the version of the query service, use the N1QL commands `SELECT version();` and `SELECT min_version();`.
 
-Copyright::
+=== Copyright
+
 You can view the copyright, attributions, and distribution terms of the command line query tool using the `\COPYRIGHT;` command.
-+
+
+[source,console]
 ----
 cbq> \COPYRIGHT;
 Copyright (c) 2015 Couchbase, Inc. Licensed under the Apache License, Version 2.0 (the "License");
@@ -1511,68 +1590,68 @@ The following table lists the shortcut keys used by the [.cmd]`cbq` shell.
 |===
 | Keystroke | Action
 
-| Ctrl-A, Home
+| kbd:[Ctrl+A], kbd:[Home]
 | Move cursor to beginning of line
 
-| Ctrl-E, End
+| kbd:[Ctrl+E], kbd:[End]
 | Move cursor to end of line
 
-| Ctrl-B, Left
+| kbd:[Ctrl+B], kbd:[Left]
 | Move cursor one character left
 
-| Ctrl-F, Right
+| kbd:[Ctrl+F], kbd:[Right]
 | Move cursor one character right
 
-| Ctrl-Left
+| kbd:[Ctrl+Left]
 | Move cursor to previous word
 
-| Ctrl-Right
+| kbd:[Ctrl+Right]
 | Move cursor to next word
 
-| Ctrl-D, Del
+| kbd:[Ctrl+D], kbd:[Del]
 | (if line is not empty) Delete character under cursor
 
-| Ctrl-D
+| kbd:[Ctrl+D]
 | (if line is empty) End of File - usually quits application
 
-| Ctrl-C
+| kbd:[Ctrl+C]
 | Reset input (create new empty prompt)
 
-| Ctrl-L
+| kbd:[Ctrl+L]
 | Clear screen (line is unmodified)
 
-| Ctrl-T
+| kbd:[Ctrl+T]
 | Transpose previous character with current character
 
-| Ctrl-H, BackSpace
+| kbd:[Ctrl+H], kbd:[BackSpace]
 | Delete character before cursor
 
-| Ctrl-W
+| kbd:[Ctrl+W]
 | Delete word leading up to cursor
 
-| Ctrl-K
+| kbd:[Ctrl+K]
 | Delete from cursor to end of line
 
-| Ctrl-U
+| kbd:[Ctrl+U]
 | Delete from start of line to cursor
 
-| Ctrl-P, Up
+| kbd:[Ctrl+P], kbd:[Up]
 | Previous match from history
 
-| Ctrl-N, Down
+| kbd:[Ctrl+N], kbd:[Down]
 | Next match from history
 
-| Ctrl-R
-| Reverse Search history (Ctrl-S forward, Ctrl-G cancel)
+| kbd:[Ctrl+R]
+| Reverse Search history (kbd:[Ctrl+S] forward, kbd:[Ctrl+G] cancel)
 
-| Ctrl-Y
-| Paste from Yank buffer (Alt-Y to paste next yank instead)
+| kbd:[Ctrl+Y]
+| Paste from Yank buffer (kbd:[Alt+Y] to paste next yank instead)
 
-| Tab
+| kbd:[Tab]
 | Next completion
 
-| Shift-Tab
-| (after Tab) Previous completion
+| kbd:[Shift+Tab]
+| (after kbd:[Tab]) Previous completion
 |===
 
 Source: [.cite]_\https://github.com/peterh/liner_

--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -151,7 +151,7 @@ cbq> \HELP;
 `--engine`
 | <[.var]``url``>
 | `+http://localhost:8091+`
-a|
+a| [[opt-engine]]
 The connection string consists of a protocol scheme followed by a host, including a port number to connect to the query service (8093) or the Couchbase cluster (8091).
 
 The cbq shell supports [.path]_http://_, [.path]_https://_, [.path]_couchbase://_ and [.path]_couchbases://_ protocol schemes.
@@ -186,7 +186,7 @@ cbq>
 `--no-engine`
 | None
 | false
-a|
+a| [[opt-no-engine]]
 The cbq shell does not connect to any query service.
 You must explicitly connect to a query service using the [.cmd]`\CONNECT` shell command.
 
@@ -200,7 +200,7 @@ $ ./cbq --no-engine
 `--quiet`
 | None
 | false
-a|
+a| [[opt-quiet]]
 Enables or disables the startup connection message for the cbq shell.
 
 .Examples
@@ -220,7 +220,7 @@ cbq>
 `--batch`
 | None
 | None
-a|
+a| [[opt-batch]]
 This option is available only with Analytics service.
 When invoked with the batch option, cbq sends the queries to server only when you hit EOF or \ to indicate the end of the batch input.
 
@@ -241,7 +241,7 @@ You can also set the batch mode in the interactive session using the following c
 `--timeout`
 | [.var]`value`
 | None
-a|
+a| [[opt-timeout]]
 Sets the query timeout parameter.
 
 .Examples
@@ -254,9 +254,9 @@ $ ./cbq -e http://localhost:8091 --timeout="1s"
 `--user`
 | [.var]`username`
 | None
-a|
+a| [[opt-user]]
 Specifies a single user name to log in to Couchbase.
-When used by itself, without the -p option to specify the password, you will be prompted for the password.
+When used by itself, without the `-p` option to specify the password, you will be prompted for the password.
 
 This option requires administration credentials and you cannot switch the credentials during a session.
 
@@ -273,7 +273,7 @@ $ ./cbq -e http://localhost:8091 -u=Administrator
 `--password`
 | [.var]`password`
 | None
-a|
+a| [[opt-password]]
 Specifies the password for the given user name.
 You cannot use this option by itself.
 It must be used with the -u option to specify the user name.
@@ -292,7 +292,7 @@ $ ./cbq -e http://localhost:8091 -u=Administrator -p=password
 `--credentials`
 | [.var]`list of credentials`
 | None
-a|
+a| [[opt-credentials]]
 Specify the login credentials in the form of [.var]`username`:[.var]``password``.
 You can specify credentials for different buckets by separating them with a comma.
 
@@ -310,7 +310,7 @@ $ ./cbq -e http://localhost:8091 -c=beer-sample:password,Administrator:password
 `--version`
 | None
 | false
-a|
+a| [[opt-version]]
 Provides the version of the cbq shell.
 To display the query engine version of Couchbase Server (this is not the same as the version of Couchbase Server itself), use one of the following N1QL queries:
 
@@ -345,7 +345,7 @@ $ ./cbq --version
 `--help`
 | None
 | None
-a|
+a| [[opt-help]]
 Provides help for the command line options.
 
 Shell command: <<cbq-help,\HELP>>
@@ -360,7 +360,7 @@ $ ./cbq --help
 `-script`
 | [.var]`query`
 | None
-a|
+a| [[opt-script]]
 Provides a single command mode to execute a query from the command line.
 
 You can also use multiple `-s` options on the command line.
@@ -394,7 +394,7 @@ $ ./cbq  -s="\SET v 1" -s="\SET b 2" -s="\PUSH b3" -s="\SET b 5" -s="\SET"  -ne
 `--file`
 | [.var]`input-file`
 | None
-a|
+a| [[opt-file]]
 Provides an input file which contains all the commands to be run.
 
 Shell command: <<cbq-source,\SOURCE>>
@@ -408,7 +408,7 @@ $ ./cbq --file="sample.txt"
 `--output`
 | [.var]`output-file`
 | None
-a|
+a| [[opt-output]]
 Specifies an output file where the commands and their results are to be written.
 
 If the file doesn't exist, it is created.
@@ -424,7 +424,7 @@ $ ./cbq -o="results.txt" -s="select * from `travel-sample` limit 1"
 | `--exit-on-error`
 | None
 | false
-a|
+a| [[opt-exit-on-error]]
 Specifies that the cbq shell must exit when it encounters the first error.
 
 .Examples
@@ -437,7 +437,7 @@ $ ./cbq --exit-on-error -f="sample.txt"
 `-skip-verify`
 | None
 | false
-a|
+a| [[opt-skip-verify]]
 Specifies that cbq shell can skip the verification of certificates.
 
 The default ports are 18091 and 18093.
@@ -468,7 +468,7 @@ When using the [.path]_couchbase://_ or [.path]_couchbases://_ protocol schemes,
 
 The cbq shell supports both IPV4 and IPV6 addresses.
 
-Command Line Option: `-e` or `--engine`
+Command Line Option: <<opt-engine,-e>> or <<opt-engine,--engine>>
 
 .Examples
 [source,console]
@@ -703,6 +703,8 @@ select version()
 a| [[cbq-version]]
 Displays the version of the client shell.
 
+Command Line Option: <<opt-version,-v>> or <<opt-version,--version>>
+
 .Example
 [source,console]
 ----
@@ -715,6 +717,8 @@ cbq> \VERSION;
 a| [[cbq-help]]
 Displays the help information for the specified command.
 When used without any arguments, it lists all the commands supported by the cbq shell.
+
+Command Line Option: <<opt-help,-h>> or <<opt-help,--help>>
 
 .Example
 [source,console]
@@ -745,6 +749,8 @@ a| [[cbq-source]]
 Reads and executes the commands from a file.
 Multiple commands in the input file must be separated by `;` [.var]`<newline>`.
 
+Command Line Option: <<opt-file,-f>> or <<opt-file,--file>>
+
 For example, [.path]_sample.txt_ contains the following commands:
 
 ----
@@ -770,6 +776,8 @@ You can specify a different location using relative paths.
 If the file doesn't exist, it is created.
 If the file already exists, it is overwritten.
 In Couchbase Server 6.0.4, you can append redirected output to an existing file using <<file-append-mode>>.
+
+Command Line Option:  <<opt-output,-o>> or <<opt-output,--output>>
 
 .Example
 [source,console]
@@ -1555,7 +1563,7 @@ When you do so, the output file changes to the specified files and switches back
 [.labels]
 [.status]#Couchbase Server 6.0.4#
 
-In Couchbase Server 6.0.4, you can use _file append mode_ to specify that cbq should append redirected output to the end of an existing file, rather than overwriting it.
+In Couchbase Server 6.0.4, you can use _file append mode_ to specify that cbq should append redirected output to the end of an existing file, rather than overwriting the existing file.
 
 To use file append mode, include a plus sign `+` at the start of the output path or filename.
 

--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -18,7 +18,7 @@ If no options are present then it assumes default values for expected options.
 NOTE: The cbq shell commands are case insensitive.
 However, the command line options are case sensitive.
 
-For the complete list of command line options and shell commands, see tables <<table_a3h_rhz_dw>> and <<table_htk_hgc_fw>>.
+For the complete list of command line options and shell commands, refer to <<table_a3h_rhz_dw>> and <<table_htk_hgc_fw>>.
 
 The cbq shell enables you to manipulate parameters based on the REST API.
 See <<cbq-parameter-manipulation>> for details.
@@ -324,6 +324,8 @@ select version();
 select min_version();
 ----
 
+Shell command: <<cbq-version,\VERSION>>
+
 .Examples
 [source,console]
 ----
@@ -453,7 +455,7 @@ $ ./cbq -skip-verify https://127.0.0.1:18091
 
 | [.cmd]`\CONNECT`
 | [.var]`url`
-a|
+a| [[cbq-connect]]
 Connects cbq shell to the specified query engine or Couchbase cluster.
 
 The connection string consists of a protocol scheme followed by a host, including a port number to connect to the query service (8093) or the Couchbase cluster (8091).
@@ -478,7 +480,7 @@ cbq> \CONNECT http://[fd63:6f75:6368:1075:816:3c1d:789b:bc4]:8091
 
 | [.cmd]`\DISCONNECT`
 | None
-a|
+a| [[cbq-disconnect]]
 Disconnects the cbq shell from the query service or cluster endpoint.
 
 .Example
@@ -494,7 +496,7 @@ cbq> \DISCONNECT;
 
 [.cmd]`\QUIT`
 | None
-a|
+a| [[cbq-quit]]
 Exits cbq shell.
 
 .Examples
@@ -509,10 +511,10 @@ cbq> \QUIT;
 ----
 
 | [.cmd]`\SET`
-| [.var]`parameter`[.var]`value`
+| [.var]`parameter` [.var]`value`
 
 [.var]`parameter`=[.var]`prefix`:[.var]``variable name``
-a|
+a| [[cbq-set]]
 Sets the top most value of the stack for the given variable with the specified value.
 
 Variables can be of the following types:
@@ -537,7 +539,7 @@ cbq> \SET -args [6,7];
 
 | [.cmd]`\PUSH`
 | [.var]`parameter value`
-a|
+a| [[cbq-push]]
 Pushes the specified value on to the given parameter stack.
 
 When the [.cmd]`\PUSH` command is used without any arguments, it copies the top element of every variable's stack, and then pushes that copy to the top of the respective variable's stack.
@@ -568,7 +570,7 @@ cbq>
 
 | [.cmd]`\UNSET`
 | [.var]`parameter`
-a|
+a| [[cbq-unset]]
 Deletes or resets the entire stack for the specified parameter.
 
 .Examples
@@ -587,7 +589,7 @@ cbq>
 
 | [.cmd]`\POP`
 | [.var]`parameter`
-a|
+a| [[cbq-pop]]
 Pops the top most value from the specified parameter's stack.
 
 When the [.cmd]`\POP` command is used without any arguments, it pops the top most value of every variable's stack.
@@ -607,7 +609,7 @@ cbq> \SET;
 
 | [.cmd]`\ALIAS`
 | [.var]`shell-command` or [.var]`n1ql-statement`
-a|
+a| [[cbq-alias]]
 Creates a command alias for the specified cbq shell command or N1QL statement.
 You can then execute the alias using `\\alias-name;`.
 
@@ -652,7 +654,7 @@ cbq> \\serverversion;
 
 | [.cmd]`\UNALIAS`
 | [.var]`alias-name`
-a|
+a| [[cbq-unalias]]
 Deletes the specified alias.
 
 .Examples
@@ -672,7 +674,7 @@ cbq>
 | [.var]`args`
 
 where [.var]`args` can be parameters, aliases, or any input.
-a|
+a| [[cbq-echo]]
 If the input is a parameter, this command echoes (displays) the value of the parameter.
 The parameter must be prefixed according to it's type.
 See <<table_ltk_c5s_5v>> for details.
@@ -695,7 +697,7 @@ select version()
 
 | [.cmd]`\VERSION`
 | None
-a|
+a| [[cbq-version]]
 Displays the version of the client shell.
 
 .Example
@@ -707,7 +709,7 @@ cbq> \VERSION;
 
 | [.cmd]`\HELP`
 | [.var]`command`
-a|
+a| [[cbq-help]]
 Displays the help information for the specified command.
 When used without any arguments, it lists all the commands supported by the cbq shell.
 
@@ -725,7 +727,7 @@ Example :
 
 | [.cmd]`\COPYRIGHT`
 | None
-a|
+a| [[cbq-copyright]]
 Displays the copyright, attributions, and distribution terms.
 
 .Example
@@ -736,7 +738,7 @@ cbq> \COPYRIGHT;
 
 | [.cmd]`\SOURCE`
 | [.var]`input-file`
-a|
+a| [[cbq-source]]
 Reads and executes the commands from a file.
 Multiple commands in the input file must be separated by "; [.var]``<newline>``"
 
@@ -757,7 +759,7 @@ cbq> \SOURCE sample.txt;
 
 | [.cmd]`\REDIRECT`
 | [.var]`filename`
-a|
+a| [[cbq-redirect]]
 Redirects the output of all the commands to the specified file until the cbq shell receives the [.cmd]`\REDIRECT OFF` command.
 By default, the file is created in the [.path]_/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin_ directory.
 You can specify a different location using relative paths.
@@ -772,7 +774,7 @@ cbq>
 
 | [.cmd]`\REDIRECT OFF`
 | None
-a|
+a| [[cbq-redirect-off]]
 Redirects the output of subsequent commands from a custom file to standard output (os.stdout).
 
 .Example

--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -761,7 +761,7 @@ cbq> \SOURCE sample.txt;
 | [.var]`filename`
 a| [[cbq-redirect]]
 Redirects the output of all the commands to the specified file until the cbq shell receives the [.cmd]`\REDIRECT OFF` command.
-By default, the file is created in the [.path]_/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin_ directory.
+By default, the file is created in the directory that you were in when you started the cbq shell.
 You can specify a different location using relative paths.
 
 .Example
@@ -1514,13 +1514,13 @@ You can redirect all the output for a session or part of a session to a specifie
 --output=filename
 ----
 
-To redirect a specific set of commands during a session, you must specify the commands between REDIRECT and REDIRECT OFF as shown:
+To redirect a specific set of commands during a session, you must specify the commands between `\REDIRECT` and `\REDIRECT OFF` as shown:
 
 [source,console]
 ----
 cbq> \REDIRECT filename;
 command-1; command-2;, ..., command-n;
-\REDIRECT OFF;
+cbq> \REDIRECT OFF;
 ----
 
 All the commands specified after `\REDIRECT` and before `\REDIRECT OFF` are saved into the specified output file.
@@ -1530,14 +1530,15 @@ If the file doesn't exist then it is created.
 [source,console]
 ----
 cbq> \REDIRECT temp_output.txt;
-> CREATE PRIMARY INDEX on `beer-sample` USING GSI;
-> SELECT * from `beer-sample` LIMIT 1;
-> \HELP;
-> \REDIRECT OFF;
+cbq> CREATE PRIMARY INDEX on `beer-sample` USING GSI;
+cbq> SELECT * from `beer-sample` LIMIT 1;
+cbq> \HELP;
+cbq> \REDIRECT OFF;
 ----
 
-You can specify multiple `REDIRECT` commands.
-When you do so, the output file changes to the specified files and switches back to [.out]`stdout` only when you specify "[.code]``\REDIRECT OFF``;".
+You can specify multiple `\REDIRECT` commands.
+When you do so, the output file changes to the specified files and switches back to [.out]`stdout` only when you specify `\REDIRECT OFF`.
+
 
 [#cbq-server-shell-info]
 == Server and Shell Information


### PR DESCRIPTION
The following documentation is ready for review:

* [cbq › File Based Operations › File Append Mode](https://simon-dew.github.io/docs-site/DOC-6115/server/6.0/tools/cbq-shell.html#file-append-mode) — new section

Notes: 

* There are links to the new section from the [\REDIRECT](https://simon-dew.github.io/docs-site/DOC-6115/server/6.0/tools/cbq-shell.html#cbq-redirect) command and the [Redirecting Results to a File](https://simon-dew.github.io/docs-site/DOC-6115/server/6.0/tools/cbq-shell.html#redirecting-results-to-a-file) section.

* Formatting updates throughout — backport from [DOC-4852](https://issues.couchbase.com/browse/DOC-4852).

Docs issue: [DOC-6115](https://issues.couchbase.com/browse/DOC-6115)