### PR TITLE
DOC-6482: Make sure view indexes deprecated

### DIFF
--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -858,7 +858,7 @@ The node-to-node traffic uses the HTTP/2 protocol and is encrypted with either t
 For more information, refer to xref:install:install-ports.adoc[Network and Firewall Requirements].
 
 [#deprecation-600]
-=== Deprecated Platforms
+=== Deprecated Platforms and Features
 
 Support for the following platforms will be removed in a future release:
 
@@ -869,6 +869,8 @@ Support for the following platforms will be removed in a future release:
 * SUSE Linux Enterprise Server (SLES) 11
 * Ubuntu 14.04
 * Windows Server 2012
+
+The use of view indexes is deprecated in N1QL only and will be removed in a future release.
 
 [#supported-platforms-600]
 === New Supported Platforms


### PR DESCRIPTION
Retroactively add deprecation notice to release notes in release/6.0 for view indexes in N1QL.

(Added deprecation notices to the syntax pages in #1325.)

Docs issue: [DOC-6482](https://issues.couchbase.com/browse/DOC-6482)