### PR TITLE
DOC-5727: In CE version Query service limits 4 core per node

### DIFF
--- a/modules/introduction/pages/editions.adoc
+++ b/modules/introduction/pages/editions.adoc
@@ -27,6 +27,7 @@ However, CE is not subjected to the iterative "test, fix, and verify" quality as
 The release version of CE is several months behind EE.
 CE also do not include the latest bug fixes.
 Documentation, mailing lists, and forums provide support for the Couchbase user community to help troubleshoot issues and answer questions.
+CE comes with limited concurrency and parallelism and supports a maximum of 4 cores per node.
 
 Open source project::
 The Couchbase Server open source project is a platform for innovation.

--- a/modules/introduction/pages/editions.adoc
+++ b/modules/introduction/pages/editions.adoc
@@ -8,8 +8,8 @@ Each edition offers different features and levels of support.
 
 Enterprise Edition::
 The Enterprise edition (EE) represents the latest, most stable, production-ready release of Couchbase Server.
-We recommend the enterprise edition binaries for commercial production systems running Couchbase Server.
-The enterprise edition contains some unique features that make it the best fit for production deployments running in data centers or a public cloud infrastructure.
+We recommend the Enterprise Edition binaries for commercial production systems running Couchbase Server.
+The Enterprise Edition contains some unique features that make it the best fit for production deployments running in data centers or a public cloud infrastructure.
 // These
 // features, which are not available in the community edition, are listed in the
 // <xref href="#couchbase-editions/ee-vs-ce" format="dita"/>.
@@ -23,15 +23,15 @@ The capabilities ensure that an application running on EE should simply transiti
 Community Edition::
 The Community Edition (CE) is best for noncommercial developers where basic availability, performance, scale, tooling, security capabilities and community support is sufficient.
 CE comes free and there are no constraints on using these binaries in production systems.
-However, CE is not subjected to the iterative "test, fix, and verify" quality assurance cycle that is a part of the enterprise edition release process.
+However, CE is not subjected to the iterative "test, fix, and verify" quality assurance cycle that is a part of the Enterprise Edition release process.
 The release version of CE is several months behind EE.
-CE also do not include the latest bug fixes.
+CE also does not include the latest bug fixes.
 Documentation, mailing lists, and forums provide support for the Couchbase user community to help troubleshoot issues and answer questions.
 CE comes with limited concurrency and parallelism and supports a maximum of 4 cores per node.
 
 Open source project::
 The Couchbase Server open source project is a platform for innovation.
-Couchbase is committed to open source development and the open source project continues to serve as the foundation for both the community edition and the enterprise edition.
+Couchbase is committed to open source development and the open source project continues to serve as the foundation for both the Community Edition and the Enterprise Edition.
 There are many ways to contribute to the open source project: You can contribute code to our core engine, to our SDKs, connectors and other integration components that help us connect to other products through https://github.com/couchbase[github.com/couchbase^], you can report issues on our tracking system: https://issues.couchbase.com/projects/MB?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page[JIRA^], and https://docs.couchbase.com/home/contribute/index.html[contribute to the documentation] either by submitting changes on GitHub or by simply clicking the "Feedback" link in our online documentation.
 The full details on contributing to open source can be found on the open source page http://developer.couchbase.com/open-source-projects[developer.couchbase.com/open-source-projects^].
 

--- a/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
@@ -600,7 +600,7 @@ When new index nodes are added or removed from the cluster, the rebalance operat
 At the time of rebalancing, the rebalance operation gathers statistics from each index.
 These statistics are fed to an optimization algorithm to  determine the possible placement of each partition in order to minimize the variation of resource consumption across index nodes.
 
-The  rebalancer will only attempt to balance resource consumption on a best try basis.
+The rebalancer will only attempt to balance resource consumption on a best try basis.
 There are situations where the resource consumption cannot be fully balanced.
 For example:
 
@@ -624,7 +624,8 @@ The lost partitions cannot be repaired when the number of remaining nodes is les
 
 Along with aggregate pushdown optimization, an application can further enhance the aggregate query performance by computing aggregation in parallel for each partition in the index service.
 This can be achieved by specifying the parameter `max_parallelism` when issuing a query.
-The value for `max_parallelism` should match the number of partitions of the index Note than when this is enabled, the index service uses more CPU and memory since the query traffic is increased according to the value set in the parameter `max_parallelism`.
+The value for `max_parallelism` should match the number of partitions of the index.
+Note than when this is enabled, the index service uses more CPU and memory since the query traffic is increased according to the value set in the parameter `max_parallelism`.
 
 ****
 [.edition]#{community}#

--- a/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
@@ -620,7 +620,7 @@ The lost partitions cannot be repaired when the number of remaining nodes is les
 
 == Performance Considerations
 
-=== Max_parallelism
+=== Max Parallelism
 
 Along with aggregate pushdown optimization, an application can further enhance the aggregate query performance by computing aggregation in parallel for each partition in the index service.
 This can be achieved by specifying the parameter `max_parallelism` when issuing a query.

--- a/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
@@ -626,6 +626,12 @@ Along with aggregate pushdown optimization, an application can further enhance t
 This can be achieved by specifying the parameter `max_parallelism` when issuing a query.
 The value for `max_parallelism` should match the number of partitions of the index Note than when this is enabled, the index service uses more CPU and memory since the query traffic is increased according to the value set in the parameter `max_parallelism`.
 
+****
+[.edition]#{community}#
+
+In Couchbase Server Community Edition, `max_parallelism` has a maximum value of 4.
+****
+
 === OFFSET Pushdown
 
 When there are more than one qualifying partitions involved in a range query, the query engine will not push down the OFFSET clause to the index service.

--- a/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
@@ -630,7 +630,7 @@ Note than when this is enabled, the index service uses more CPU and memory since
 ****
 [.edition]#{community}#
 
-In Couchbase Server Community Edition, `max_parallelism` has a maximum value of 4.
+In Couchbase Server Community Edition, `max_parallelism` cannot be greater than 4.
 ****
 
 === OFFSET Pushdown


### PR DESCRIPTION
The following documentation is ready for review:

* [Couchbase Server Editions](https://simon-dew.github.io/docs-site/DOC-5727/server/6.5/introduction/editions.html) — new sentence in CE section, ≤ 4 cores per node
* [Index Partitioning › Performance Considerations › Max Parallelism](https://simon-dew.github.io/docs-site/DOC-5727/server/6.5/n1ql/n1ql-language-reference/index-partitioning.html#max-parallelism) — CE sidebar

Docs issue: [DOC-5727](https://issues.couchbase.com/browse/DOC-5727)