### PR TITLE
The Functions REST API endpoints are out of Beta

### DIFF
--- a/modules/eventing/pages/eventing-api.adoc
+++ b/modules/eventing/pages/eventing-api.adoc
@@ -4,7 +4,7 @@
 [abstract]
 The Eventing REST API, available by default at port 8096, provides the methods available to work with Couchbase Eventing Functions.
 
-NOTE: The Eventing REST API is a Beta feature intended for development purposes only, do not use them in production; no Enterprise Support is provided for Beta features.
+NOTE: The Functions REST API endpoints on this page are supported, as long as the content of the handler body is not created or modified externally (as the internal format of the body is not yet standardized).
 
 .Eventing Functions API
 [cols="2,3,6"]


### PR DESCRIPTION
As per https://issues.couchbase.com/browse/CBSE-8433 and discussion with Engineering