### PR TITLE
fixed a comment and corrected a URL typo

### DIFF
--- a/modules/rest-api/pages/rest-node-provisioning.adoc
+++ b/modules/rest-api/pages/rest-node-provisioning.adoc
@@ -90,7 +90,7 @@ curl  -u Administrator:password -v -X POST \
   -d 'cbas_path=%2Fopt%2Fcouchbase%2Fvar%2Flib%2Fcouchbase%2Fdata&' \
   -d 'eventing_path=%2Fopt%2Fcouchbase%2Fvar%2Flib%2Fcouchbase%2Fdata&'
 
-// Rename Node
+// Rename Cluster
 curl  -u Administrator:password -v -X POST http://192.168.42.101:8091/node/controller/rename \
   -d 'hostname=127.0.0.1'
 
@@ -99,7 +99,7 @@ curl  -u Administrator:password -v -X POST http://192.168.42.101:8091/node/contr
   -d 'services=kv%2Cn1ql%2Cindex%2Cfts'
 
 // Setup Memory Quotas
-curl  -u Administrator:password -v -X POST http://192.168.42.101:8091//pools/default \
+curl  -u Administrator:password -v -X POST http://192.168.42.101:8091/pools/default \
   -d 'memoryQuota=256' \
   -d 'indexMemoryQuota=256' \
   -d 'ftsMemoryQuota=256'


### PR DESCRIPTION
there's an extra slash in one of the URLs

also, the comment says "rename node" but it's really the cluster name, not a node name