### PR TITLE
DOC-6115: CBQ shell redirect output overwritten

### DIFF
--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -833,7 +833,7 @@ You can specify a different location using relative paths.
 
 If the file doesn't exist, it is created.
 If the file already exists, it is overwritten.
-In Couchbase Server 6.1.5, you can append redirected output to an existing file using <<file-append-mode>>.
+In Couchbase Server 6.5.1, you can append redirected output to an existing file using <<file-append-mode>>.
 
 Command Line Option:  <<opt-output,-o>> or <<opt-output,--output>>
 
@@ -1625,7 +1625,7 @@ All the commands specified after `\REDIRECT` and before `\REDIRECT OFF` are save
 
 If the file doesn't exist, it is created.
 If the file already exists, it is overwritten.
-In Couchbase Server 6.1.5, you can append redirected output to an existing file using <<file-append-mode>>.
+In Couchbase Server 6.5.1, you can append redirected output to an existing file using <<file-append-mode>>.
 
 .Example
 [source,console]
@@ -1644,9 +1644,9 @@ When you do so, the output file changes to the specified files and switches back
 === File Append Mode
 
 [.labels]
-[.status]#Couchbase Server 6.1.5#
+[.status]#Couchbase Server 6.5.1#
 
-In Couchbase Server 6.1.5, you can use _file append mode_ to specify that cbq should append redirected output to the end of an existing file, rather than overwriting the existing file.
+In Couchbase Server 6.5.1, you can use _file append mode_ to specify that cbq should append redirected output to the end of an existing file, rather than overwriting the existing file.
 
 To use file append mode, include a plus sign `+` at the start of the output path or filename.
 

--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -819,7 +819,7 @@ cbq> \SOURCE sample.txt;
 | [.var]`filename`
 a| [[cbq-redirect]]
 Redirects the output of all the commands to the specified file until the cbq shell receives the [.cmd]`\REDIRECT OFF` command.
-By default, the file is created in the [.path]_/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin_ directory.
+By default, the file is created in the directory that you were in when you started the cbq shell.
 You can specify a different location using relative paths.
 
 .Example
@@ -1597,13 +1597,13 @@ You can redirect all the output for a session or part of a session to a specifie
 --output=filename
 ----
 
-To redirect a specific set of commands during a session, you must specify the commands between REDIRECT and REDIRECT OFF as shown:
+To redirect a specific set of commands during a session, you must specify the commands between `\REDIRECT` and `\REDIRECT OFF` as shown:
 
 [source,console]
 ----
 cbq> \REDIRECT filename;
 command-1; command-2;, ..., command-n;
-\REDIRECT OFF;
+cbq> \REDIRECT OFF;
 ----
 
 All the commands specified after `\REDIRECT` and before `\REDIRECT OFF` are saved into the specified output file.
@@ -1613,14 +1613,15 @@ If the file doesn't exist then it is created.
 [source,console]
 ----
 cbq> \REDIRECT temp_output.txt;
-> CREATE PRIMARY INDEX on `beer-sample` USING GSI;
-> SELECT * from `beer-sample` LIMIT 1;
-> \HELP;
-> \REDIRECT OFF;
+cbq> CREATE PRIMARY INDEX on `beer-sample` USING GSI;
+cbq> SELECT * from `beer-sample` LIMIT 1;
+cbq> \HELP;
+cbq> \REDIRECT OFF;
 ----
 
-You can specify multiple `REDIRECT` commands.
-When you do so, the output file changes to the specified files and switches back to [.out]`stdout` only when you specify "[.code]``\REDIRECT OFF``;".
+You can specify multiple `\REDIRECT` commands.
+When you do so, the output file changes to the specified files and switches back to [.out]`stdout` only when you specify `\REDIRECT OFF`.
+
 
 [#cbq-server-shell-info]
 == Server and Shell Information

--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -209,7 +209,7 @@ cbq> \HELP;
 `--engine`
 | <[.var]``url``>
 | `+http://localhost:8091+`
-a|
+a| [[opt-engine]]
 The connection string consists of a protocol scheme followed by a host, including a port number to connect to the query service (8093) or the Couchbase cluster (8091).
 
 The cbq shell supports [.path]_http://_, [.path]_https://_, [.path]_couchbase://_ and [.path]_couchbases://_ protocol schemes.
@@ -244,7 +244,7 @@ cbq>
 `--no-engine`
 | None
 | false
-a|
+a| [[opt-no-engine]]
 The cbq shell does not connect to any query service.
 You must explicitly connect to a query service using the [.cmd]`\CONNECT` shell command.
 
@@ -258,7 +258,7 @@ $ ./cbq --no-engine
 `--quiet`
 | None
 | false
-a|
+a| [[opt-quiet]]
 Enables or disables the startup connection message for the cbq shell.
 
 .Examples
@@ -278,7 +278,7 @@ cbq>
 `--batch`
 | None
 | None
-a|
+a| [[opt-batch]]
 This option is available only with Analytics service.
 When invoked with the batch option, cbq sends the queries to server only when you hit EOF or \ to indicate the end of the batch input.
 
@@ -299,7 +299,7 @@ You can also set the batch mode in the interactive session using the following c
 `--timeout`
 | [.var]`value`
 | None
-a|
+a| [[opt-timeout]]
 Sets the query timeout parameter.
 
 .Examples
@@ -312,9 +312,9 @@ $ ./cbq -e http://localhost:8091 --timeout="1s"
 `--user`
 | [.var]`username`
 | None
-a|
+a| [[opt-user]]
 Specifies a single user name to log in to Couchbase.
-When used by itself, without the -p option to specify the password, you will be prompted for the password.
+When used by itself, without the `-p` option to specify the password, you will be prompted for the password.
 
 This option requires administration credentials and you cannot switch the credentials during a session.
 
@@ -331,7 +331,7 @@ $ ./cbq -e http://localhost:8091 -u=Administrator
 `--password`
 | [.var]`password`
 | None
-a|
+a| [[opt-password]]
 Specifies the password for the given user name.
 You cannot use this option by itself.
 It must be used with the -u option to specify the user name.
@@ -350,7 +350,7 @@ $ ./cbq -e http://localhost:8091 -u=Administrator -p=password
 `--credentials`
 | [.var]`list of credentials`
 | None
-a|
+a| [[opt-credentials]]
 Specify the login credentials in the form of [.var]`username`:[.var]``password``.
 You can specify credentials for different buckets by separating them with a comma.
 
@@ -368,7 +368,7 @@ $ ./cbq -e http://localhost:8091 -c=beer-sample:password,Administrator:password
 `--version`
 | None
 | false
-a|
+a| [[opt-version]]
 Provides the version of the cbq shell.
 To display the query engine version of Couchbase Server (this is not the same as the version of Couchbase Server itself), use one of the following N1QL queries:
 
@@ -403,7 +403,7 @@ $ ./cbq --version
 `--help`
 | None
 | None
-a|
+a| [[opt-help]]
 Provides help for the command line options.
 
 Shell command: <<cbq-help,\HELP>>
@@ -418,7 +418,7 @@ $ ./cbq --help
 `-script`
 | [.var]`query`
 | None
-a|
+a| [[opt-script]]
 Provides a single command mode to execute a query from the command line.
 
 You can also use multiple `-s` options on the command line.
@@ -452,7 +452,7 @@ $ ./cbq  -s="\SET v 1" -s="\SET b 2" -s="\PUSH b3" -s="\SET b 5" -s="\SET"  -ne
 `--file`
 | [.var]`input-file`
 | None
-a|
+a| [[opt-file]]
 Provides an input file which contains all the commands to be run.
 
 Shell command: <<cbq-source,\SOURCE>>
@@ -466,7 +466,7 @@ $ ./cbq --file="sample.txt"
 `--output`
 | [.var]`output-file`
 | None
-a|
+a| [[opt-output]]
 Specifies an output file where the commands and their results are to be written.
 
 If the file doesn't exist, it is created.
@@ -482,7 +482,7 @@ $ ./cbq -o="results.txt" -s="select * from `travel-sample` limit 1"
 | `--exit-on-error`
 | None
 | false
-a|
+a| [[opt-exit-on-error]]
 Specifies that the cbq shell must exit when it encounters the first error.
 
 .Examples
@@ -495,7 +495,7 @@ $ ./cbq --exit-on-error -f="sample.txt"
 `-skip-verify`
 | None
 | false
-a|
+a| [[opt-skip-verify]]
 Specifies that cbq shell can skip the verification of certificates.
 
 The default ports are 18091 and 18093.
@@ -526,7 +526,7 @@ When using the [.path]_couchbase://_ or [.path]_couchbases://_ protocol schemes,
 
 The cbq shell supports both IPV4 and IPV6 addresses.
 
-Command Line Option: `-e` or `--engine`
+Command Line Option: <<opt-engine,-e>> or <<opt-engine,--engine>>
 
 .Examples
 [source,console]
@@ -761,6 +761,8 @@ select version()
 a| [[cbq-version]]
 Displays the version of the client shell.
 
+Command Line Option: <<opt-version,-v>> or <<opt-version,--version>>
+
 .Example
 [source,console]
 ----
@@ -773,6 +775,8 @@ cbq> \VERSION;
 a| [[cbq-help]]
 Displays the help information for the specified command.
 When used without any arguments, it lists all the commands supported by the cbq shell.
+
+Command Line Option: <<opt-help,-h>> or <<opt-help,--help>>
 
 .Example
 [source,console]
@@ -803,6 +807,8 @@ a| [[cbq-source]]
 Reads and executes the commands from a file.
 Multiple commands in the input file must be separated by `;` [.var]`<newline>`.
 
+Command Line Option: <<opt-file,-f>> or <<opt-file,--file>>
+
 For example, [.path]_sample.txt_ contains the following commands:
 
 ----
@@ -828,6 +834,8 @@ You can specify a different location using relative paths.
 If the file doesn't exist, it is created.
 If the file already exists, it is overwritten.
 In Couchbase Server 6.0.4, you can append redirected output to an existing file using <<file-append-mode>>.
+
+Command Line Option:  <<opt-output,-o>> or <<opt-output,--output>>
 
 .Example
 [source,console]
@@ -1638,7 +1646,7 @@ When you do so, the output file changes to the specified files and switches back
 [.labels]
 [.status]#Couchbase Server 6.0.4#
 
-In Couchbase Server 6.0.4, you can use _file append mode_ to specify that cbq should append redirected output to the end of an existing file, rather than overwriting it.
+In Couchbase Server 6.0.4, you can use _file append mode_ to specify that cbq should append redirected output to the end of an existing file, rather than overwriting the existing file.
 
 To use file append mode, include a plus sign `+` at the start of the output path or filename.
 

--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -19,7 +19,7 @@ If no options are present then it assumes default values for expected options.
 NOTE: The cbq shell commands are case insensitive.
 However, the command line options are case sensitive.
 
-For the complete list of command line options and shell commands, see tables <<table_a3h_rhz_dw>> and <<table_htk_hgc_fw>>.
+For the complete list of command line options and shell commands, refer to <<table_a3h_rhz_dw>> and <<table_htk_hgc_fw>>.
 
 The cbq shell enables you to manipulate parameters based on the REST API.
 See <<cbq-parameter-manipulation>> for details.
@@ -382,6 +382,8 @@ select version();
 select min_version();
 ----
 
+Shell command: <<cbq-version,\VERSION>>
+
 .Examples
 [source,console]
 ----
@@ -511,7 +513,7 @@ $ ./cbq -skip-verify https://127.0.0.1:18091
 
 | [.cmd]`\CONNECT`
 | [.var]`url`
-a|
+a| [[cbq-connect]]
 Connects cbq shell to the specified query engine or Couchbase cluster.
 
 The connection string consists of a protocol scheme followed by a host, including a port number to connect to the query service (8093) or the Couchbase cluster (8091).
@@ -536,7 +538,7 @@ cbq> \CONNECT http://[fd63:6f75:6368:1075:816:3c1d:789b:bc4]:8091
 
 | [.cmd]`\DISCONNECT`
 | None
-a|
+a| [[cbq-disconnect]]
 Disconnects the cbq shell from the query service or cluster endpoint.
 
 .Example
@@ -552,7 +554,7 @@ cbq> \DISCONNECT;
 
 [.cmd]`\QUIT`
 | None
-a|
+a| [[cbq-quit]]
 Exits cbq shell.
 
 .Examples
@@ -567,10 +569,10 @@ cbq> \QUIT;
 ----
 
 | [.cmd]`\SET`
-| [.var]`parameter`[.var]`value`
+| [.var]`parameter` [.var]`value`
 
 [.var]`parameter`=[.var]`prefix`:[.var]``variable name``
-a|
+a| [[cbq-set]]
 Sets the top most value of the stack for the given variable with the specified value.
 
 Variables can be of the following types:
@@ -595,7 +597,7 @@ cbq> \SET -args [6,7];
 
 | [.cmd]`\PUSH`
 | [.var]`parameter value`
-a|
+a| [[cbq-push]]
 Pushes the specified value on to the given parameter stack.
 
 When the [.cmd]`\PUSH` command is used without any arguments, it copies the top element of every variable's stack, and then pushes that copy to the top of the respective variable's stack.
@@ -626,7 +628,7 @@ cbq>
 
 | [.cmd]`\UNSET`
 | [.var]`parameter`
-a|
+a| [[cbq-unset]]
 Deletes or resets the entire stack for the specified parameter.
 
 .Examples
@@ -645,7 +647,7 @@ cbq>
 
 | [.cmd]`\POP`
 | [.var]`parameter`
-a|
+a| [[cbq-pop]]
 Pops the top most value from the specified parameter's stack.
 
 When the [.cmd]`\POP` command is used without any arguments, it pops the top most value of every variable's stack.
@@ -665,7 +667,7 @@ cbq> \SET;
 
 | [.cmd]`\ALIAS`
 | [.var]`shell-command` or [.var]`n1ql-statement`
-a|
+a| [[cbq-alias]]
 Creates a command alias for the specified cbq shell command or N1QL statement.
 You can then execute the alias using `\\alias-name;`.
 
@@ -710,7 +712,7 @@ cbq> \\serverversion;
 
 | [.cmd]`\UNALIAS`
 | [.var]`alias-name`
-a|
+a| [[cbq-unalias]]
 Deletes the specified alias.
 
 .Examples
@@ -730,7 +732,7 @@ cbq>
 | [.var]`args`
 
 where [.var]`args` can be parameters, aliases, or any input.
-a|
+a| [[cbq-echo]]
 If the input is a parameter, this command echoes (displays) the value of the parameter.
 The parameter must be prefixed according to it's type.
 See <<table_ltk_c5s_5v>> for details.
@@ -753,7 +755,7 @@ select version()
 
 | [.cmd]`\VERSION`
 | None
-a|
+a| [[cbq-version]]
 Displays the version of the client shell.
 
 .Example
@@ -765,7 +767,7 @@ cbq> \VERSION;
 
 | [.cmd]`\HELP`
 | [.var]`command`
-a|
+a| [[cbq-help]]
 Displays the help information for the specified command.
 When used without any arguments, it lists all the commands supported by the cbq shell.
 
@@ -783,7 +785,7 @@ Example :
 
 | [.cmd]`\COPYRIGHT`
 | None
-a|
+a| [[cbq-copyright]]
 Displays the copyright, attributions, and distribution terms.
 
 .Example
@@ -794,7 +796,7 @@ cbq> \COPYRIGHT;
 
 | [.cmd]`\SOURCE`
 | [.var]`input-file`
-a|
+a| [[cbq-source]]
 Reads and executes the commands from a file.
 Multiple commands in the input file must be separated by "; [.var]``<newline>``"
 
@@ -815,7 +817,7 @@ cbq> \SOURCE sample.txt;
 
 | [.cmd]`\REDIRECT`
 | [.var]`filename`
-a|
+a| [[cbq-redirect]]
 Redirects the output of all the commands to the specified file until the cbq shell receives the [.cmd]`\REDIRECT OFF` command.
 By default, the file is created in the [.path]_/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin_ directory.
 You can specify a different location using relative paths.
@@ -830,7 +832,7 @@ cbq>
 
 | [.cmd]`\REDIRECT OFF`
 | None
-a|
+a| [[cbq-redirect-off]]
 Redirects the output of subsequent commands from a custom file to standard output (os.stdout).
 
 .Example

--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -833,7 +833,7 @@ You can specify a different location using relative paths.
 
 If the file doesn't exist, it is created.
 If the file already exists, it is overwritten.
-In Couchbase Server 6.0.4, you can append redirected output to an existing file using <<file-append-mode>>.
+In Couchbase Server 6.1.5, you can append redirected output to an existing file using <<file-append-mode>>.
 
 Command Line Option:  <<opt-output,-o>> or <<opt-output,--output>>
 
@@ -1625,7 +1625,7 @@ All the commands specified after `\REDIRECT` and before `\REDIRECT OFF` are save
 
 If the file doesn't exist, it is created.
 If the file already exists, it is overwritten.
-In Couchbase Server 6.0.4, you can append redirected output to an existing file using <<file-append-mode>>.
+In Couchbase Server 6.1.5, you can append redirected output to an existing file using <<file-append-mode>>.
 
 .Example
 [source,console]
@@ -1644,9 +1644,9 @@ When you do so, the output file changes to the specified files and switches back
 === File Append Mode
 
 [.labels]
-[.status]#Couchbase Server 6.0.4#
+[.status]#Couchbase Server 6.1.5#
 
-In Couchbase Server 6.0.4, you can use _file append mode_ to specify that cbq should append redirected output to the end of an existing file, rather than overwriting the existing file.
+In Couchbase Server 6.1.5, you can use _file append mode_ to specify that cbq should append redirected output to the end of an existing file, rather than overwriting the existing file.
 
 To use file append mode, include a plus sign `+` at the start of the output path or filename.
 

--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -469,6 +469,9 @@ $ ./cbq --file="sample.txt"
 a|
 Specifies an output file where the commands and their results are to be written.
 
+If the file doesn't exist, it is created.
+If the file already exists, it is overwritten.
+
 Shell command: <<cbq-redirect,\REDIRECT>>
 
 .Examples
@@ -821,6 +824,10 @@ a| [[cbq-redirect]]
 Redirects the output of all the commands to the specified file until the cbq shell receives the [.cmd]`\REDIRECT OFF` command.
 By default, the file is created in the directory that you were in when you started the cbq shell.
 You can specify a different location using relative paths.
+
+If the file doesn't exist, it is created.
+If the file already exists, it is overwritten.
+In Couchbase Server 6.0.4, you can append redirected output to an existing file using <<file-append-mode>>.
 
 .Example
 [source,console]
@@ -1607,7 +1614,10 @@ cbq> \REDIRECT OFF;
 ----
 
 All the commands specified after `\REDIRECT` and before `\REDIRECT OFF` are saved into the specified output file.
-If the file doesn't exist then it is created.
+
+If the file doesn't exist, it is created.
+If the file already exists, it is overwritten.
+In Couchbase Server 6.0.4, you can append redirected output to an existing file using <<file-append-mode>>.
 
 .Example
 [source,console]
@@ -1622,6 +1632,36 @@ cbq> \REDIRECT OFF;
 You can specify multiple `\REDIRECT` commands.
 When you do so, the output file changes to the specified files and switches back to [.out]`stdout` only when you specify `\REDIRECT OFF`.
 
+[[file-append-mode]]
+=== File Append Mode
+
+[.labels]
+[.status]#Couchbase Server 6.0.4#
+
+In Couchbase Server 6.0.4, you can use _file append mode_ to specify that cbq should append redirected output to the end of an existing file, rather than overwriting it.
+
+To use file append mode, include a plus sign `+` at the start of the output path or filename.
+
+.Example
+[source,console]
+----
+cbq> \REDIRECT +temp_output.txt;
+cbq> SELECT * from `beer-sample` LIMIT 1;
+cbq> \REDIRECT OFF;
+----
+
+Every time you start appending to the output file, a timestamp is added to the end of the output file, followed by any redirected commands and results.
+
+----
+-- <2020-03-06T03:37:28.484-08:00> : opened in append mode
+
+SELECT * from `beer-sample` LIMIT 1
+...
+----
+
+Note that file append mode is only available with the `\REDIRECT` command within a shell session.
+It is not available for the `-o` or `--output` command line option.
+When you use the `-o` or `--output` command line option, the specified output file is always overwritten.
 
 [#cbq-server-shell-info]
 == Server and Shell Information

--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -106,8 +106,8 @@ Connected to : http://localhost:8091/. Type Ctrl-D to exit.
 === Support for Multi-line Queries
 
 The cbq shell supports multi-line queries by default, enabling you to enter a query over multiple lines.
-When entering a query, you can hit kbd:[Enter] without specifying a semi-colon (;) at the end of the line to move the cursor to the next line.
-The prompt ">" indicates that the shell is in multi-line mode.
+When entering a query, you can hit kbd:[Enter] without specifying a semi-colon (`;`) at the end of the line to move the cursor to the next line.
+The prompt `>` indicates that the shell is in multi-line mode.
 For example:
 
 [source,console]
@@ -117,12 +117,12 @@ cbq> select *
 > LIMIT 1;
 ----
 
-When you're done, use a semi-colon ";" to indicate the end of the query, and then press kbd:[Enter] to execute the query.
+When you're done, use a semi-colon `;` to indicate the end of the query, and then press kbd:[Enter] to execute the query.
 
 === Handling Comments
 
-You can add comments in your query by preceding the comment with a '&#35;' or '--'.
-The cbq shell interprets a line that starts with '&#35;' or '--' as a comment, logs the line into history, and returns a new prompt.
+You can add comments in your query by preceding the comment with a `&num;` or `--`.
+The cbq shell interprets a line that starts with `&num;` or `--` as a comment, logs the line into history, and returns a new prompt.
 No other action is taken.
 
 [source,console]
@@ -135,7 +135,7 @@ cbq> select *
 ----
 
 However, if a comment exists within a statement, it is considered as part of the N1QL command.
-If the cbq shell encounters a block comment (enclosed between /* \... */) within a statement, it sends the block comment to the query service.
+If the cbq shell encounters a block comment (enclosed between `/{asterisk}` \... `{asterisk}/`) within a statement, it sends the block comment to the query service.
 
 [source,console]
 ----
@@ -421,7 +421,7 @@ $ ./cbq --help
 a|
 Provides a single command mode to execute a query from the command line.
 
-You can also use multiple "-s" options on the command line.
+You can also use multiple `-s` options on the command line.
 If one of the commands is incorrect, an error is displayed for that command and cbq continues to execute the remaining commands.
 
 .Examples
@@ -734,7 +734,7 @@ cbq>
 where [.var]`args` can be parameters, aliases, or any input.
 a| [[cbq-echo]]
 If the input is a parameter, this command echoes (displays) the value of the parameter.
-The parameter must be prefixed according to it's type.
+The parameter must be prefixed according to its type.
 See <<table_ltk_c5s_5v>> for details.
 
 If the input is not a parameter, the command echoes the statement as is.
@@ -798,9 +798,9 @@ cbq> \COPYRIGHT;
 | [.var]`input-file`
 a| [[cbq-source]]
 Reads and executes the commands from a file.
-Multiple commands in the input file must be separated by "; [.var]``<newline>``"
+Multiple commands in the input file must be separated by `;` [.var]`<newline>`.
 
-For example, sample.txt contains the following commands:
+For example, [.path]_sample.txt_ contains the following commands:
 
 ----
 select * from `travel-sample` limit 1;
@@ -991,7 +991,7 @@ You can pass a single user name credential to the cbq shell on startup using the
 ----
 
 The shell then prompts you for a password.
-You can also provide a single password credential using the -p option.
+You can also provide a single password credential using the `-p` option.
 You cannot use this option by itself.
 It must be used with the `-u` option to specify the user name that the password is associated with.
 
@@ -1031,7 +1031,7 @@ To set the credentials for different users on startup, use one of the following 
 ----
 
 The [.var]`list-of-creds` can take either one or multiple credentials.
-The credentials consist of an identity and a password separated by a colon ":".
+The credentials consist of an identity and a password separated by a colon `:`.
 To specify multiple credentials, append all the user names and passwords to the same credentials array.
 For example:
 
@@ -1183,7 +1183,7 @@ The cbq shell uses the prefix to differentiate between the different types of pa
 
 NOTE: Positional parameters are set using the [.param]`-args` query parameter.
 
-You can use the cbq shell to set all the REST API settings by specifying the settings as query parameters prefixed by '-'.
+You can use the cbq shell to set all the REST API settings by specifying the settings as query parameters prefixed by `-`.
 As a best practice, we recommend that you save the initial set of basic parameters and their default values using the [.cmd]`\PUSH` command (with no arguments).
 
 .Examples
@@ -1298,14 +1298,14 @@ The following table lists the available predefined session variables.
 | Specifies the file name to store the command history.
 By default the file is saved in the user's home directory.
 
-Default:[.path]__.cbq_history__
+Default: [.path]__.cbq_history__
 |===
 
 === Handling Named Parameters
 
 Use the \SET command to define named parameters.
-For each named parameter, prefix the variable name with '-$'.
-The following example creates named parameters 'r' and 'date' with values 9.5 and "1-1-2016" respectively.
+For each named parameter, prefix the variable name with `-$`.
+The following example creates named parameters `r` and `date` with values 9.5 and "1-1-2016" respectively.
 
 ----
 \SET -$r 9.5;
@@ -1489,7 +1489,7 @@ This parameter specifies the time to wait before returning an error when executi
 --timeout=value
 ----
 
-Timeout can be specified in the following units: "ns" for nanoseconds, "μs" for microseconds, "ms" for milliseconds, "s" for seconds, "m" for minutes, and "h" for hours.
+Timeout can be specified in the following units: `ns` for nanoseconds, `μs` for microseconds, `ms` for milliseconds, `s` for seconds, `m` for minutes, and `h` for hours.
 Examples of valid values include "0.5s", "10ms", or "1m".
 
 You can also the SET shell command to set this parameter.


### PR DESCRIPTION
The following documentation is ready for review:

* [cbq › File Based Operations › File Append Mode](https://simon-dew.github.io/docs-site/DOC-6115/server/6.5/tools/cbq-shell.html#file-append-mode) — new section

Notes: 

* Merged forward to 6.5.1 from #1119 
* Updated version number for File Append Mode feature.

Docs issue: [DOC-6115](https://issues.couchbase.com/browse/DOC-6115)