### PR TITLE
Reference the controlling Eventing 6.5 spec

### DIFF
--- a/modules/eventing/pages/eventing-language-constructs.adoc
+++ b/modules/eventing/pages/eventing-language-constructs.adoc
@@ -10,6 +10,8 @@ Couchbase Functions inherit support for most ECMAScript constructs by using Goog
 However, to support the ability to shard and scale Function-execution automatically, some capabilities have been removed.
 Additionally, to optimize language-utilization of the server environment, some new constructs have been added.
 
+NOTE: While every effort is made to ensure the accuracy of the content of the Eventing documentation herein, it should be noted that the controlling technical document is the https://github.com/couchbase/eventing/blob/master/docs/specification-65.pdf[Couchbase 6.5 Eventing Specification] available on GitHub.
+
 [#removed-lang-features]
 == Removed Language Features
 


### PR DESCRIPTION
 Disclaimer added as per Siri's request that the Couchbase 6.5 Eventing Specification is the controlling document, such that the document set is not considered a contract of behavior and functionality.  Engineering stands behind the specification on GitHub not the expanded documentation on docs.couchbase.com

Adding a note to this page seemed like the most logical place.