### PR TITLE
DOC-6792: Fix Services xrefs

### DIFF
--- a/modules/cli/pages/cbstats/cbstats-vbucket-details.adoc
+++ b/modules/cli/pages/cbstats/cbstats-vbucket-details.adoc
@@ -1,5 +1,6 @@
 = vbucket-details
 :page-topic-type: reference
+:page-partial:
 
 [abstract]
 Provides details for vBuckets.
@@ -16,9 +17,11 @@ cbstats host:11210 [common options] vbucket-details [vbid]
 
 This command provides details for the specified vBucket, or for each vBucket if none is specified.
 
+// tag::stat_id[]
 [#stat_id]
 The identifier for each vBucket statistic begins with the string `vb_` followed by the vBucket ID and a colon.
 For example, for vBucket 1023, the identifier for the `uuid` statistic is `vb_1023:uuid`.
+// end::stat_id[]
 
 .vBucket statistics
 |===

--- a/modules/cli/pages/cbstats/cbstats-vbucket-seqno.adoc
+++ b/modules/cli/pages/cbstats/cbstats-vbucket-seqno.adoc
@@ -16,7 +16,7 @@ cbstats host:11210 [common options] vbucket-seqno [vbid]
 
 This command provides details connected to the sequence number (seqno) for the specified vBucket, or for each vBucket if none is specified.
 
-include::cbstats-vbucket-details.dita[tag=cbstats-vbucket-details/stat_id]
+include::page$cbstats/cbstats-vbucket-details.adoc[tag=stat_id]
 
 .vBucket seqno statistics
 |===

--- a/modules/eventing/pages/eventing-adding-function.adoc
+++ b/modules/eventing/pages/eventing-adding-function.adoc
@@ -68,7 +68,7 @@ This deploys the Function and returns you to the main Eventing screen.
 The display indicates that the Function is now deployed and running.
 From this point, your defined Function will run, first, on all existing documents; and subsequently, whenever a creation or mutation occurs.
 . Click *Undeploy* to undeploy a Function.
-
+--
 
 
 NOTE: The Function lifecycle operations (deploying, undeploying and deleting operations) and the Eventing +

--- a/modules/eventing/pages/eventing-adding-function.adoc
+++ b/modules/eventing/pages/eventing-adding-function.adoc
@@ -71,9 +71,9 @@ From this point, your defined Function will run, first, on all existing document
 --
 
 
-NOTE: The Function lifecycle operations (deploying, undeploying and deleting operations) and the Eventing +
-rebalance operation are mutually exclusive. The Eventing rebalance operation fails when a Function lifecycle +
-operation is currently in progress. Likewise, when the Eventing rebalance operation is in progress, you cannot +
+NOTE: The Function lifecycle operations (deploying, undeploying and deleting operations) and the Eventing
+rebalance operation are mutually exclusive. The Eventing rebalance operation fails when a Function lifecycle
+operation is currently in progress. Likewise, when the Eventing rebalance operation is in progress, you cannot
 perform a Function lifecycle operation.
 
 

--- a/modules/eventing/pages/eventing-examples-docexpiry.adoc
+++ b/modules/eventing/pages/eventing-examples-docexpiry.adoc
@@ -1,5 +1,8 @@
 = Document Expiry and Archival
 
+:start-using-sdk: xref:2.5@python-sdk::start-using-sdk.adoc
+:document-operations: xref:2.5@python-sdk::document-operations.adoc
+
 *Goal*: When a document in an existing bucket is about to expire, a new document is created in a newly created bucket.
 
 *Implementation*: Write an OnUpdate handler, which runs whenever a document is created or mutated.
@@ -14,6 +17,7 @@ Python script for this Example is provided for reference.
 Using the Couchbase SDK, you can create or modify the document expiration.
 In this example, the Couchbase SDK Python client creates a document and sets the document's expiration.
 
+[source,python]
 ----
 from couchbase.cluster import Cluster
 from couchbase.cluster import PasswordAuthenticator
@@ -30,8 +34,8 @@ cb.touch('SampleDocument2', ttl=10*60)
 The script imports a Couchbase cluster object, and authenticates against it, using (for demonstration purposes) the Full Administrator username and password (the cluster is assumed to be accessible on localhost).
 The script then opens the existing source bucket, and inserts a new document, named *SampleDocument2*, whose body is *{'a_key': 'a_value'}*.
 
-For information on installing the Couchbase Python SDK, refer to xref:2.7@java-sdk::start-using-sdk.adoc[Start Using the SDK].
-For information on using the Couchbase Python SDK to establish bucket-expiration, refer to xref:dotnet-sdk::document-operations.adoc[Document Operations].
+For information on installing the Couchbase Python SDK, refer to {start-using-sdk}[Start Using the SDK].
+For information on using the Couchbase Python SDK to establish bucket-expiration, refer to {document-operations}[Document Operations].
 
 *Procedure*
 
@@ -39,12 +43,14 @@ Proceed as follows:
 
 . Install the Couchbase SDK Python client and from the appropriate folder, start Python.
 +
+[source,console]
 ----
 ./python
 ----
 
 . On the Python prompt, enter the provided code.
 +
+[source,python]
 ----
 >>> from couchbase.cluster import Cluster
 >>> from couchbase.cluster import PasswordAuthenticator

--- a/modules/fts/pages/fts-demonstration-indexes.adoc
+++ b/modules/fts/pages/fts-demonstration-indexes.adoc
@@ -1,22 +1,27 @@
 = Demonstration Indexes
 
+:full-text-searching-with-sdk: xref:2.7@java-sdk::full-text-searching-with-sdk.adoc
+:fts-creating-indexes: xref:fts-creating-indexes.adoc
+:index-creation-with-the-rest-api: xref:fts-creating-indexes.adoc#index-creation-with-the-rest-api
+:fts-geospatial-queries: xref:fts-geospatial-queries.adoc
+
 [abstract]
 Demonstration indexes are provided, to exemplify the running of Full Text Searches.
 
 [#using-demonstration-indexes]
 == Using Demonstration Indexes
 
-An extensive code-example, which uses the Couchbase Java SDK, is provided in xref:java-sdk::full-text-searching-with-sdk.adoc[Searching from the SDK].
+An extensive code-example, which uses the Couchbase Java SDK, is provided in {full-text-searching-with-sdk}[Searching from the SDK].
 This relies on three index definitions, respectively named `travel-sample-index-unstored`, `travel-sample-index-stored`, and `travel-sample-index-hotel-definition`.
 Therefore, for the code-example to be successfully run, the three indexes must be established on Couchbase Server.
 
-Optionally, the indexes can each be set up by means of the Couchbase Web Console, based on the descriptions provided in xref:java-sdk::full-text-searching-with-sdk.adoc[Searching from the SDK].
-Information on this process is provided in xref:fts-creating-indexes.adoc[Creating Indexes].
+Optionally, the indexes can each be set up by means of the Couchbase Web Console, based on the descriptions provided in {full-text-searching-with-sdk}[Searching from the SDK].
+Information on this process is provided in {fts-creating-indexes}[Creating Indexes].
 However, each index can also be established by means of a single REST command, which specifies all required index-details as a JSON document.
-Information on doing so can be found in the section xref:fts-creating-indexes.adoc#index-creation-with-the-rest-api[Index-Creation with the REST API], on the _Creating Indexes_ page.
+Information on doing so can be found in the section {index-creation-with-the-rest-api}[Index-Creation with the REST API], on the _Creating Indexes_ page.
 The three definitions are provided below.
 
-This page also provides a definition for the `geoIndex` definition, used in the section xref:fts-geospatial-queries.adoc[Geospatial Queries].
+This page also provides a definition for the `geoIndex` definition, used in the section {fts-geospatial-queries}[Geospatial Queries].
 
 [#travel-sample-index-unstored]
 == Index Definition: travel-sample-index-unstored
@@ -193,7 +198,7 @@ This page also provides a definition for the `geoIndex` definition, used in the 
 [#index-definition-geoIndex]
 == Index Definition: geoIndex
 
-The following index is used to support the _geospatial_ queries described in xref:fts-geospatial-queries.adoc[Geospatial Queries].
+The following index is used to support the _geospatial_ queries described in {fts-geospatial-queries}[Geospatial Queries].
 
 [source,javascript]
 ----

--- a/modules/install/pages/install-environments.adoc
+++ b/modules/install/pages/install-environments.adoc
@@ -25,3 +25,4 @@ Version 8, Update 181 or later
 | Version 11
 
 Version 8
+|===

--- a/modules/manage/pages/manage-settings/change-failover-settings.adoc
+++ b/modules/manage/pages/manage-settings/change-failover-settings.adoc
@@ -53,3 +53,4 @@ curl -i -X POST -u Administrator:password http://10.142.180.103:8091/settings/au
   -d 'enabled=true&timeout=72' \
   -d 'failoverServerGroup=true&maxCount=2' \
   -d 'failoverOnDataDiskIssues[enabled]=true&failoverOnDataDiskIssues[timePeriod]=89'
+----

--- a/modules/manage/pages/manage-settings/change-failover-settings.adoc
+++ b/modules/manage/pages/manage-settings/change-failover-settings.adoc
@@ -47,7 +47,7 @@ The automatic failover settings can be changed using the REST API xref:rest-api:
 
 Below is an example of changing the automatic failover settings using the REST API:
 
-[source#curl-example,javascript]
+[source#curl-example,console]
 ----
 curl -i -X POST -u Administrator:password http://10.142.180.103:8091/settings/autoFailover \
   -d 'enabled=true&timeout=72' \


### PR DESCRIPTION
Fixed broken links for release/6.0:

* modules/eventing/pages/eventing-examples-docexpiry.adoc
* modules/fts/pages/fts-demonstration-indexes.adoc

Also fixed broken include for `cbstats-vbucket-seqno.adoc` and unterminated blocks in `install-environments.adoc`, `change-failover-settings.adoc`, and `eventing-adding-function.adoc`.

Docs issue: [DOC-6792](https://issues.couchbase.com/browse/DOC-6792)