### PR TITLE
Clarify binary Eventing support

### DIFF
--- a/modules/eventing/pages/eventing-faq.adoc
+++ b/modules/eventing/pages/eventing-faq.adoc
@@ -26,7 +26,7 @@ Yes, the Eventing Service node can be co-located with other MDS-enabled services
 
 * Is it supported for both text and binary formats of the documents?
 +
-No, the value or the document must always be text. Eventing currently can't handle binary document mutations (binary documents will not generate mutations).  In addition an Eventing handler can’t currently read a binary value from a bucket alias. The documents are based on a key-value format where the value can be arbitrary text. However in practice the value is typically a well formatted JSON text payload.  There is one exception, Eventing handlers via the curl() function can handle binary data to and from an external REST endpoint.
+No, the value or the document must always be text. Eventing currently doesn't process binary documents (binary documents will not generate mutations).  In addition an Eventing handler can’t currently read a binary value from a bucket alias. The documents are based on a key-value format where the value can be arbitrary text. However in practice the value is typically a well formatted JSON text payload.  There is one exception, Eventing handlers via the curl() function can handle binary data to and from an external REST endpoint.
 
 == Change Capture
 

--- a/modules/eventing/pages/eventing-faq.adoc
+++ b/modules/eventing/pages/eventing-faq.adoc
@@ -26,7 +26,7 @@ Yes, the Eventing Service node can be co-located with other MDS-enabled services
 
 * Is it supported for both text and binary formats of the documents?
 +
-No, the value or the document must always be text. Eventing currently doesn't process binary documents (binary documents will not generate mutations).  In addition an Eventing handler can’t currently read a binary value from a bucket alias. The documents are based on a key-value format where the value can be arbitrary text. However in practice the value is typically a well formatted JSON text payload.  There is one exception, Eventing handlers via the curl() function can handle binary data to and from an external REST endpoint.
+No, the value or the document must always be text. Eventing currently doesn't process binary documents (binary documents will not generate mutations).  Additionally, an Eventing handler can’t currently read a binary value from a bucket alias. The documents are based on a key-value format where the value can be arbitrary text. However, in practice the value is typically a well formatted JSON text payload.  There is one exception, Eventing handlers via the curl() function can handle binary data to and from an external REST endpoint.
 
 == Change Capture
 

--- a/modules/eventing/pages/eventing-faq.adoc
+++ b/modules/eventing/pages/eventing-faq.adoc
@@ -26,8 +26,7 @@ Yes, the Eventing Service node can be co-located with other MDS-enabled services
 
 * Is it supported for both text and binary formats of the documents?
 +
-The value or the document must always be text in the form of a JSON document.
-
+No, the value or the document must always be text. Eventing currently can't handle binary document mutations (binary documents will not generate mutations).  In addition an Eventing handler can’t currently read a binary value from a bucket alias. The documents are based on a key-value format where the value can be arbitrary text. However in practice the value is typically a well formatted JSON text payload.  There is one exception, Eventing handlers via the curl() function can handle binary data to and from an external REST endpoint.
 
 == Change Capture
 
@@ -99,8 +98,7 @@ We do not allow import of node modules or external JS libraries or Node modules.
 * Are Functions supported for both Data Node and Document storage?
 +
 The Eventing Service listens to changes that appear in the Database Change Protocol (DCP) stream.
-DCP is valid for the Data Service, and Functions operate on documents that are either in key-value or in document (JSON) format.
-
+Since DCP is valid for the Data Service, and Eventing Functions only operate on documents that are text based. The documents are based on a key-value format where the value can be arbitrary text. However in practice the value is typically a well formatted JSON text payload. Note, the key is passed as meta.id and the value is passed as doc to the OnUpdate handler and only the key as meta.id is passed to the OnDelete handler.
 
 * Can Functions interact with external processes?
 +


### PR DESCRIPTION
Add discussion of binary, test, and well formatted JSON, these changes can be back ported to 6.5.