### PR TITLE
Two new clarifications

### DIFF
--- a/modules/eventing/pages/eventing-faq.adoc
+++ b/modules/eventing/pages/eventing-faq.adoc
@@ -141,8 +141,8 @@ Couchbase’s Kafka connector is an SDK component that needs an application cont
 * Do I have to update and/or deploy my Functions on each Eventing node?
 +
 No. The Eventing service will properly distribute the Function code or lifecycle requests across all Eventing nodes.
-It is a best practice to only have one (1) admin UI to a single node in your cluster when developing or modifying your Eventing Functions.
-Note if you edit handlers (code or settings) in two browser windows or tabs (to same node or different nodes) you might inadvertently deploy a slightly older or “stale” definition if you switch back and forth between different UI sessions.
+It is a best practice to only have one (1) Admin UI to a single node in your cluster when developing or modifying your Eventing Functions.
+Note that if you edit handlers (code or settings) in two browser windows or tabs (to same node or different nodes), you might inadvertently deploy a slightly older or “stale” definition if you switch back and forth between different UI sessions.
 
 == Function Handler Code
 

--- a/modules/eventing/pages/eventing-faq.adoc
+++ b/modules/eventing/pages/eventing-faq.adoc
@@ -138,6 +138,11 @@ To invoke a REST Endpoint from inside the Function, refer to the https://docs.co
 The Functions offering is about server-side processing or compute of business logic; it does not require any additional infrastructure layer or middleware to be deployed or managed.
 Couchbase’s Kafka connector is an SDK component that needs an application container or middleware to run.
 
+* Do I have to update and/or deploy my Functions on each Eventing node?
++
+No. The Eventing service will properly distribute the Function code or lifecycle requests across all Eventing nodes.
+It is a best practice to only have one (1) admin UI to a single node in your cluster when developing or modifying your Eventing Functions.
+Note if you edit handlers (code or settings) in two browser windows or tabs (to same node or different nodes) you might inadvertently deploy a slightly older or “stale” definition if you switch back and forth between different UI sessions.
 
 == Function Handler Code
 

--- a/modules/eventing/pages/eventing-handler-docControlledSelfExpiry.adoc
+++ b/modules/eventing/pages/eventing-handler-docControlledSelfExpiry.adoc
@@ -11,7 +11,7 @@
 * In Couchbase, when using a simple integer expiry value (as opposed to a proper date or time object), the expiration can be specified in two ways:
 ** As an offset from the current time. If the absolute value of the expiry is less than 30 days (60 * 60 * 24 * 30 seconds), it is considered an offset.
 ** As an absolute Unix time stamp. If the value is greater than 30 days (60 * 60 * 24 * 30 seconds), it is considered an absolute time stamp.
-** As described in xref:learn:buckets-memory-and-storage:kv-operations.adoc [Expiration], if a "Bucket Max Time-To-Live" is set, (specified in seconds) it is an enforced hard upper limit.  As such any subsequent document mutation (by N1QL, Eventing, or any Couchbase SDK) will result in the document having its expiration adjusted and set to the bucket’s maximum TTL if the operation has: 
+** As described in xref:learn:buckets-memory-and-storage/expiration.adoc[Expiration], if a "Bucket Max Time-To-Live" is set, (specified in seconds) it is an enforced hard upper limit.  As such any subsequent document mutation (by N1QL, Eventing, or any Couchbase SDK) will result in the document having its expiration adjusted and set to the bucket’s maximum TTL if the operation has: 
 *** No TTL.
 *** A TTL of zero.
 *** A TTL greater than the bucket TTL.

--- a/modules/eventing/pages/eventing-handler-docControlledSelfExpiry.adoc
+++ b/modules/eventing/pages/eventing-handler-docControlledSelfExpiry.adoc
@@ -11,6 +11,10 @@
 * In Couchbase, when using a simple integer expiry value (as opposed to a proper date or time object), the expiration can be specified in two ways:
 ** As an offset from the current time. If the absolute value of the expiry is less than 30 days (60 * 60 * 24 * 30 seconds), it is considered an offset.
 ** As an absolute Unix time stamp. If the value is greater than 30 days (60 * 60 * 24 * 30 seconds), it is considered an absolute time stamp.
+** As described in xref:learn:buckets-memory-and-storage:kv-operations.adoc [Expiration], if a "Bucket Max Time-To-Live" is set, (specified in seconds) it is an enforced hard upper limit.  As such any subsequent document mutation (by N1QL, Eventing, or any Couchbase SDK) will result in the document having its expiration adjusted and set to the bucket’s maximum TTL if the operation has: 
+*** No TTL.
+*** A TTL of zero.
+*** A TTL greater than the bucket TTL.
 * Will operate on any document with type == "trial_customers".
 * Will ignore any doc with a non-zero TTL (prevents infinite recursion)
 * Uses the _N1QL(...)_ function to update the source bucket instead of an inline N1QL statement because inline N1QL is prohibited from updating the source bucket of an Eventing handler to prevent infinite recursion scenarios.

--- a/modules/eventing/pages/eventing-handler-docControlledSelfExpiry.adoc
+++ b/modules/eventing/pages/eventing-handler-docControlledSelfExpiry.adoc
@@ -11,7 +11,7 @@
 * In Couchbase, when using a simple integer expiry value (as opposed to a proper date or time object), the expiration can be specified in two ways:
 ** As an offset from the current time. If the absolute value of the expiry is less than 30 days (60 * 60 * 24 * 30 seconds), it is considered an offset.
 ** As an absolute Unix time stamp. If the value is greater than 30 days (60 * 60 * 24 * 30 seconds), it is considered an absolute time stamp.
-** As described in xref:learn:buckets-memory-and-storage/expiration.adoc[Expiration], if a "Bucket Max Time-To-Live" is set, (specified in seconds) it is an enforced hard upper limit.  As such any subsequent document mutation (by N1QL, Eventing, or any Couchbase SDK) will result in the document having its expiration adjusted and set to the bucket’s maximum TTL if the operation has: 
+** As described in xref:learn:buckets-memory-and-storage/expiration.adoc[Expiration], if a "Bucket Max Time-To-Live" is set (specified in seconds), it is an enforced hard upper limit. As such, any subsequent document mutation (by N1QL, Eventing, or any Couchbase SDK) will result in the document having its expiration adjusted and set to the bucket’s maximum TTL if the operation has: 
 *** No TTL.
 *** A TTL of zero.
 *** A TTL greater than the bucket TTL.


### PR DESCRIPTION
Understand that the Bucket TTL can override attempts to exceed the Bucket TTL (consider it a hard limit).
Develop in one UI as sessions may not properly sync up.
