### PR TITLE
Add Limitations section as per DOC-7067

### DIFF
--- a/modules/eventing/pages/eventing-timers.adoc
+++ b/modules/eventing/pages/eventing-timers.adoc
@@ -109,6 +109,27 @@ However, if timer is created and scheduled to close the wall clock of the system
 
 The additional overall delay is an implementation artifact and may change between releases.
 
+== Limitations
+
+In the 5.5.x, 6.0.x and 6.5.x releases
+
+* Eventing timers once created cannot be overwritten by using the same reference. 
+* In addition, a function that is invoked by a timer callback cannot reliably create a fresh timer (a work around can be done via a second cooperative Function).
+
+In the 6.5.X releases
+
+* Creating timers in the future (as in one hour+) in an otherwise idle system can result in a growing number of metadata bucket operations which can eventually block mutations for a given Eventing function. In 6.5.X a user space work around can be accomplished via a second cooperative Function.  
++
+The severity is governed by:
++
+** The number of vBuckets holding an active timer. Therefore if there are only a few timers in the future the issue may not be noticeable or materialize.
+** Whether an Eventing timer has fired recently on a vBucket (which clears the issue for the given vBucket on a per function basis). Therefore systems with lots of near term timer activity will not experience this issue even if timers are scheduled far into the future. 
+
+All of these limitations are removed in release 6.6.0
+
+* Eventing timers can be cancelled using cancelTimer() function, or by creating a new timer with the same reference as an existing timer.
+* Recurring timers are fully supported, i.e. a function that is invoked by a timer callback can reliably create fresh timers.
+* Timers can be created days/weeks/years in the future with no adverse performance impact on an otherwise idle Eventing system.
 
 == Examples
 

--- a/modules/eventing/pages/eventing-timers.adoc
+++ b/modules/eventing/pages/eventing-timers.adoc
@@ -111,25 +111,21 @@ The additional overall delay is an implementation artifact and may change betwee
 
 == Limitations
 
-In the 5.5.x, 6.0.x and 6.5.x releases
+In the 5.5.x, 6.0.x and 6.5.x releases:
 
 * Eventing timers once created cannot be overwritten by using the same reference. 
 * In addition, a function that is invoked by a timer callback cannot reliably create a fresh timer (a work around can be done via a second cooperative Function).
 
-In the 6.5.X releases
+In the 6.5.X releases:
 
-* Creating timers in the future (as in one hour+) in an otherwise idle system can result in a growing number of metadata bucket operations which can eventually block mutations for a given Eventing function. In 6.5.X a user space work around can be accomplished via a second cooperative Function.  
+* Creating timers in the future (as in one hour+) in an otherwise idle system can result in a growing number of metadata bucket operations which can eventually block mutations for a given Eventing function. In 6.5.X a user space workaround can be accomplished via a second cooperative Function.  
 +
 The severity is governed by:
 +
-** The number of vBuckets holding an active timer. Therefore if there are only a few timers in the future the issue may not be noticeable or materialize.
+** The number of vBuckets holding an active timer. Therefore, if there are only a few timers in the future the issue may not be noticeable or materialize.
 ** Whether an Eventing timer has fired recently on a vBucket (which clears the issue for the given vBucket on a per function basis). Therefore systems with lots of near term timer activity will not experience this issue even if timers are scheduled far into the future. 
 
-All of these limitations are removed in release 6.6.0
-
-* Eventing timers can be cancelled using cancelTimer() function, or by creating a new timer with the same reference as an existing timer.
-* Recurring timers are fully supported, i.e. a function that is invoked by a timer callback can reliably create fresh timers.
-* Timers can be created days/weeks/years in the future with no adverse performance impact on an otherwise idle Eventing system.
+All of these limitations are planned to be addressed in the next version.
 
 == Examples
 


### PR DESCRIPTION
Timers have limitations and/or bugs depending on the version, these issues need to be documented and communicated to the end user.
MB-28734 (fix)
MB-39301 (fix)