### PR TITLE
DOC-4752: "Indexing Metadata Information" is inaccurate

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/indexing-meta-info.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/indexing-meta-info.adoc
@@ -6,7 +6,6 @@ This improves performance of queries involving predicates on the metadata fields
 == Overview
 
 The xref:n1ql:n1ql-language-reference/metafun.adoc#meta[META()] function enables you to return the metadata for a keyspace or document.
-
 To index a selected metadata field, you must use a xref:n1ql-language-reference/nestedops.adoc#field-selection[nested expression] containing the `META()` function and the required property, for example `META().id`.
 
 The property name must be separated from the `META()` function by a dot (`.`) and only the following metadata properties can be indexed.

--- a/modules/n1ql/pages/n1ql-language-reference/indexing-meta-info.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/indexing-meta-info.adoc
@@ -26,26 +26,34 @@ The property name must be separated from the `META()` function by a dot (`.`) an
 
 cas:::
 Value representing the current state of an item which changes every time the item is modified.
-+
 For details, see xref:3.0@java-sdk:howtos:concurrent-document-mutations.adoc[Concurrent Document Mutations].
++
+This property is indexable.
 
 expiration:::
 Value representing a document's expiration date.
 A value of 0 (zero) means no expiration date.
-+
-Note that this property gives correct results only when used in a xref:n1ql-language-reference/covering-indexes.adoc[Covered Index].
-+
 For details, see xref:3.0@java-sdk:howtos:kv-operations.adoc#document-expiration[KV Operations].
++
+This property is indexable.
+Note that this property gives correct results only when used in a xref:n1ql-language-reference/covering-indexes.adoc[Covered Index].
 
 flags:::
 Value set by the SDKs for non-JSON documents.
-+
 For details, see xref:3.0@java-sdk:howtos:transcoders-nonjson.adoc[Non-JSON Documents].
++
+This property is not indexable.
+If you attempt to build an index on this property, an error is returned.
 
 id:::
 Value representing a document's unique ID number.
++
+This property is indexable.
 
 type::: Value for the type of document; currently only "json" is supported.
++
+This property is not indexable.
+If you attempt to build an index on this property, an error is returned.
 
 === Return Value
 

--- a/modules/n1ql/pages/n1ql-language-reference/indexing-meta-info.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/indexing-meta-info.adoc
@@ -1,65 +1,31 @@
 = Indexing Metadata Information
 
-Couchbase Server allows indexing on metadata fields of any document, for example the expiration and CAS properties.
+Couchbase Server allows indexing on selected metadata fields, for example the expiration and CAS properties.
 This improves performance of queries involving predicates on the metadata fields, such as expired documents or recently modified documents.
 
-== META( {startsb} `keyspace_expr` {endsb} ) {startsb} .`property` {endsb}
+== Overview
 
-=== Description
+The xref:n1ql:n1ql-language-reference/metafun.adoc#meta[META()] function enables you to return the metadata for a keyspace or document.
 
-Returns metadata for the document [.var]`keyspace_expr`.
+To index a selected metadata field, you must use a xref:n1ql-language-reference/nestedops.adoc#field-selection[nested expression] containing the `META()` function and the required property, for example `META().id`.
 
-You can use the `META()` function with a property when creating an index, for example `META().id`.
-The `META()` function does not require a keyspace parameter when creating an index, since it implicitly uses the keyspace being indexed.
+The property name must be separated from the `META()` function by a dot (`.`) and only the following metadata properties can be indexed.
+If you attempt to build an index on a metadata field that is not indexable, an error is returned.
 
-=== Arguments
+cas::
+include::./metafun.adoc[tag=metadata-cas]
 
-keyspace_expr::
-[Optional.
-Default is current keyspace.]
+expiration::
+include::./metafun.adoc[tag=metadata-expiration]
 +
-String or an expression that results in a keyspace or a document.
-
-property::
-[Optional] The name of a single metadata property.
-The property name must be separated from the `META()` function by a dot (`.`) and may be one of the following:
-
-cas:::
-Value representing the current state of an item which changes every time the item is modified.
-For details, see xref:3.0@java-sdk:howtos:concurrent-document-mutations.adoc[Concurrent Document Mutations].
-+
-This property is indexable.
-
-expiration:::
-Value representing a document's expiration date.
-A value of 0 (zero) means no expiration date.
-For details, see xref:3.0@java-sdk:howtos:kv-operations.adoc#document-expiration[KV Operations].
-+
-This property is indexable.
 Note that this property gives correct results only when used in a xref:n1ql-language-reference/covering-indexes.adoc[Covered Index].
 
-flags:::
-Value set by the SDKs for non-JSON documents.
-For details, see xref:3.0@java-sdk:howtos:transcoders-nonjson.adoc[Non-JSON Documents].
-+
-This property is not indexable.
-If you attempt to build an index on this property, an error is returned.
+id::
+include::./metafun.adoc[tag=metadata-id]
 
-id:::
-Value representing a document's unique ID number.
-+
-This property is indexable.
+The `META()` function does not require a keyspace parameter when creating an index, since it implicitly uses the keyspace being indexed.
 
-type::: Value for the type of document; currently only "json" is supported.
-+
-This property is not indexable.
-If you attempt to build an index on this property, an error is returned.
-
-=== Return Value
-
-JSON value of the document's metadata.
-
-=== Examples
+== Examples
 
 .Find two documents that have no expiration date
 ====
@@ -150,14 +116,14 @@ LIMIT 2;
 [source,json]
 ----
 [
-        {
-            "cas": 1503510338735374337,
-            "name": "Hotel Formule 1"
-        },
-        {
-            "cas": 1503510338734850048,
-            "name": "Harbour Cottage Gardenstown"
-        }
-    ]
+    {
+        "cas": 1503510338735374337,
+        "name": "Hotel Formule 1"
+    },
+    {
+        "cas": 1503510338734850048,
+        "name": "Harbour Cottage Gardenstown"
+    }
+]
 ----
 ====

--- a/modules/n1ql/pages/n1ql-language-reference/metafun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/metafun.adoc
@@ -23,8 +23,8 @@ Reverses the encoding done by the <<base64>> or <<base64-encode>> functions.
 == META( {startsb} `keyspace_expr` {endsb} ) {startsb} .`property` {endsb}
 
 This function returns the xref:learn:data/data.adoc#metadata[metadata] for the document or keyspace specified by [.var]`keyspace_expr`.
-
 The metadata is returned as a JSON object.
+
 To return a single property from the metadata, you must use a xref:n1ql-language-reference/nestedops.adoc#field-selection[nested expression] containing the `META()` function and the required property, for example `META().id`.
 The supported metadata properties are described below.
 

--- a/modules/n1ql/pages/n1ql-language-reference/metafun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/metafun.adoc
@@ -1,5 +1,6 @@
 = Miscellaneous Utility Functions
 :page-topic-type: concept
+:page-partial:
 
 Meta functions retrieve information about the document or item as well as perform base64 encoding.
 
@@ -19,9 +20,179 @@ Alias of <<base64>>.
 Reverses the encoding done by the <<base64>> or <<base64-encode>> functions.
 
 [[meta,META()]]
-== META([.var]`expression`)
+== META( {startsb} `keyspace_expr` {endsb} ) {startsb} .`property` {endsb}
 
-For details, see xref:n1ql-language-reference/indexing-meta-info.adoc[Indexing Meta Info].
+This function returns the xref:learn:data/data.adoc#metadata[metadata] for the document or keyspace specified by [.var]`keyspace_expr`.
+
+The metadata is returned as a JSON object.
+To return a single property from the metadata, you must use a xref:n1ql-language-reference/nestedops.adoc#field-selection[nested expression] containing the `META()` function and the required property, for example `META().id`.
+The supported metadata properties are described below.
+
+You can use the `META()` function with a property to xref:n1ql-language-reference/indexing-meta-info.adoc[index metadata information].
+Only certain metadata properties are indexable; these are indicated in the description below.
+
+You can also use the `META()` function with a property in the predicate of an xref:n1ql:n1ql-language-reference/join.adoc#section_ek1_jnx_1db[ANSI JOIN Clause].
+
+=== Arguments
+
+keyspace_expr::
+[Optional.
+Default is current keyspace.]
++
+String or an expression that results in a keyspace or a document.
+This argument is not required when creating an index, since the `META()` function implicitly uses the keyspace being indexed.
+
+property::
+[Optional] The name of a single metadata property.
+The property name must be separated from the `META()` function by a dot (`.`) and may be one of the following:
+
+cas:::
+// tag::metadata-cas[]
+Value representing the current state of an item which changes every time the item is modified.
+For details, refer to xref:3.0@java-sdk:howtos:concurrent-document-mutations.adoc[Concurrent Document Mutations].
+// end::metadata-cas[]
++
+This property is indexable.
+
+expiration:::
+// tag::metadata-expiration[]
+Value representing a document's expiration date.
+A value of 0 (zero) means no expiration date.
+For details, refer to xref:3.0@java-sdk:howtos:kv-operations.adoc#document-expiration[KV Operations].
+// end::metadata-expiration[]
++
+This property is indexable.
+
+flags:::
+Value set by the SDKs for non-JSON documents.
+For details, refer to xref:3.0@java-sdk:howtos:transcoders-nonjson.adoc[Non-JSON Documents].
++
+This property is not indexable.
+If you attempt to build an index on this property, an error is returned.
+
+id:::
+// tag::metadata-id[]
+Value representing a document's unique ID number.
+// end::metadata-id[]
++
+This property is indexable.
+
+type::: Value for the type of document; currently only `json` is supported.
++
+This property is not indexable.
+If you attempt to build an index on this property, an error is returned.
+
+=== Return Value
+
+The bare function returns a JSON object containing the specified document's metadata.
+When the function is used with a property as part of a nested expression, the expression returns the JSON value of the property.
+
+=== Examples
+
+.Return all metadata
+====
+[source,n1ql]
+----
+SELECT META() AS metadata
+FROM `travel-sample`
+LIMIT 3;
+----
+
+.Results
+[source,json]
+----
+[
+  {
+      "metadata": {
+          "cas": 1583859008179798016,
+          "expiration": 0,
+          "flags": 33554432,
+          "id": "airline_10",
+          "type": "json"
+      }
+  },
+  {
+      "metadata": {
+          "cas": 1583859008180846592,
+          "expiration": 0,
+          "flags": 33554432,
+          "id": "airline_10123",
+          "type": "json"
+      }
+  },
+  {
+      "metadata": {
+          "cas": 1583859008181895168,
+          "expiration": 0,
+          "flags": 33554432,
+          "id": "airline_10226",
+          "type": "json"
+      }
+  }
+]
+----
+====
+
+.Return a single metadata property
+====
+[source,n1ql]
+----
+SELECT META().id AS id
+FROM `travel-sample`
+LIMIT 3;
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "id": "airline_10"
+  },
+  {
+    "id": "airline_10123"
+  },
+  {
+    "id": "airline_10226"
+  }
+]
+----
+====
+
+.Return a single metadata property for a specified keyspace
+====
+[source,n1ql]
+----
+SELECT META(route).id AS id -- <1>
+FROM `travel-sample` AS route
+JOIN `travel-sample` AS airport
+ON route.sourceairport = airport.faa
+WHERE airport.city = "Paris"
+LIMIT 3;
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "id": "route_10136"
+  },
+  {
+    "id": "route_10137"
+  },
+  {
+    "id": "route_10138"
+  }
+]
+----
+====
+
+<1> You must specify a keyspace for the `META()` function because there is more than one FROM term.
+
+For examples showing how to index metadata information, refer to xref:n1ql-language-reference/indexing-meta-info.adoc[Indexing Meta Info].
+
+For examples showing how to use metadata information in the predicate of an ANSI JOIN clause, refer to xref:n1ql:n1ql-language-reference/join.adoc[JOIN Clause].
 
 [[pairs,PAIRS()]]
 == PAIRS([.var]`obj`)


### PR DESCRIPTION
The following documentation is ready for review:

* [Miscellaneous Utility Functions › META()](https://simon-dew.github.io/docs-site/DOC-4752/server/6.5/n1ql/n1ql-language-reference/metafun.html#meta)
* [Indexing Metadata Information](https://simon-dew.github.io/docs-site/DOC-4752/server/6.5/n1ql/n1ql-language-reference/indexing-meta-info.html)

Docs issue: [DOC-4752](https://issues.couchbase.com/browse/DOC-4752)