### PR TITLE
DOC-6482: Make sure view indexes deprecated

### DIFF
--- a/modules/learn/pages/views/view-indexes-for-n1ql.adoc
+++ b/modules/learn/pages/views/view-indexes-for-n1ql.adoc
@@ -13,6 +13,8 @@ Views provide the following advantages:
 xref:learn:clusters-and-availability/groups.adoc[Server Group Awareness] support and rebalance support.
 * Simple Scaling Model: Views are automatically placed and scaled with the data service.
 
+NOTE: The Views for N1QL feature is deprecated and will be removed in a future release.
+
 == Creating Views for N1QL
 
 You can define a primary or secondary index using Views for N1QL using the CREATE INDEX statement and USING VIEW clause.

--- a/modules/n1ql/pages/n1ql-language-reference/adaptive-indexing.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/adaptive-indexing.adoc
@@ -142,6 +142,8 @@ image::n1ql-language-reference/index-using.png["'USING' ( 'VIEW' | 'GSI' )"]
 The USING clause specifies the index type to use.
 To create an adaptive index, the index type must be `GSI`; as this is the default, the USING clause may be omitted.
 
+(Note that USING VIEW is deprecated and will be removed in a future release.)
+
 [[index-with,index-with]]
 === WITH Clause
 

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -132,6 +132,8 @@ Secondary indexes can be created using global secondary indexes (GSI) or views.
 
 This clause is optional; if omitted, the default is `USING GSI`.
 
+(Note that USING VIEW is deprecated and will be removed in a future release.)
+
 [[index-with,index-with]]
 === WITH Clause
 

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -129,7 +129,6 @@ image::n1ql-language-reference/index-using.png["'USING' ( 'VIEW' | 'GSI' )"]
 
 The USING clause specifies the index type to use.
 Secondary indexes can be created using global secondary indexes (GSI) or views.
-
 This clause is optional; if omitted, the default is `USING GSI`.
 
 (Note that USING VIEW is deprecated and will be removed in a future release.)

--- a/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
@@ -74,6 +74,8 @@ USING GSI | USING VIEW;;
 The USING clause specifies the index type to use.
 Primary indexes can be created as global secondary indexes (`GSI`) or views (`VIEW`).
 If the USING clause is not specified, by default `GSI` is used as the indexer.
++
+(Note that USING VIEW is deprecated and will be removed in a future release.)
 
 WITH options;; The `WITH` clause specifies additional options for the `GSI` type primary indexes.
 "nodes":["node name"]:::

--- a/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
@@ -39,6 +39,8 @@ USING clause specify the index type to use.
 Indexes can be created using GSI or views.
 If USING clause is not specified, by default GSI is used as the indexer.
 
+(Note that USING VIEW is deprecated and will be removed in a future release.)
+
 When using memory-optimized indexes, DROP INDEX is an expensive operation and may take a few minutes to complete.
 
 [caption=Attention]

--- a/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
@@ -35,6 +35,8 @@ USING clause specify the index type to use.
 Indexes can be created using GSI or views.
 If USING clause is not specified, by default GSI is used as the indexer.
 
+(Note that USING VIEW is deprecated and will be removed in a future release.)
+
 *RBAC Privileges*
 
 User executing the DROP PRIMARY INDEX statement must have the _Query Manage Index_ privilege granted on the keyspace/bucket.

--- a/modules/n1ql/pages/n1ql-language-reference/hints.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/hints.adoc
@@ -205,6 +205,8 @@ Specifies which index form to use.
 
 This clause is optional; if omitted, the default is `USING GSI`.
 
+(Note that USING VIEW is deprecated and will be removed in a future release.)
+
 === Examples
 
 .Use an existing index with GSI in a query

--- a/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
@@ -102,6 +102,8 @@ image::n1ql-language-reference/index-using.png["'USING' ( 'VIEW' | 'GSI' )"]
 The USING clause specifies the index type to use.
 To create a partitioned index, the index type must be `GSI`; as this is the default, the USING clause may be omitted.
 
+(Note that USING VIEW is deprecated and will be removed in a future release.)
+
 [[index-with,index-with]]
 === WITH Clause
 

--- a/modules/n1ql/pages/n1ql-language-reference/indexing-arrays.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/indexing-arrays.adoc
@@ -151,6 +151,8 @@ image::n1ql-language-reference/index-using.png["'USING' ( 'VIEW' | 'GSI' )"]
 
 The USING clause specifies the index type to use.
 
+(Note that USING VIEW is deprecated and will be removed in a future release.)
+
 [[index-with,index-with]]
 === WITH Clause
 

--- a/modules/n1ql/pages/n1ql-language-reference/select-syntax.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/select-syntax.adoc
@@ -605,6 +605,8 @@ index-using ::= USING ( VIEW | GSI )
 image::n1ql-language-reference/index-using.png[]
 --
 
+(Note that USING VIEW is deprecated and will be removed in a future release.)
+
 [[let-clause,let-clause]]
 == LET Clause
 


### PR DESCRIPTION
The following draft documentation is ready for review:

* [View Indexes for N1QL](https://github.com/couchbase/docs-server/blob/6d1aa53ce10feee26922ee78e2f1ab2c1f08c1c9/modules/learn/pages/views/view-indexes-for-n1ql.adoc)
* [Create Index](https://github.com/couchbase/docs-server/blob/c1b8a642731ad3c377db5d769bf739fcbeb6d1e9/modules/n1ql/pages/n1ql-language-reference/createindex.adoc#using-clause)
  * [Adaptive Index](https://github.com/couchbase/docs-server/blob/c1b8a642731ad3c377db5d769bf739fcbeb6d1e9/modules/n1ql/pages/n1ql-language-reference/adaptive-indexing.adoc#using-clause)
  * [Index Partitioning](https://github.com/couchbase/docs-server/blob/c1b8a642731ad3c377db5d769bf739fcbeb6d1e9/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc#using-clause)
  * [Indexing Arrays](https://github.com/couchbase/docs-server/blob/c1b8a642731ad3c377db5d769bf739fcbeb6d1e9/modules/n1ql/pages/n1ql-language-reference/indexing-arrays.adoc#using-clause)
* [Create Primary Index](https://github.com/couchbase/docs-server/blob/c1b8a642731ad3c377db5d769bf739fcbeb6d1e9/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc#syntax)
* [Drop Index](https://github.com/couchbase/docs-server/blob/c1b8a642731ad3c377db5d769bf739fcbeb6d1e9/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc)
* [Drop Primary Index](https://github.com/couchbase/docs-server/blob/c1b8a642731ad3c377db5d769bf739fcbeb6d1e9/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc)
* [SELECT Syntax](https://github.com/couchbase/docs-server/blob/c1b8a642731ad3c377db5d769bf739fcbeb6d1e9/modules/n1ql/pages/n1ql-language-reference/select-syntax.adoc#use-clause)
  * [Hints](https://github.com/couchbase/docs-server/blob/c1b8a642731ad3c377db5d769bf739fcbeb6d1e9/modules/n1ql/pages/n1ql-language-reference/hints.adoc#using-clause)

Docs issue: [DOC-6482](https://issues.couchbase.com/browse/DOC-6482)