### PR TITLE
DOC-6155: Document n1ql REST API parameter auto-execute

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
@@ -55,6 +55,7 @@ You can prepare a statement in three ways:
 
 * Using the xref:n1ql:n1ql-rest-api/index.adoc[Query REST API] (`/query/service` endpoint).
 
+// FIXME: Links
 For information on how to use prepared statements with various SDKs, refer to xref:java-sdk::n1ql-query.adoc#prepare-stmts[Querying with N1QL] and xref:nodejs-sdk::n1ql-queries-with-sdk.adoc[N1QL from the SDK].
 
 [[parameters]]
@@ -168,7 +169,7 @@ _(Introduced in Couchbase Server 6.5)_
 
 When the _auto-prepare_ feature is active, a prepared statement is created every time you submit a N1QL request, whether you use the PREPARE statement or not.
 
-The process is similar to creating prepare statement without a local name:
+The process is similar to creating a prepared statement without a local name:
 
 * The query engine generates a UUID from the statement text.
 
@@ -180,9 +181,29 @@ The process is similar to creating prepare statement without a local name:
 
 The auto-prepare feature is inactive by default.
 You can turn the auto-prepare feature on or off using the `auto-prepare` service-level query setting.
-For more details, refer to xref:settings:query-settings.adoc[Query Settings].
+For more details, refer to xref:settings:query-settings.adoc#auto-prepare[Query Settings].
 
 Auto-prepare is disabled for N1QL requests which contain parameters, if they do not use the PREPARE statement.
+
+[[auto-execute]]
+== Auto-Execute
+
+_(Introducted in Couchbase Server 6.5)_
+
+When the _auto-execute_ feature is active, a prepared statement is executed automatically as soon as it is created.
+This saves you from having to make two separate N1QL requests in cases where you want to prepare a statement and execute it immediately.
+
+When this feature is active, a N1QL request to prepare a statement returns the xref:n1ql:n1ql-intro/queriesandresults.adoc#results[result of the execution step].
+It does not return the full <<result,result of the preparation step>>, such as the execution plan.
+However, the output of the N1QL request does include a `prepared` field, which contains the full name of the prepared statement.
+You can use this when you need to execute the prepared statement again.
+
+The auto-execute feature is inactive by default.
+You can turn the auto-execute feature on or off using the `auto_execute` request-level query setting.
+For more details, refer to xref:settings:query-settings.adoc#auto_execute[Query Settings].
+
+The auto-execute feature only works for N1QL requests which actually contain the PREPARE statement.
+Prepared statements created by the <<auto-prepare,auto-prepare>> feature are not executed by the auto-execute feature.
 
 [[propagation]]
 == Statement Propagation

--- a/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
@@ -55,8 +55,7 @@ You can prepare a statement in three ways:
 
 * Using the xref:n1ql:n1ql-rest-api/index.adoc[Query REST API] (`/query/service` endpoint).
 
-// FIXME: Links
-For information on how to use prepared statements with various SDKs, refer to xref:java-sdk::n1ql-query.adoc#prepare-stmts[Querying with N1QL] and xref:nodejs-sdk::n1ql-queries-with-sdk.adoc[N1QL from the SDK].
+For information on how to use prepared statements with various SDKs, refer to xref:2.7@java-sdk::n1ql-query.adoc#prepare-stmts[Querying with N1QL] and xref:2.7@java-sdk::n1ql-queries-with-sdk.adoc[N1QL from the SDK].
 
 [[parameters]]
 == Parameters

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -121,6 +121,8 @@ a| <<auto-prepare,auto-prepare>>
 
 a|<<args,args>>
 
+<<auto_execute,auto_execute>>
+
 <<batch_args,batch_args>>
 
 <<batch_named_args,batch_named_args>>
@@ -240,6 +242,26 @@ See section <<section_srh_tlm_n1b,Named Parameters VS. Positional Parameters>> f
 cbq> \set -args ["LAX", 6];
 ----
 | array
+
+|**auto_execute** +
+__Optional__
+| [[auto_execute]]
+Specifies that prepared statements should be executed automatically as soon as they are created.
+This saves you from having to make two separate requests in cases where you want to prepare a statement and execute it immediately.
+
+Refer to xref:n1ql:n1ql-language-reference/prepare.adoc#auto-execute[Auto-Execute] for more information.
+
+.Default
+`false`
+
+.Example
+[source,console]
+----
+cbq> \set -auto_execute true;
+
+$ curl http://localhost:8093/query/service -u user:pword -d 'statement=prepare select * from default&auto_execute=true'
+----
+| boolean
 
 |**batch_args** +
 __Optional__

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -507,6 +507,9 @@ Response:
     "indexApiVersion":3,
     "name":"[127.0.0.1:8091]pricy_hotel",
 ...
+    }
+  ]
+}
 ----
 
 Execute the prepared statement:


### PR DESCRIPTION
The following documentation is ready for review:

* [Settings and Parameters › Request-Level Parameters › auto_execute](https://simon-dew.github.io/docs-site/DOC-6155/server/6.5/settings/query-settings.html#auto_execute)
* [PREPARE › Auto-Execute](https://simon-dew.github.io/docs-site/DOC-6155/server/6.5/n1ql/n1ql-language-reference/prepare.html#auto-execute)

Docs issue: [DOC-6155](https://issues.couchbase.com/browse/DOC-6155)