### PR TITLE
Added Hyperlink to vBuckets

### DIFF
--- a/modules/learn/pages/clusters-and-availability/rebalance.adoc
+++ b/modules/learn/pages/clusters-and-availability/rebalance.adoc
@@ -25,7 +25,7 @@ When all stages have been completed, the rebalance process itself is complete.
 [#rebalancing-the-data-service]
 == Rebalance and the Data Service
 
-On rebalance, vBuckets are redistributed evenly among currently available Data Service nodes.
+On rebalance, xref:learn:buckets-memory-and-storage/vbuckets.adoc[vBuckets] are redistributed evenly among currently available Data Service nodes.
 After rebalance, operations are directed to active vBuckets in their updated locations.
 Rebalance does not interrupt applications' data-access.
 vBucket data-transfer occurs sequentially: therefore, if rebalance stops for any reason, it can be restarted from the point at which it was stopped.


### PR DESCRIPTION
Hi - Added hyperlink to vBuckets for quick redirection.

On rebalance, xref:learn:buckets-memory-and-storage/vbuckets.adoc[vBuckets] are redistributed evenly among currently available Data Service nodes.
After rebalance, operations are directed to active vBuckets in their updated locations.

Thanks,
Ashish