### PR TITLE
Update timer delay info, and add fix XREF links

### DIFF
--- a/modules/eventing/pages/eventing-faq.adoc
+++ b/modules/eventing/pages/eventing-faq.adoc
@@ -116,7 +116,7 @@ mutation rates are low.
 Yes.
 Functions offer multiple diagnosability solutions (debugger, logs, and statistics), all designed to have minimal impact on overall 
 performance and scalability. 
-When debugging a function a single mutation is blocked and handed off to the debugger session, while the rest of the mutations continue to be serviced by the event handler, refer to the https://docs.couchbase.com/server/6.5/eventing/eventing-debugging-and-diagnosability.html[eventing-debugging-and-diagnosability] section.
+When debugging a function a single mutation is blocked and handed off to the debugger session, while the rest of the mutations continue to be serviced by the event handler, refer to the xref:eventing:eventing-debugging-and-diagnosability.adoc[Debugging and Diagnosability] section.
 
 
 * Can the logic in a Function in production be altered while it is running?
@@ -145,7 +145,7 @@ Couchbase’s Kafka connector is an SDK component that needs an application cont
 
 * What languages are supported?
 +
-Only JavaScript (ECMAScript 6) is supported. However, to support the ability to shard and scale Function execution automatically, some capabilities have been removed (Global state, Asynchrony, etc.), refer to the https://docs.couchbase.com/server/6.5/eventing/eventing-language-constructs.html[removed-lang-features] section.
+Only JavaScript (ECMAScript 6) is supported. However, to support the ability to shard and scale Function execution automatically, some capabilities have been removed (Global state, Asynchrony, etc.), refer to the xref:eventing:eventing-language-constructs.adoc#removed-lang-features[Language Constructs: Removed Language Features] section.
 
 
 * Why can’t I create global variables?
@@ -155,8 +155,9 @@ Functions do not allow global variables, this restriction is mandatory for the F
 
 * What is in the "meta" Function parameter (OnUpdate, OnDelete)? Is this the metadata we currently write in order to figure out what has changed in the document?
 +
-These are the meta fields associated with the document. For more information, refer to the https://docs.couchbase.com/server/6.5/learn/data/data.html#metadata[metadata] section.
-
+No, the meta parameter does not include information on what fields changed or mutated in the document. This parameter is composed of the meta fields associated with the document. For more information, refer to the https://docs.couchbase.com/server/6.5/learn/data/data.html#metadata[metadata] section.  
++
+It should be noted, “document metadata” is different from the “metadata bucket”, described in the next section, used by the Eventing Service to maintain state and checkpoints.
 
 * What is the metadata bucket? Do I need to create a separate bucket?
 +
@@ -183,7 +184,8 @@ Yes.
 More than one Function can be defined for the same source bucket.
 This lets you process the change according to the business logic that you enforce.
 But there is no enforced ordering; for example, if bucket 'wine' has three different Functions, which are FunctionA, FunctionB, and FunctionC, you cannot enforce the order in which these Functions are executed.
-
++
+However, for each Function you start a set of DCP streams so for a busy system you will get better performance by coalescing  multiple Eventing Functions that have the same source bucket into a single Function.  This merging is easy to do with a JavaScript switch statement or a simple if-then-else block.
 
 * Is it possible to get additional state during a Function execution? 
 +
@@ -197,13 +199,14 @@ Function via a binding.  It is also possible to utilize the cURL API to read add
 Yes.
 For example, you can your enrich or update a document with data from another document (using a document id) from any other bucket that is exposed to the Function via a binding with access level of "Read Write" inclusive of the source bucket.
 
-== Timers
+== Timer Delays
 
-* When I define a timer to fire at an exact time I see some delay why?
+* When I schedule a timer to fire at an exact time, I see some delay why?
 +
-Timers are not wall-clock accurate events. Timers are designed to handle large number of distributed timers (i.e., millions of timers) and only promise to run timers as soon as possible,  e.g. no timers lost in a healthy system without crashing nodes. 
+The timer implementation is designed to handle large numbers of distributed timers (i.e., millions of timers) and the only promise is to run timers as soon as possible, e.g. no timers lost.
 +
-Couchbase currently scans for active timers every 7 seconds this creates a maximum delay of 7secs + the time it takes to process timers ahead of the given timer on a given thread. Thus, in an Eventing system in a steady state you will experience an average timer firing delay of about 3-4 seconds after the scheduled time.
+In a steady state you may see a 3-4 second delay from the scheduled time, however if scheduling timers close to the system wall-clock this delay may increase to about 14 seconds.  
+For more details on Timer scheduling refer to xref:eventing-timers.adoc#wall-clock-accuracy[Timers: Wall-clock Accuracy] section.
 
 == Cluster Behavior
 

--- a/modules/eventing/pages/eventing-timers.adoc
+++ b/modules/eventing/pages/eventing-timers.adoc
@@ -19,7 +19,7 @@ A few important aspects related to timers are listed below:
 * Bindings for bucket-aliases can be reused in timers. Bucket-aliases, created during the Eventing Function definition, can be accessed by the timer constructs in the handler code.
 * Timers get deleted when the associated Function is deleted or undeployed.
 
-== Language Constructs
+== The Timer Construct
 
 The Timers language construct is added to support requirements of Couchbase Eventing Functions.
 
@@ -71,19 +71,19 @@ function OnUpdate(doc,meta) {
 }
 ----
 
-=== Sharding of Timers
+== Sharding of Timers
 
 Timers get automatically sharded across Eventing nodes and therefore are elastically scalable. Triggering of timers at or after a specified time interval is guaranteed. However, triggering of timers may either be on the same node (where the timer was created), or on a different node. Relative ordering between two specific timers cannot be maintained.
 
-=== Debugging and Logs
+== Debugging and Logs
 
 Timers cannot be debugged using the Visual Debugger. For debugging, Couchbase recommends enclosing of timers in a try-catch block. When logging is enabled, timer related logs get captured as part of the Eventing Function's application logs.
 
-=== Elapsed Timestamps
+== Elapsed Timestamps
 
 During runtime, when a Function handler code contains a timestamp in the past (elapsed timestamp), the system executes the code in the next available time window, as soon as the required resources are available.
 
-=== Handling Delays
+== Handling Delays
 
 During Function backlogs, execution of timers may be delayed. To handle these delays, you need to program additional time window in your code. If your business logic is time-sensitive after this additional time window the code should refrain from its Function execution.
 
@@ -99,7 +99,16 @@ func callback(context) {
 }
 ----
 
-Couchbase currently scans for active timers every 7 seconds this creates a maximum delay of 7secs + the time it takes to process timers ahead of the given timer on a given thread.
+== Wall-clock Accuracy
+
+Timers are not wall-clock accurate events. The timer implementation is designed to handle large numbers of distributed timers (i.e., millions of timers) and only promise to run timers as soon as possible, e.g. no timers lost in a healthy system without crashing nodes.
+
+Couchbase currently scans for active timers every 7 seconds this creates a maximum delay of 7 seconds + the time it takes too process timers ahead of the given timer on a given thread. Thus, in an Eventing system in a steady state you will typically experience an average timer firing delay of about 3-4 seconds after the scheduled time. 
+
+However, if timer is created and scheduled to close the wall clock of the system Couchbase may delay the actual scheduling by an additional 1 to 2 scan periods (up to a 14 second delay after the scheduled time) to avoid races. 
+
+The additional overall delay is an implementation artifact and may change between releases.
+
 
 == Examples
 


### PR DESCRIPTION
Simplify the timer delay description in this page.
Move the detailed timer delay description into the "eventing-timers.html" page and link to it.
Answer the Question about "document metadata"
Clarify that "document metadata" is different than the Eventing "metadata bucket".
Fix a few internal Eventing module cross page links.
Explain there is overhead for each Eventing Function and for performance it is best to only have one per source bucket.