### PR TITLE
Note that user needs read access to couchbase group

### DIFF
--- a/modules/manage/pages/manage-security/manage-system-secrets.adoc
+++ b/modules/manage/pages/manage-security/manage-system-secrets.adoc
@@ -39,7 +39,12 @@ Enter the password by means of the `master-password` CLI command, with the `--se
 couchbase-cli master-password --send-password
 ----
 
-Note that this CLI command needs to be run on the same host on which Couchbase Server is running and it allows you three attempts to enter the password correctly.
+[IMPORTANT] 
+==== 
+ * This CLI command needs to be run on the same host on which Couchbase Server is running.
+ * The user running the command needs to have read access to the `couchbase` group.
+ * You have three attempts to enter the password correctly. If the password is not entered correctly after 3 attempts, the server will need to be restarted before you can try again.
+====
 
 [#password_rotation]
 == Performing Rotation


### PR DESCRIPTION
Add a note that the user needs read access to the couchbase
group and place in an "important" admonition box.