### PR TITLE
Fixing link to node SDK

### DIFF
--- a/modules/getting-started/pages/try-a-query.adoc
+++ b/modules/getting-started/pages/try-a-query.adoc
@@ -275,7 +275,7 @@ The final step in the _Getting Started_ sequence, xref:choose-your-next-steps.ad
 
 == Other Destinations
 
-* xref:nodejs-sdk:n1ql-queries-with-sdk.adoc[N1QL from the SDK]: Explains how to execute N1QL queries programmatically using the official Couchbase SDKs.
+* xref:nodejs-sdk:howtos:n1ql-queries-with-sdk.adoc[N1QL from the SDK]: Explains how to execute N1QL queries programmatically using the official Couchbase SDKs.
 * https://query-tutorial.couchbase.com/tutorial/#1[N1QL Query Language Tutorial^]: Provides interactive web modules where you can learn about N1QL without having Couchbase Server installed in your own environment.
 The modules are self-contained and let you modify and run sample queries.
 The tutorial covers `SELECT` statements in detail, including examples of `JOIN`, `NEST`, `GROUP BY`, and other typical clauses.

--- a/modules/getting-started/pages/try-a-query.adoc
+++ b/modules/getting-started/pages/try-a-query.adoc
@@ -275,7 +275,7 @@ The final step in the _Getting Started_ sequence, xref:choose-your-next-steps.ad
 
 == Other Destinations
 
-* xref:nodejs-sdk::n1ql-queries-with-sdk.adoc[N1QL from the SDK]: Explains how to execute N1QL queries programmatically using the official Couchbase SDKs.
+* xref:nodejs-sdk:n1ql-queries-with-sdk.adoc[N1QL from the SDK]: Explains how to execute N1QL queries programmatically using the official Couchbase SDKs.
 * https://query-tutorial.couchbase.com/tutorial/#1[N1QL Query Language Tutorial^]: Provides interactive web modules where you can learn about N1QL without having Couchbase Server installed in your own environment.
 The modules are self-contained and let you modify and run sample queries.
 The tutorial covers `SELECT` statements in detail, including examples of `JOIN`, `NEST`, `GROUP BY`, and other typical clauses.


### PR DESCRIPTION
The link is broken on the site. I *think* it's just a matter of an extra colon?

Also, why does this link just to node? Would it be okay to change this to something like: 

**Execute N1QL queries programmatically using the official Couchbase SDKs: <Java> <.NET> <Node> <Python> <PHP> <Scala>**

So the reader can choose the path they want with a single click instead of being dropped to node and then having to figure out how to switch to a different SDK?