### PR TITLE
DOC-7072: cbq docs missing many options

### DIFF
--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -202,13 +202,13 @@ cbq> \HELP;
 .Command Line Options for cbq Shell
 [#table_a3h_rhz_dw,cols="1,1,1,5"]
 |===
-| Option | Arguments | Default Value | Description and Examples
+| Option | Arguments | Default | Description and Examples
 
 | [[opt-engine]]
 `-e`
 
 `--engine`
-| <[.var]``url``>
+| string (url)
 | `+http://localhost:8091+`
 a| The connection string consists of a protocol scheme followed by a host, including a port number to connect to the query service (8093) or the Couchbase cluster (8091).
 
@@ -243,10 +243,10 @@ cbq>
 `-ne`
 
 `--no-engine`
-| None
-| false
-a| The cbq shell does not connect to any query service.
-You must explicitly connect to a query service using the [.cmd]`\CONNECT` shell command.
+| boolean footnote:boolean[Invoking a boolean option with no value sets the value to `true`.]
+| `false`
+a| When specified, the cbq shell does not connect to any query service.
+You must explicitly connect to a query service using the <<cbq-connect,\CONNECT>> shell command.
 
 .Examples
 [source,console]
@@ -260,10 +260,10 @@ $ ./cbq --no-engine
 `--networkconfig`
 | string (`auto`, `default`, `external`)
 | `auto`
-a| Specifies whether to connect to a node's principle or alternate address.
+a| Specifies whether to connect to a node's principal or alternate address.
 
-* `auto` -- Select the internal address or alternate address automatically, depending on input.
-* `default` -- Use the principle address.
+* `auto` -- Select the principal address or alternate address automatically, depending on the input IP.
+* `default` -- Use the principal address.
 * `external` -- Use the alternate addresses.
 
 .Examples
@@ -276,9 +276,9 @@ $ ./cbq -ncfg default -e http://localhost:8091
 `-q`
 
 `--quiet`
-| None
-| false
-a| Enables or disables the startup connection message for the cbq shell.
+| boolean footnote:boolean[]
+| `false`
+a| When specified, disables the startup connection message for the cbq shell.
 
 .Examples
 [source,console]
@@ -296,10 +296,10 @@ cbq>
 `-a`
 
 `--analytics`
-| None
-| None
+| boolean footnote:boolean[]
+| `false`
 a| Only applicable when connecting to the Analytics Service.
-When you connect to a cluster, this option specifies that cbq should automatically discover and connect to an Analytics server.
+When specified, if you are connecting to a cluster, cbq automatically discovers and connects to an Analytics node.
 This option also switches on <<opt-batch,batch mode>>.
 
 [source,console]
@@ -311,17 +311,17 @@ $ ./cbq --analytics
 `-b`
 
 `--batch`
-| None
-| None
+| string (`on`, `off`)  footnote:[Invoking this option with no value sets the value to `on`.]
+| `off`
 a| This option is available only with the Analytics Service.
-When invoked with the batch option, cbq sends the queries to server only when you hit EOF or \ to indicate the end of the batch input.
+When specified, cbq sends the queries to server only when you hit EOF or \ to indicate the end of the batch input.
 
 [source,console]
 ----
 $ ./cbq --batch
 ----
 
-You can also set the batch mode in the interactive session using the following commands:
+You can also set the batch mode in the interactive session using the <<cbq-set,\SET>> command:
 
 ----
 \set batch on
@@ -332,8 +332,8 @@ You can also set the batch mode in the interactive session using the following c
 `-t`
 
 `--timeout`
-| [.var]`value`
-| None
+| string (duration)
+| `0ms`
 a| Sets the query timeout parameter.
 
 .Examples
@@ -346,8 +346,8 @@ $ ./cbq -e http://localhost:8091 --timeout="1s"
 `-u`
 
 `--user`
-| [.var]`username`
-| None
+| string
+| none
 a| Specifies a single user name to log in to Couchbase.
 When used by itself, without the `-p` option to specify the password, you will be prompted for the password.
 
@@ -366,8 +366,8 @@ $ ./cbq -e http://localhost:8091 -u=Administrator
 `-p`
 
 `--password`
-| [.var]`password`
-| None
+| string
+| none
 a| Specifies the password for the given user name.
 You cannot use this option by itself.
 It must be used with the -u option to specify the user name.
@@ -386,8 +386,8 @@ $ ./cbq -e http://localhost:8091 -u=Administrator -p=password
 `-c`
 
 `--credentials`
-| [.var]`list of credentials`
-| None
+| string
+| none
 a| Specify the login credentials in the form of [.var]`username`:[.var]``password``.
 You can specify credentials for different buckets by separating them with a comma.
 
@@ -405,9 +405,9 @@ $ ./cbq -e http://localhost:8091 -c=beer-sample:password,Administrator:password
 `-v`
 
 `--version`
-| None
-| false
-a| Provides the version of the cbq shell.
+| boolean footnote:boolean[]
+| `false`
+a| When specified, provides the version of the cbq shell.
 To display the query engine version of Couchbase Server (this is not the same as the version of Couchbase Server itself), use one of the following N1QL queries:
 
 [source,n1ql]
@@ -440,8 +440,8 @@ $ ./cbq --version
 `-h`
 
 `--help`
-| None
-| None
+| none
+| none
 a| Provides help for the command line options.
 
 Shell command: <<cbq-help,\HELP>>
@@ -456,8 +456,8 @@ $ ./cbq --help
 `-s`
 
 `-script`
-| [.var]`query`
-| None
+| string
+| none
 a| Provides a single command mode to execute a query from the command line.
 
 You can also use multiple `-s` options on the command line.
@@ -490,8 +490,8 @@ $ ./cbq  -s="\SET v 1" -s="\SET b 2" -s="\PUSH b3" -s="\SET b 5" -s="\SET"  -ne
 `-f`
 
 `--file`
-| [.var]`input-file`
-| None
+| string (path)
+| none
 a| Provides an input file which contains all the commands to be run.
 
 Shell command: <<cbq-source,\SOURCE>>
@@ -505,8 +505,8 @@ $ ./cbq --file="sample.txt"
 `-o`
 
 `--output`
-| [.var]`output-file`
-| None
+| string (path)
+| none
 a| Specifies an output file where the commands and their results are to be written.
 
 If the file doesn't exist, it is created.
@@ -522,12 +522,12 @@ $ ./cbq -o="results.txt" -s="select * from `travel-sample` limit 1"
 
 | [[opt-pretty]]
 `--pretty`
-| none
-| true
+| boolean footnote:boolean[]
+| `true`
 a| Specifies whether the output should be formatted with line breaks and indents.
 
 This option is set to `true` by default.
-To specify that the output should _not_ be formatted with line breaks and indents, you must set this option to `false`.
+To specify that the output should _not_ be formatted with line breaks and indents, you must explicitly set this option to `false`.
 
 .Examples
 [source,console]
@@ -537,9 +537,9 @@ $ ./cbq --pretty=false -s="select * from `travel-sample` limit 1"
 
 | [[opt-exit-on-error]]
 `--exit-on-error`
-| None
-| false
-a| Specifies that the cbq shell must exit when it encounters the first error.
+| boolean footnote:boolean[]
+| `false`
+a| When specified, the cbq shell must exit when it encounters the first error.
 
 .Examples
 [source,console]
@@ -593,11 +593,11 @@ $ ./cbq --key ./client/client/client.key
 `--no-ssl-verify` or
 
 `-skip-verify`
-| None
-| false
+| boolean footnote:boolean[]
+| `false`
 a| Only applicable when using an encrypted protocol scheme -- either _https://_ or _couchbase://_.
 
-Specifies that cbq shell can skip the verification of certificates.
+When specified, the cbq shell can skip the verification of certificates.
 
 .Examples
 [source,console]
@@ -639,7 +639,7 @@ cbq> \CONNECT http://[fd63:6f75:6368:1075:816:3c1d:789b:bc4]:8091
 
 | [[cbq-disconnect]]
 [.cmd]`\DISCONNECT`
-| None
+| none
 a| Disconnects the cbq shell from the query service or cluster endpoint.
 
 .Example
@@ -655,7 +655,7 @@ cbq> \DISCONNECT;
 [.cmd]`\EXIT`
 
 [.cmd]`\QUIT`
-| None
+| none
 a| Exits cbq shell.
 
 .Examples
@@ -856,7 +856,7 @@ select version()
 
 | [[cbq-version]]
 [.cmd]`\VERSION`
-| None
+| none
 a| Displays the version of the client shell.
 
 Command Line Option: <<opt-version,-v>> or <<opt-version,--version>>
@@ -890,7 +890,7 @@ Example :
 
 | [[cbq-copyright]]
 [.cmd]`\COPYRIGHT`
-| None
+| none
 a| Displays the copyright, attributions, and distribution terms.
 
 .Example
@@ -945,7 +945,7 @@ cbq>
 
 | [[cbq-redirect-off]]
 [.cmd]`\REDIRECT OFF`
-| None
+| none
 a| Redirects the output of subsequent commands from a custom file to standard output (os.stdout).
 
 .Example

--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -253,6 +253,23 @@ You must explicitly connect to a query service using the [.cmd]`\CONNECT` shell 
 ----
 $ ./cbq --no-engine
 ----
+| `-ncfg`
+
+`--networkconfig`
+| string (`auto`, `default`, `external`)
+| `auto`
+a| [[opt-ncfg]]
+Specifies whether to connect to a node's principle or alternate address.
+
+* `auto` -- Select the internal address or alternate address automatically, depending on input.
+* `default` -- Use the principle address.
+* `external` -- Use the alternate addresses.
+
+.Examples
+[source,console]
+----
+$ ./cbq -ncfg default -e http://localhost:8091
+----
 | `-q`
 
 `--quiet`
@@ -273,13 +290,28 @@ $ ./cbq -q -e http://localhost:8091
 cbq>
 ----
 
+| `-a`
+
+`--analytics`
+| None
+| None
+a| [[opt-analytics]]
+Only applicable when connecting to the Analytics Service.
+When you connect to a cluster, this option specifies that cbq should automatically discover and connect to an Analytics server.
+This option also switches on <<opt-batch,batch mode>>.
+
+[source,console]
+----
+$ ./cbq --analytics
+----
+
 | `-b`
 
 `--batch`
 | None
 | None
 a| [[opt-batch]]
-This option is available only with Analytics service.
+This option is available only with the Analytics Service.
 When invoked with the batch option, cbq sends the queries to server only when you hit EOF or \ to indicate the end of the batch input.
 
 [source,console]
@@ -479,6 +511,22 @@ Shell command: <<cbq-redirect,\REDIRECT>>
 ----
 $ ./cbq -o="results.txt" -s="select * from `travel-sample` limit 1"
 ----
+
+| `--pretty`
+| none
+| true
+a| [[opt-pretty]]
+Specifies whether the output should be formatted with line breaks and indents.
+
+This option is set to `true` by default.
+To specify that the output should _not_ be formatted with line breaks and indents, you must set this option to `false`.
+
+.Examples
+[source,console]
+----
+$ ./cbq --pretty=false -s="select * from `travel-sample` limit 1"
+----
+
 | `--exit-on-error`
 | None
 | false
@@ -490,6 +538,49 @@ Specifies that the cbq shell must exit when it encounters the first error.
 ----
 $ ./cbq --exit-on-error -f="sample.txt"
 ----
+
+| `--cacert`
+| string (path)
+| none
+a| [[opt-cacert]]
+Only applicable when using an encrypted protocol scheme -- either _https://_ or _couchbase://_.
+
+Specifies the path to the root CA certificate to verify the identity of the server.
+
+.Examples
+[source,console]
+----
+$ ./cbq --cacert ./root/ca.pem
+----
+
+| `--cert`
+| string (path)
+| none
+a| [[opt-cert]]
+Only applicable when using an encrypted protocol scheme -- either _https://_ or _couchbase://_.
+
+Specifies the path to the chain certificate.
+
+.Examples
+[source,console]
+----
+$ ./cbq --cert ./client/client/chain.pem
+----
+
+| `--key`
+| string (path)
+| none
+a| [[opt-key]]
+Only applicable when using an encrypted protocol scheme -- either _https://_ or _couchbase://_.
+
+Specifies the path to the client key file. 
+
+.Examples
+[source,console]
+----
+$ ./cbq --key ./client/client/client.key
+----
+
 | `--no-ssl-verify` or
 
 `-skip-verify`

--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -204,13 +204,13 @@ cbq> \HELP;
 |===
 | Option | Arguments | Default Value | Description and Examples
 
-| `-e`
+| [[opt-engine]]
+`-e`
 
 `--engine`
 | <[.var]``url``>
 | `+http://localhost:8091+`
-a| [[opt-engine]]
-The connection string consists of a protocol scheme followed by a host, including a port number to connect to the query service (8093) or the Couchbase cluster (8091).
+a| The connection string consists of a protocol scheme followed by a host, including a port number to connect to the query service (8093) or the Couchbase cluster (8091).
 
 The cbq shell supports [.path]_http://_, [.path]_https://_, [.path]_couchbase://_ and [.path]_couchbases://_ protocol schemes.
 When using the [.path]_couchbase://_ or [.path]_couchbases://_ protocol schemes, you need not specify the port when connecting to the Couchbase cluster.
@@ -239,13 +239,13 @@ Path to history file for the shell : /Users/myuser1/.cbq_history
 cbq>
 ----
 
-| `-ne`
+| [[opt-no-engine]]
+`-ne`
 
 `--no-engine`
 | None
 | false
-a| [[opt-no-engine]]
-The cbq shell does not connect to any query service.
+a| The cbq shell does not connect to any query service.
 You must explicitly connect to a query service using the [.cmd]`\CONNECT` shell command.
 
 .Examples
@@ -253,13 +253,14 @@ You must explicitly connect to a query service using the [.cmd]`\CONNECT` shell 
 ----
 $ ./cbq --no-engine
 ----
-| `-ncfg`
+
+| [[opt-ncfg]]
+`-ncfg`
 
 `--networkconfig`
 | string (`auto`, `default`, `external`)
 | `auto`
-a| [[opt-ncfg]]
-Specifies whether to connect to a node's principle or alternate address.
+a| Specifies whether to connect to a node's principle or alternate address.
 
 * `auto` -- Select the internal address or alternate address automatically, depending on input.
 * `default` -- Use the principle address.
@@ -270,13 +271,14 @@ Specifies whether to connect to a node's principle or alternate address.
 ----
 $ ./cbq -ncfg default -e http://localhost:8091
 ----
-| `-q`
+
+| [[opt-quiet]]
+`-q`
 
 `--quiet`
 | None
 | false
-a| [[opt-quiet]]
-Enables or disables the startup connection message for the cbq shell.
+a| Enables or disables the startup connection message for the cbq shell.
 
 .Examples
 [source,console]
@@ -290,13 +292,13 @@ $ ./cbq -q -e http://localhost:8091
 cbq>
 ----
 
-| `-a`
+| [[opt-analytics]]
+`-a`
 
 `--analytics`
 | None
 | None
-a| [[opt-analytics]]
-Only applicable when connecting to the Analytics Service.
+a| Only applicable when connecting to the Analytics Service.
 When you connect to a cluster, this option specifies that cbq should automatically discover and connect to an Analytics server.
 This option also switches on <<opt-batch,batch mode>>.
 
@@ -305,13 +307,13 @@ This option also switches on <<opt-batch,batch mode>>.
 $ ./cbq --analytics
 ----
 
-| `-b`
+| [[opt-batch]]
+`-b`
 
 `--batch`
 | None
 | None
-a| [[opt-batch]]
-This option is available only with the Analytics Service.
+a| This option is available only with the Analytics Service.
 When invoked with the batch option, cbq sends the queries to server only when you hit EOF or \ to indicate the end of the batch input.
 
 [source,console]
@@ -326,26 +328,27 @@ You can also set the batch mode in the interactive session using the following c
 \set batch off
 ----
 
-| `-t`
+| [[opt-timeout]]
+`-t`
 
 `--timeout`
 | [.var]`value`
 | None
-a| [[opt-timeout]]
-Sets the query timeout parameter.
+a| Sets the query timeout parameter.
 
 .Examples
 [source,console]
 ----
 $ ./cbq -e http://localhost:8091 --timeout="1s"
 ----
-| `-u`
+
+| [[opt-user]]
+`-u`
 
 `--user`
 | [.var]`username`
 | None
-a| [[opt-user]]
-Specifies a single user name to log in to Couchbase.
+a| Specifies a single user name to log in to Couchbase.
 When used by itself, without the `-p` option to specify the password, you will be prompted for the password.
 
 This option requires administration credentials and you cannot switch the credentials during a session.
@@ -358,13 +361,14 @@ Couchbase recommends using the `-u` and `-p` option if your password contains sp
 $ ./cbq -e http://localhost:8091 -u=Administrator
                     Enter Password:
 ----
-| `-p`
+
+| [[opt-password]]
+`-p`
 
 `--password`
 | [.var]`password`
 | None
-a| [[opt-password]]
-Specifies the password for the given user name.
+a| Specifies the password for the given user name.
 You cannot use this option by itself.
 It must be used with the -u option to specify the user name.
 
@@ -377,13 +381,14 @@ Couchbase recommends using the `-u` and `-p` option if your password contains sp
 ----
 $ ./cbq -e http://localhost:8091 -u=Administrator -p=password
 ----
-| `-c`
+
+| [[opt-credentials]]
+`-c`
 
 `--credentials`
 | [.var]`list of credentials`
 | None
-a| [[opt-credentials]]
-Specify the login credentials in the form of [.var]`username`:[.var]``password``.
+a| Specify the login credentials in the form of [.var]`username`:[.var]``password``.
 You can specify credentials for different buckets by separating them with a comma.
 
 Shell command: <<cbq-set,\SET>> `-creds`
@@ -395,13 +400,14 @@ REST API: `-creds` parameter
 ----
 $ ./cbq -e http://localhost:8091 -c=beer-sample:password,Administrator:password
 ----
-| `-v`
+
+| [[opt-version]]
+`-v`
 
 `--version`
 | None
 | false
-a| [[opt-version]]
-Provides the version of the cbq shell.
+a| Provides the version of the cbq shell.
 To display the query engine version of Couchbase Server (this is not the same as the version of Couchbase Server itself), use one of the following N1QL queries:
 
 [source,n1ql]
@@ -430,13 +436,13 @@ $ ./cbq --version
                 or select min_version(); to display server version.
 ----
 
-| `-h`
+| [[opt-help]]
+`-h`
 
 `--help`
 | None
 | None
-a| [[opt-help]]
-Provides help for the command line options.
+a| Provides help for the command line options.
 
 Shell command: <<cbq-help,\HELP>>
 
@@ -445,13 +451,14 @@ Shell command: <<cbq-help,\HELP>>
 ----
 $ ./cbq --help
 ----
-| `-s`
+
+| [[opt-script]]
+`-s`
 
 `-script`
 | [.var]`query`
 | None
-a| [[opt-script]]
-Provides a single command mode to execute a query from the command line.
+a| Provides a single command mode to execute a query from the command line.
 
 You can also use multiple `-s` options on the command line.
 If one of the commands is incorrect, an error is displayed for that command and cbq continues to execute the remaining commands.
@@ -479,13 +486,13 @@ $ ./cbq  -s="\SET v 1" -s="\SET b 2" -s="\PUSH b3" -s="\SET b 5" -s="\SET"  -ne
  Value : ["off"]
 ----
 
-| `-f`
+| [[opt-file]]
+`-f`
 
 `--file`
 | [.var]`input-file`
 | None
-a| [[opt-file]]
-Provides an input file which contains all the commands to be run.
+a| Provides an input file which contains all the commands to be run.
 
 Shell command: <<cbq-source,\SOURCE>>
 
@@ -493,13 +500,14 @@ Shell command: <<cbq-source,\SOURCE>>
 ----
 $ ./cbq --file="sample.txt"
 ----
-| `-o`
+
+| [[opt-output]]
+`-o`
 
 `--output`
 | [.var]`output-file`
 | None
-a| [[opt-output]]
-Specifies an output file where the commands and their results are to be written.
+a| Specifies an output file where the commands and their results are to be written.
 
 If the file doesn't exist, it is created.
 If the file already exists, it is overwritten.
@@ -512,11 +520,11 @@ Shell command: <<cbq-redirect,\REDIRECT>>
 $ ./cbq -o="results.txt" -s="select * from `travel-sample` limit 1"
 ----
 
-| `--pretty`
+| [[opt-pretty]]
+`--pretty`
 | none
 | true
-a| [[opt-pretty]]
-Specifies whether the output should be formatted with line breaks and indents.
+a| Specifies whether the output should be formatted with line breaks and indents.
 
 This option is set to `true` by default.
 To specify that the output should _not_ be formatted with line breaks and indents, you must set this option to `false`.
@@ -527,11 +535,11 @@ To specify that the output should _not_ be formatted with line breaks and indent
 $ ./cbq --pretty=false -s="select * from `travel-sample` limit 1"
 ----
 
-| `--exit-on-error`
+| [[opt-exit-on-error]]
+`--exit-on-error`
 | None
 | false
-a| [[opt-exit-on-error]]
-Specifies that the cbq shell must exit when it encounters the first error.
+a| Specifies that the cbq shell must exit when it encounters the first error.
 
 .Examples
 [source,console]
@@ -539,11 +547,11 @@ Specifies that the cbq shell must exit when it encounters the first error.
 $ ./cbq --exit-on-error -f="sample.txt"
 ----
 
-| `--cacert`
+| [[opt-cacert]]
+`--cacert`
 | string (path)
 | none
-a| [[opt-cacert]]
-Only applicable when using an encrypted protocol scheme -- either _https://_ or _couchbase://_.
+a| Only applicable when using an encrypted protocol scheme -- either _https://_ or _couchbase://_.
 
 Specifies the path to the root CA certificate to verify the identity of the server.
 
@@ -553,11 +561,11 @@ Specifies the path to the root CA certificate to verify the identity of the serv
 $ ./cbq --cacert ./root/ca.pem
 ----
 
-| `--cert`
+| [[opt-cert]]
+`--cert`
 | string (path)
 | none
-a| [[opt-cert]]
-Only applicable when using an encrypted protocol scheme -- either _https://_ or _couchbase://_.
+a| Only applicable when using an encrypted protocol scheme -- either _https://_ or _couchbase://_.
 
 Specifies the path to the chain certificate.
 
@@ -567,11 +575,11 @@ Specifies the path to the chain certificate.
 $ ./cbq --cert ./client/client/chain.pem
 ----
 
-| `--key`
+| [[opt-key]]
+`--key`
 | string (path)
 | none
-a| [[opt-key]]
-Only applicable when using an encrypted protocol scheme -- either _https://_ or _couchbase://_.
+a| Only applicable when using an encrypted protocol scheme -- either _https://_ or _couchbase://_.
 
 Specifies the path to the client key file. 
 
@@ -581,13 +589,13 @@ Specifies the path to the client key file.
 $ ./cbq --key ./client/client/client.key
 ----
 
-| `--no-ssl-verify` or
+| [[opt-skip-verify]]
+`--no-ssl-verify` or
 
 `-skip-verify`
 | None
 | false
-a| [[opt-skip-verify]]
-Only applicable when using an encrypted protocol scheme -- either _https://_ or _couchbase://_.
+a| Only applicable when using an encrypted protocol scheme -- either _https://_ or _couchbase://_.
 
 Specifies that cbq shell can skip the verification of certificates.
 
@@ -604,10 +612,10 @@ $ ./cbq -skip-verify https://127.0.0.1:18091
 |===
 | Shell Command | Arguments | Description and Examples
 
-| [.cmd]`\CONNECT`
+| [[cbq-connect]]
+[.cmd]`\CONNECT`
 | [.var]`url`
-a| [[cbq-connect]]
-Connects cbq shell to the specified query engine or Couchbase cluster.
+a| Connects cbq shell to the specified query engine or Couchbase cluster.
 
 The connection string consists of a protocol scheme followed by a host, including a port number to connect to the query service (8093) or the Couchbase cluster (8091).
 
@@ -629,10 +637,10 @@ cbq> \CONNECT http://localhost:8093;
 cbq> \CONNECT http://[fd63:6f75:6368:1075:816:3c1d:789b:bc4]:8091
 ----
 
-| [.cmd]`\DISCONNECT`
+| [[cbq-disconnect]]
+[.cmd]`\DISCONNECT`
 | None
-a| [[cbq-disconnect]]
-Disconnects the cbq shell from the query service or cluster endpoint.
+a| Disconnects the cbq shell from the query service or cluster endpoint.
 
 .Example
 [source,console]
@@ -643,12 +651,12 @@ cbq> \DISCONNECT;
  Use \CONNECT command to connect.
 ----
 
-| [.cmd]`\EXIT`
+| [[cbq-quit]]
+[.cmd]`\EXIT`
 
 [.cmd]`\QUIT`
 | None
-a| [[cbq-quit]]
-Exits cbq shell.
+a| Exits cbq shell.
 
 .Examples
 [source,console]
@@ -661,12 +669,12 @@ cbq> \EXIT;
 cbq> \QUIT;
 ----
 
-| [.cmd]`\SET`
+| [[cbq-set]]
+[.cmd]`\SET`
 | [.var]`parameter` [.var]`value`
 
 [.var]`parameter`=[.var]`prefix`:[.var]``variable name``
-a| [[cbq-set]]
-Sets the top most value of the stack for the given variable with the specified value.
+a| Sets the top most value of the stack for the given variable with the specified value.
 
 Variables can be of the following types:
 
@@ -688,10 +696,10 @@ cbq> \SET -args [5, "12-14-1987"];
 cbq> \SET -args [6,7];
 ----
 
-| [.cmd]`\PUSH`
+| [[cbq-push]]
+[.cmd]`\PUSH`
 | [.var]`parameter value`
-a| [[cbq-push]]
-Pushes the specified value on to the given parameter stack.
+a| Pushes the specified value on to the given parameter stack.
 
 When the [.cmd]`\PUSH` command is used without any arguments, it copies the top element of every variable's stack, and then pushes that copy to the top of the respective variable's stack.
 
@@ -719,10 +727,10 @@ cbq> \SET;
 cbq>
 ----
 
-| [.cmd]`\UNSET`
+| [[cbq-unset]]
+[.cmd]`\UNSET`
 | [.var]`parameter`
-a| [[cbq-unset]]
-Deletes or resets the entire stack for the specified parameter.
+a| Deletes or resets the entire stack for the specified parameter.
 
 .Examples
 [source,console]
@@ -738,10 +746,10 @@ cbq> \SET;
 cbq>
 ----
 
-| [.cmd]`\POP`
+| [[cbq-pop]]
+[.cmd]`\POP`
 | [.var]`parameter`
-a| [[cbq-pop]]
-Pops the top most value from the specified parameter's stack.
+a| Pops the top most value from the specified parameter's stack.
 
 When the [.cmd]`\POP` command is used without any arguments, it pops the top most value of every variable's stack.
 
@@ -758,10 +766,10 @@ cbq> \SET;
  Value : [[6,7] [8]]
 ----
 
-| [.cmd]`\ALIAS`
+| [[cbq-alias]]
+[.cmd]`\ALIAS`
 | [.var]`shell-command` or [.var]`n1ql-statement`
-a| [[cbq-alias]]
-Creates a command alias for the specified cbq shell command or N1QL statement.
+a| Creates a command alias for the specified cbq shell command or N1QL statement.
 You can then execute the alias using `\\alias-name;`.
 
 When the [.cmd]`\ALIAS` command is used without any arguments, it lists all the available aliases.
@@ -803,10 +811,10 @@ cbq> \\serverversion;
 }
 ----
 
-| [.cmd]`\UNALIAS`
+| [[cbq-unalias]]
+[.cmd]`\UNALIAS`
 | [.var]`alias-name`
-a| [[cbq-unalias]]
-Deletes the specified alias.
+a| Deletes the specified alias.
 
 .Examples
 [source,console]
@@ -821,12 +829,12 @@ serverversion  select version()
 cbq>
 ----
 
-| [.cmd]`\ECHO`
+| [[cbq-echo]]
+[.cmd]`\ECHO`
 | [.var]`args`
 
 where [.var]`args` can be parameters, aliases, or any input.
-a| [[cbq-echo]]
-If the input is a parameter, this command echoes (displays) the value of the parameter.
+a| If the input is a parameter, this command echoes (displays) the value of the parameter.
 The parameter must be prefixed according to its type.
 See <<table_ltk_c5s_5v>> for details.
 
@@ -846,10 +854,10 @@ cbq> \ECHO \\serverversion;
 select version()
 ----
 
-| [.cmd]`\VERSION`
+| [[cbq-version]]
+[.cmd]`\VERSION`
 | None
-a| [[cbq-version]]
-Displays the version of the client shell.
+a| Displays the version of the client shell.
 
 Command Line Option: <<opt-version,-v>> or <<opt-version,--version>>
 
@@ -860,10 +868,10 @@ cbq> \VERSION;
  SHELL VERSION  : 1.5
 ----
 
-| [.cmd]`\HELP`
+| [[cbq-help]]
+[.cmd]`\HELP`
 | [.var]`command`
-a| [[cbq-help]]
-Displays the help information for the specified command.
+a| Displays the help information for the specified command.
 When used without any arguments, it lists all the commands supported by the cbq shell.
 
 Command Line Option: <<opt-help,-h>> or <<opt-help,--help>>
@@ -880,10 +888,10 @@ Example :
 \ECHO \\tempalias;
 ----
 
-| [.cmd]`\COPYRIGHT`
+| [[cbq-copyright]]
+[.cmd]`\COPYRIGHT`
 | None
-a| [[cbq-copyright]]
-Displays the copyright, attributions, and distribution terms.
+a| Displays the copyright, attributions, and distribution terms.
 
 .Example
 [source,console]
@@ -891,10 +899,10 @@ Displays the copyright, attributions, and distribution terms.
 cbq> \COPYRIGHT;
 ----
 
-| [.cmd]`\SOURCE`
+| [[cbq-source]]
+[.cmd]`\SOURCE`
 | [.var]`input-file`
-a| [[cbq-source]]
-Reads and executes the commands from a file.
+a| Reads and executes the commands from a file.
 Multiple commands in the input file must be separated by `;` [.var]`<newline>`.
 
 Command Line Option: <<opt-file,-f>> or <<opt-file,--file>>
@@ -914,10 +922,10 @@ EOF
 cbq> \SOURCE sample.txt;
 ----
 
-| [.cmd]`\REDIRECT`
+| [[cbq-redirect]]
+[.cmd]`\REDIRECT`
 | [.var]`filename`
-a| [[cbq-redirect]]
-Redirects the output of all the commands to the specified file until the cbq shell receives the [.cmd]`\REDIRECT OFF` command.
+a| Redirects the output of all the commands to the specified file until the cbq shell receives the [.cmd]`\REDIRECT OFF` command.
 By default, the file is created in the directory that you were in when you started the cbq shell.
 You can specify a different location using relative paths.
 
@@ -935,10 +943,10 @@ cbq> select * from `travel-sample` limit 1;
 cbq>
 ----
 
-| [.cmd]`\REDIRECT OFF`
+| [[cbq-redirect-off]]
+[.cmd]`\REDIRECT OFF`
 | None
-a| [[cbq-redirect-off]]
-Redirects the output of subsequent commands from a custom file to standard output (os.stdout).
+a| Redirects the output of subsequent commands from a custom file to standard output (os.stdout).
 
 .Example
 [source,console]

--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -587,10 +587,9 @@ $ ./cbq --key ./client/client/client.key
 | None
 | false
 a| [[opt-skip-verify]]
-Specifies that cbq shell can skip the verification of certificates.
+Only applicable when using an encrypted protocol scheme -- either _https://_ or _couchbase://_.
 
-The default ports are 18091 and 18093.
-You need not specify the port when connecting to the cluster.
+Specifies that cbq shell can skip the verification of certificates.
 
 .Examples
 [source,console]
@@ -1231,6 +1230,16 @@ User Defined Session Parameters ::
 Predefined Session Parameters ::
 Parameter name : histfile Value  [".cbq_history"]
 ----
+
+[#cbq-encrypted]
+== Using an Encrypted Connection
+
+You can connect to the cluster or node with an encrypted protocol scheme -- that is, either _https://_ or _couchbase://_.
+To do this, you can provide the root CA certificate, the chain certificate, and the client key file using the <<opt-cacert,--cacert>>, <<opt-cert,--cert>>, and <<opt-key,--key>> options.
+You can use the <<opt-skip-verify,--no-ssl-verify>> option to skip the verification of certificates.
+
+When connecting to a cluster or node with an encrypted protocol scheme, the default ports are 18091 and 18093.
+You need not specify the port when connecting to the cluster.
 
 [#cbq-parameter-manipulation]
 == Parameter Manipulation

--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -223,16 +223,24 @@ Shell command: <<cbq-connect,\CONNECT>>
 [source,console]
 ----
 $ ./cbq -e couchbase://localhost
+----
 
+[source,console]
+----
 $ ./cbq --engine http://localhost:8091
+----
 
+[source,console]
+----
 $ ./cbq -e http://localhost:8091
+----
 
+[source,console]
+----
 $ ./cbq -e http://[fd63:6f75:6368:1075:816:3c1d:789b:bc4]:8091
 ----
 
 .Result
-[source,console]
 ----
 Connected to : http://localhost:8091/. Type Ctrl-D or \QUIT to exit.
 Path to history file for the shell : /Users/myuser1/.cbq_history
@@ -248,7 +256,7 @@ cbq>
 a| When specified, the cbq shell does not connect to any query service.
 You must explicitly connect to a query service using the <<cbq-connect,\CONNECT>> shell command.
 
-.Examples
+.Example
 [source,console]
 ----
 $ ./cbq --no-engine
@@ -266,7 +274,7 @@ a| Specifies whether to connect to a node's principal or alternate address.
 * `default` -- Use the principal address.
 * `external` -- Use the alternate addresses.
 
-.Examples
+.Example
 [source,console]
 ----
 $ ./cbq -ncfg default -e http://localhost:8091
@@ -280,7 +288,7 @@ $ ./cbq -ncfg default -e http://localhost:8091
 | `false`
 a| When specified, disables the startup connection message for the cbq shell.
 
-.Examples
+.Example
 [source,console]
 ----
 $ ./cbq -q -e http://localhost:8091
@@ -336,7 +344,7 @@ You can also set the batch mode in the interactive session using the <<cbq-set,\
 | `0ms`
 a| Sets the query timeout parameter.
 
-.Examples
+.Example
 [source,console]
 ----
 $ ./cbq -e http://localhost:8091 --timeout="1s"
@@ -355,11 +363,15 @@ This option requires administration credentials and you cannot switch the creden
 
 Couchbase recommends using the `-u` and `-p` option if your password contains special characters such as #, $, %, &, (,), or '.
 
-.Examples
+.Example
 [source,console]
 ----
 $ ./cbq -e http://localhost:8091 -u=Administrator
-                    Enter Password:
+----
+
+.Result
+----
+Enter Password:
 ----
 
 | [[opt-password]]
@@ -376,7 +388,7 @@ This option requires administration credentials and you cannot switch the creden
 
 Couchbase recommends using the `-u` and `-p` option if your password contains special characters such as #, $, %, &, (,), or '.
 
-.Examples
+.Example
 [source,console]
 ----
 $ ./cbq -e http://localhost:8091 -u=Administrator -p=password
@@ -395,7 +407,7 @@ Shell command: <<cbq-set,\SET>> `-creds`
 
 REST API: `-creds` parameter
 
-.Examples
+.Example
 [source,console]
 ----
 $ ./cbq -e http://localhost:8091 -c=beer-sample:password,Administrator:password
@@ -422,7 +434,7 @@ select min_version();
 
 Shell command: <<cbq-version,\VERSION>>
 
-.Examples
+.Example
 [source,console]
 ----
 $ ./cbq --version
@@ -446,7 +458,7 @@ a| Provides help for the command line options.
 
 Shell command: <<cbq-help,\HELP>>
 
-.Examples
+.Example
 [source,console]
 ----
 $ ./cbq --help
@@ -467,8 +479,15 @@ If one of the commands is incorrect, an error is displayed for that command and 
 [source,console]
 ----
 $ ./cbq -s="select * from \`travel-sample\` limit 1"
+----
 
+[source,console]
+----
 $ ./cbq  -s="\SET v 1" -s="\SET b 2" -s="\PUSH b3" -s="\SET b 5" -s="\SET"  -ne
+----
+
+.Result
+----
  Path to history file for the shell : /Users/isha/.cbq_history
  \PUSH b3
  ERROR 139 : Too few input arguments to command.
@@ -496,6 +515,7 @@ a| Provides an input file which contains all the commands to be run.
 
 Shell command: <<cbq-source,\SOURCE>>
 
+.Example
 [source,console]
 ----
 $ ./cbq --file="sample.txt"
@@ -514,7 +534,7 @@ If the file already exists, it is overwritten.
 
 Shell command: <<cbq-redirect,\REDIRECT>>
 
-.Examples
+.Example
 [source,console]
 ----
 $ ./cbq -o="results.txt" -s="select * from `travel-sample` limit 1"
@@ -529,7 +549,7 @@ a| Specifies whether the output should be formatted with line breaks and indents
 This option is set to `true` by default.
 To specify that the output should _not_ be formatted with line breaks and indents, you must explicitly set this option to `false`.
 
-.Examples
+.Example
 [source,console]
 ----
 $ ./cbq --pretty=false -s="select * from `travel-sample` limit 1"
@@ -541,7 +561,7 @@ $ ./cbq --pretty=false -s="select * from `travel-sample` limit 1"
 | `false`
 a| When specified, the cbq shell must exit when it encounters the first error.
 
-.Examples
+.Example
 [source,console]
 ----
 $ ./cbq --exit-on-error -f="sample.txt"
@@ -555,7 +575,7 @@ a| Only applicable when using an encrypted protocol scheme -- either _https://_ 
 
 Specifies the path to the root CA certificate to verify the identity of the server.
 
-.Examples
+.Example
 [source,console]
 ----
 $ ./cbq --cacert ./root/ca.pem
@@ -569,7 +589,7 @@ a| Only applicable when using an encrypted protocol scheme -- either _https://_ 
 
 Specifies the path to the chain certificate.
 
-.Examples
+.Example
 [source,console]
 ----
 $ ./cbq --cert ./client/client/chain.pem
@@ -603,6 +623,10 @@ When specified, the cbq shell can skip the verification of certificates.
 [source,console]
 ----
 $ ./cbq --no-ssl-verify -f="sample.txt"
+----
+
+[source,console]
+----
 $ ./cbq -skip-verify https://127.0.0.1:18091
 ----
 |===
@@ -646,7 +670,10 @@ a| Disconnects the cbq shell from the query service or cluster endpoint.
 [source,console]
 ----
 cbq> \DISCONNECT;
+----
 
+.Result
+----
  Couchbase query shell not connected to any endpoint.
  Use \CONNECT command to connect.
 ----
@@ -716,15 +743,18 @@ cbq> \PUSH -args  [8];
 cbq> \PUSH;
 ----
 
-.Resulting variable stack
+.Check variable stack
 [source,console]
 ----
 cbq> \SET;
+----
+
+.Result
+----
  Query Parameters :
  Parameter name : args
  Value : [[6,7] [8] [8]]
 ...
-cbq>
 ----
 
 | [[cbq-unset]]
@@ -741,9 +771,12 @@ cbq> \UNSET -args;
 [source,console]
 ----
 cbq> \SET;
+----
+
+.Result
+----
  Query Parameters :
  ...
-cbq>
 ----
 
 | [[cbq-pop]]
@@ -761,6 +794,10 @@ When the [.cmd]`\POP` command is used without any arguments, it pops the top mos
 [source,console]
 ----
 cbq> \SET;
+----
+
+.Result
+----
  Query Parameters :
  Parameter name : args
  Value : [[6,7] [8]]
@@ -783,14 +820,23 @@ cbq> \ALIAS travel-limit1 select * from `travel-sample` limit 1;
 [source,console]
 ----
 cbq> \ALIAS;
-serverversion  select version()
-travel-limit1  select * from `travel-sample` limit 1
-cbq>
 ----
 
+.Result
+----
+serverversion  select version()
+travel-limit1  select * from `travel-sample` limit 1
+----
+
+.Execute alias
 [source,console]
 ----
 cbq> \\serverversion;
+----
+
+.Result
+[source,json]
+----
 {
     "requestID": "21b0efdb-b1ec-44bc-adab-071831792c03",
     "signature": {
@@ -825,8 +871,11 @@ cbq> \UNALIAS travel-limit1;
 [source,console]
 ----
 cbq> \ALIAS;
+----
+
+.Result
+----
 serverversion  select version()
-cbq>
 ----
 
 | [[cbq-echo]]
@@ -851,6 +900,10 @@ cbq> \ECHO -$r;
 [source,console]
 ----
 cbq> \ECHO \\serverversion;
+----
+
+.Result
+----
 select version()
 ----
 
@@ -865,6 +918,10 @@ Command Line Option: <<opt-version,-v>> or <<opt-version,--version>>
 [source,console]
 ----
 cbq> \VERSION;
+----
+
+.Result
+----
  SHELL VERSION  : 1.5
 ----
 
@@ -880,6 +937,10 @@ Command Line Option: <<opt-help,-h>> or <<opt-help,--help>>
 [source,console]
 ----
 cbq> \HELP ECHO;
+----
+
+.Result
+----
 \ECHO args ...
 Echo the input value. args can be a name (a prefixed-parameter), an alias (command alias) or
 a value (any input statement).
@@ -939,8 +1000,6 @@ Command Line Option:  <<opt-output,-o>> or <<opt-output,--output>>
 [source,console]
 ----
 cbq> \REDIRECT temp_out.txt;
-cbq> select * from `travel-sample` limit 1;
-cbq>
 ----
 
 | [[cbq-redirect-off]]


### PR DESCRIPTION
Backporting #1573 to release/6.5

Docs issue: [DOC-7072](https://issues.couchbase.com/browse/DOC-7072)