### PR TITLE
Minor correction in documentation to remove a redundant word

### DIFF
--- a/modules/cloud/pages/couchbase-aws-marketplace.adoc
+++ b/modules/cloud/pages/couchbase-aws-marketplace.adoc
@@ -5,7 +5,7 @@ Couchbase partners with Amazon to provide a packaged solution on AWS Marketplace
 This solution is based on Amazon CloudFormation templates that incorporate the latest features and best practices for deploying Couchbase Server on Amazon Web Services.
 
 Couchbase Server on AWS Marketplace provides one of the fastest and easiest ways to get up and running on Amazon Web Services (AWS).
-At the core of this experience are Amazon CloudFormation templates templates that are developed in close collaboration with Amazon in order to adopt the latest features and best practices.
+At the core of this experience are Amazon CloudFormation templates that are developed in close collaboration with Amazon in order to adopt the latest features and best practices.
 Amazon Machine Images (AMIs) also provide the information required to launch an instance of a virtual server in AWS,
 thus making it easier and faster to deploy Couchbase Server without having to create and manage schemas, or normalize, shard, and tune the database.
 


### PR DESCRIPTION
Removing redundant term 'templates' in one of the statement