### PR TITLE
DOC-6707: OPTIONS is reserve word from 6.5.1 as part of TTL

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
@@ -130,14 +130,14 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 | INTO
 
 | IS
-| xref:n1ql-language-reference/createfunction.adoc[JAVASCRIPT] (developer preview)
+| xref:n1ql-language-reference/createfunction.adoc[JAVASCRIPT] footnote:dp[Developer Preview]
 | xref:n1ql-language-reference/join.adoc[JOIN]
 | KEY
 | KEYS
 | KEYSPACE
 | KNOWN
 
-| xref:n1ql-language-reference/createfunction.adoc[LANGUAGE] (developer preview)
+| xref:n1ql-language-reference/createfunction.adoc[LANGUAGE] footnote:dp[]
 | LAST
 | LEFT
 | xref:n1ql-language-reference/let.adoc[LET]
@@ -169,7 +169,7 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 
 | ON
 | OPTION
-| xref:n1ql-language-reference/insert.adoc[OPTIONS] (6.5.1)
+| xref:n1ql-language-reference/insert.adoc[OPTIONS] footnote:[Couchbase Server 6.5.1]
 | xref:n1ql-language-reference/logicalops.adoc#or-operator[OR]
 | xref:n1ql-language-reference/orderby.adoc[ORDER]
 | xref:n1ql-language-reference/window.adoc#window-frame-exclusion[OTHERS]

--- a/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
@@ -40,104 +40,105 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 | ANALYZE
 | xref:n1ql-language-reference/logicalops.adoc#logical-op-and[AND]
 | xref:n1ql-language-reference/collectionops.adoc#collection-op-any[ANY]
-| xref:n1ql-language-reference/collectionops.adoc#collection-op-array[ARRAY]
 
+| xref:n1ql-language-reference/collectionops.adoc#collection-op-array[ARRAY]
 | xref:n1ql-language-reference/from.adoc#section_ax5_2nx_1db[AS]
 | ASC
 | BEGIN
 | BETWEEN
 | xref:n1ql-language-reference/datatypes.adoc#datatype-binary[BINARY]
-| xref:n1ql-language-reference/datatypes.adoc#datatype-boolean[BOOLEAN]
 
+| xref:n1ql-language-reference/datatypes.adoc#datatype-boolean[BOOLEAN]
 | BREAK
 | BUCKET
 | BUILD
 | BY
 | CALL
-| CASE
 
+| CASE
 | CAST
 | CLUSTER
 | COLLATE
 | COLLECTION
 | COMMIT
-| CONNECT
 
+| CONNECT
 | CONTINUE
 | CORRELATED
 | COVER
 | xref:n1ql-language-reference/createindex.adoc[CREATE]
 | xref:n1ql-language-reference/window.adoc#window-frame-clause[CURRENT]
-| DATABASE
 
+| DATABASE
 | DATASET
 | DATASTORE
 | DECLARE
 | DECREMENT
 | xref:n1ql-language-reference/delete.adoc[DELETE]
-| DERIVED
 
+| DERIVED
 | DESC
 | DESCRIBE
 | xref:n1ql-language-reference/selectintro.adoc#distinct[DISTINCT]
 | DO
 | xref:n1ql-language-reference/dropindex.adoc[DROP]
-| EACH
 
+| EACH
 | ELEMENT
 | ELSE
 | END
 | xref:n1ql-language-reference/collectionops.adoc#collection-op-every[EVERY]
 | xref:n1ql-language-reference/union.adoc[EXCEPT]
-| EXCLUDE
 
+| EXCLUDE
 | EXECUTE
 | xref:n1ql-language-reference/collectionops.adoc#collection-op-exists[EXISTS]
 | xref:n1ql-language-reference/explain.adoc#topic_11_4[EXPLAIN]
 | FALSE
 | FETCH
-| FIRST
 
+| FIRST
 | FLATTEN
 | xref:n1ql-language-reference/window.adoc#window-frame-clause[FOLLOWING]
 | FOR
 | FORCE
 | xref:n1ql-language-reference/from.adoc[FROM]
+
 | xref:n1ql-language-reference/hints.adoc#use-index-clause[FTS]
 | xref:n1ql-language-reference/createfunction.adoc[FUNCTION]
-
 | GOLANG
 | GRANT
 | xref:n1ql-language-reference/groupby.adoc[GROUP]
 | xref:n1ql-language-reference/window.adoc#window-frame-clause[GROUPS]
+
 | xref:n1ql-language-reference/hints.adoc#use-index-clause[GSI]
 | xref:n1ql-language-reference/join.adoc#ansi-join-hints[HASH]
 | HAVING
 | IF
-
 | IGNORE
 | ILIKE
+
 | xref:n1ql-language-reference/collectionops.adoc#collection-op-in[IN]
 | INCLUDE
 | INCREMENT
 | INDEX
-
 | INFER
 | INLINE
+
 | INNER
 | xref:n1ql-language-reference/insert.adoc#topic_11_5[INSERT]
 | xref:n1ql-language-reference/union.adoc[INTERSECT]
 | INTO
-
 | IS
 | xref:n1ql-language-reference/createfunction.adoc[JAVASCRIPT] footnote:dp[Developer Preview]
+
 | xref:n1ql-language-reference/join.adoc[JOIN]
 | KEY
 | KEYS
 | KEYSPACE
 | KNOWN
-
 | xref:n1ql-language-reference/createfunction.adoc[LANGUAGE] footnote:dp[]
+
 | LAST
 | LEFT
 | xref:n1ql-language-reference/let.adoc[LET]
@@ -158,105 +159,109 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 | xref:n1ql-language-reference/nest.adoc[NEST]
 | xref:n1ql-language-reference/join.adoc#ansi-join-hints[NL]
 | xref:n1ql-language-reference/window.adoc#window-frame-exclusion[NO]
-| xref:n1ql-language-reference/logicalops.adoc#logical-op-not[NOT]
 
+| xref:n1ql-language-reference/logicalops.adoc#logical-op-not[NOT]
 | xref:n1ql-language-reference/windowfun.adoc#fn-window-nth-value[NTH_VALUE]
 | xref:n1ql-language-reference/datatypes.adoc#datatype-null[NULL]
 | xref:n1ql-language-reference/window.adoc#nulls-treatment[NULLS]
 | NUMBER
 | OBJECT
-| xref:n1ql-language-reference/offset.adoc[OFFSET]
 
+| xref:n1ql-language-reference/offset.adoc[OFFSET]
 | ON
 | OPTION
-| xref:n1ql-language-reference/insert.adoc[OPTIONS] footnote:[Couchbase Server 6.5.1]
+| xref:n1ql-language-reference/insert.adoc[OPTIONS] footnote:[Couchbase Server 6.5.1 and later.]
 | xref:n1ql-language-reference/logicalops.adoc#or-operator[OR]
 | xref:n1ql-language-reference/orderby.adoc[ORDER]
+
 | xref:n1ql-language-reference/window.adoc#window-frame-exclusion[OTHERS]
 | OUTER
-
 | xref:n1ql-language-reference/window.adoc[OVER]
 | PARSE
 | PARTITION
 | PASSWORD
+
 | PATH
 | POOL
-
 | xref:n1ql-language-reference/window.adoc#window-frame-clause[PRECEDING]
 | PREPARE
 | PRIMARY
 | PRIVATE
+
 | PRIVILEGE
 | xref:n1ql-language-reference/join.adoc#ansi-join-hints[PROBE]
 | PROCEDURE
-
 | PUBLIC
 | xref:n1ql-language-reference/window.adoc#window-frame-clause[RANGE]
 | RAW
+
 | REALM
 | REDUCE
 | RENAME
-
 | xref:n1ql-language-reference/window.adoc#nulls-treatment[RESPECT]
 | RETURN
 | RETURNING
+
 | REVOKE
 | RIGHT
 | ROLE
-
 | ROLLBACK
 | xref:n1ql-language-reference/window.adoc#window-frame-clause[ROW]
 | xref:n1ql-language-reference/window.adoc#window-frame-clause[ROWS]
+
 | SATISFIES
 | SCHEMA
 | xref:n1ql-language-reference/selectintro.adoc#topic_11_7[SELECT]
-
 | SELF
 | SEMI
 | SET
+
 | SHOW
 | SOME
 | START
-
 | STATISTICS
 | STRING
 | SYSTEM
+
 | THEN
 | xref:n1ql-language-reference/window.adoc#window-frame-exclusion[TIES]
 | TO
-
 | TRANSACTION
 | TRIGGER
 | TRUE
+
 | TRUNCATE
 | xref:n1ql-language-reference/window.adoc#window-frame-clause[UNBOUNDED]
 | UNDER
-
 | xref:n1ql-language-reference/union.adoc[UNION]
 | UNIQUE
 | UNKNOWN
+
 | xref:n1ql-language-reference/unnest.adoc[UNNEST]
 | UNSET
 | xref:n1ql-language-reference/update.adoc[UPDATE]
-
 | xref:n1ql-language-reference/upsert.adoc[UPSERT]
 | xref:n1ql-language-reference/hints.adoc[USE]
 | USER
+
 | USING
 | VALIDATE
 | VALUE
-
 | VALUED
 | VALUES
 | VIA
+
 | VIEW
 | WHEN
 | xref:n1ql-language-reference/where.adoc[WHERE]
-
 | WHILE
 | WITH
 | xref:n1ql-language-reference/collectionops.adoc#collection-op-within[WITHIN]
+
 | WORK
 | XOR
+|
+|
+|
 |
 |===

--- a/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
@@ -35,13 +35,13 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 [cols=6*]
 |===
 | xref:n1ql-language-reference/advise.adoc[ADVISE]
-| xref:n1ql-language-reference/selectintro.adoc#all[ALL]
+| xref:n1ql-language-reference/selectclause.adoc#all[ALL]
 | ALTER
 | ANALYZE
 | xref:n1ql-language-reference/logicalops.adoc#logical-op-and[AND]
 | xref:n1ql-language-reference/collectionops.adoc#collection-op-any[ANY]
 
-| xref:n1ql-language-reference/collectionops.adoc#collection-op-array[ARRAY]
+| xref:n1ql-language-reference/collectionops.adoc#array[ARRAY]
 | xref:n1ql-language-reference/from.adoc#section_ax5_2nx_1db[AS]
 | ASC
 | BEGIN
@@ -67,7 +67,7 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 | CORRELATED
 | COVER
 | xref:n1ql-language-reference/createindex.adoc[CREATE]
-| xref:n1ql-language-reference/window.adoc#window-frame-clause[CURRENT]
+| xref:n1ql-language-reference/window.adoc#window-frame-extent[CURRENT]
 
 | DATABASE
 | DATASET
@@ -79,7 +79,7 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 | DERIVED
 | DESC
 | DESCRIBE
-| xref:n1ql-language-reference/selectintro.adoc#distinct[DISTINCT]
+| xref:n1ql-language-reference/selectclause.adoc#distinct[DISTINCT]
 | DO
 | xref:n1ql-language-reference/dropindex.adoc[DROP]
 
@@ -92,27 +92,27 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 
 | EXCLUDE
 | EXECUTE
-| xref:n1ql-language-reference/collectionops.adoc#collection-op-exists[EXISTS]
-| xref:n1ql-language-reference/explain.adoc#topic_11_4[EXPLAIN]
+| xref:n1ql-language-reference/collectionops.adoc#exists[EXISTS]
+| xref:n1ql-language-reference/explain.adoc[EXPLAIN]
 | FALSE
 | FETCH
 
 | FIRST
 | FLATTEN
-| xref:n1ql-language-reference/window.adoc#window-frame-clause[FOLLOWING]
+| xref:n1ql-language-reference/window.adoc#window-frame-extent[FOLLOWING]
 | FOR
 | FORCE
 | xref:n1ql-language-reference/from.adoc[FROM]
 
-| xref:n1ql-language-reference/hints.adoc#use-index-clause[FTS]
+| xref:n1ql-language-reference/hints.adoc#index-using[FTS]
 | xref:n1ql-language-reference/createfunction.adoc[FUNCTION]
 | GOLANG
 | GRANT
 | xref:n1ql-language-reference/groupby.adoc[GROUP]
 | xref:n1ql-language-reference/window.adoc#window-frame-clause[GROUPS]
 
-| xref:n1ql-language-reference/hints.adoc#use-index-clause[GSI]
-| xref:n1ql-language-reference/join.adoc#ansi-join-hints[HASH]
+| xref:n1ql-language-reference/hints.adoc#index-using[GSI]
+| xref:n1ql-language-reference/join.adoc#use-hash-hint[HASH]
 | HAVING
 | IF
 | IGNORE
@@ -126,7 +126,7 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 | INLINE
 
 | INNER
-| xref:n1ql-language-reference/insert.adoc#topic_11_5[INSERT]
+| xref:n1ql-language-reference/insert.adoc[INSERT]
 | xref:n1ql-language-reference/union.adoc[INTERSECT]
 | INTO
 | IS
@@ -154,15 +154,15 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 | xref:n1ql-language-reference/merge.adoc[MERGE]
 
 | MINUS
-| xref:n1ql-language-reference/datatypes.adoc#datatype-missing[MISSING]
+| xref:n1ql-language-reference/comparisonops.adoc#null-and-missing[MISSING]
 | NAMESPACE
 | xref:n1ql-language-reference/nest.adoc[NEST]
-| xref:n1ql-language-reference/join.adoc#ansi-join-hints[NL]
+| xref:n1ql-language-reference/join.adoc#use-nl-hint[NL]
 | xref:n1ql-language-reference/window.adoc#window-frame-exclusion[NO]
 
 | xref:n1ql-language-reference/logicalops.adoc#logical-op-not[NOT]
 | xref:n1ql-language-reference/windowfun.adoc#fn-window-nth-value[NTH_VALUE]
-| xref:n1ql-language-reference/datatypes.adoc#datatype-null[NULL]
+| xref:n1ql-language-reference/comparisonops.adoc#null-and-missing[NULL]
 | xref:n1ql-language-reference/window.adoc#nulls-treatment[NULLS]
 | NUMBER
 | OBJECT
@@ -170,7 +170,7 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 | xref:n1ql-language-reference/offset.adoc[OFFSET]
 | ON
 | OPTION
-| xref:n1ql-language-reference/insert.adoc[OPTIONS] footnote:[Couchbase Server 6.5.1 and later.]
+| xref:n1ql-language-reference/insert.adoc#insert-values[OPTIONS] footnote:[Couchbase Server 6.5.1 and later.]
 | xref:n1ql-language-reference/logicalops.adoc#or-operator[OR]
 | xref:n1ql-language-reference/orderby.adoc[ORDER]
 
@@ -183,13 +183,13 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 
 | PATH
 | POOL
-| xref:n1ql-language-reference/window.adoc#window-frame-clause[PRECEDING]
+| xref:n1ql-language-reference/window.adoc#window-frame-extent[PRECEDING]
 | PREPARE
 | PRIMARY
 | PRIVATE
 
 | PRIVILEGE
-| xref:n1ql-language-reference/join.adoc#ansi-join-hints[PROBE]
+| xref:n1ql-language-reference/join.adoc#use-hash-hint[PROBE]
 | PROCEDURE
 | PUBLIC
 | xref:n1ql-language-reference/window.adoc#window-frame-clause[RANGE]
@@ -206,12 +206,12 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 | RIGHT
 | ROLE
 | ROLLBACK
-| xref:n1ql-language-reference/window.adoc#window-frame-clause[ROW]
+| xref:n1ql-language-reference/window.adoc#window-frame-extent[ROW]
 | xref:n1ql-language-reference/window.adoc#window-frame-clause[ROWS]
 
 | SATISFIES
 | SCHEMA
-| xref:n1ql-language-reference/selectintro.adoc#topic_11_7[SELECT]
+| xref:n1ql-language-reference/selectclause.adoc[SELECT]
 | SELF
 | SEMI
 | SET
@@ -231,7 +231,7 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 | TRUE
 
 | TRUNCATE
-| xref:n1ql-language-reference/window.adoc#window-frame-clause[UNBOUNDED]
+| xref:n1ql-language-reference/window.adoc#window-frame-extent[UNBOUNDED]
 | UNDER
 | xref:n1ql-language-reference/union.adoc[UNION]
 | UNIQUE

--- a/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
@@ -130,14 +130,14 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 | xref:n1ql-language-reference/union.adoc[INTERSECT]
 | INTO
 | IS
-| xref:n1ql-language-reference/createfunction.adoc[JAVASCRIPT] footnote:dp[Developer Preview]
+| xref:n1ql-language-reference/createfunction.adoc[JAVASCRIPT]
 
 | xref:n1ql-language-reference/join.adoc[JOIN]
 | KEY
 | KEYS
 | KEYSPACE
 | KNOWN
-| xref:n1ql-language-reference/createfunction.adoc[LANGUAGE] footnote:dp[]
+| xref:n1ql-language-reference/createfunction.adoc[LANGUAGE]
 
 | LAST
 | LEFT

--- a/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
@@ -34,6 +34,7 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 
 [cols=6*]
 |===
+| xref:n1ql-language-reference/advise.adoc[ADVISE]
 | xref:n1ql-language-reference/selectintro.adoc#all[ALL]
 | ALTER
 | ANALYZE
@@ -63,7 +64,7 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 | CONNECT
 
 | CONTINUE
-| CORRELATE
+| CORRELATED
 | COVER
 | xref:n1ql-language-reference/createindex.adoc[CREATE]
 | xref:n1ql-language-reference/window.adoc#window-frame-clause[CURRENT]
@@ -102,12 +103,15 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 | FOR
 | FORCE
 | xref:n1ql-language-reference/from.adoc[FROM]
-| xref:n1ql-language-reference/functions.adoc[FUNCTION]
+| xref:n1ql-language-reference/hints.adoc#use-index-clause[FTS]
+| xref:n1ql-language-reference/createfunction.adoc[FUNCTION]
 
+| GOLANG
 | GRANT
 | xref:n1ql-language-reference/groupby.adoc[GROUP]
 | xref:n1ql-language-reference/window.adoc#window-frame-clause[GROUPS]
-| GSI
+| xref:n1ql-language-reference/hints.adoc#use-index-clause[GSI]
+| xref:n1ql-language-reference/join.adoc#ansi-join-hints[HASH]
 | HAVING
 | IF
 
@@ -126,12 +130,14 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 | INTO
 
 | IS
+| xref:n1ql-language-reference/createfunction.adoc[JAVASCRIPT] (developer preview)
 | xref:n1ql-language-reference/join.adoc[JOIN]
 | KEY
 | KEYS
 | KEYSPACE
 | KNOWN
 
+| xref:n1ql-language-reference/createfunction.adoc[LANGUAGE] (developer preview)
 | LAST
 | LEFT
 | xref:n1ql-language-reference/let.adoc[LET]
@@ -150,6 +156,7 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 | xref:n1ql-language-reference/datatypes.adoc#datatype-missing[MISSING]
 | NAMESPACE
 | xref:n1ql-language-reference/nest.adoc[NEST]
+| xref:n1ql-language-reference/join.adoc#ansi-join-hints[NL]
 | xref:n1ql-language-reference/window.adoc#window-frame-exclusion[NO]
 | xref:n1ql-language-reference/logicalops.adoc#logical-op-not[NOT]
 
@@ -162,6 +169,7 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 
 | ON
 | OPTION
+| xref:n1ql-language-reference/insert.adoc[OPTIONS] (6.5.1)
 | xref:n1ql-language-reference/logicalops.adoc#or-operator[OR]
 | xref:n1ql-language-reference/orderby.adoc[ORDER]
 | xref:n1ql-language-reference/window.adoc#window-frame-exclusion[OTHERS]
@@ -179,6 +187,7 @@ The following keywords are reserved and cannot be used as unescaped identifiers:
 | PRIMARY
 | PRIVATE
 | PRIVILEGE
+| xref:n1ql-language-reference/join.adoc#ansi-join-hints[PROBE]
 | PROCEDURE
 
 | PUBLIC


### PR DESCRIPTION
The following documentation is ready for review:

* [Reserved Words](https://github.com/couchbase/docs-server/blob/6c2f996646b49f4bcddcf5a8f7445627cc2882e5/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc) — added OPTIONS and updated other keywords

Docs issue: [DOC-6707](https://issues.couchbase.com/browse/DOC-6707)