### PR TITLE
Added hyperlink to XDCR page for easy redirection.

### DIFF
--- a/modules/learn/pages/clusters-and-availability/automatic-failover.adoc
+++ b/modules/learn/pages/clusters-and-availability/automatic-failover.adoc
@@ -48,7 +48,7 @@ Therefore, even a single event may not be responded to; and an administrator-spe
 
 Note that auto-failover should be configured only when the cluster contains sufficient resources to handle all possible consequences: workload-intensity on remaining nodes may increase significantly.
 
-Auto-failover is for intra-cluster use only: it does not work with Cross Data Center Replication (XDCR).
+Auto-failover is for intra-cluster use only: it does not work with xref:learn:clusters-and-availability/xdcr-overview.adoc[Cross Data Center Replication (XDCR)].
 
 Auto-failover may take significantly longer if the unresponsive node is that on which the _orchestrator_ is running; since _time-outs_ must occur, before available nodes can elect a new orchestrator-node and thereby continue.
 


### PR DESCRIPTION
Added a missing reference to Cross Data Center Replication (XDCR) page which is helpful in redirecting.