### PR TITLE
DOC-5321: setting query timeout from rest is in nanoseconds

### DIFF
--- a/modules/n1ql/partials/n1ql-rest-api/admin/definitions.adoc
+++ b/modules/n1ql/partials/n1ql-rest-api/admin/definitions.adoc
@@ -667,6 +667,9 @@ The default value means no timeout is applied and the request runs for however l
 There is also a xref:settings:query-settings.adoc#timeout_req[request-level] `timeout` parameter.
 The minimum of that and the service-level `timeout` setting is applied.
 
+Unlike the request-level `timeout` parameter , the service-level `timeout` setting is an integer, representing a duration in nanoseconds.
+It must not be delimited by quotes, and must not include a unit.
+
 Specify `0` or a negative integer to disable. +
 **Default** : `0` +
 **Example** : `500000000`|integer (int64)

--- a/modules/n1ql/partials/n1ql-rest-api/admin/definitions.adoc
+++ b/modules/n1ql/partials/n1ql-rest-api/admin/definitions.adoc
@@ -667,7 +667,7 @@ The default value means no timeout is applied and the request runs for however l
 There is also a xref:settings:query-settings.adoc#timeout_req[request-level] `timeout` parameter.
 The minimum of that and the service-level `timeout` setting is applied.
 
-Unlike the request-level `timeout` parameter , the service-level `timeout` setting is an integer, representing a duration in nanoseconds.
+The service-level `timeout` setting is an integer, representing a duration in nanoseconds.
 It must not be delimited by quotes, and must not include a unit.
 
 Specify `0` or a negative integer to disable. +

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -757,7 +757,7 @@ The default value means no timeout is applied and the request runs for however l
 There is also a <<timeout-srv,server-level>> `timeout` setting.
 The minimum of that and the request-level `timeout` parameter is applied.
 
-Unlike the server-level `timeout` setting, the request-level `timeout` parameter is a string.
+The request-level `timeout` parameter is a string.
 Its format includes an amount and a mandatory unit, e.g. `10ms` (10 milliseconds) or `0.5s` (half a second).
 Valid units are:
 

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -768,7 +768,7 @@ Valid units are:
 * `m` (minutes)
 * `h` (hours)
 
-NOTE: Specify `0` or a negative integer to disable.
+NOTE: Specify a duration of `0` or a negative duration to disable.
 
 .Default
 `"0s"`

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -757,6 +757,7 @@ The default value means no timeout is applied and the request runs for however l
 There is also a <<timeout-srv,server-level>> `timeout` setting.
 The minimum of that and the request-level `timeout` parameter is applied.
 
+Unlike the server-level `timeout` setting, the request-level `timeout` parameter is a string.
 Its format includes an amount and a mandatory unit, e.g. `10ms` (10 milliseconds) or `0.5s` (half a second).
 Valid units are:
 


### PR DESCRIPTION
The following documentation is ready for review:

* [Settings and Parameters › Service-Level Query Settings](https://simon-dew.github.io/docs-site/DOC-5321/server/6.5/settings/query-settings.html#timeout-srv)
* [Settings and Parameters › Request-Level Parameters](https://simon-dew.github.io/docs-site/DOC-5321/server/6.5/settings/query-settings.html#timeout_req)
* [Admin REST API › Definitions › Settings](https://simon-dew.github.io/docs-site/DOC-5321/server/6.5/n1ql/n1ql-rest-api/admin.html#timeout-srv)

Docs issue: [DOC-5321](https://issues.couchbase.com/browse/DOC-5321) — reopened after [further comments](https://issues.couchbase.com/browse/DOC-5321?focusedCommentId=404505&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-404505)