### PR TITLE
DOC-5381: Missing Argument Descriptions

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
@@ -171,6 +171,14 @@ arrSize;;
 [Optional] An integer, specifying the average length of the array fields.
 For more details and examples, refer to <<sizing-hints>>.
 
+numDoc;;
+[Optional] An integer, specifying the number of documents in the index.
+For more details and examples, refer to <<sizing-hints>>.
+
+residentRatio;;
+[Optional] An integer, specifying the resident ratio of the index.
+For more details and examples, refer to <<sizing-hints>>.
+
 [[partition-keys]]
 == Partition Keys
 

--- a/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
@@ -548,17 +548,25 @@ Based on the estimated memory and CPU usage, the planner tries to place the part
 | Optional Sizing Hint | Description | Example
 
 | *secKeySize*
-| The average length of the combined index keys
+| The average length of the combined index keys.
 | `20`
 
 | *docKeySize*
-| The average length of the document key meta().id
+| The average length of the document key `meta().id`.
 | `20`
 
 | *arrSize*
 | The average length of the array field.
 Non-array fields will be ignored.
 | `10`
+
+| *numDoc*
+| The number of documents in the index.
+| `7303`
+
+| *residentRatio*
+| The memory usage of the index, as a percentage of its estimated data size.
+| `50`
 |===
 
 To provide sizing estimation, you can use a command similar to the following examples.


### PR DESCRIPTION
The following draft documentation is ready for review:

* [Index Partitioning › Syntax › WITH Clause](https://github.com/couchbase/docs-server/blob/40446a49be50326d519d3f5eb7b967b0bcd247b6/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc#with-clause)

* [Index Partitioning › Partition Placement › Sizing Hints](https://github.com/couchbase/docs-server/blob/40446a49be50326d519d3f5eb7b967b0bcd247b6/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc#sizing-hints)

Docs issue: [DOC-5381](https://issues.couchbase.com/browse/DOC-5381)