### PR TITLE
DOC-6784: Check backup and restore manpages for 6.6.0

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -193,6 +193,7 @@
  ** xref:backup-restore:enterprise-backup-restore.adoc[Backup]
   *** xref:backup-restore:cbbackupmgr-strategies.adoc[Strategies]
   *** xref:backup-restore:cbbackupmgr-tutorial.adoc[Tutorial]
+  *** xref:backup-restore:cbbackupmgr-cloud.adoc[Cloud]
   *** xref:backup-restore:cbbackupmgr-archivelayout.adoc[Archive Layout]
  ** xref:backup-restore:incremental-backup.adoc[Incremental Backup and Restore]
 * xref:manage:troubleshoot/troubleshoot.adoc[Troubleshoot]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -193,7 +193,7 @@
  ** xref:backup-restore:enterprise-backup-restore.adoc[Backup]
   *** xref:backup-restore:cbbackupmgr-strategies.adoc[Strategies]
   *** xref:backup-restore:cbbackupmgr-tutorial.adoc[Tutorial]
-  *** xref:backup-restore:cbbackupmgr-cloud.adoc[Cloud]
+  *** xref:backup-restore:cbbackupmgr-cloud.adoc[Cloud Backup]
   *** xref:backup-restore:cbbackupmgr-archivelayout.adoc[Archive Layout]
  ** xref:backup-restore:incremental-backup.adoc[Incremental Backup and Restore]
 * xref:manage:troubleshoot/troubleshoot.adoc[Troubleshoot]


### PR DESCRIPTION
Added Backup Cloud tutorial to server nav:

* [cbbackupmgr cloud](https://simon-dew.github.io/docs-site/DOC-6784/server/6.6/backup-restore/cbbackupmgr-cloud.html)

Docs issue: [DOC-6784](https://issues.couchbase.com/browse/DOC-6784)