### PR TITLE
Update manage-system-secrets.adoc

### DIFF
--- a/modules/manage/pages/manage-security/manage-system-secrets.adoc
+++ b/modules/manage/pages/manage-security/manage-system-secrets.adoc
@@ -36,10 +36,10 @@ At start-up, Couchbase Server waits for the master password to be entered at the
 Enter the password by means of the `master-password` CLI command, with the `--send-password` option:
 
 ----
-couchbase-cli master-password -c server-ip-address:8091 --send-password
+couchbase-cli master-password --send-password
 ----
 
-This CLI command allows you three attempts to enter the password correctly.
+Note that this CLI command needs to be run on the same host on which Couchbase Server is running and it allows you three attempts to enter the password correctly.
 
 [#password_rotation]
 == Performing Rotation


### PR DESCRIPTION
The master-password command that's part of couchbase-cli only accepts a --send-password command. Here's the usage info:

$ /opt/couchbase/bin/couchbase-cli master-password -h     
usage: couchbase-cli master-password [-h] [--send-password [<password>]]

Local command options:
  This command has to be execute on the locally running Couchbase Server.

  -h,--help                   Prints the short or long help message

Master password options:
  --send-password [<password>]
                              Sends the master password to start the server