### PR TITLE
DOC-6258: Behavior for query request max_parallelism

### DIFF
--- a/modules/n1ql/partials/n1ql-rest-api/admin/definitions.adoc
+++ b/modules/n1ql/partials/n1ql-rest-api/admin/definitions.adoc
@@ -553,9 +553,14 @@ Max index API.
 This setting is provided for technical support only.|integer (int32)
 |**max-parallelism** +
 __optional__|[[max-parallelism-srv]]
-Maximum number of index partitions, for computing aggregation in parallel.
+Specifies the maximum parallelism for queries on this node.
 
-A zero or negative value means the number of logical CPUs will be used as the parallelism for the query.
+If the value is zero or negative, the parallelism is set to the number of allowed cores.
+Similarly, if the value is greater than the number of allowed cores, the parallelism is limited to the number of allowed cores.
+
+(The number of allowed cores is the same as the number of logical CPUs.
+In Community Edition, the number of allowed cores cannot be greater than 4.
+In Enterprise Edition, there is no limit to the number of allowed cores.)
 
 There is also a xref:settings:query-settings.adoc#max_parallelism_req[request-level] `max_parallelism` parameter.
 If a request includes this parameter, it will be capped by the server-wide `max-parallelism` setting.
@@ -563,7 +568,7 @@ If a request includes this parameter, it will be capped by the server-wide `max-
 [NOTE]
 To enable queries to run in parallel, you must specify the Server-level `max-parallelism` parameter on all Query nodes.
 
-Refer to xref:n1ql:n1ql-language-reference/index-partitioning.adoc#max_parallelism[Max Parallelism] for more information. +
+Refer to xref:n1ql:n1ql-language-reference/index-partitioning.adoc#max-parallelism[Max Parallelism] for more information. +
 **Default** : `1` +
 **Example** : `0`|integer (int32)
 |**memprofile** +

--- a/modules/n1ql/partials/n1ql-rest-api/admin/definitions.adoc
+++ b/modules/n1ql/partials/n1ql-rest-api/admin/definitions.adoc
@@ -555,8 +555,8 @@ This setting is provided for technical support only.|integer (int32)
 __optional__|[[max-parallelism-srv]]
 Specifies the maximum parallelism for queries on this node.
 
-If the value is zero or negative, the parallelism is set to the number of allowed cores.
-Similarly, if the value is greater than the number of allowed cores, the parallelism is limited to the number of allowed cores.
+If the value is zero or negative, the maximum parallelism is restricted to the number of allowed cores.
+Similarly, if the value is greater than the number of allowed cores, the maximum parallelism is restricted to the number of allowed cores.
 
 (The number of allowed cores is the same as the number of logical CPUs.
 In Community Edition, the number of allowed cores cannot be greater than 4.

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -408,14 +408,13 @@ __Optional__
 | [[max_parallelism_req]]
 Specifies the maximum parallelism for the query.
 
-A zero or negative value means the number of logical CPUs will be used as the parallelism for the query.
-
-The <<max-parallelism-srv,server-level>> `max-parallelism` setting defaults to `1`.
-This is used when a request does not include this parameter.
-
-If a request includes `max_parallelism`, it will be capped by the server `max-parallelism`.
+If the value is zero or negative, the parallelism for the query is set to the <<max-parallelism-srv,server-level>> `max-parallelism` setting.
+Similarly, if the value is greater than the server-level `max-parallelism`, the parallelism for the query is limited to the server-level setting.
 
 NOTE: To enable queries to run in parallel, you must specify the Server-level `max-parallelism` parameter on all Query nodes.
+
+.Default
+The same as the number of partitions of the index selected for the query.
 
 .Example
 [source,console]


### PR DESCRIPTION
The following documentation is ready for review:

* [Settings and Parameters › Service-Level Query Settings › max-parallelism](https://simon-dew.github.io/docs-site/DOC-6258/server/6.5/settings/query-settings.html#max-parallelism-srv)
* [Settings and Parameters › Request-Level Parameters › max_parallelism](https://simon-dew.github.io/docs-site/DOC-6258/server/6.5/settings/query-settings.html#max_parallelism_req)
* [Admin REST API › Definitions › Settings › max-parallelism](https://simon-dew.github.io/docs-site/DOC-6258/server/6.5/n1ql/n1ql-rest-api/admin.html#max-parallelism-srv)

Documentation issue: [DOC-6258](https://issues.couchbase.com/browse/DOC-6258)