### PR TITLE
BP of 6.5.X docs REST API to 6.0.X

### DIFF
--- a/modules/eventing/pages/eventing-api.adoc
+++ b/modules/eventing/pages/eventing-api.adoc
@@ -1,11 +1,11 @@
-= Functions REST API
+= Eventing REST API
 
 [abstract]
-The Functions REST API, available by default at port 8096, provides the methods available to work with Couchbase Functions.
+The Eventing REST API, available by default at port 8096, provides the methods available to work with Couchbase Eventing Functions.
 
 NOTE: The Functions REST API endpoints on this page are supported, as long as the content of the handler body is not created or modified externally (as the internal format of the body is not yet standardized).
 
-.Functions API
+.Eventing Functions API
 [cols="2,3,6"]
 |===
 | HTTP Method | *URI Path* | *Description*
@@ -21,6 +21,12 @@ Function definition includes current settings.
 | Creates multiple Functions.
 Function names must be unique.
 When multiple Functions have the same name, an error is reported.
+
+| POST
+| [.path]_/api/v1/import/_
+| Imports multiple Functions.
+Function names must be unique.
+When multiple Functions have the same name, an error is reported. Note if any Function's langauge_compatibility field is missing the value will be set to 6.0.0 (unlike the [.path]_/api/v1/functions_ above which will set the value to the highest version supported by the server).
 
 | GET
 | [.path]_/api/v1/functions_
@@ -49,17 +55,29 @@ During an edit, settings provided are merged.
 Unspecified attributes retain their prior values.
 The response indicates whether the Eventing service must be restarted for the new changes to take effect.
 
+| GET
+| [.path]_/api/v1/functions/[function_name]/settings_
+a|
+Retruns the information for one function Functions in the cluster.
+
+Sample API:
+
+----
+curl
+http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
+----
+
 | POST
 | [.path]_/api/v1/functions/[function_name]/settings_
 a|
-Deploys a Function.
+Deploys an undeployed Function.
 A deploy CURL example is provided for reference.
 
 Sample API:
 
 ----
 curl -XPOST -d '{"deployment_status":true,"processing_status":true}'
-http://Administrator@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
+http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
 ----
 
 | POST
@@ -72,10 +90,62 @@ Sample API:
 
 ----
 curl -XPOST -d '{"deployment_status":false,"processing_status":false}'
-http://Administrator@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
+http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
 ----
 
 | POST
 | [.path]_/api/v1/functions/[function_name]/settings_
-| Deploys a Function with the provided code.
+a|
+Updates an undeployed a Function with the provided setting. Do not update settings for a deployed function.
+Note you must always specify deployment_status (deplyed/undeployed) and processing_status (they must match in 6.0) when using this REST endpoint to opdate any option(s).
+
+Sample API (alter worker_count):
+
+----
+curl -XPOST -d '{"deployment_status":false,"processing_status":false,"worker_count":6}'
+http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
+----
+
+| POST
+| [.path]_/api/v1/functions/[function_name]/settings_
+a|
+Updates an undeployed a Function with the provided settings. Do not update settings for a deployed.
+Note you must always specify deployment_status (deplyed/undeployed) and processing_status (they must match in 6.0) when using this REST endpoint to opdate any option(s).
+
+Sample API (alter app_log_max_files and app_log_max_size):
+
+----
+curl -XPOST -d '{"deployment_status":false,"processing_status":false,"app_log_max_files":5,"app_log_max_size":10485760}'
+http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
+----
+
+|===
+
+
+.Eventing Statistics API
+[cols="2,3,4"]
+|===
+| HTTP Method | *URI Path* | *Description*
+
+| GET
+| [.path]_/api/v1/stats?type=full_
+| Retrive all statistics for the node.
+This will return the full statistics set inclusive of events processing, events remaining, execution, failure, latency, worker PIDs and sequence processed.
+
+Note, omitting the parameter type=full will exclude dcp_event_backlog_per_vb, doc_timer_debug_stats, latency_stats, plasma_stats and seqs_processed from the response.
+
+| GET
+| [.path]_/getExecutionStats?name=[function_name]_
+| Retrive only execution statistics.
+This will return the the subset of statistics for the node.
+
+| GET
+| [.path]_/getLatencyStats?name=[function_name]_
+| Retrive only latency statistics.
+This will return the the subset of statistics for the node.
+
+| GET
+| [.path]_/getFailureStats?name=[function_name]_
+| Retrive only falure statistics.
+This will return the the subset of statistics for the node.
 |===

--- a/modules/eventing/pages/eventing-api.adoc
+++ b/modules/eventing/pages/eventing-api.adoc
@@ -58,7 +58,7 @@ The response indicates whether the Eventing service must be restarted for the ne
 | GET
 | [.path]_/api/v1/functions/[function_name]/settings_
 a|
-Retruns the information for one function Functions in the cluster.
+Returns the information for one function Functions in the cluster.
 
 Sample API:
 
@@ -97,7 +97,7 @@ http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/se
 | [.path]_/api/v1/functions/[function_name]/settings_
 a|
 Updates an undeployed a Function with the provided setting. Do not update settings for a deployed function.
-Note you must always specify deployment_status (deplyed/undeployed) and processing_status (they must match in 6.0) when using this REST endpoint to opdate any option(s).
+Note you must always specify deployment_status (deplyed/undeployed) and processing_status (they must match in 6.0) when using this REST endpoint to update any option(s).
 
 Sample API (alter worker_count):
 
@@ -109,8 +109,8 @@ http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/se
 | POST
 | [.path]_/api/v1/functions/[function_name]/settings_
 a|
-Updates an undeployed a Function with the provided settings. Do not update settings for a deployed.
-Note you must always specify deployment_status (deplyed/undeployed) and processing_status (they must match in 6.0) when using this REST endpoint to opdate any option(s).
+Updates an undeployed Function with the provided settings. Do not update settings for a deployed Function.
+Note that you must always specify deployment_status (deplyed/undeployed) and processing_status (they must match in 6.0) when using this REST endpoint to opdate any option(s).
 
 Sample API (alter app_log_max_files and app_log_max_size):
 
@@ -130,22 +130,22 @@ http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/se
 | GET
 | [.path]_/api/v1/stats?type=full_
 | Retrive all statistics for the node.
-This will return the full statistics set inclusive of events processing, events remaining, execution, failure, latency, worker PIDs and sequence processed.
+This will return the full statistics set inclusive of events processing, events remaining, execution, failure, latency, worker PIDs, and sequence processed.
 
 Note, omitting the parameter type=full will exclude dcp_event_backlog_per_vb, doc_timer_debug_stats, latency_stats, plasma_stats and seqs_processed from the response.
 
 | GET
 | [.path]_/getExecutionStats?name=[function_name]_
 | Retrive only execution statistics.
-This will return the the subset of statistics for the node.
+This will return the subset of statistics for the node.
 
 | GET
 | [.path]_/getLatencyStats?name=[function_name]_
 | Retrive only latency statistics.
-This will return the the subset of statistics for the node.
+This will return the subset of statistics for the node.
 
 | GET
 | [.path]_/getFailureStats?name=[function_name]_
 | Retrive only falure statistics.
-This will return the the subset of statistics for the node.
+This will return the subset of statistics for the node.
 |===


### PR DESCRIPTION
This is a BP of 6.5.X docs REST API to 6.0.X (the last 6.5 update was https://github.com/couchbase/docs-server/pull/1393)

Essentially 6.0 does not support pause/resume all other functions including stats were tested on 6.0.4 to ensure correctness

Some text needs to differ because of lack of Pause/Resume in 6.0.X "deployment_status (deplyed/undeployed) and processing_status (they must match in 6.0)"