### PR TITLE
DOC-5475: Remove unnecessary version information

### DIFF
--- a/modules/learn/pages/services-and-indexes/indexes/index_pushdowns.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/index_pushdowns.adoc
@@ -15,8 +15,6 @@ This helps performance, predominantly, in two ways:
 
 == Index Projection
 
-_(Introduced in Couchbase Server 5.0)_
-
 When processing a SELECT or DML with a WHERE clause, the Query engine picks one or more qualified indexes to be used for the query.
 Note that each index will have document field names explicitly specified as index-keys, and some metadata fields, such as `meta().id`, implicitly stored in the index.
 In earlier releases, the Indexer used to return all index-keys available in the index for the matching documents.
@@ -252,10 +250,6 @@ For example,
 Subsequent JOIN phrases may filter some documents, after which only LIMIT/OFFSET can be applied.
 Hence, the pagination operators cannot be pushed when a query has JOIN clauses.
 
-_(LIMIT pushdown is supported in Couchbase Server 4.5.0 versions.)_
-
-_(OFFSET pushdown is introduced in Couchbase Server 5.0.)_
-
 [[example-page-1]]
 .Pagination with Secondary Index
 ====
@@ -470,8 +464,6 @@ In such cases, the Query engine pushes down necessary hints or options to the In
 
 == MAX() Pushdown
 
-_(Introduced in Couchbase Server 5.0)_
-
 This function returns the highest value of the input field based on the default collation rules. (For details, see xref:n1ql:n1ql-language-reference/datatypes.adoc[Data types] and xref:n1ql:n1ql-language-reference/comparisonops.adoc[Comparison Operators].)
 
 Prior to Couchbase Server 5.5, MAX() could be pushed to the Indexer only when the index was created with matching index keys in descending order.
@@ -507,8 +499,6 @@ include::example$services-and-indexes/indexes/pushdown-max.json[tag=excerpt]
 
 == MIN() Pushdown
 
-_(Introduced in Couchbase Server 5.0)_
-
 This function returns the lowest value of the input field based on the default collation rules. (For details, see xref:n1ql:n1ql-language-reference/datatypes.adoc[Data types] and xref:n1ql:n1ql-language-reference/comparisonops.adoc[Comparison Operators].)
 
 Prior to Couchbase Server 5.5, MIN() could be pushed to the Indexer only when the index was created with matching index keys in ascending order.
@@ -543,8 +533,6 @@ include::example$services-and-indexes/indexes/pushdown-min.json[tag=excerpt]
 ====
 
 == COUNT() Pushdown
-
-_(Introduced in Couchbase Server 5.0)_
 
 This function returns the total number of non-Null values of an input field from the matching documents of an index scan.
 
@@ -605,8 +593,6 @@ include::example$services-and-indexes/indexes/pushdown-count.json[tag=excerpt]
 <1> In Couchbase Server 5.5 and later, the index operator `IndexCountScan3` counts values so the Query Service does not need to do additional processing.
 
 == COUNT(DISTINCT) Pushdown
-
-_(Introduced in Couchbase Server 5.0)_
 
 This function returns the total number of unique non-Null values of an input field from the matching documents of an index scan.
 

--- a/modules/learn/pages/services-and-indexes/indexes/index_pushdowns.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/index_pushdowns.adoc
@@ -194,7 +194,9 @@ include::example$services-and-indexes/indexes/pushdown-comp-plan.json[tag=final]
 
 === Composite Predicate with Skip-Key Range Scan
 
+ifeval::['{page-component-version}' == '6.5']
 _(Introduced in Couchbase Server 6.5)_
+endif::[]
 
 In <<example-comp-explain>> above, the query has a composite predicate on continuous leading index-keys, namely the index-keys `distance` and `sourceairport`, which occur together at the start of the index definition.
 In Couchbase Server 6.5 and later, it is possible to push down a composite predicate on non-continuous leading index-keys.

--- a/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
+++ b/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
@@ -713,8 +713,6 @@ cbq> SELECT * FROM `travel-sample` WHERE type = "airline" LIMIT 1;
 [[plan]]
 === Attribute Meta in System Keyspaces
 
-_(Introduced in Couchbase Server 5.0)_
-
 The `meta().plan` virtual attribute captures the whole query plan, and monitoring stats of various phases and involved query operators.
 The `meta().plan` must be explicitly called in the SELECT query projection list.
 
@@ -756,9 +754,7 @@ The small disadvantage of this is that it has to be maintained as new system key
 
 === cbq-engine-cbauth
 
-_(Introduced in Couchbase Server 5.0)_
-
-Cbq-engine-cbauth is a new internal user that the query service uses to allow Query Workbench clients to query across multiple query nodes.
+Cbq-engine-cbauth is an internal user that the query service uses to allow Query Workbench clients to query across multiple query nodes.
 
 Since Query Workbench can connect to the same node only when cbq-engine is running, Query Workbench cannot do any query-clustered operations.
 

--- a/modules/n1ql/pages/n1ql-language-reference/arrayfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/arrayfun.adoc
@@ -617,8 +617,6 @@ LIMIT 1;
 [[fn-array-intersect,ARRAY_INTERSECT()]]
 == ARRAY_INTERSECT([.var]`expr1`, [.var]`expr2`, \...)
 
-_(Introduced in Couchbase Server 4.5.1)_
-
 === Description
 This function takes two or more arrays and returns the intersection of the input arrays as the result; that is, the array containing values that are present in all of the input arrays.
 

--- a/modules/n1ql/pages/n1ql-language-reference/execute.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/execute.adoc
@@ -29,9 +29,7 @@ TIP: If the name of the prepared statement contains hyphens, wrap the entire nam
 
 === USING Clause
 
-[.status]#Couchbase Server 6.5#
-
-[Optional] The USING clause enables you to specify parameter values to use in the prepared statement.
+[Optional] In Couchbase Server 6.5 and later, the USING clause enables you to specify parameter values to use in the prepared statement.
 
 parameters::
 The parameter values to use in the prepared statement.
@@ -74,8 +72,6 @@ Once the resources are available again, execution proceeds without any further i
 
 [[parameters]]
 == Parameters
-
-[.status]#Couchbase Server 6.5#
 
 A prepared statement may contain parameters.
 These are replaced by a supplied value when the statement is executed.

--- a/modules/n1ql/pages/n1ql-language-reference/execute.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/execute.adoc
@@ -29,7 +29,11 @@ TIP: If the name of the prepared statement contains hyphens, wrap the entire nam
 
 === USING Clause
 
-[Optional] In Couchbase Server 6.5 and later, the USING clause enables you to specify parameter values to use in the prepared statement.
+ifeval::['{page-component-version}' == '6.5']
+_(Introduced in Couchbase Server 6.5)_
+endif::[]
+
+[Optional] The USING clause enables you to specify parameter values to use in the prepared statement.
 
 parameters::
 The parameter values to use in the prepared statement.

--- a/modules/n1ql/pages/n1ql-language-reference/groupby.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/groupby.adoc
@@ -36,7 +36,9 @@ expr:: String or expression representing an xref:n1ql-language-reference/aggrega
 [[alias,alias]]
 === AS Alias
 
+ifeval::['{page-component-version}' == '6.5']
 _(Introduced in Couchbase Server 6.5)_
+endif::[]
 
 Assigns another name to the group term.
 For details, see xref:n1ql-language-reference/from.adoc#section_ax5_2nx_1db[AS Clause].

--- a/modules/n1ql/pages/n1ql-language-reference/groupby.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/groupby.adoc
@@ -1,5 +1,4 @@
 = GROUP BY Clause
-:page-status: Couchbase Server 4.0
 :imagesdir: ../../assets/images
 
 [abstract]

--- a/modules/n1ql/pages/n1ql-language-reference/hints.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/hints.adoc
@@ -148,8 +148,6 @@ USE KEYS ["airport_1254","airport_1255"];
 [#use-index-clause]
 == USE INDEX clause
 
-_(Introduced in Couchbase Server 3.0)_
-
 === Purpose
 
 Use the `USE INDEX` clause to specify which index to use as part of the query execution.

--- a/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
@@ -1,5 +1,4 @@
 = Index Partitioning
-:page-status: Couchbase Server 5.5
 :page-edition: Enterprise Edition
 :imagesdir: ../../assets/images
 

--- a/modules/n1ql/pages/n1ql-language-reference/index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/index.adoc
@@ -64,8 +64,6 @@ There may also be further N1QL statements on the same line after the end of a bl
 
 ==== Line Comments
 
-[.status]#Couchbase Server 6.5#
-
 ----
 -- [text]
 ----

--- a/modules/n1ql/pages/n1ql-language-reference/indexing-arrays.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/indexing-arrays.adoc
@@ -112,8 +112,6 @@ See <<examples>> below.
 [[simple-array-expr,simple-array-expr]]
 ==== Simple Array Expression
 
-_(Introduced in Couchbase Server 5.0)_
-
 [subs="normal"]
 ----
 simple-array-expr ::= ( ALL | DISTINCT ) <<simple-array-expr-args,expr>>

--- a/modules/n1ql/pages/n1ql-language-reference/indexing-arrays.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/indexing-arrays.adoc
@@ -1,6 +1,5 @@
 = Array Indexing
 :imagesdir: ../../assets/images
-:page-status: Couchbase Server 4.5
 
 Array Indexing adds the capability to create global indexes on array elements and optimizes the execution of queries involving array elements.
 

--- a/modules/n1ql/pages/n1ql-language-reference/join.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/join.adoc
@@ -33,8 +33,6 @@ include::partial$n1ql-language-reference/from-term.adoc[]
 [#section_ek1_jnx_1db]
 == ANSI JOIN Clause
 
-_(Introduced in Couchbase Server Enterprise Edition 5.5)_
-
 === Purpose
 
 To be closer to standard SQL syntax, ANSI JOIN can join arbitrary fields of the documents and can be chained together.
@@ -515,8 +513,6 @@ AND airport.city = "San Francisco";
 [#ansi-join-hints]
 == ANSI JOIN Hints
 
-_(Introduced in Couchbase Server Enterprise Edition 5.5)_
-
 [subs="normal"]
 ----
 ansi-join-hints ::= <<use-hash-hint,use-hash-hint>> | <<use-nl-hint,use-nl-hint>> | <<multiple-hints,multiple-hints>>
@@ -966,8 +962,6 @@ WHERE b1.c11 = 10
 [#lookup-join-clause]
 == Lookup JOIN Clause
 
-_(Introduced in Couchbase Server 4.0)_
-
 === Purpose
 
 Lookup joins allow only left-to-right joins, which means the ON KEYS expression must produce a document key which is then used to retrieve documents from the right-hand side keyspace.
@@ -1274,8 +1268,6 @@ AND airline.callsign = "JETBLUE";
 
 [#index-join-clause]
 == Index JOIN Clause
-
-_(Introduced in Couchbase Server 4.0)_
 
 === Purpose
 

--- a/modules/n1ql/pages/n1ql-language-reference/join.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/join.adoc
@@ -1,5 +1,4 @@
 = JOIN Clause
-:page-status: Couchbase Server 4.0
 :imagesdir: ../../assets/images
 :clause: JOIN
 

--- a/modules/n1ql/pages/n1ql-language-reference/let.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/let.adoc
@@ -1,5 +1,4 @@
 = LET clause
-:page-status: Couchbase Server 4.0
 :imagesdir: ../../assets/images
 
 [abstract]

--- a/modules/n1ql/pages/n1ql-language-reference/limit.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/limit.adoc
@@ -3,8 +3,6 @@
 [abstract]
 The `LIMIT` clause specifies the maximum number of documents to be returned in a resultset by a `SELECT` statement.
 
-_(Introduced in Couchbase Server 4.0)_
-
 == Purpose
 
 When you don't need the entire resultset, use the `LIMIT` clause to specify the maximum number of documents to be returned in a resultset by a `SELECT` query.

--- a/modules/n1ql/pages/n1ql-language-reference/merge.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/merge.adoc
@@ -42,7 +42,9 @@ image::n1ql-language-reference/merge.png["'MERGE' 'INTO' ( ansi-merge | lookup-m
 [[ansi-merge,ansi-merge]]
 == ANSI Merge
 
+ifeval::['{page-component-version}' == '6.5']
 _(Introduced in Couchbase Server 6.5)_
+endif::[]
 
 [subs="normal"]
 ----

--- a/modules/n1ql/pages/n1ql-language-reference/nest.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/nest.adoc
@@ -32,8 +32,6 @@ include::partial$n1ql-language-reference/from-term.adoc[]
 [#section_tc1_nnx_1db]
 == ANSI NEST Clause
 
-_(Introduced in Couchbase Server Enterprise Edition 5.5)_
-
 include::partial$n1ql-language-reference/ansi-join-nest.adoc[]
 
 ANSI NEST supports more nest types than Lookup NEST or Index NEXT.
@@ -167,8 +165,6 @@ AND r.destinationairport = "BOS";
 
 [#nest]
 == Lookup NEST Clause
-
-_(Introduced in Couchbase Server 4.0)_
 
 Nesting is conceptually the inverse of unnesting.
 Nesting performs a join across two keyspaces.
@@ -442,8 +438,6 @@ LIMIT 1;
 
 [#section_rgr_rnx_1db]
 == Index NEST Clause
-
-_(Introduced in Couchbase Server 4.0)_
 
 Index NESTs allow you to flip the direction of a Lookup NEST clause.
 Index NESTs can be used efficiently when Lookup NESTs cannot efficiently nest left-hand side documents with right-to-left nests, and your situation cannot be flipped because your predicate needs to be on the left-hand side, such as <<Lookup-NEST-Example-1>> above where airline documents have no reference to route documents.

--- a/modules/n1ql/pages/n1ql-language-reference/nest.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/nest.adoc
@@ -1,5 +1,4 @@
 = NEST Clause
-:page-status: Couchbase Server 4.0
 :imagesdir: ../../assets/images
 :clause: NEST
 

--- a/modules/n1ql/pages/n1ql-language-reference/offset.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/offset.adoc
@@ -3,8 +3,6 @@
 [abstract]
 The `OFFSET` clause specifies the number of resultset objects to skip in a `SELECT` query.
 
-_(Introduced in Couchbase Server 4.0)_
-
 == Purpose
 
 When you want the resultset to skip over the first few resulting objects, use the `OFFSET` clause to specify that number of objects to ignore.

--- a/modules/n1ql/pages/n1ql-language-reference/orderby.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/orderby.adoc
@@ -48,7 +48,10 @@ If the collation clause is missing, the default is `ASC`.
 
 [[nulls-ordering]]
 === Nulls Ordering
+
+ifeval::['{page-component-version}' == '6.5']
 _(Introduced in Couchbase Server 6.5)_
+endif::[]
 
 The nulls ordering clause determines how NULL or MISSING values are treated when ordering the results:
 

--- a/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
@@ -164,7 +164,9 @@ The anonymous prepared statement is added to the cache in addition to the named 
 [[auto-prepare]]
 == Auto-Prepare
 
+ifeval::['{page-component-version}' == '6.5']
 _(Introduced in Couchbase Server 6.5)_
+endif::[]
 
 When the _auto-prepare_ feature is active, a prepared statement is created every time you submit a N1QL request, whether you use the PREPARE statement or not.
 
@@ -187,7 +189,9 @@ Auto-prepare is disabled for N1QL requests which contain parameters, if they do 
 [[auto-execute]]
 == Auto-Execute
 
-_(Introducted in Couchbase Server 6.5)_
+ifeval::[{page-component-version} == '6.5']
+_(Introduced in Couchbase Server 6.5)_
+endif::[]
 
 When the _auto-execute_ feature is active, a prepared statement is executed automatically as soon as it is created.
 This saves you from having to make two separate N1QL requests in cases where you want to prepare a statement and execute it immediately.


### PR DESCRIPTION
Docs issue: [DOC-5475](https://issues.couchbase.com/browse/DOC-5475)

- Removed _(Introduced in ...)_ captions for versions earlier than 6.5.
- Removed `:page-status:` attribute for versions earlier than 6.5.
- Removed section `status` role for features that were not specific to a patch release.

The orange status label should now only appear in the following cases:

1. For pages only: to show that this feature is new in the current version.
1. For pages only: to show that this feature is specific to a developer preview.
1. For sections within a page: to show that a feature is specific to a patch release.

The italic _(Introduced in ...)_ caption should now only appear in the following cases:

1. For sections within a page: to show that this feature is new in the current version.

Anecdotal comments about versions, e.g. "Since Couchbase Server 5.5, you can..." still occur in the running text — I think this is okay.