### PR TITLE
DOC-6681: Document FTS FLEX index

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -276,7 +276,7 @@
     ***** xref:n1ql:n1ql-language-reference/adaptive-indexing.adoc[Adaptive Index]
     ***** xref:n1ql:n1ql-language-reference/indexing-meta-info.adoc[Indexing Metadata Information]
     ***** xref:n1ql:n1ql-language-reference/index-partitioning.adoc[Index Partitioning]
-    ***** xref:n1ql:n1ql-language-reference/flex-indexes.adoc[Flex Indexes]
+    ***** xref:n1ql:n1ql-language-reference/flex-indexes.adoc[Full Text Search Indexes in N1QL]
     ***** xref:n1ql:n1ql-language-reference/groupby-aggregate-performance.adoc[Group By and Aggregate Performance]
     ***** xref:n1ql:n1ql-language-reference/cost-based-optimizer.adoc[Cost-Based Optimizer]
    **** xref:n1ql:n1ql-language-reference/createprimaryindex.adoc[CREATE PRIMARY INDEX]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -276,7 +276,7 @@
     ***** xref:n1ql:n1ql-language-reference/adaptive-indexing.adoc[Adaptive Index]
     ***** xref:n1ql:n1ql-language-reference/indexing-meta-info.adoc[Indexing Metadata Information]
     ***** xref:n1ql:n1ql-language-reference/index-partitioning.adoc[Index Partitioning]
-    ***** xref:n1ql:n1ql-language-reference/flex-indexes.adoc[Full Text Search Indexes in N1QL]
+    ***** xref:n1ql:n1ql-language-reference/flex-indexes.adoc[Flex Indexes]
     ***** xref:n1ql:n1ql-language-reference/groupby-aggregate-performance.adoc[Group By and Aggregate Performance]
     ***** xref:n1ql:n1ql-language-reference/cost-based-optimizer.adoc[Cost-Based Optimizer]
    **** xref:n1ql:n1ql-language-reference/createprimaryindex.adoc[CREATE PRIMARY INDEX]

--- a/modules/learn/pages/services-and-indexes/services/search-service.adoc
+++ b/modules/learn/pages/services-and-indexes/services/search-service.adoc
@@ -56,7 +56,7 @@ For extensive information on how to use the service, see xref:fts:full-text-intr
 The Search Service can be accessed by means of the _search functions_ provided by the _N1QL_ language &#8212; which provides the principal interface to the _Query_ and _Index_ Services.
 For detailed information, see xref:n1ql:n1ql-language-reference/searchfun.adoc[Search Functions].
 
-In Couchbase Server 6.6 Enterprise Edition and later, you can specify that any N1QL query should attempt to use a Full Text Search index, to take advantage of the Search Service's natural-language capabilities.
-For detailed information, see xref:n1ql:n1ql-language-reference/flex-indexes.adoc[Full Text Search Indexes in N1QL].
+In Couchbase Server 6.6 Enterprise Edition and later, the _Flex Index_ feature provides the ability for a N1QL query to use a Full Text Search index transparently with standard N1QL syntax.
+For detailed information, see xref:n1ql:n1ql-language-reference/flex-indexes.adoc[Flex Indexes].
 
 To use the Search Service in N1QL, the Query, Index, and Search Services must all be running on the cluster.

--- a/modules/n1ql/pages/n1ql-language-reference/flex-indexes.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/flex-indexes.adoc
@@ -1,4 +1,4 @@
-= Full-Text Search Indexes in N1QL
+= Flex Indexes
 :page-topic-type: concept
 :page-status: Couchbase Server 6.6
 :page-edition: Enterprise Edition
@@ -19,17 +19,26 @@
 :index_pushdowns: xref:learn:services-and-indexes/indexes/index_pushdowns.adoc
 
 [abstract]
-You can specify a full-text index when running a N1QL query.
-This enables you to run the N1QL query as an FTS query against the full-text index, as long as the full-text index and the N1QL query both meet certain requirements.
+The Flex Index feature enables you run a N1QL query as a full-text search query, using a full-text index.
+This means that you can write queries in N1QL to leverage the Search service's keyword search capabilities.
 
-In prior versions of Couchbase Server, it was possible to perform an FTS search within a N1QL query using {searchfun}[search functions].
-Starting with Couchbase Server 6.6, it is also possible to specify a full-text index for a N1QL query that does not contain a search function.
+In Couchbase Server, a global secondary index (GSI) uses a B-tree structure for fast exact search, whereas full-text search (FTS) uses an inverted index to provide efficient term search.
+In Couchbase Server 6.5 and later, it is possible to perform a full-text search within a N1QL query using {searchfun}[search functions].
+However this requires you to write the full-text search using the FTS syntax.
 
-The full-text index must meet certain requirements to be usable by a N1QL query; similarly, the N1QL query must have certain characteristics to be able to use the full-text index.
+Starting with Couchbase Server 6.6, the _Flex Index_ feature provides the ability for a N1QL query to leverage either a global secondary index or full-text index transparently with standard N1QL syntax, simplifying the application development process.
+
+The full-text index must be defined in a certain way to be usable by a N1QL query; similarly, the N1QL query must have certain characteristics to be able to use the full-text index.
 If these requirements are met, the query is transformed into an FTS query, and run against the full-text index.
-Using a full-text index in this way may offer advantages over a GSI index when performing text-based or language-aware queries.
 
-For more information on full-text indexes, refer to {fts-creating-indexes}[Creating Indexes].
+Using a Flex Index query may offer advantages in the following situations:
+
+* When the search conditions are not predetermined.
+* When the search predicate involves a large number of fields combined using AND or OR.
+* When the search predicate involves multiple arrays.
+* When an application requires a full-text search combined with N1QL aggregation or joins.
+
+For a general introduction to creating full-text indexes, refer to {fts-creating-indexes}[Creating Indexes].
 
 [[overview]]
 == Overview
@@ -42,16 +51,13 @@ To understand how a N1QL query can make use of a full-text index, it's important
 Full-text indexes have different semantics to N1QL queries.
 Some of the main differences are described here.
 
-* N1QL field names can have special characters.
-Special characters can be escaped with backticks.
+* N1QL field names can have special characters, which can be escaped with backticks.
+The Search service cannot index fields whose names contain special characters.
 
 * N1QL uses escaped path names, whereas full-text indexes flatten the field names.
 
 * N1QL uses array subscripts to identify array objects, for example `1.arr1[0].b`; whereas full-text indexes ignore subscripts, for example `f1.arr1.b`.
 This means full-text indexes cannot uniquely identify the path.
-
-* N1QL supports case-sensitive and case-insensitive field names.
-Full-text indexes only support case-sensitive field names.
 
 * In N1QL, data can be compared across data types.
 This is not possible with a full-text index.
@@ -61,16 +67,17 @@ This is not possible with a full-text index.
 [[restrictions]]
 === Restrictions
 
-Because of the semantic differences described above, there are several restrictions to the way the query engine can make use of full-text indexes.
+Because of the semantic differences described above, there are several restrictions to the way a Flex Index query can use a full-text index.
 
-* A full-text index cannot be used as a {covering-indexes}[covering index].
-* LIMIT and OFFSET clauses may be used with a full-text index, but they cannot be {index_pushdowns}[pushed down to the indexer].
-* Aggregate functions and Window functions may be used with a full-text index, but they cannot be {index_pushdowns}[pushed down to the indexer].
+* A Flex Index query cannot use a full-text index as a {covering-indexes}[covering index].
+* A Flex Index query cannot use a full-text index with a query on fields whose names contain special characters.
+* A Flex Index query may include LIMIT and OFFSET clauses, but they cannot be {index_pushdowns}[pushed down to the full-text index].
+* A Flex Index query may include Aggregate functions and Window functions, but they cannot be {index_pushdowns}[pushed down to the full-text index].
 
-Queries only make use of full-text indexes to find the access path to the required data.
+Flex Index queries only make use of full-text indexes to find the access path to the required data.
 The query engine then fetches the data from the data service.
 
-Full-text indexes may be used to do an intersect scan with other indexes.
+Flex Index queries may use full-text indexes to do an intersect scan with other indexes.
 For further details, refer to <<usage>> below.
 
 [[index-availability]]
@@ -174,7 +181,7 @@ The full-text index _must_ use one of the following type mappings:
 * A single custom type mapping
 * Multiple custom type mappings
 
-The full-text index may _not_ use the default type mapping along with one more more custom type mappings.
+The full-text index may _not_ use the default type mapping along with one or more custom type mappings.
 
 [[indexed-fields]]
 === Indexed Fields
@@ -340,7 +347,7 @@ WHERE type = "xyz" OR type = "abc"
 [[n1ql-predicates]]
 === N1QL Predicates
 
-N1QL predicates can be used with a full-text search query, as long as they meet certain requirements, as detailed below.
+N1QL predicates can be used with a Flex Index query, as long as they meet certain requirements, as detailed below.
 
 [[equality]]
 ==== Equality Expressions

--- a/modules/n1ql/pages/n1ql-language-reference/flex-indexes.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/flex-indexes.adoc
@@ -51,9 +51,6 @@ To understand how a N1QL query can make use of a full-text index, it's important
 Full-text indexes have different semantics to N1QL queries.
 Some of the main differences are described here.
 
-* N1QL field names can have special characters, which can be escaped with backticks.
-The Search service cannot index fields whose names contain special characters.
-
 * N1QL uses escaped path names, whereas full-text indexes flatten the field names.
 
 * N1QL uses array subscripts to identify array objects, for example `1.arr1[0].b`; whereas full-text indexes ignore subscripts, for example `f1.arr1.b`.

--- a/modules/n1ql/pages/n1ql-language-reference/hints.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/hints.adoc
@@ -197,9 +197,9 @@ Specifies which index form to use.
 
 `USING GSI`:: A Global Secondary Index, which lives on an index node and can possibly be separate from a data node.
 
-`USING FTS`:: A Full Text Search index, for use with queries containing xref:n1ql-language-reference/searchfun.adoc[Search Functions].
-In Couchbase Server 6.6 Enterprise Edition and later, you can specify that any N1QL query should attempt to use a Full Text Search index, to take advantage of the Search Service's natural-language capabilities.
-For detailed information, see xref:n1ql:n1ql-language-reference/flex-indexes.adoc[Full Text Search Indexes in N1QL].
+`USING FTS`:: A Full Text Search index, for use with queries containing xref:n1ql-language-reference/searchfun.adoc[Search functions].
+In Couchbase Server 6.6 Enterprise Edition and later, you can use this hint to specify that the query is a xref:n1ql:n1ql-language-reference/flex-indexes.adoc[Flex Index] query using a Full Text Search index.
+In Couchbase Server 6.6 Community Edition and later, this hint is ignored if the query does not contain a Search function.
 
 This clause is optional; if omitted, the default is `USING GSI`.
 

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -797,7 +797,7 @@ If the query does not contain a `USING FTS` hint, and this parameter is set to t
 If a qualified full-text index is available, it is selected for the query.
 If none of the available full-text indexes are qualified, the available GSI indexes are considered instead.
 
-Refer to xref:n1ql:n1ql-language-reference/flex-indexes.adoc[Full Text Search Indexes in N1QL] for more information.
+Refer to xref:n1ql:n1ql-language-reference/flex-indexes.adoc[Flex Indexes] for more information.
 
 .Default
 `false`


### PR DESCRIPTION
The following draft documentation is ready for review:

* [Flex Indexes](https://simon-dew.github.io/docs-site/DOC-6681/server/6.6/n1ql/n1ql-language-reference/flex-indexes.html) — updates after review
* [USE Clause › USE INDEX clause › Syntax › USING clause](https://simon-dew.github.io/docs-site/DOC-6681/server/6.6/n1ql/n1ql-language-reference/hints.html#index-type) — minor updates
* [Settings and Parameters › Request-Level Parameters › `use_fts`](https://simon-dew.github.io/docs-site/DOC-6681/server/6.6/settings/query-settings.html#use_fts) — minor updates
* [Search Service › Accessing the Search Service with N1QL](https://simon-dew.github.io/docs-site/DOC-6681/server/6.6/learn/services-and-indexes/services/search-service.html#search_via_query) — minor updates

Docs issue: [DOC-6681](https://issues.couchbase.com/browse/DOC-6681)