### PR TITLE
DOC-5602: description of identifier argument of search function

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
@@ -63,7 +63,8 @@ However, if the path is omitted, the keyspace or keyspace alias is mandatory.
 
 * When the identifier contains a path, it is used as the default field in the _query_ argument, as long as the _query_ argument is a query string.
 If the path is omitted, the default field is set to `{underscore}all`.
-If the _query_ argument is a query object, the path is ignored.
+If the _query_ argument is a query string which specifies a field, this field takes priority, and the path in the identifier is ignored.
+Similarly, if the _query_ argument is a query object, the path is ignored.
 
 * The path must use Search syntax rather than N1QL syntax; in other words, you cannot specify array locations such as `[*]` or `[3]` in the path.
 


### PR DESCRIPTION
The following draft documentation is ready for review:

* [Search Functions › SEARCH() › Arguments](https://github.com/couchbase/docs-server/pull/1123/files#diff-ca957de7fb542ab484147334ab10f381) — path in identifier vs. field in query string

Docs issue: [DOC-5602](https://issues.couchbase.com/browse/DOC-5602)