### PR TITLE
DOC-6311: Incomplete links in the "Indexing Metadata Information" document

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/indexing-meta-info.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/indexing-meta-info.adoc
@@ -27,7 +27,7 @@ The property name must be separated from the `META()` function by a dot (`.`) an
 cas:::
 Value representing the current state of an item which changes every time the item is modified.
 +
-For details, see xref:2.7@java-sdk::concurrent-mutations-cluster.adoc[Concurrent Document Mutations].
+For details, see xref:3.0@java-sdk:howtos:concurrent-document-mutations.adoc[Concurrent Document Mutations].
 
 expiration:::
 Value representing a document's expiration date.

--- a/modules/n1ql/pages/n1ql-language-reference/indexing-meta-info.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/indexing-meta-info.adoc
@@ -35,12 +35,12 @@ A value of 0 (zero) means no expiration date.
 +
 Note that this property gives correct results only when used in a xref:n1ql-language-reference/covering-indexes.adoc[Covered Index].
 +
-For details, see xref:2.7@java-sdk::core-operations.adoc[Core Operations].
+For details, see xref:3.0@java-sdk:howtos:kv-operations.adoc#document-expiration[KV Operations].
 
 flags:::
 Value set by the SDKs for non-JSON documents.
 +
-For details, see xref:2.7@java-sdk::nonjson.adoc[Non-JSON Documents].
+For details, see xref:3.0@nodejs-sdk:howtos:transcoders-nonjson.adoc[Non-JSON Documents].
 
 id:::
 Value representing a document's unique ID number.

--- a/modules/n1ql/pages/n1ql-language-reference/indexing-meta-info.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/indexing-meta-info.adoc
@@ -24,7 +24,7 @@ property::
 .cas:::
 Value representing the current state of an item which changes every time the item is modified.
 +
-_Indexable from Couchbase Server 5.0_ For details, see xref:java-sdk::concurrent-mutations-cluster.adoc[Concurrent Document Mutations].
+For details, see xref:java-sdk::concurrent-mutations-cluster.adoc[Concurrent Document Mutations].
 
 .expiration:::
 Value representing a document's expiration date.
@@ -32,7 +32,7 @@ A value of 0 (zero) means no expiration date.
 +
 Note that this property gives correct results only when used in a xref:indexes:covering-indexes.adoc[Covered Index].
 +
-_Indexable from Couchbase Server 5.0_ For details, see xref:java-sdk::core-operations.adoc[Core Operations].
+For details, see xref:java-sdk::core-operations.adoc[Core Operations].
 
 .flags:::
 Value set by the SDKs for non-JSON documents.
@@ -41,8 +41,6 @@ For details, see xref:java-sdk::nonjson.adoc[Non-JSON].
 
 .id:::
 Value representing a document's unique ID number.
-+
-_Indexable from Couchbase Server 4.0_
 
 .type::: Value for the type of document, currently only "json" is supported.
 

--- a/modules/n1ql/pages/n1ql-language-reference/indexing-meta-info.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/indexing-meta-info.adoc
@@ -4,21 +4,23 @@ Couchbase Server allows indexing on metadata fields of any document.
 These fields have existed before, and now version 5.0 has added support for indexing and querying the expiration and cas properties.
 This improves performance of queries involving predicates on the metadata fields, such as expired documents or recently modified documents.
 
-== META([.var]`keyspace_expr`).[.var]`property`
+== META( {startsb} `keyspace_expr` {endsb} ) {startsb} .`property` {endsb}
 
-Description::
+=== Description
+
 Returns metadata for the document [.var]`keyspace_expr`.
-+
+
 You can use the `meta()` and `meta().id` functions when creating an index; and in this context, the `meta()` and `meta().id` functions do not require a parameter since they implicitly use the keyspace being indexed.
 
-Arguments::
-keyspace_expr;;
+=== Arguments
+
+keyspace_expr::
 [Optional.
 Default is current keyspace.]
 +
 String or an expression that results in a keyspace or a document.
 
-property;;
+property::
 .cas:::
 Value representing the current state of an item which changes every time the item is modified.
 +
@@ -44,20 +46,33 @@ _Indexable from Couchbase Server 4.0_
 
 .type::: Value for the type of document, currently only "json" is supported.
 
-Return Value:: JSON value of the document's metadata.
+=== Return Value
 
-*Example 1*: Find two documents that have no expiration date.
+JSON value of the document's metadata.
 
+=== Examples
+
+.Find two documents that have no expiration date
+====
+.Index
+[source,n1ql]
 ----
 CREATE INDEX idx_expir ON `travel-sample` ( META().expiration );
+----
 
+.Query
+[source,n1ql]
+----
 SELECT META().id, META().expiration
 FROM `travel-sample`
 WHERE META().expiration = 0
 ORDER BY META().id
 LIMIT 2;
+----
 
-Results:
+.Results
+[source,json]
+----
 [
   {
     "expiration": 0,
@@ -69,18 +84,28 @@ Results:
   }
 ]
 ----
+====
 
-*Example 2*: Find all documents whose meta ID tag starts with a letter higher than "g".
-
+.Find all documents whose meta ID tag starts with a letter higher than "g"
+====
+.Index
+[source,n1ql]
 ----
 CREATE INDEX idx_id ON `travel-sample` (META().id );
+----
 
+.Query
+[source,n1ql]
+----
 SELECT name, META().id
 FROM `travel-sample`
 WHERE META().id > "g"
 LIMIT 2;
+----
 
-Results:
+.Results
+[source,json]
+----
 [
   {
     "id": "hotel_10025",
@@ -92,19 +117,29 @@ Results:
   }
 ]
 ----
+====
 
-*Example 3*: Find the two most recently modified hotel documents.
-
+.Find the two most recently modified hotel documents
+====
+.Index
+[source,n1ql]
 ----
 CREATE INDEX idx_cas ON `travel-sample` ( META().cas );
+----
 
+.Query
+[source,n1ql]
+----
 SELECT name, META().cas
 FROM `travel-sample`
 WHERE type="hotel"
 ORDER BY META().cas DESC
 LIMIT 2;
+----
 
-Results:
+.Results
+[source,json]
+----
 [
         {
             "cas": 1503510338735374337,
@@ -116,3 +151,4 @@ Results:
         }
     ]
 ----
+====

--- a/modules/n1ql/pages/n1ql-language-reference/indexing-meta-info.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/indexing-meta-info.adoc
@@ -27,20 +27,20 @@ The property name must be separated from the `META()` function by a dot (`.`) an
 cas:::
 Value representing the current state of an item which changes every time the item is modified.
 +
-For details, see xref:java-sdk::concurrent-mutations-cluster.adoc[Concurrent Document Mutations].
+For details, see xref:2.7@java-sdk::concurrent-mutations-cluster.adoc[Concurrent Document Mutations].
 
 expiration:::
 Value representing a document's expiration date.
 A value of 0 (zero) means no expiration date.
 +
-Note that this property gives correct results only when used in a xref:indexes:covering-indexes.adoc[Covered Index].
+Note that this property gives correct results only when used in a xref:n1ql-language-reference/covering-indexes.adoc[Covered Index].
 +
-For details, see xref:java-sdk::core-operations.adoc[Core Operations].
+For details, see xref:2.7@java-sdk::core-operations.adoc[Core Operations].
 
 flags:::
 Value set by the SDKs for non-JSON documents.
 +
-For details, see xref:java-sdk::nonjson.adoc[Non-JSON].
+For details, see xref:2.7@java-sdk::nonjson.adoc[Non-JSON Documents].
 
 id:::
 Value representing a document's unique ID number.

--- a/modules/n1ql/pages/n1ql-language-reference/indexing-meta-info.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/indexing-meta-info.adoc
@@ -21,12 +21,12 @@ Default is current keyspace.]
 String or an expression that results in a keyspace or a document.
 
 property::
-.cas:::
+cas:::
 Value representing the current state of an item which changes every time the item is modified.
 +
 For details, see xref:java-sdk::concurrent-mutations-cluster.adoc[Concurrent Document Mutations].
 
-.expiration:::
+expiration:::
 Value representing a document's expiration date.
 A value of 0 (zero) means no expiration date.
 +
@@ -34,15 +34,15 @@ Note that this property gives correct results only when used in a xref:indexes:c
 +
 For details, see xref:java-sdk::core-operations.adoc[Core Operations].
 
-.flags:::
+flags:::
 Value set by the SDKs for non-JSON documents.
 +
 For details, see xref:java-sdk::nonjson.adoc[Non-JSON].
 
-.id:::
+id:::
 Value representing a document's unique ID number.
 
-.type::: Value for the type of document, currently only "json" is supported.
+type::: Value for the type of document; currently only "json" is supported.
 
 === Return Value
 

--- a/modules/n1ql/pages/n1ql-language-reference/indexing-meta-info.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/indexing-meta-info.adoc
@@ -40,7 +40,7 @@ For details, see xref:3.0@java-sdk:howtos:kv-operations.adoc#document-expiration
 flags:::
 Value set by the SDKs for non-JSON documents.
 +
-For details, see xref:3.0@nodejs-sdk:howtos:transcoders-nonjson.adoc[Non-JSON Documents].
+For details, see xref:3.0@java-sdk:howtos:transcoders-nonjson.adoc[Non-JSON Documents].
 
 id:::
 Value representing a document's unique ID number.

--- a/modules/n1ql/pages/n1ql-language-reference/indexing-meta-info.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/indexing-meta-info.adoc
@@ -1,7 +1,6 @@
 = Indexing Metadata Information
 
-Couchbase Server allows indexing on metadata fields of any document.
-These fields have existed before, and now version 5.0 has added support for indexing and querying the expiration and cas properties.
+Couchbase Server allows indexing on metadata fields of any document, for example the `expiration` and `cas` properties.
 This improves performance of queries involving predicates on the metadata fields, such as expired documents or recently modified documents.
 
 == META( {startsb} `keyspace_expr` {endsb} ) {startsb} .`property` {endsb}
@@ -10,7 +9,8 @@ This improves performance of queries involving predicates on the metadata fields
 
 Returns metadata for the document [.var]`keyspace_expr`.
 
-You can use the `meta()` and `meta().id` functions when creating an index; and in this context, the `meta()` and `meta().id` functions do not require a parameter since they implicitly use the keyspace being indexed.
+You can use the `META()` function with a property when creating an index, for example `META().id`.
+The `META()` function does not require a keyspace parameter when creating an index, since it implicitly uses the keyspace being indexed.
 
 === Arguments
 
@@ -21,6 +21,9 @@ Default is current keyspace.]
 String or an expression that results in a keyspace or a document.
 
 property::
+[Optional] The name of a single metadata property.
+The property name must be separated from the `META()` function by a dot (`.`) and may be one of the following:
+
 cas:::
 Value representing the current state of an item which changes every time the item is modified.
 +

--- a/modules/n1ql/pages/n1ql-language-reference/indexing-meta-info.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/indexing-meta-info.adoc
@@ -1,6 +1,6 @@
 = Indexing Metadata Information
 
-Couchbase Server allows indexing on metadata fields of any document, for example the `expiration` and `cas` properties.
+Couchbase Server allows indexing on metadata fields of any document, for example the expiration and CAS properties.
 This improves performance of queries involving predicates on the metadata fields, such as expired documents or recently modified documents.
 
 == META( {startsb} `keyspace_expr` {endsb} ) {startsb} .`property` {endsb}


### PR DESCRIPTION
The following documentation is ready for review:

* [Indexing Metadata Information](https://simon-dew.github.io/docs-site/DOC-6311/server/6.5/n1ql/n1ql-language-reference/indexing-meta-info.html)

Docs issue: [DOC-6311](https://issues.couchbase.com/browse/DOC-6311)