### PR TITLE
Add new "pause" description and add password

### DIFF
--- a/modules/eventing/pages/eventing-api.adoc
+++ b/modules/eventing/pages/eventing-api.adoc
@@ -65,20 +65,20 @@ Sample API:
 
 ----
 curl 
-http://Administrator@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
+http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
 ----
 
 | POST
 | [.path]_/api/v1/functions/[function_name]/settings_
 a|
-Deploys a Function.
-A deploy CURL example is provided for reference.
+Deploys an undeployed Function or resumes a paused function from its paused DCP checkpoint.
+A deploy/resume CURL example is provided for reference.
 
 Sample API:
 
 ----
 curl -XPOST -d '{"deployment_status":true,"processing_status":true}'
-http://Administrator@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
+http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
 ----
 
 | POST
@@ -91,7 +91,20 @@ Sample API:
 
 ----
 curl -XPOST -d '{"deployment_status":false,"processing_status":false}'
-http://Administrator@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
+http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
+----
+
+| POST
+| [.path]_/api/v1/functions/[function_name]/settings_
+a|
+Pauses a Function and creates a DCP checkpoint such that on a subsequent resume no mutations will be lost.
+A pause CURL example is provided for reference.
+
+Sample API:
+
+----
+curl -XPOST -d '{"deployment_status":true,"processing_status":false}'
+http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
 ----
 
 | POST
@@ -104,7 +117,7 @@ Sample API (alter worker_count):
 
 ----
 curl -XPOST -d '{"deployment_status":false,"processing_status":false,"worker_count":6}'
-http://Administrator@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
+http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
 ----
 
 | POST
@@ -117,7 +130,7 @@ Sample API (alter app_log_max_files and app_log_max_size):
 
 ----
 curl -XPOST -d '{"deployment_status":false,"processing_status":false,"app_log_max_files":5,"app_log_max_size":10485760}'
-http://Administrator@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
+http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
 ----
 
 |===


### PR DESCRIPTION
A description of "Pause" was missing, also the "Deploy" block doubles as "Resume" if the function was paused.

Fix credentials instead of Administrator@ it should be Administrator:password@ for all occurances.