### PR TITLE
DOC-6792: Fix Services xrefs

### DIFF
--- a/modules/cli/pages/cbstats/cbstats-vbucket-details.adoc
+++ b/modules/cli/pages/cbstats/cbstats-vbucket-details.adoc
@@ -1,5 +1,6 @@
 = vbucket-details
 :page-topic-type: reference
+:page-partial:
 
 [abstract]
 Provides details for vBuckets.
@@ -16,9 +17,11 @@ cbstats host:11210 [common options] vbucket-details [vbid]
 
 This command provides details for the specified vBucket, or for each vBucket if none is specified.
 
+// tag::stat_id[]
 [#stat_id]
 The identifier for each vBucket statistic begins with the string `vb_` followed by the vBucket ID and a colon.
 For example, for vBucket 1023, the identifier for the `uuid` statistic is `vb_1023:uuid`.
+// end::stat_id[]
 
 .vBucket statistics
 |===

--- a/modules/cli/pages/cbstats/cbstats-vbucket-seqno.adoc
+++ b/modules/cli/pages/cbstats/cbstats-vbucket-seqno.adoc
@@ -16,7 +16,7 @@ cbstats host:11210 [common options] vbucket-seqno [vbid]
 
 This command provides details connected to the sequence number (seqno) for the specified vBucket, or for each vBucket if none is specified.
 
-include::cbstats-vbucket-details.dita[tag=cbstats-vbucket-details/stat_id]
+include::page$cbstats/cbstats-vbucket-details.adoc[tag=stat_id]
 
 .vBucket seqno statistics
 |===

--- a/modules/fts/pages/fts-demonstration-indexes.adoc
+++ b/modules/fts/pages/fts-demonstration-indexes.adoc
@@ -1,22 +1,27 @@
 = Demonstration Indexes
 
+:full-text-searching-with-sdk: xref:2.7@java-sdk::full-text-searching-with-sdk.adoc
+:fts-creating-indexes: xref:fts-creating-indexes.adoc
+:index-creation-with-the-rest-api: xref:fts-creating-indexes.adoc#index-creation-with-the-rest-api
+:fts-geospatial-queries: xref:fts-geospatial-queries.adoc
+
 [abstract]
 Demonstration indexes are provided, to exemplify the running of Full Text Searches.
 
 [#using-demonstration-indexes]
 == Using Demonstration Indexes
 
-An extensive code-example, which uses the Couchbase Java SDK, is provided in xref:java-sdk::full-text-searching-with-sdk.adoc[Searching from the SDK].
+An extensive code-example, which uses the Couchbase Java SDK, is provided in {full-text-searching-with-sdk}[Searching from the SDK].
 This relies on three index definitions, respectively named `travel-sample-index-unstored`, `travel-sample-index-stored`, and `travel-sample-index-hotel-definition`.
 Therefore, for the code-example to be successfully run, the three indexes must be established on Couchbase Server.
 
-Optionally, the indexes can each be set up by means of the Couchbase Web Console, based on the descriptions provided in xref:java-sdk::full-text-searching-with-sdk.adoc[Searching from the SDK].
-Information on this process is provided in xref:fts-creating-indexes.adoc[Creating Indexes].
+Optionally, the indexes can each be set up by means of the Couchbase Web Console, based on the descriptions provided in {full-text-searching-with-sdk}[Searching from the SDK].
+Information on this process is provided in {fts-creating-indexes}[Creating Indexes].
 However, each index can also be established by means of a single REST command, which specifies all required index-details as a JSON document.
-Information on doing so can be found in the section xref:fts-creating-indexes.adoc#index-creation-with-the-rest-api[Index-Creation with the REST API], on the _Creating Indexes_ page.
+Information on doing so can be found in the section {index-creation-with-the-rest-api}[Index-Creation with the REST API], on the _Creating Indexes_ page.
 The three definitions are provided below.
 
-This page also provides a definition for the `geoIndex` definition, used in the section xref:fts-geospatial-queries.adoc[Geospatial Queries].
+This page also provides a definition for the `geoIndex` definition, used in the section {fts-geospatial-queries}[Geospatial Queries].
 
 [#travel-sample-index-unstored]
 == Index Definition: travel-sample-index-unstored
@@ -193,7 +198,7 @@ This page also provides a definition for the `geoIndex` definition, used in the 
 [#index-definition-geoIndex]
 == Index Definition: geoIndex
 
-The following index is used to support the _geospatial_ queries described in xref:fts-geospatial-queries.adoc[Geospatial Queries].
+The following index is used to support the _geospatial_ queries described in {fts-geospatial-queries}[Geospatial Queries].
 
 [source,javascript]
 ----

--- a/modules/fts/pages/fts-query-types.adoc
+++ b/modules/fts/pages/fts-query-types.adoc
@@ -1,5 +1,13 @@
 = Query Types
 
+:fts-demonstration-indexes: xref:fts-demonstration-indexes.adoc
+:fts-searching-with-the-rest-api: xref:fts-searching-with-the-rest-api.adoc
+:fts-using-analyzers: xref:fts-using-analyzers.adoc
+:full-text-searching-with-sdk: xref:2.7@java-sdk::full-text-searching-with-sdk.adoc
+:fts-searching-from-the-ui: xref:fts-searching-from-the-ui.adoc
+:query-string-queries: xref:query-string-queries.adoc
+:fts-geospatial-queries: xref:fts-geospatial-queries.adoc
+
 [abstract]
 Couchbase Full Text Search supports multiple types of query.
 
@@ -26,7 +34,7 @@ Special Queries:: For testing purposes, return either all of the documents in an
 These query-types are explained in greater detail below.
 Examples are provided, using the Couchbase REST API query-syntax.
 (Note that Full Text Search can also be performed with the Couchbase Web Console and the Couchbase SDK.)
-The JSON data refers to the `travel-sample` bucket, and assumes that demonstration full text indexes have been created, as described in xref:fts-demonstration-indexes.adoc[Demonstration Indexes].
+The JSON data refers to the `travel-sample` bucket, and assumes that demonstration full text indexes have been created, as described in {fts-demonstration-indexes}[Demonstration Indexes].
 
 To run the examples using `curl`, use the following syntax:
 
@@ -52,7 +60,7 @@ For actual use in a Full Text Search, these JSON fragments should be wrapped in 
 }
 ----
 
-For more information on using the REST API to perform queries, see xref:fts-searching-with-the-rest-api.adoc[Searching with the REST API].
+For more information on using the REST API to perform queries, see {fts-searching-with-the-rest-api}[Searching with the REST API].
 
 [#simple-queries]
 == Simple Queries
@@ -63,7 +71,7 @@ For more information on using the REST API to perform queries, see xref:fts-sear
 A match query _analyzes_ input text, and uses the results to query an index.
 Options include specifying an analyzer, performing a _fuzzy match_, and performing a _prefix match_.
 By default, the analyzer used for the input-text is that previously used on the target-text, during index-creation.
-For information on analyzers, see xref:fts-using-analyzers.adoc[Understanding Analyzers].
+For information on analyzers, see {fts-using-analyzers}[Understanding Analyzers].
 
 When fuzzy matching is used, if the single parameter is set to a non-zero integer, the analyzed text is matched with a corresponding level of fuzziness.
 The maximum supported fuzziness is 2.
@@ -83,7 +91,7 @@ The following JSON object demonstrates specification of a match query:
 }
 ----
 
-A match query is also demonstrated by means of the Java SDK, in xref:java-sdk::full-text-searching-with-sdk.adoc[Searching from the SDK].
+A match query is also demonstrated by means of the Java SDK, in {full-text-searching-with-sdk}[Searching from the SDK].
 
 [[match-phrase-query]]
 === Match Phrase Query
@@ -103,7 +111,7 @@ Following this processing, the tokens `locat` and `function` are recognized as _
 }
 ----
 
-A match phrase query is also demonstrated by means of the Java SDK, in xref:java-sdk::full-text-searching-with-sdk.adoc[Searching from the SDK].
+A match phrase query is also demonstrated by means of the Java SDK, in {full-text-searching-with-sdk}[Searching from the SDK].
 
 === Fuzzy Query
 
@@ -122,7 +130,7 @@ For example:
 }
 ----
 
-__Fuzziness__ is demonstrated by means of the Java SDK, in the context of the _term query_ (see below), in xref:java-sdk::full-text-searching-with-sdk.adoc[Searching from the SDK].
+__Fuzziness__ is demonstrated by means of the Java SDK, in the context of the _term query_ (see below), in {full-text-searching-with-sdk}[Searching from the SDK].
 Note that two such queries are specified, with the difference in fuzziness between them resulting in different forms of match, and different sizes of result-sets.
 
 === Prefix Query
@@ -149,7 +157,7 @@ A _regexp_ query finds documents containing terms that match the specified regul
 }
 ----
 
-A regexp query is also demonstrated by means of the Java SDK, in xref:java-sdk::full-text-searching-with-sdk.adoc[Searching from the SDK].
+A regexp query is also demonstrated by means of the Java SDK, in {full-text-searching-with-sdk}[Searching from the SDK].
 
 === Wildcard Query
 
@@ -165,7 +173,7 @@ Wildcard expressions can appear in the middle or end of a term, but not at the b
 }
 ----
 
-A wildcard query is also demonstrated by means of the Java SDK, in xref:java-sdk::full-text-searching-with-sdk.adoc[Searching from the SDK].
+A wildcard query is also demonstrated by means of the Java SDK, in {full-text-searching-with-sdk}[Searching from the SDK].
 
 === Boolean Field Query
 
@@ -198,7 +206,7 @@ Its result documents must satisfy all of the child queries.
 }
 ----
 
-A conjunction query is also demonstrated by means of the Java SDK, in xref:java-sdk::full-text-searching-with-sdk.adoc[Searching from the SDK].
+A conjunction query is also demonstrated by means of the Java SDK, in {full-text-searching-with-sdk}[Searching from the SDK].
 
 === Disjunction Query (OR)
 
@@ -217,7 +225,7 @@ For example, if three child queries — A, B, and C — are specified, a `min` o
 }
 ----
 
-A disjunction query is also demonstrated by means of the Java SDK, in xref:java-sdk::full-text-searching-with-sdk.adoc[Searching from the SDK].
+A disjunction query is also demonstrated by means of the Java SDK, in {full-text-searching-with-sdk}[Searching from the SDK].
 
 [[boolean-query]]
 === Boolean Query
@@ -251,7 +259,7 @@ This is typically used in conjunction queries, to restrict the scope of other qu
 { "ids": [ "hotel_10158", "hotel_10159" ] }
 ----
 
-A doc ID Query is demonstrated by means of the Java SDK, in xref:java-sdk::full-text-searching-with-sdk.adoc[Searching from the SDK].
+A doc ID Query is demonstrated by means of the Java SDK, in {full-text-searching-with-sdk}[Searching from the SDK].
 
 [#range-queries]
 == Range Queries
@@ -295,7 +303,7 @@ By default, [.param]`min` is inclusive and [.param]`max` is exclusive.
 }
 ----
 
-A numeric range Query is also demonstrated by means of the Java SDK, in xref:java-sdk::full-text-searching-with-sdk.adoc[Searching from the SDK].
+A numeric range Query is also demonstrated by means of the Java SDK, in {full-text-searching-with-sdk}[Searching from the SDK].
 
 [#query-string-query-syntax]
 == Query String Query
@@ -307,14 +315,14 @@ A _query string_ can be used, to express a given query by means of a special syn
 { "query": "+nice +view" }
 ----
 
-A query string Query is demonstrated by means of the Java SDK, in xref:java-sdk::full-text-searching-with-sdk.adoc[Searching from the SDK].
+A query string Query is demonstrated by means of the Java SDK, in {full-text-searching-with-sdk}[Searching from the SDK].
 Note also that the Full Text Searches conducted with the Couchbase Web Console themselves use query strings.
-(See xref:fts-searching-from-the-ui.adoc[Searching from the UI].)
+(See {fts-searching-from-the-ui}[Searching from the UI].)
 
 Certain queries supported by FTS are not yet supported by the query string syntax.
 These include wildcards and regular expressions.
 
-More detailed information is provided in xref:query-string-queries.adoc[Query String Queries].
+More detailed information is provided in {query-string-queries}[Query String Queries].
 
 [#non-analytic-queries]
 == Non-Analytic Queries
@@ -323,7 +331,7 @@ _Term_ and _Phrase_ queries support no analysis on their inputs.
 This means that only exact matches are returned.
 
 In most cases, given the benefits of using analyzers, use of match and match phrase queries is preferable to that of term and phrase.
-For information on analyzers, see xref:fts-using-analyzers.adoc[Understanding Analyzers].
+For information on analyzers, see {fts-using-analyzers}[Understanding Analyzers].
 
 === Term Query
 
@@ -338,7 +346,7 @@ It performs an exact match in the index for the provided term.
 }
 ----
 
-Term queries are also demonstrated by means of the Java SDK, in xref:java-sdk::full-text-searching-with-sdk.adoc[Searching from the SDK].
+Term queries are also demonstrated by means of the Java SDK, in {full-text-searching-with-sdk}[Searching from the SDK].
 
 === Phrase Query
 
@@ -353,7 +361,7 @@ It performs an exact term-match for all the phrase-constituents, without using a
 }
 ----
 
-A phrase query is also demonstrated by means of the Java SDK, in xref:java-sdk::full-text-searching-with-sdk.adoc[Searching from the SDK].
+A phrase query is also demonstrated by means of the Java SDK, in {full-text-searching-with-sdk}[Searching from the SDK].
 
 [#geospatial-queries]
 == Geospatial Queries
@@ -369,7 +377,7 @@ Documents are returned if they specify a location that lies within the bounding 
 
 A geospatial query must be applied to an index that applies the _geopoint_ type mapping to the document-field that contains the target longitude-latitude coordinate pair.
 
-More detailed information is provided in xref:fts-geospatial-queries.adoc[Geospatial Queries].
+More detailed information is provided in {fts-geospatial-queries}[Geospatial Queries].
 
 [#special-queries]
 == Special Queries

--- a/modules/n1ql/pages/n1ql-language-reference/curl.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/curl.adoc
@@ -527,7 +527,7 @@ SELECT CURL("https://maps.googleapis.com/maps/api/geocode/json",
 .Join two buckets on different Couchbase clusters
 ====
 This N1QL query shows how to JOIN two buckets on different Couchbase clusters.
-It is same as explained in the xref:n1ql-language-reference/join.adoc[JOIN Clause] example, but with the left and right side buckets for the JOIN are in two different Couchbase clusters.
+It is same as explained in the xref:n1ql-language-reference/from.adoc#lookup-join-clause[JOIN Clause] example, but with the left and right side buckets for the JOIN are in two different Couchbase clusters.
 
 * The left side bucket `route` is the `pass:c[`travel-sample`]` route documents from cluster running on `hostname`.
 If you don't have a second cluster running, you should substitute the `hostname` with 127.0.0.1 or the IP-address of the local cluster.

--- a/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
@@ -1,6 +1,11 @@
 = PREPARE
 :page-topic-type: concept
 
+:prepare-stmts: xref:2.7@java-sdk::n1ql-query.adoc#prepare-stmts
+:n1ql-queries-with-sdk: xref:2.6@nodejs-sdk::n1ql-queries-with-sdk.adoc
+:security-authorization: xref:security:security-authorization.adoc
+:execute: xref:n1ql-language-reference/execute.adoc
+
 == PREPARE statement
 
 _prepare:_
@@ -29,12 +34,12 @@ A PREPARE statement that uses a name that was used for a different statement wil
 Prepared statements are stored in memory until you restart the Couchbase Server.
 After restarting the server, you must prepare the statements again before you can execute the prepared statements.
 
-For information on how to use prepared statements with various SDKs, refer to xref:java-sdk::n1ql-query.adoc#prepare-stmts[Querying with N1QL] and xref:nodejs-sdk::n1ql-queries-with-sdk.adoc[N1QL from the SDK].
+For information on how to use prepared statements with various SDKs, refer to {prepare-stmts}[Querying with N1QL] and {n1ql-queries-with-sdk}[N1QL from the SDK].
 
 *RBAC Privileges*
 
 User executing the PREPARE statement must have the privileges of the statement being prepared.
-For more details about user roles, see xref:security:security-authorization.adoc[Authorization].
+For more details about user roles, see {security-authorization}[Authorization].
 
 For example,
 
@@ -55,4 +60,4 @@ RETURNING *
 
 == EXECUTE statement
 
-For details, see xref:n1ql-language-reference/execute.adoc[EXECUTE].
+For details, see {execute}[EXECUTE].

--- a/modules/rest-api/pages/rest-xdcr-adv-settings.adoc
+++ b/modules/rest-api/pages/rest-xdcr-adv-settings.adoc
@@ -139,4 +139,4 @@ The upper limit for network usage during replication, for the entire cluster, sp
 The default, 0, means that no limit is applied.
 The limit applies only to mutations: it does not apply to other XDCR communications, such as those related to server topology and runtime statistics.
 Note that the limit for each individual node is the limit for the entire cluster divided by the number of nodes in the cluster.
-|==
+|===


### PR DESCRIPTION
Fixed broken links for release/5.5:

* modules/fts/pages/fts-demonstration-indexes.adoc
* modules/fts/pages/fts-query-types.adoc
* modules/n1ql/pages/n1ql-language-reference/curl.adoc
* modules/n1ql/pages/n1ql-language-reference/prepare.adoc

Also fixed broken include for `cbstats-vbucket-seqno.adoc` and unterminated table in `rest-xdcr-adv-settings.adoc`.

Docs issue: [DOC-6792](https://issues.couchbase.com/browse/DOC-6792)