### PR TITLE
Eventing document change in debug-url 6.6 (also BP to 5.5, 6.0, 6.5)

### DIFF
--- a/modules/eventing/pages/eventing-debugging-and-diagnosability.adoc
+++ b/modules/eventing/pages/eventing-debugging-and-diagnosability.adoc
@@ -56,7 +56,13 @@ image::debug_3.png[,400]
 
 . Paste the URL from the Debugging pop-up that you copied into a new window (or tab) in your Google Chrome browser's address bar.
 +
-WARNING: You might have to manually alter the start of the debugging URL from *chrome-devtools://* to just *devtools://* depending on the version of your Google Chrome browser due to a recent change made by Google.
+WARNING: You might have to manually alter the start of the debugging URL from *chrome-devtools://* to just *devtools://* and also at the end of debugging URL from *js_app.html* to *inspector.html* depending on the version of your Google Chrome browser due to a recent changes made by Google.  Currently these manual changes (if needed) have to be done after pasting the URL into a new Chrome browser tab.
++
+There are currently three known URL variants from the oldest Chrome release to newest Chrome release:
+
+* chrome-devtools://devtools/bundled/js_app.html
+* devtools://devtools/bundled/js_app.html
+* devtools://devtools/bundled/inspector.html
 +
 image::debug_4.png[,100%]
 


### PR DESCRIPTION
Document issues in debug-url due to Chrome Browser changes (these changes to the URL to invoke the Chrome debugger are beyond the control of couchbase).  Unfortunately we have seen two (2) changes in recent months.

Need to back port this section as the Chrome browser changes impacts all releases with Eventing. See MB-40479 for eventual solutions(s).

This impacts all Eventing releases i.e. 5.5, 6.0, 6.5, and 6.6