### PR TITLE
Add another docker inspect command

### DIFF
--- a/modules/install/pages/getting-started-docker.adoc
+++ b/modules/install/pages/getting-started-docker.adoc
@@ -160,6 +160,15 @@ $ docker inspect --format '{{ .NetworkSettings.IPAddress }}' db1
 $ docker inspect --format '{{ .NetworkSettings.IPAddress }}' db2
 ----
 +
+If the above commands return an empty result, then run the following commands to discover the local IP addresses of `db1` and `db2`:
++
+[source,console]
+----
+$ docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' db1
+
+$ docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' db2
+----
++
 You need the IP addresses of `db1` and `db2` to set up the three-node Couchbase Server cluster.
 The initial cluster setup will automatically pick up the IP address for `db3`.
 


### PR DESCRIPTION
When I run the following command I was getting an empty result:
```bash
$ docker inspect --format '{{ .NetworkSettings.IPAddress }}' db1

$ docker inspect --format '{{ .NetworkSettings.IPAddress }}' db2
```

I've added the following commands into the documentation if the above commands does not return any IP Addresses:
```bash
$ docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' db1

$ docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' db2
```

Documentation link: https://docs.couchbase.com/server/current/install/getting-started-docker.html