### PR TITLE
"command line interface" confusion: terminal or CLI tools

### DIFF
--- a/modules/eventing/pages/eventing-debugging-and-diagnosability.adoc
+++ b/modules/eventing/pages/eventing-debugging-and-diagnosability.adoc
@@ -227,7 +227,7 @@ The output now indicates the exact error that occured via the Function's Applica
 
 As previously indicated, by selecting the "Edit JavaScript" button when the function is deployed a [X] indicator at the exact line in the JavaScript code failed will be displayed. By hovering over the [X] indicator more information is revealed.
     
-You can access a Function's Application log file using the UI in the Eventing view or via the command line interface via selecting the Function name and clicking on the 'Log' hyperlink.
+You can access a Function's Application log file using the UI by selecting the Function name and clicking on the 'Log' hyperlink/button or by opening a terminal and issuing Linux commands such a _cat_, _more_, _head_, _tail_, or ‘_tail -F_’ on a specific Eventing function’s log.
 
 Couchbase Server creates an individual log file for every Function in the cluster on each Eventing node. Application logs will only contain information for the mutations processed on a given Eventing node.
 

--- a/modules/eventing/pages/eventing-debugging-and-diagnosability.adoc
+++ b/modules/eventing/pages/eventing-debugging-and-diagnosability.adoc
@@ -227,7 +227,7 @@ The output now indicates the exact error that occured via the Function's Applica
 
 As previously indicated, by selecting the "Edit JavaScript" button when the function is deployed a [X] indicator at the exact line in the JavaScript code failed will be displayed. By hovering over the [X] indicator more information is revealed.
     
-You can access a Function's Application log file using the UI by selecting the Function name and clicking on the 'Log' hyperlink/button or by opening a terminal and issuing Linux commands such a _cat_, _more_, _head_, _tail_, or ‘_tail -F_’ on a specific Eventing function’s log.
+You can access a Function's Application log file using the UI by selecting the Function name and clicking on the 'Log' hyperlink/button or by opening a terminal and issuing Linux commands such as _cat_, _more_, _head_, _tail_, or ‘_tail -F_’ on a specific Eventing function’s log.
 
 Couchbase Server creates an individual log file for every Function in the cluster on each Eventing node. Application logs will only contain information for the mutations processed on a given Eventing node.
 


### PR DESCRIPTION
This cause confusion for one customer, to be clear call out "opening a terminal" and issuing Linux commands