### PR TITLE
DOC-6482: Make sure view indexes deprecated

### DIFF
--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -176,10 +176,10 @@ Instead, the following ports are now required for cluster management:
 
 For more information about required network ports, refer to xref:install:install-ports.adoc[Network and Firewall Requirements].
 
-==== VIEW Indexes
+==== View Indexes
 
-Starting with this release, the use of VIEW indexes is deprecated in N1QL only.
-Node-to-node encryption is unsupported for the use of VIEW indexes in N1QL only.
+The use of view indexes is deprecated in N1QL only and will be removed in a future release.
+Node-to-node encryption is unsupported for the use of view indexes in N1QL only.
 
 ==== Features Now Available in Couchbase Server Community Edition
 


### PR DESCRIPTION
Deprecation of view indexes in N1QL does not start with release/6.5.

(Retroactively added deprecation notice to release notes for release/6.0 in #1338.)

Docs issue: [DOC-6482](https://issues.couchbase.com/browse/DOC-6482)