### PR TITLE
DOC-6792: Fix Services xrefs

### DIFF
--- a/modules/cli/pages/cbstats/cbstats-checkpoint.adoc
+++ b/modules/cli/pages/cbstats/cbstats-checkpoint.adoc
@@ -61,4 +61,4 @@ If successful, the command returns the following information for each vBucket on
           .
           .
           .
- ----
+----

--- a/modules/cli/pages/cbstats/cbstats-vbucket-details.adoc
+++ b/modules/cli/pages/cbstats/cbstats-vbucket-details.adoc
@@ -1,5 +1,6 @@
 = vbucket-details
 :page-topic-type: reference
+:page-partial:
 
 [abstract]
 Provides details for vBuckets.
@@ -16,9 +17,11 @@ cbstats host:11210 [common options] vbucket-details [vbid]
 
 This command provides details for the specified vBucket, or for each vBucket if none is specified.
 
+// tag::stat_id[]
 [#stat_id]
 The identifier for each vBucket statistic begins with the string `vb_` followed by the vBucket ID and a colon.
 For example, for vBucket 1023, the identifier for the `uuid` statistic is `vb_1023:uuid`.
+// end::stat_id[]
 
 .vBucket statistics
 |===

--- a/modules/cli/pages/cbstats/cbstats-vbucket-seqno.adoc
+++ b/modules/cli/pages/cbstats/cbstats-vbucket-seqno.adoc
@@ -16,7 +16,7 @@ cbstats host:11210 [common options] vbucket-seqno [vbid]
 
 This command provides details connected to the sequence number (seqno) for the specified vBucket, or for each vBucket if none is specified.
 
-include::cbstats-vbucket-details.adoc[tag=cbstats-vbucket-details/stat_id]
+include::page$cbstats/cbstats-vbucket-details.adoc[tag=stat_id]
 
 .vBucket seqno statistics
 |===

--- a/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
@@ -96,7 +96,7 @@ For more details, refer to xref:fts:fts-sorting.adoc[Sorting Query Results].
 
 [NOTE]
 ====
-When specifying a complete full text search request with the N1QL SEARCH() function, if the value of the `size` parameter is greater than the xref:xref:fts:fts-response-object-schema.adoc#request[maximum number of full text search results], the query ignores the `size` parameter and returns all matching results.
+When specifying a complete full text search request with the N1QL SEARCH() function, if the value of the `size` parameter is greater than the xref:fts:fts-response-object-schema.adoc#request[maximum number of full text search results], the query ignores the `size` parameter and returns all matching results.
 
 This is different to the behavior of a complete full text search request in the Search service, where the query returns an error if the value of the `size` parameter is greater than the maximum number of full text search results.
 ====

--- a/modules/rest-api/pages/rest-configure-ldap.adoc
+++ b/modules/rest-api/pages/rest-configure-ldap.adoc
@@ -122,4 +122,4 @@ Value must be an integer between 1 and 100: the default is 10.
 | cacheValueLifetime
 | Lifetime of values in cache in milliseconds. Default 300000 ms.
 
-|==
+|===

--- a/modules/rest-api/pages/rest-configure-saslauthd.adoc
+++ b/modules/rest-api/pages/rest-configure-saslauthd.adoc
@@ -57,4 +57,4 @@ If either an asterisk or the word 'asterisk' is specified as the value, all SASL
 | enabled
 | Enables or disables SASL on the cluster. 1 enables, 0 disables.
 
-|==
+|===


### PR DESCRIPTION
Fixed broken links for release/6.5:

* modules/n1ql/pages/n1ql-language-reference/searchfun.adoc

Also fixed broken include for `cbstats-vbucket-seqno.adoc` and unterminated blocks in `rest-configure-ldap.adoc`, `rest-configure-saslauthd.adoc`, and `cbstats-checkpoint.adoc`.

Docs issue: [DOC-6792](https://issues.couchbase.com/browse/DOC-6792)