### PR TITLE
links to all languages under 'other destinations'

### DIFF
--- a/modules/getting-started/pages/try-a-query.adoc
+++ b/modules/getting-started/pages/try-a-query.adoc
@@ -276,6 +276,7 @@ The final step in the _Getting Started_ sequence, xref:choose-your-next-steps.ad
 == Other Destinations
 
 * xref:nodejs-sdk:howtos:n1ql-queries-with-sdk.adoc[N1QL from the SDK]: Explains how to execute N1QL queries programmatically using the official Couchbase SDKs.
+* Execute N1QL queries programmatically using the official Couchbase SDKs: xref:nodejs-sdk:howtos:n1ql-queries-with-sdk.adoc[Node.js], xref:c-sdk:howtos:n1ql-queries-with-sdk.adoc[C], xref:dotnet-sdk:howtos:n1ql-queries-with-sdk.adoc[.NET], xref:go-sdk:howtos:n1ql-queries-with-sdk.adoc[Go], xref:java-sdk:howtos:n1ql-queries-with-sdk.adoc[Java], xref:php-sdk:howtos:n1ql-queries-with-sdk.adoc[PHP], xref:python-sdk:howtos:n1ql-queries-with-sdk.adoc[Python]
 * https://query-tutorial.couchbase.com/tutorial/#1[N1QL Query Language Tutorial^]: Provides interactive web modules where you can learn about N1QL without having Couchbase Server installed in your own environment.
 The modules are self-contained and let you modify and run sample queries.
 The tutorial covers `SELECT` statements in detail, including examples of `JOIN`, `NEST`, `GROUP BY`, and other typical clauses.

--- a/modules/getting-started/pages/try-a-query.adoc
+++ b/modules/getting-started/pages/try-a-query.adoc
@@ -276,7 +276,7 @@ The final step in the _Getting Started_ sequence, xref:choose-your-next-steps.ad
 == Other Destinations
 
 * xref:nodejs-sdk:howtos:n1ql-queries-with-sdk.adoc[N1QL from the SDK]: Explains how to execute N1QL queries programmatically using the official Couchbase SDKs.
-* Execute N1QL queries programmatically using the official Couchbase SDKs: xref:nodejs-sdk:howtos:n1ql-queries-with-sdk.adoc[Node.js], xref:c-sdk:howtos:n1ql-queries-with-sdk.adoc[C], xref:dotnet-sdk:howtos:n1ql-queries-with-sdk.adoc[.NET], xref:go-sdk:howtos:n1ql-queries-with-sdk.adoc[Go], xref:java-sdk:howtos:n1ql-queries-with-sdk.adoc[Java], xref:php-sdk:howtos:n1ql-queries-with-sdk.adoc[PHP], xref:python-sdk:howtos:n1ql-queries-with-sdk.adoc[Python]
+* Execute N1QL queries programmatically using the official Couchbase SDKs: xref:nodejs-sdk:howtos:n1ql-queries-with-sdk.adoc[Node.js], xref:c-sdk:howtos:n1ql-queries-with-sdk.adoc[C], xref:dotnet-sdk:howtos:n1ql-queries-with-sdk.adoc[.NET], xref:go-sdk:howtos:n1ql-queries-with-sdk.adoc[Go], xref:java-sdk:howtos:n1ql-queries-with-sdk.adoc[Java], xref:php-sdk:howtos:n1ql-queries-with-sdk.adoc[PHP], xref:python-sdk:howtos:n1ql-queries-with-sdk.adoc[Python], xref:scala-sdk:howtos:n1ql-queries-with-sdk.adoc[Scala]
 * https://query-tutorial.couchbase.com/tutorial/#1[N1QL Query Language Tutorial^]: Provides interactive web modules where you can learn about N1QL without having Couchbase Server installed in your own environment.
 The modules are self-contained and let you modify and run sample queries.
 The tutorial covers `SELECT` statements in detail, including examples of `JOIN`, `NEST`, `GROUP BY`, and other typical clauses.

--- a/modules/getting-started/pages/try-a-query.adoc
+++ b/modules/getting-started/pages/try-a-query.adoc
@@ -275,8 +275,16 @@ The final step in the _Getting Started_ sequence, xref:choose-your-next-steps.ad
 
 == Other Destinations
 
-* xref:nodejs-sdk:howtos:n1ql-queries-with-sdk.adoc[N1QL from the SDK]: Explains how to execute N1QL queries programmatically using the official Couchbase SDKs.
-* Execute N1QL queries programmatically using the official Couchbase SDKs: xref:nodejs-sdk:howtos:n1ql-queries-with-sdk.adoc[Node.js], xref:c-sdk:howtos:n1ql-queries-with-sdk.adoc[C], xref:dotnet-sdk:howtos:n1ql-queries-with-sdk.adoc[.NET], xref:go-sdk:howtos:n1ql-queries-with-sdk.adoc[Go], xref:java-sdk:howtos:n1ql-queries-with-sdk.adoc[Java], xref:php-sdk:howtos:n1ql-queries-with-sdk.adoc[PHP], xref:python-sdk:howtos:n1ql-queries-with-sdk.adoc[Python], xref:scala-sdk:howtos:n1ql-queries-with-sdk.adoc[Scala]
+* Execute N1QL queries programmatically using the official Couchbase SDKs: 
++
+// xref:c-sdk:howtos:n1ql-queries-with-sdk.adoc[C] | 
+xref:dotnet-sdk:howtos:n1ql-queries-with-sdk.adoc[.NET] | 
+xref:go-sdk:howtos:n1ql-queries-with-sdk.adoc[Go] | 
+xref:java-sdk:howtos:n1ql-queries-with-sdk.adoc[Java] | 
+xref:nodejs-sdk:howtos:n1ql-queries-with-sdk.adoc[Node.js] | 
+xref:php-sdk:howtos:n1ql-queries-with-sdk.adoc[PHP] | 
+xref:3.0@python-sdk:howtos:n1ql-queries-with-sdk.adoc[Python] | 
+xref:scala-sdk:howtos:n1ql-queries-with-sdk.adoc[Scala]
 * https://query-tutorial.couchbase.com/tutorial/#1[N1QL Query Language Tutorial^]: Provides interactive web modules where you can learn about N1QL without having Couchbase Server installed in your own environment.
 The modules are self-contained and let you modify and run sample queries.
 The tutorial covers `SELECT` statements in detail, including examples of `JOIN`, `NEST`, `GROUP BY`, and other typical clauses.


### PR DESCRIPTION
Side notes: the C page is blank, and the Scala page kicks me to the docs homepage.