### PR TITLE
remove SDK doctor

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -203,7 +203,6 @@
 .Develop
 * xref:sdk:development-intro.adoc[Developer's Intro]
 * xref:sdk:overview.adoc[SDKs]
- ** xref:sdk:sdk-doctor.adoc[SDK doctor]
 * xref:getting-started:starter-kits.adoc[Starter Kits]
 * xref:n1ql:query.adoc[Query]
  ** xref:n1ql:n1ql-intro/index.adoc[Running Queries]


### PR DESCRIPTION
As there are no other sub-items below SDK in the nav,
and as SDK doctor is linked from the landing page,
remove potential source of confusion (It looks like SDK doctor is listed as the one-and-only SDK =o) ).