### PR TITLE
DOC-6691: Minor 6.5.1 documentation changes [Query]

### DIFF
--- a/modules/learn/pages/security/usernames-and-passwords.adoc
+++ b/modules/learn/pages/security/usernames-and-passwords.adoc
@@ -66,6 +66,12 @@ To authenticate, every Couchbase Server-user must specify a _username_ as well a
 The restrictions on username-design are that each should be unique to the cluster; and that none of the following characters be used: `( ) < > @ , ; : \ " / [ ]  ? = { }`.
 Usernames _may not_ be more than 128 UTF-8 characters in length; and it is recommended that they be no more than 64 UTF-8 characters in length, in order to ensure successful onscreen display.
 
+****
+[.status]#Couchbase Server 6.5.1#
+
+In Couchbase Server 6.5.1, a username may contain the `@` character, as long as it does not occur at the start: for example, `first.last@domain`.
+****
+
 Each user is associated with one or more _roles_, which permit limited access-privileges.
 Therefore, once a user has authenticated, their role-assignment is examined, and an appropriate degree of access is granted to them by Couchbase Server.
 See


### PR DESCRIPTION
The following documentation is ready for review:

* [Usernames and Passwords](https://github.com/couchbase/docs-server/pull/1283/files) — 6.5.1 allows '@' in usernames

Docs issue: [DOC-6691](https://issues.couchbase.com/browse/DOC-6691)