### PR TITLE
Refined words

### DIFF
--- a/modules/manage/pages/manage-buckets/create-bucket.adoc
+++ b/modules/manage/pages/manage-buckets/create-bucket.adoc
@@ -7,7 +7,7 @@ _Full_ and _Cluster_ Administrators can use Couchbase Web Console, the CLI, or t
 [#create-bucket-using-couchbase-web-console]
 == Create a Bucket Using Couchbase Web Console
 
-Access Couchbase Web Console, and left-click on the [.ui]*Buckets* tab, in the vertical navigation-bar at the left-hand side:
+Access Couchbase Web Console, and click on the [.ui]*Buckets* tab, in the vertical navigation-bar at the left-hand side:
 
 [#access_bucket_tab]
 image::manage-buckets/accessBucketTab.png[,100,align=left]
@@ -18,7 +18,7 @@ If you are accessing this screen immediately after cluster-initialization, no bu
 [#buckets_view_initial]
 image::manage-buckets/bucketsViewInitial.png[,880,align=left]
 
-To create a new bucket, left-click on the btn:[Add Bucket] button, at the upper-right:
+To create a new bucket, click on the btn:[Add Bucket] button, at the upper-right:
 
 [#add-bucket-button]
 image::manage-buckets/addBucketButton.png[,110,align=left]
@@ -49,7 +49,7 @@ xref:learn:buckets-memory-and-storage/buckets.adoc[Buckets].
 
 Selection of each bucket-type provides a different set of advanced settings, which can be used to configure the bucket.
 The bucket-type selected by default is [.ui]*Couchbase*.
-Therefore, to see the advanced settings associated with this bucket-type, left-click on the right-pointing arrowhead labelled [.ui]*Advanced bucket settings*.
+Therefore, to see the advanced settings associated with this bucket-type, click on the right-pointing arrowhead labelled [.ui]*Advanced bucket settings*.
 This causes the [.ui]*Add Data Bucket* dialog to expand vertically, as shown below.
 
 == Couchbase Bucket-Settings


### PR DESCRIPTION
At 3 places 'left-click' was written which is much more descriptive than required. So changed it to 'click' as it is a web based documentation (not a window tool based) and click is enough I guess and looks more refined.