### PR TITLE
Small description correction

### DIFF
--- a/modules/eventing/pages/eventing-examples-high-risk.adoc
+++ b/modules/eventing/pages/eventing-examples-high-risk.adoc
@@ -612,7 +612,7 @@ image::high_risk_txns_10_resume.png[,%100]
 +
 image::high_risk_txns_10_resume_confirm.png[,346]
 
-. The Eventing function is resumed from the check point created when you paused the function and will start running within a few seconds. The defined function is executed on all new document documents and on subsequent mutations. Until a mutation is triggered there will be no processing at all by our modified handler's JavaScript code.
+. The Eventing function is resumed from the check point created when you paused the function and will start running within a few seconds. The defined function is resumed form a checkpoint created when you paused the function.  The function will execute on all new documents and any mutations occuring after the checkpoint. Until a mutation is triggered there will be no processing at all by our modified handler's JavaScript code.
 
 . The next step is to create one mutation, to do this access 
 the *Couchbase Web Console* > *Buckets* page. 


### PR DESCRIPTION
Text was for "Deploy" "From now" the description of a "Resume" is slightly different