### PR TITLE
Refined words

### DIFF
--- a/modules/manage/pages/manage-buckets/create-bucket.adoc
+++ b/modules/manage/pages/manage-buckets/create-bucket.adoc
@@ -8,7 +8,7 @@ _Full_ and _Cluster_ Administrators can use Couchbase Web Console, the CLI, or t
 == Create a Bucket Using Couchbase Web Console
 
 A maximum of 30 buckets can be created per cluster.
-To create a bucket, access Couchbase Web Console, and left-click on the [.ui]*Buckets* tab, in the vertical navigation-bar at the left-hand side:
+To create a bucket, access Couchbase Web Console, and click on the [.ui]*Buckets* tab, in the vertical navigation-bar at the left-hand side:
 
 [#access_bucket_tab]
 image::manage-buckets/accessBucketTab.png[,100,align=left]
@@ -19,7 +19,7 @@ If you are accessing this screen immediately after setting up the cluster, no bu
 [#buckets_view_initial]
 image::manage-buckets/bucketsViewInitial.png[,880,align=left]
 
-To create a new bucket, left-click on the btn:[Add Bucket] button, at the upper-right:
+To create a new bucket, click on the btn:[Add Bucket] button, at the upper-right:
 
 [#add-bucket-button]
 image::manage-buckets/addBucketButton.png[,110,align=left]
@@ -50,7 +50,7 @@ xref:learn:buckets-memory-and-storage/buckets.adoc[Buckets].
 
 Selection of each bucket-type provides a different set of advanced settings, which can be used to configure the bucket.
 The bucket-type selected by default is [.ui]*Couchbase*.
-Therefore, to see the advanced settings associated with this bucket-type, left-click on the right-pointing arrowhead labelled [.ui]*Advanced bucket settings*.
+Therefore, to see the advanced settings associated with this bucket-type, click on the right-pointing arrowhead labelled [.ui]*Advanced bucket settings*.
 This causes the [.ui]*Add Data Bucket* dialog to expand vertically, as shown below.
 
 == Couchbase Bucket-Settings

--- a/modules/manage/pages/manage-buckets/delete-bucket.adoc
+++ b/modules/manage/pages/manage-buckets/delete-bucket.adoc
@@ -8,7 +8,7 @@ Full, Cluster, and Bucket Administrators can delete a bucket.
 
 Bucket-deletion may be appropriate either when an existing bucket is no longer needed; or when all items within an existing bucket need to be replaced — and bucket-deletion (followed by bucket-recreation) is determined to constitute a faster process than the deletion of each individual item.
 
-To delete a bucket using Couchbase Web Console: access the console, and leftclick on the [.ui]*Buckets* tab, in the vertical navigation-bar at the left-hand side.
+To delete a bucket using Couchbase Web Console: access the console, and click on the [.ui]*Buckets* tab, in the vertical navigation-bar at the left-hand side.
 
 [#access_bucket_tab]
 image::manage-buckets/accessBucketTab.png[,80,align=left]

--- a/modules/manage/pages/manage-buckets/delete-bucket.adoc
+++ b/modules/manage/pages/manage-buckets/delete-bucket.adoc
@@ -8,7 +8,7 @@ Full, Cluster, and Bucket Administrators can delete a bucket.
 
 Bucket-deletion may be appropriate either when an existing bucket is no longer needed; or when all items within an existing bucket need to be replaced — and bucket-deletion (followed by bucket-recreation) is determined to constitute a faster process than the deletion of each individual item.
 
-To delete a bucket using Couchbase Web Console: access the console, and left-click on the [.ui]*Buckets* tab, in the vertical navigation-bar at the left-hand side.
+To delete a bucket using Couchbase Web Console: access the console, and leftclick on the [.ui]*Buckets* tab, in the vertical navigation-bar at the left-hand side.
 
 [#access_bucket_tab]
 image::manage-buckets/accessBucketTab.png[,80,align=left]
@@ -18,7 +18,7 @@ The [.ui]*Buckets* screen now appears, showing the buckets that have already bee
 
 image::manage-buckets/newBucketDisplay.png[,880,align=left]
 
-To delete a particular bucket, left-click on the bucket's row in the UI; then, when the *Delete* button appears, left-click on it:
+To delete a particular bucket, click on the bucket's row in the UI; then, when the *Delete* button appears, click on it:
 
 [#access_delete_button]
 image::manage-buckets/accessDeleteButton.png[,260,align=left]
@@ -28,7 +28,7 @@ A confirmation-dialog is now provided, by means of which you can now either canc
 [#delete_bucket_warning]
 image::manage-buckets/deleteBucketWarning.png[,320,align=left]
 
-If you elect to proceed, by left-clicking on the *Delete Bucket* button, the bucket and all its data are deleted from the system; and the bucket is no longer represented within the [.ui]*Buckets* screen of Couchbase Web Console.
+If you elect to proceed, by clicking on the *Delete Bucket* button, the bucket and all its data are deleted from the system; and the bucket is no longer represented within the [.ui]*Buckets* screen of Couchbase Web Console.
 
 == Using the CLI and REST API
 

--- a/modules/manage/pages/manage-buckets/edit-bucket.adoc
+++ b/modules/manage/pages/manage-buckets/edit-bucket.adoc
@@ -7,7 +7,7 @@ This section explains how to do so; and notes the possible consequences of such 
 
 == Edit an Existing Bucket-Configuration
 
-To edit an existing bucket-configuration, access Couchbase Web Console, and left-click on the [.ui]*Buckets* tab, in the vertical navigation-bar at the left-hand side.
+To edit an existing bucket-configuration, access Couchbase Web Console, and click on the [.ui]*Buckets* tab, in the vertical navigation-bar at the left-hand side.
 
 [#access_bucket_tab]
 image::manage-buckets/accessBucketTab.png[,80,align=left]
@@ -17,7 +17,7 @@ The [.ui]*Buckets* screen now appears, showing the buckets that have already bee
 [#buckets_view_initial]
 image::manage-buckets/bucketsViewInitialEdit.png[,880,align=left]
 
-To edit the settings for a particular bucket, left-click on the bucket's row in the UI.
+To edit the settings for a particular bucket, click on the bucket's row in the UI.
 This expands the row, to display additional information:
 
 [#buckets_view_with_expanded_bucket_row]
@@ -31,7 +31,7 @@ Further values are displayed in successive columns, to the right of the bucket-n
 These indicate the number of items in the bucket, the number of items with data that is currently resident in memory (for Couchbase buckets only), the number of operations performed on the bucket during the last second, the amount of RAM currently in use from the available quota, and the amount of disk-space used (for Couchbase buckets only).
 
 At the lower right, buttons are provided for deleting, compacting (for Couchbase buckets only), and editing the bucket.
-To display the user-interface for editing, left-click on the *Edit* button:
+To display the user-interface for editing, click on the *Edit* button:
 
 [#edit_bucket_button]
 image::manage-buckets/editBucketButton.png[,260,align=left]

--- a/modules/manage/pages/manage-buckets/flush-bucket.adoc
+++ b/modules/manage/pages/manage-buckets/flush-bucket.adoc
@@ -6,7 +6,7 @@ _Flushing_ deletes every object that a bucket contains.
 
 == Enable Flushing
 
-To edit an existing bucket-configuration, access Couchbase Web Console, and left-click on the [.ui]*Buckets* tab, in the vertical navigation-bar at the left-hand side.
+To edit an existing bucket-configuration, access Couchbase Web Console, and click on the [.ui]*Buckets* tab, in the vertical navigation-bar at the left-hand side.
 
 [#access_bucket_tab]
 image:manage-buckets/accessBucketTab.png[,80,align=left]
@@ -16,13 +16,13 @@ The [.ui]*Buckets* screen now appears, showing the buckets that have already bee
 [#new_bucket_display]
 image:manage-buckets/newBucketDisplay.png[,880,align=left]
 
-To edit the settings for a particular bucket, left-click on the bucket's row in the UI; then, when the *Edit* button appears, left-click on it:
+To edit the settings for a particular bucket, click on the bucket's row in the UI; then, when the *Edit* button appears, click on it:
 
 This displays the [.ui]*Edit Bucket Settings* dialog, which permits changes to be made to a subset of existing settings.
 All the settings contained here are described in detail for the [.ui]*Add Data Bucket* dialog, in the section
 xref:manage:manage-buckets/create-bucket.adoc[Create a Bucket]
 
-Left-click on the [.ui]*Show advanced bucket settings* tab.
+Click on the [.ui]*Show advanced bucket settings* tab.
 This causes the [.ui]*Add Data Bucket* dialog to expand vertically; and thereby display additional information.
 Navigate to the bottom of the expanded dialog, and locate the *Flush* panel.
 This provides a checkbox, the checking of which enables flushing for the current bucket:
@@ -33,13 +33,13 @@ image:manage-buckets/flushOptionEnabled.png[,350,align=left]
 Note that flushing can also be enabled during bucket-creation.
 See xref:manage:manage-buckets/create-bucket.adoc[Create a Bucket] for details.
 
-Once enabled, flushing can be performed by means of Couchbase Web Console: with the [.ui]*Buckets* screen displayed, left-click on the row of a bucket for which flushing has been enabled.
+Once enabled, flushing can be performed by means of Couchbase Web Console: with the [.ui]*Buckets* screen displayed, click on the row of a bucket for which flushing has been enabled.
 The displayed options now include the [.ui]*Flush* button.
 
 [#flush_bucket_button]
 image:manage-buckets/flushBucketButton.png[,350,align=left]
 
-When the *Flush* button is left-clicked on, flushing of the bucket occurs.
+When the *Flush* button is clicked on, flushing of the bucket occurs.
 This causes all items in the bucket to be deleted by the system at the earliest opportunity.
 Note that for this reason, you are recommended _not_ to run with the [.ui]*Flush* setting enabled in production; due to the danger of all a bucket's data being inadvertently lost.
 

--- a/modules/manage/pages/manage-groups/manage-groups.adoc
+++ b/modules/manage/pages/manage-groups/manage-groups.adoc
@@ -24,9 +24,9 @@ The examples in the subsections below show how to create and manage groups, usin
 [#manage-groups-with-the-ui]
 == Manage Groups with the UI
 
-To manage groups, left-click on the *Servers* tab, in the left-hand navigation bar.
+To manage groups, click on the *Servers* tab, in the left-hand navigation bar.
 This brings up the *Servers* screen.
-Now left-click on the *Groups* tab, at the upper right:
+Now click on the *Groups* tab, at the upper right:
 
 [#groups_tab]
 image::manage-groups/groupsTab.png[,72,align=left]
@@ -38,7 +38,7 @@ image::manage-groups/groupsServerGroupsScreen.png[,820,align=left]
 
 This display indicates that the cluster currently contains three servers.
 Note that the list of servers is headed by the name *Group 1*: this is because by default, Couchbase Server puts each new server into a group with this name.
-To change the name, left-click on the *edit name* tab, adjacent to the name:
+To change the name, click on the *edit name* tab, adjacent to the name:
 
 [#groups_edit_group_name_tab]
 image::manage-groups/groupsEditGroupNameTab.png[,140,align=left]
@@ -48,7 +48,7 @@ This brings up the *Edit Group Name* dialog:
 [#groups_edit_group_name_dialog]
 image::manage-groups/groupsEditGroupNameDialog.png[,260,align=left]
 
-If you wish to change the group name, edit it within the interactive text-field, and then left-click on the *Rename Group* button.
+If you wish to change the group name, edit it within the interactive text-field, and then click on the *Rename Group* button.
 
 [#add-a-group-with-the-ui]
 === Add a Group, with the UI
@@ -56,7 +56,7 @@ If you wish to change the group name, edit it within the interactive text-field,
 To add a new group, proceed as follows:
 
 [#server-grp]
-. Left-click on the *Add Group* tab, which is located at the upper right of the *Server Groups* screen:
+. Click on the *Add Group* tab, which is located at the upper right of the *Server Groups* screen:
 +
 [#groups_add_group_tab]
 image::manage-groups/groupsAddGroupTab.png[,120,align=left]
@@ -67,7 +67,7 @@ This brings up the *Add Group* dialog:
 image::manage-groups/groupsAddGroupDialog.png[,260,align=left]
 
 . Access the interactive text-field of the *Add Group* dialog, and enter an appropriate name for the new group.
-Then, left-click on the *Add Group* button, to the lower right of the dialog.
+Then, click on the *Add Group* button, to the lower right of the dialog.
 The new group is added, the dialog disappears, and the *Server Groups* screen is now displayed as follows:
 +
 [#groups_server_groups_new_group_added]
@@ -95,8 +95,8 @@ A *pending move* notification now appears.
 image::manage-groups/groupsPendingMoveNotification.png[,740,align=left]
 
 . Toward the upper right of the *Server Groups* screen a *Reset* tab and an *Apply Changes* button have become available.
-If you left-click on the *Reset* tab, the pending move is cancelled, and the selected server remains in its current group.
-Left-click on the *Apply Changes* button to complete the move.
+If you click on the *Reset* tab, the pending move is cancelled, and the selected server remains in its current group.
+Click on the *Apply Changes* button to complete the move.
 +
 [#groups_reset_and_apply_changes_buttons]
 image::manage-groups/groupsResetAndApplyChangesButtons.png[,220,align=left]
@@ -107,7 +107,7 @@ Note that a rebalance is now recommended, due to the change you have made:
 [#groups_rebalance_following_move]
 image::manage-groups/groupsRebalanceFollowingMove.png[,820,align=left]
 +
-Left-click on the *Rebalance* button, to start the rebalance.
+Click on the *Rebalance* button, to start the rebalance.
 
 [#delete-a-group-with-the-ui]
 === Delete a Group, with the UI
@@ -116,20 +116,20 @@ To delete a group, first remove all nodes from the group — either by moving th
 Then, delete the group.
 To delete a group by removing servers, proceed as follows.
 
-. Access the *Servers* screen, and left-click on the row for each server you need to remove, in order to delete their group.
+. Access the *Servers* screen, and click on the row for each server you need to remove, in order to delete their group.
 This expands the row-display.
 The *Remove* button appears at the lower right:
 +
 [#groups_screen_with_open_group]
 image::manage-groups/groupsScreenWithOpenGroup.png[,820,align=left]
 
-. Left-click on the *Remove* button, to remove the server.
+. Click on the *Remove* button, to remove the server.
 A confirmation notification appears:
 +
 [#groups_confirm_server_removal_notice]
 image::manage-groups/groupsConfirmServerRemovalNotice.png[,340,align=left]
 +
-Left-click on the *Remove Server* button, to confirm.
+Click on the *Remove Server* button, to confirm.
 +
 A *REMOVAL pending rebalance* notification now appears on the row.
 A *Cancel Remove* button is also provided, to allow cancellation:
@@ -137,7 +137,7 @@ A *Cancel Remove* button is also provided, to allow cancellation:
 [#groups_removal_pending_notification]
 image::manage-groups/groupsRemovalPendingNotification.png[,740,align=left]
 
-. Left-click on the *Rebalance* button to perform a rebalance, and thereby complete the server-removal process:
+. Click on the *Rebalance* button to perform a rebalance, and thereby complete the server-removal process:
 +
 [#groups_rebalance_button]
 image::manage-groups/groupsRebalanceButton.png[,100,align=left]
@@ -149,13 +149,13 @@ image::manage-groups/groupsFollowingServerRemoval.png[,740,align=left]
 +
 Perform server-removal in this way for every server in the group to be deleted, until the group contains no servers.
 
-. Access the *Server Groups* screen, by left-clicking the *Groups* button, located at the upper right of the *Servers* screen.
+. Access the *Server Groups* screen, by clicking the *Groups* button, located at the upper right of the *Servers* screen.
 The group that now contains no servers is represented by a row that displays a notification:
 +
 [#groups_empty_group]
 image::manage-groups/groupsEmptyGroup.png[,740,align=left]
 
-. Left-click on the *delete group* tab:
+. Click on the *delete group* tab:
 +
 [#groups_delete_group]
 image::manage-groups/groupsDeleteGroup.png[,100,align=left]
@@ -165,7 +165,7 @@ A confirmation dialog now appears:
 [#groups_delete_group_confirmation]
 image::manage-groups/groupsDeleteGroupConfirmation.png[,260,align=left]
 +
-Left-click on the *Delete Group* button.
+Click on the *Delete Group* button.
 The group is deleted, and now longer appears as a row on the *Server Groups* screen.
 
 [#assign-a-group-when-adding-a-server-with-the-ui]

--- a/modules/manage/pages/manage-indexes/manage-indexes.adoc
+++ b/modules/manage/pages/manage-indexes/manage-indexes.adoc
@@ -22,7 +22,7 @@ You can manage primary indexes and global secondary indexes through the Couchbas
 [[access-indexes]]
 == Access the Indexes Screen
 
-To access the *Indexes* screen, left-click on the tab in the left-hand navigation bar:
+To access the *Indexes* screen, click on the tab in the left-hand navigation bar:
 
 image::manage-ui/indexesTab.png[,100,align=left]
 

--- a/modules/manage/pages/manage-logging/manage-logging.adoc
+++ b/modules/manage/pages/manage-logging/manage-logging.adoc
@@ -160,7 +160,7 @@ Guidance on redaction is displayed below it:
 [#partial_redaction_selection]
 image::manage-logging/partialRedactionSelection.png[,682,align=left]
 
-Left-click on the *Start Collection* button.
+Click on the *Start Collection* button.
 A notification explains that the collection-process is now running.
 When the process has completed, a further notification appears, specifying the location (local or remote) of each created zip file.
 Note that, when redaction has been specified, two zip files are provided for each node: one file containing redacted data, the other unredacted data.

--- a/modules/manage/pages/manage-logging/manage-logging.adoc
+++ b/modules/manage/pages/manage-logging/manage-logging.adoc
@@ -36,7 +36,7 @@ Explicit logging can be performed by means of the Couchbase CLI utility `cbcolle
 The documentation for this utility, provided
 xref:cli:cbcollect-info-tool.adoc[here], includes a complete list of the log files that can be created, and a description of the contents of each.
 
-Explicit logging can also be performed by means of Couchbase Web Console: on the *Logs* page, left-click on the [.ui]*Collect Information* tab, located near the top.
+Explicit logging can also be performed by means of Couchbase Web Console: on the *Logs* page, click on the [.ui]*Collect Information* tab, located near the top.
 
 [#collect_info]
 image::manage-logging/collectInfo.png[,248,align=left]
@@ -55,7 +55,7 @@ The *Specify custom destination directory* can be checked to specify the absolut
 The *Upload to Couchbase* checkbox is described in
 xref:manage:manage-logging/manage-logging.adoc#uploading_log_files[Uploading Log Files], below.
 
-To start the collection-process, left-click on the *Start Collecting* button.
+To start the collection-process, click on the *Start Collecting* button.
 A notification is displayed, indicating that the collection-process is running.
 When the process has completed, the following information is displayed:
 
@@ -85,7 +85,7 @@ The dialog now features an *Upload to Host* field, which contains the server-loc
 Fields are also provided for *Customer Name* (required) and *Ticket Number* (optional).
 The *Upload Proxy* field optionally takes the hostname of a remote system, which contains the directory specified by the pathname.
 
-Left-click on the *Start Collecting* button.
+Click on the *Start Collecting* button.
 When collection is complete, a notification provides the URL of the uploaded zip file.
 
 [#getting-a-cluster-summary]
@@ -99,7 +99,7 @@ This brings up the *Cluster Summary Info* dialog:
 
 image::manage-logging/clusterSummaryInfo.png[,520,align=left]
 
-The displayed JSON document, which contains detailed status on the current configuration and status of the entire cluster, can be copied to the clipboard, by left-clicking on the *Copy to Clipboard* button, at the lower left.
+The displayed JSON document, which contains detailed status on the current configuration and status of the entire cluster, can be copied to the clipboard, by clicking on the *Copy to Clipboard* button, at the lower left.
 This information can then be manually shared with Couchbase Support; either in addition to, or as an alternative to log-collection
 
 [#understanding_redaction]

--- a/modules/manage/pages/manage-nodes/add-node-and-rebalance.adoc
+++ b/modules/manage/pages/manage-nodes/add-node-and-rebalance.adoc
@@ -61,7 +61,7 @@ image::manage-nodes/newNodeWelcomeScreen.png[,400,align=middle]
 This indicates that Couchbase Server is installed and running on the new node, but has not yet been provisioned.
 Do not use this interface: instead, return to Couchbase Web Console for the cluster, `10.142.181.101`.
 
-. In the *Servers* panel for the cluster, left-click on the *ADD SERVER* button, at the upper right:
+. In the *Servers* panel for the cluster, click on the *ADD SERVER* button, at the upper right:
 +
 [#add-server-button]
 image::manage-nodes/addServerButton.png[,140,align=middle]
@@ -94,7 +94,7 @@ image::manage-nodes/addServerNodeDialogVerticallyExtended.png[,400,align=middle]
 +
 For the current example, the displayed, default paths do not need to be modified.
 +
-Left-click on the *Add Server* button to save the settings.
+Click on the *Add Server* button to save the settings.
 The *Servers* screen is redisplayed, with the following appearance:
 +
 [#servers-screen-with-node-added]
@@ -106,7 +106,7 @@ Meanwhile, the *Items* figure for `10.142.181.102` is 0/0, indicating that no it
 +
 For an architectural description of how vBuckets and their items are distributed across a cluster, see xref:learn:clusters-and-availability/intra-cluster-replication.adoc[Intra-Cluster Replication].
 
-. To perform a rebalance, left-click on the *Rebalance* button, at the upper right:
+. To perform a rebalance, click on the *Rebalance* button, at the upper right:
 +
 [#rebalance-button]
 image::manage-nodes/rebalanceButton.png[,140,align=middle]
@@ -118,7 +118,7 @@ Additionally, a *Rebalance* dialog is displayed:
 image::manage-nodes/rebalanceInOfNodeTwo6.5v2.png[,800,align=middle]
 +
 The dialog indicates rebalance progress for each of the services on the cluster.
-To see more information on the progress related to the Data Service, left-click on the *Data* tab:
+To see more information on the progress related to the Data Service, click on the *Data* tab:
 The pane expands to provide additional information on the progress of data-transfer:
 +
 image::manage-nodes/rebalanceOpenedDataTabfor6.5.png[,430,align=middle]
@@ -132,14 +132,14 @@ When the rebalance is complete, the dialog appears as follows:
 image::manage-nodes/rebalanceCompletion6.5.png[,430,align=middle]
 +
 Note that time-completion figures are also provided for the other services, *Index* and *Query*.
-Additionally, a complete report on the concluded rebalance activity can be downloaded, by left-clicking on the *Download Report* button:
+Additionally, a complete report on the concluded rebalance activity can be downloaded, by clicking on the *Download Report* button:
 +
 [#download-button]
 image::manage-nodes/downloadButton.png[,180,align=middle]
 +
 See the xref:rebalance-reference:rebalance-reference.adoc[Rebalance Reference], for information on the contents of the report.
 +
-Left-click on the *X* at the upper-right of the dialog, to dismiss the dialog.
+Click on the *X* at the upper-right of the dialog, to dismiss the dialog.
 +
 The *Servers* screen now appears as follows:
 +
@@ -158,7 +158,7 @@ If rebalance fails &#8212; for example, due to a node's becoming non-responsive 
 
 image::manage-nodes/rebalanceFailureNotification.png[,250,align=middle]
 
-As this indicates, detailed information can be found by left-clicking on the *Logs* tab, in the left-hand, vertical navigation bar.
+As this indicates, detailed information can be found by clicking on the *Logs* tab, in the left-hand, vertical navigation bar.
 This brings up the *Logs* screen, containing information such as the following:
 
 image::manage-nodes/rebalanceFailureLog.png[,800,align=middle]
@@ -199,7 +199,7 @@ If one or more retries have been configured, and, following a rebalance failure,
 Instead, _either_ allow configured retries continue occurring &#8212; until one has succeeded, or all have failed; _or_ cancel the entire retry sequence.
 Then, continue performing administrative tasks as appropriate.
 
-To cancel, left-click on the *CANCEL RETRY* link, on the retry notification.
+To cancel, click on the *CANCEL RETRY* link, on the retry notification.
 Note that this cancels *all* currently scheduled retries.
 However, the configured number of retries will be rescheduled for each subsequent, manually initiated rebalance.
 

--- a/modules/manage/pages/manage-nodes/create-cluster.adoc
+++ b/modules/manage/pages/manage-nodes/create-cluster.adoc
@@ -41,7 +41,7 @@ image::manage-nodes/welcome.png[Welcome Screen,400,align=left]
 
 The *Welcome* screen lets you either *Setup New Cluster*, or *Join Existing Cluster*.
 Information on joining an existing cluster is provided in xref:manage:manage-nodes/join-cluster-and-rebalance.adoc[Join a Cluster and Rebalance].
-To set up a new cluster, left-click on *Setup New Cluster*.
+To set up a new cluster, click on *Setup New Cluster*.
 
 [#set-up-a-new-cluster]
 === Set Up a New Cluster
@@ -65,7 +65,7 @@ Usernames _may not_ be more than 128 UTF-8 characters in length; and it is recom
 The only default format-requirement is that the password be at least 6 characters in length.
 However, following cluster-initialization, you can modify (and indeed strengthen) the default password-policy, by means of the Couchbase CLI xref:cli:cbcli/couchbase-cli-setting-password-policy.adoc[setting-password-policy] command.
 
-When you have entered appropriate data into each field, left-click on the *Next: Accept Terms* button, at the lower right.
+When you have entered appropriate data into each field, click on the *Next: Accept Terms* button, at the lower right.
 
 [#accept-terms]
 === Accept Terms
@@ -78,10 +78,10 @@ image::manage-nodes/TsAndCs01.png[Terms and Conditions Screen,400,align=left]
 Check the *I accept the terms & conditions* checkbox.
 
 You now have two options for proceeding.
-If you left-click on the *Finish With Defaults* button, cluster-initialization is performed with default settings, provided by Couchbase; the Couchbase Web Console *Dashboard* appears, and your configuration is complete.
+If you click on the *Finish With Defaults* button, cluster-initialization is performed with default settings, provided by Couchbase; the Couchbase Web Console *Dashboard* appears, and your configuration is complete.
 _All_ Couchbase services will have been deployed.
 
-However, if you wish to customize those settings, left-click on the *Configure Disk, Memory, Services* button, and proceed as follows.
+However, if you wish to customize those settings, click on the *Configure Disk, Memory, Services* button, and proceed as follows.
 
 [#configure-couchbase-server]
 === Configure Couchbase Server
@@ -166,7 +166,7 @@ See xref:learn:services-and-indexes/indexes/global-secondary-indexes.adoc[Global
 * *Enable software update notifications in the web console*: Check this checkbox to allow notifications in the Couchbase Web Console when a new version of Couchbase Server is available.
 Configuration information transferred in the update check is anonymous and doesn't include any stored key-value data.
 
-When you have finished entering your configuration-details, left-click on the *Save & Finish* button, at the lower right.
+When you have finished entering your configuration-details, click on the *Save & Finish* button, at the lower right.
 This configures the server accordingly, and brings up the Couchbase Web Console *Dashboard*, for the first time.
 
 [#dashboard_01]
@@ -182,7 +182,7 @@ If this is the first server in the cluster, a notification appears, stating that
 A _bucket_ is the principal unit of data-storage used by Couchbase Server.
 In order to save and subsequently access documents and other objects, you must create one or more buckets.
 
-As specified by the notification, you can go to *Buckets*, and begin bucket-creation; or add a *sample bucket*: left-click on the links provided.
+As specified by the notification, you can go to *Buckets*, and begin bucket-creation; or add a *sample bucket*: click on the links provided.
 A description of how to create, edit, flush, and delete buckets can be found in the section
 xref:manage:manage-buckets/bucket-management-overview.adoc[Manage Buckets].
 An architectural description of buckets can be found in the section xref:learn:buckets-memory-and-storage/buckets.adoc[Buckets].

--- a/modules/manage/pages/manage-nodes/failover-graceful.adoc
+++ b/modules/manage/pages/manage-nodes/failover-graceful.adoc
@@ -26,19 +26,19 @@ The examples in the subsections below fail the same node over gracefully, from t
 
 Proceed as follows:
 
-. Access the Couchbase Web Console *Servers* screen, on node `10.142.181.101`, by left-clicking on the *Servers* tab in the left-hand navigation bar.
+. Access the Couchbase Web Console *Servers* screen, on node `10.142.181.101`, by clicking on the *Servers* tab in the left-hand navigation bar.
 The display is as follows:
 +
 [#servers-screen-with-node-added-after-rebalance]
 image::manage-nodes/twoNodeClusterAfterRebalanceCompressedView.png[,800,align=middle]
 +
-. To see further details of each node, left-click on the row for the node.
+. To see further details of each node, click on the row for the node.
 The row expands vertically, as follows:
 +
 [#two-node-cluster-after-rebalance-expanded]
 image::manage-nodes/twoNodeClusterAfterRebalance.png[,800,align=middle]
 
-. To initiate failover, left-click on the *Failover* button, at the lower right of the row for `101.142.181.102`:
+. To initiate failover, click on the *Failover* button, at the lower right of the row for `101.142.181.102`:
 +
 [#failover-button]
 image::manage-nodes/failoverButton.png[,140,align=middle]
@@ -51,7 +51,7 @@ image::manage-nodes/confirmFailoverDialog.png[,400,align=middle]
 Two radio buttons are provided, to allow selection of either *Graceful* or *Hard* failover.
 *Graceful* is selected by default.
 
-. Confirm _graceful_ failover by left-clicking on the *Failover Node* button.
+. Confirm _graceful_ failover by clicking on the *Failover Node* button.
 +
 Graceful failover is now initiated, and a rebalance occurs as part of the procedure.
 A progress dialog appears, summarizing overall progress:
@@ -68,7 +68,7 @@ image::manage-nodes/gracefulFailoverFullScreenRebalanceNeeded.png[,800,align=mid
 +
 This indicates the graceful failover has successfully completed, but an additional rebalance is required to complete the reduction of the cluster to one node.
 +
-. Left-click the *Rebalance* button, at the upper right, to initiate a further rebalance.
+. Click the *Rebalance* button, at the upper right, to initiate a further rebalance.
 When the process is complete, the *Server* screen appears as follows:
 +
 [#graceful-failover-after-rebalance]

--- a/modules/manage/pages/manage-nodes/failover-hard.adoc
+++ b/modules/manage/pages/manage-nodes/failover-hard.adoc
@@ -29,19 +29,19 @@ The examples in the subsections below perform the same _hard_ failover, on the s
 
 Proceed as follows:
 
-. Access the Couchbase Web Console *Servers* screen, on node `10.142.181.101`, by left-clicking on the *Servers* tab in the left-hand navigation bar.
+. Access the Couchbase Web Console *Servers* screen, on node `10.142.181.101`, by clicking on the *Servers* tab in the left-hand navigation bar.
 The display is as follows:
 +
 [#servers-screen-with-node-added-after-rebalance]
 image::manage-nodes/twoNodeClusterAfterRebalanceCompressedView.png[,800,align=middle]
 +
-. To see further details of the node to be failed over, which in this example will be `101.142.181.102`, left-click on the row for the node.
+. To see further details of the node to be failed over, which in this example will be `101.142.181.102`, click on the row for the node.
 The row expands vertically, as follows:
 +
 [#two-node-cluster-after-rebalance-expanded]
 image::manage-nodes/twoNodeClusterAfterRebalance.png[,800,align=middle]
 
-. To initiate failover, left-click on the *Failover* button, at the lower right of the row for `101.142.181.102`:
+. To initiate failover, click on the *Failover* button, at the lower right of the row for `101.142.181.102`:
 +
 [#failover-button]
 image::manage-nodes/failoverButton.png[,140,align=middle]
@@ -60,7 +60,7 @@ image::manage-nodes/confirmHardFailoverDialog.png[,400,align=middle]
 +
 Note the warning message that appears when hard failover is selected: in particular, this points out that hard failover may interrupt ongoing writes and replications, and that therefore it may be better to xref:manage:manage-nodes/remove-node-and-rebalance.adoc[Remove a Node and Rebalance], than use hard failover on a still-available Data Service node.
 +
-To continue with hard failover, confirm your choice by left-clicking on the *Failover Node* button.
+To continue with hard failover, confirm your choice by clicking on the *Failover Node* button.
 +
 Hard failover now occurs.
 On conclusion, the *Servers* screen appears as follows:
@@ -70,7 +70,7 @@ image::manage-nodes/twoNodeClusterAfterHardFailover.png[,800,align=middle]
 +
 This indicates that hard failover has successfully completed, but a rebalance is required to complete the reduction of the two-node cluster to one node.
 +
-. Left-click the *Rebalance* button, at the upper right, to initiate rebalance.
+. Click the *Rebalance* button, at the upper right, to initiate rebalance.
 When the process is complete, the *Server* screen appears as follows:
 +
 [#graceful-failover-after-rebalance]
@@ -90,7 +90,7 @@ Hard failover of one or more nodes can be managed by means of the *FAILOVER* tab
 image::manage-nodes/serverScreenWithFailoverTab.png[,800,align=middle]
 
 As the *Servers* screen here shows, this example features a cluster of three nodes.
-Left-click on the *FAILOVER* tab to perform hard failover on one or more of the three nodes:
+Click on the *FAILOVER* tab to perform hard failover on one or more of the three nodes:
 
 image::manage-nodes/leftClickOnFailoverTab.png[,200,align=middle]
 
@@ -101,7 +101,7 @@ image::manage-nodes/hardFailoverMultipleNodesDialog.png[,520,align=middle]
 The dialog provides the following *Data Loss Warning*: _For hard failover of multiple nodes, each Couchbase bucket must have at least as many replicas as the total number of nodes failed over or you WILL lose data.
 Since hard failover removes nodes immediately it may also result in failure of in-flight operations._
 
-Select one or more nodes from the checkboxes, then left-click on the *Failover Nodes* button, to start hard failover.
+Select one or more nodes from the checkboxes, then click on the *Failover Nodes* button, to start hard failover.
 When failover has complete, a rebalance will, as usual, be required.
 
 [#hard-failover-with-the-cli]

--- a/modules/manage/pages/manage-nodes/join-cluster-and-rebalance.adoc
+++ b/modules/manage/pages/manage-nodes/join-cluster-and-rebalance.adoc
@@ -48,7 +48,7 @@ The welcome screen is displayed:
 [#new-node-welcome-screen]
 image::manage-nodes/newNodeWelcomeScreen.png[,400,align=middle]
 
-. Left-click on the *Join Existing Cluster* button:
+. Click on the *Join Existing Cluster* button:
 +
 [#join-existing-cluster-button]
 image::manage-nodes/joinExistingClusterButton.png[,230,align=middle]
@@ -58,7 +58,7 @@ This brings up the *Join Cluster* dialog:
 [#join-cluster-dialog]
 image::manage-nodes/joinClusterDialog.png[,400,align=middle]
 
-. Left-click on the *Configure Services & Setings For This Node* control.
+. Click on the *Configure Services & Setings For This Node* control.
 The dialog expands vertically, as follows:
 +
 [#join-cluster-dialog-expanded]
@@ -67,7 +67,7 @@ image::manage-nodes/joinClusterDialogExpanded.png[,400,align=middle]
 The expanded dialog allows specification of the services, the name and IP address, and the disk paths for the new node.
 It also requires the username and password of the *Cluster Admin* (although the credentials of the *Full Admin* for the cluster are equally implied), and the name or IP address of the cluster to be joined.
 
-. Enter the cluster's IP address (in this case, `10.142.181.101`) and password, and uncheck all *Services* fields except *Data*. Leave all other details unchanged. Then, left-click on the *Join With Custom Configuration* button, at the lower right.
+. Enter the cluster's IP address (in this case, `10.142.181.101`) and password, and uncheck all *Services* fields except *Data*. Leave all other details unchanged. Then, click on the *Join With Custom Configuration* button, at the lower right.
 +
 The dashboard for the cluster now appears.
 The following notification is provided at the lower left:
@@ -75,7 +75,7 @@ The following notification is provided at the lower left:
 [#server-association-message]
 image::manage-nodes/serverAssociationMessage.png[,220,align=middle]
 
-. Access the *Servers* screen, by left-clicking on the *Servers* tab, on the left-hand navigation bar.
+. Access the *Servers* screen, by clicking on the *Servers* tab, on the left-hand navigation bar.
 The display is as follows:
 +
 [#servers-screen-with-node-added]
@@ -88,7 +88,7 @@ Meanwhile, the *Items* figure for `10.142.181.102` is 0/0, indicating that no it
 +
 To access information on buckets, vBuckets, and intra-cluster replication, see the architecture  xref:learn:architecture-overview.adoc[Overview].
 
-. To rebalance the cluster, and thereby fully add the new node, left-click on the *Rebalance* button, at the upper right:
+. To rebalance the cluster, and thereby fully add the new node, click on the *Rebalance* button, at the upper right:
 +
 [#rebalance-button]
 image::manage-nodes/rebalanceButton.png[,140,align=middle]

--- a/modules/manage/pages/manage-nodes/list-cluster-nodes.adoc
+++ b/modules/manage/pages/manage-nodes/list-cluster-nodes.adoc
@@ -28,7 +28,7 @@ Note that this display is identical for all nodes in the cluster: therefore, whe
 
 Proceed as follows:
 
-. Access the Couchbase Web Console *Servers* screen, on either node `10.142.181.101` or node `101.142.181.102`, by left-clicking on the *Servers* tab in the left-hand navigation bar.
+. Access the Couchbase Web Console *Servers* screen, on either node `10.142.181.101` or node `101.142.181.102`, by clicking on the *Servers* tab in the left-hand navigation bar.
 The display is as follows:
 +
 [#servers-screen-with-node-added-after-rebalance]
@@ -56,7 +56,7 @@ For information on Couchbase memory-management, see xref:learn:buckets-memory-an
 If the figure is `15.2 K/15.8 K`, this indicates that 15.2 K items are in active vBuckets on the node, and 15.8 in replica.
 For information on vBuckets, see xref:learn:buckets-memory-and-storage/vbuckets.adoc[vBuckets].
 
-. To see further details of each node, left-click on the row for the node.
+. To see further details of each node, click on the row for the node.
 The row expands vertically, as follows:
 +
 [#two-node-cluster-after-rebalance-expanded]
@@ -70,7 +70,7 @@ The additional information now shown includes:
 
 ** Currently available memory and disk-space.
 
-. Left-click on the `Statistics` tab, and the right-hand side of the row.
+. Click on the `Statistics` tab, and the right-hand side of the row.
 The *Statistics* screen is displayed:
 +
 [#statistics-screen]

--- a/modules/manage/pages/manage-nodes/recover-nodes.adoc
+++ b/modules/manage/pages/manage-nodes/recover-nodes.adoc
@@ -29,19 +29,19 @@ The examples assume:
 
 Proceed as follows:
 
-. Access the Couchbase Web Console *Servers* screen, on node `10.142.181.101`, by left-clicking on the *Servers* tab in the left-hand navigation bar.
+. Access the Couchbase Web Console *Servers* screen, on node `10.142.181.101`, by clicking on the *Servers* tab in the left-hand navigation bar.
 The display is as follows:
 +
 [#servers-screen-with-node-added-after-rebalance]
 image::manage-nodes/twoNodeClusterAfterRebalanceCompressedView.png[,800,align=middle]
 +
-. To see further details of each node, left-click on the row for the node.
+. To see further details of each node, click on the row for the node.
 The row expands vertically, as follows:
 +
 [#two-node-cluster-after-rebalance-expanded]
 image::manage-nodes/twoNodeClusterAfterRebalance.png[,800,align=middle]
 
-. To initiate failover, left-click on the *Failover* button, at the lower right of the row for `101.142.181.102`:
+. To initiate failover, click on the *Failover* button, at the lower right of the row for `101.142.181.102`:
 +
 [#failover-button]
 image::manage-nodes/failoverButton.png[,140,align=middle]
@@ -54,7 +54,7 @@ image::manage-nodes/confirmFailoverDialog.png[,400,align=middle]
 Two radio buttons are provided, to allow selection of either *Graceful* or *Hard* failover.
 *Graceful* is selected by default.
 
-. Confirm _graceful_ failover by left-clicking on the *Failover Node* button.
+. Confirm _graceful_ failover by clicking on the *Failover Node* button.
 +
 Graceful failover is now initiated.
 A progress dialog appears new the top of the screen, summarizing overall progress.
@@ -73,19 +73,19 @@ Additionally, the *Add Back: Full Recovery* and *Add Back: Delta Recovery* butto
 [#full-and-delta-recovery-buttons]
 image::manage-nodes/fullAndDeltaRecoveryButtons.png[,440,align=middle]
 
-. Select one of the two available forms of recovery, by left-clicking the corresponding button.
+. Select one of the two available forms of recovery, by clicking the corresponding button.
 Note that _full_ and _delta_ recovery are described in xref:learn:clusters-and-availability/recovery.adoc[Recovery].
-If you select _full_, by left-clicking on the *Add Back: Full Recovery* button, the row for `10.142.181.102` is displayed as follows:
+If you select _full_, by clicking on the *Add Back: Full Recovery* button, the row for `10.142.181.102` is displayed as follows:
 +
 [#node-row-after-full-recovery-select]
 image::manage-nodes/nodeRowAfterFullRecoverySelect.png[,800,align=middle]
 +
-The row specifies `FULL RECOVERY pending rebalance`: therefore, left-click the *Rebalance* button to apply full recovery.
+The row specifies `FULL RECOVERY pending rebalance`: therefore, click the *Rebalance* button to apply full recovery.
 +
-Similarly, left-clicking on the *Add Back: Delta Recovery* displays `DELTA RECOVERY pending rebalance`.
-Recovery can be aborted, by left-clicking on the *CANCEL ADD BACK* button.
+Similarly, clicking on the *Add Back: Delta Recovery* displays `DELTA RECOVERY pending rebalance`.
+Recovery can be aborted, by clicking on the *CANCEL ADD BACK* button.
 
-. Left-click on the *Rebalance* button. Whichever form of recovery you have chosen, _full_ or _delta_, is performed.
+. Click on the *Rebalance* button. Whichever form of recovery you have chosen, _full_ or _delta_, is performed.
 
 Note that if rebalance fails, notifications are duly provided.
 These are described in xref:manage:manage-nodes/add-node-and-rebalance.adoc#rebalance-failure-notification[Rebalance Failure Notification].

--- a/modules/manage/pages/manage-nodes/remove-node-and-rebalance.adoc
+++ b/modules/manage/pages/manage-nodes/remove-node-and-rebalance.adoc
@@ -39,12 +39,12 @@ The screen appears as follows:
 [#servers-screen-with-node-added-after-rebalance]
 image::manage-nodes/twoNodeClusterAfterRebalanceCompressedView.png[,800,align=middle]
 
-. Left-click on the row for node `10.142.181.102`. The row expands vertically, as follows:
+. Click on the row for node `10.142.181.102`. The row expands vertically, as follows:
 +
 [#two-node-cluster-after-rebalance-expanded]
 image::manage-nodes/twoNodeClusterAfterRebalance.png[,800,align=middle]
 
-. To initiate removal, left-click on the *Remove* button, at the lower left of the row:
+. To initiate removal, click on the *Remove* button, at the lower left of the row:
 +
 [#remove-button]
 image::manage-nodes/removeButton.png[,140,align=middle]
@@ -54,7 +54,7 @@ The *Confirm Server Removal* dialog appears:
 [#confirm-server-removal]
 image::manage-nodes/confirmServerRemoval.png[,400,align=middle]
 +
-Left-click on the *Remove Server* confirmation button. The *Servers* screen reappears as follows:
+Click on the *Remove Server* confirmation button. The *Servers* screen reappears as follows:
 +
 [#folowing-removal]
 image::manage-nodes/twoNodeClusterFollowingRemoval.png[,800,align=middle]
@@ -62,7 +62,7 @@ image::manage-nodes/twoNodeClusterFollowingRemoval.png[,800,align=middle]
 This indicates that node `10.142.181.102` has been `flagged for removal`, and is `Still taking traffic`.
 A rebalance must be performed to complete removal.
 
-. Left-click on the *Rebalance* button, at the upper right:
+. Click on the *Rebalance* button, at the upper right:
 +
 [#rebalance-button]
 image::manage-nodes/rebalanceButton.png[,140,align=middle]

--- a/modules/manage/pages/manage-security/configure-ldap.adoc
+++ b/modules/manage/pages/manage-security/configure-ldap.adoc
@@ -72,7 +72,7 @@ The *LDAP* tab allows an LDAP server to be specified for external authentication
 The *ADD GROUP* tab allows definition of _Couchbase-Server user-groups_, which are to be associated with _LDAP groups_, and which can be assigned Couchbase-Server _roles_.
 The *ADD USER* tab allows individual users to be added, and optionally, for their authentication to be specified as *external*.
 
-To perform LDAP configuration, left-click on the *LDAP* tab, at the upper right of the *Security* screen:
+To perform LDAP configuration, click on the *LDAP* tab, at the upper right of the *Security* screen:
 
 [#left-click-on-ldap-tab]
 image::manage-security/leftClickOnLdapTab.png[,70,align=left]
@@ -116,7 +116,7 @@ For example, if the list is `server1, server2`, provided that `server1` is acces
 * *Encryption*. Whether the connection with the LDAP server or servers should be encrypted.
 Note that use of encryption is _strongly_ recommended.
 +
-Left-click on the control at the right-hand side of the *Encryption* field, to display the pull-down menu:
+Click on the control at the right-hand side of the *Encryption* field, to display the pull-down menu:
 +
 [#encryption-pull-down-menu]
 image::manage-security/configureLDAPencryptionPullDownMenu.png[,200,align=left]
@@ -155,7 +155,7 @@ With data entered into these fields, the dialog might appear as follows:
 [#configure-ldap-dialog-half-complete]
 image::manage-security/configureLDAPhalfComplete.png[,520,align=left]
 
-Optionally, the *Check Network Settings* button can now be left-clicked on.
+Optionally, the *Check Network Settings* button can now be clicked on.
 This tests whether the specified LDAP hosts are accessible across the network.
 If none of the servers is accessible, an error is displayed on the dialog.
 
@@ -210,7 +210,7 @@ The possible values are *base*, *one*, and *sub*.
 [#test-user-auth-field]
 image::manage-security/testUserAuth.png[,400,align=left]
 
-Enter the username and password for the user, and left-click on *Test User Authentication*.
+Enter the username and password for the user, and click on *Test User Authentication*.
 Couchbase Server maps the specified username to an LDAP DN, and performs authentication on the LDAP server.
 Notifications confirming success or failure duly appear on the dialog.
 
@@ -257,12 +257,12 @@ Note that use of nested groups may significantly increase load on the LDAP serve
 ==== Test Groups Query, for User Attribute Search
 
 *Test Groups Query* permits a query to be tested for a specific user.
-Left-click to open:
+click to open:
 
 [#configure-ldap-test-groups-query]
 image::manage-security/testGroupsQuery.png[,340,align=left]
 
-To perform the search, add a username, and left-click on the *Test Groups Query* button.
+To perform the search, add a username, and click on the *Test Groups Query* button.
 Notifications confirming success or failure appear on the dialog.
 
 
@@ -299,7 +299,7 @@ See the description provided above, in xref:manage:manage-security/configure-lda
 It is strongly recommended that the *Advanced Settings* _not_ be changed; except in unusual circumstances, and in accordance with expert advice.
 Inappropriate settings may seriously impair system responsiveness.
 
-Left-click to open:
+Click to open:
 
 [#add-ldap-dialog-advanced-settings]
 image::manage-security/addLdapDialogAdvancedSettings.png[,440,align=left]
@@ -327,12 +327,12 @@ The maximum number of recursive group-queries that the server is allowed to perf
 This option is only valid when nested groups are enabled.
 The value must be an integer between 1 and 100: the default is 10.
 
-When all required data has been entered, left-click on the *Save LDAP Configuration* button, at the bottom right:
+When all required data has been entered, click on the *Save LDAP Configuration* button, at the bottom right:
 
 [#configure-ldap-dialog-save-button]
 image::manage-security/configureLDAPdialogSaveButton.png[,260,align=left]
 
-Alternatively, left-click on *Cancel* to abandon the configuration procedure.
+Alternatively, click on *Cancel* to abandon the configuration procedure.
 
 [#clearing-the-cache]
 === Clearing the Cache
@@ -350,7 +350,7 @@ Additionally, the *Clear Cache* button is provided, so that all currently cached
 
 To map an LDAP group to Couchbase-Server roles, create a Couchbase-Server user-group; associate the user-group with the LDAP group; and then assign roles to the user-group.
 
-Left-click on the *ADD GROUP* tab, at the upper right of the *Users & Groups* panel, on the *Security* screen:
+Click on the *ADD GROUP* tab, at the upper right of the *Users & Groups* panel, on the *Security* screen:
 
 [#access-groups-tab]
 image::manage-security/addGroupTab3.png[,180,align=left]
@@ -383,11 +383,11 @@ image::manage-security/addNewGroupDialogComplete.png[,420,align=left]
 This creates a group named `Admins`, and assigns the `Full Admin` role to it, specifying as its LDAP-group mapping `uid=cbadmins,ou=groups,dc=example,dc=com`.
 
 [#add-new-group-save-button]
-To save the group, left-click on the *Save* button, at the lower right.
+To save the group, click on the *Save* button, at the lower right.
 
 image::manage-security/addNewGroupSaveButton.png[,140,align=left]
 
-Alternatively, left-click on *Cancel* to abandon group configuration.
+Alternatively, click on *Cancel* to abandon group configuration.
 
 [#editing-a-group-mapping]
 === Editing a Group Mapping
@@ -396,7 +396,7 @@ Once a group-mapping has been defined, it can be edited.
 
 Access the *Users & Groups* panel of the *Security* screen.
 By default, this presents a _users_ view, listing the currently defined users for the cluster.
-To display the _groups_ view, left-click on the *Groups* tab, towards the upper right:
+To display the _groups_ view, click on the *Groups* tab, towards the upper right:
 
 image::manage-security/usersAndGroupsSelectGroups.png[,120,align=middle]
 
@@ -406,12 +406,12 @@ image::manage-security/usersAndGroupsGroupsView.png[,800,align=middle]
 
 This confirms the existence of the user-group `Admins`.
 
-Now, left-click on the row displayed for this group.
+Now, click on the row displayed for this group.
 The row expands vertically, and exposes additional controls:
 
 image::manage-security/expandedGroupRow.png[,800,align=middle]
 
-Left-click on the *Edit* button, at the lower right:
+Click on the *Edit* button, at the lower right:
 
 image::manage-security/editGroupRowButton.png[,180,align=middle]
 
@@ -422,7 +422,7 @@ image::manage-security/editGroupAdmins.png[,420,align=middle]
 Within this dialog, the description, mapping, or roles for the group can be edited.
 For details of selecting roles within the *Roles* panel, see xref:manage:manage-security/manage-users-and-roles.adoc[Manage Users, Groups, and Roles].
 
-Note that if the *Delete Group* button is left-clicked on, the group is deleted.
+Note that if the *Delete Group* button is clicked on, the group is deleted.
 This means that all mappings between LDAP groups and the roles that were assigned to this group are also deleted.
 
 [#adding-an-externally-authenticated-user]

--- a/modules/manage/pages/manage-security/configure-pam.adoc
+++ b/modules/manage/pages/manage-security/configure-pam.adoc
@@ -113,7 +113,7 @@ This brings up the [.ui]*Security* view:
 [#security_view_initial]
 image::manage-security/securityViewInitial.png[,820]
 
-. Left-click on the *ADD USER* button, situated near the right.
+. Click on the *ADD USER* button, situated near the right.
 This brings up the [.ui]*Add New User* dialog.
 Select the [.ui]*External* radio-button, in the [.ui]*Authentication Domain* panel at the upper left.
 Then, enter the name of the new user you are creating.
@@ -125,7 +125,7 @@ The panel now appears as follows:
 [#manage_user_new_subsequent2]
 image::manage-security/manageUserNewSubsequent2.png[,380]
 +
-Then, left-click on [.ui]*Save*.
+Then, click on [.ui]*Save*.
 The newly defined user now appears in the [.ui]*Security* view.
 +
 image::manage-security/linuxUser.png[,820]
@@ -155,7 +155,7 @@ When the Couchbase Web Console login-interface appears, enter the username and p
 [#couchbase_login]
 image::manage-security/couchbaseLogin.png[,360]
 +
-Left-click on the *Sign In* button.
+Click on the *Sign In* button.
 The user you created is now logged into Couchbase Server, as an administrator.
 
 [#troubleshooting]

--- a/modules/manage/pages/manage-security/configure-server-certificates.adoc
+++ b/modules/manage/pages/manage-security/configure-server-certificates.adoc
@@ -314,7 +314,7 @@ http://Administrator:password@10.143.192.102:8091/controller/uploadClusterCA
 +
 The root certificate is now activated for the entire cluster, and ready for use.
 This can be verified by means of Couchbase Web Console: access the *Security* screen, by means of the *Security* tab in the left-hand navigation bar.
-Then, left-click on the *Root Certificate* tab, located on the upper, horizontal navigation bar.
+Then, click on the *Root Certificate* tab, located on the upper, horizontal navigation bar.
 [#see-root-certificate-with-couchbase-web-console]
 The screen appears as follows:
 +

--- a/modules/manage/pages/manage-security/enable-client-certificate-handling.adoc
+++ b/modules/manage/pages/manage-security/enable-client-certificate-handling.adoc
@@ -14,7 +14,7 @@ Enablement can be accomplished with the xref:manage:manage-security/enable-clien
 
 Proceed as follows:
 
-. Access Couchbase Web Console, and left-click on the [.ui]*Security* tab, in the vertical navigation-bar, at the left-hand side of the *Dashboard*:
+. Access Couchbase Web Console, and click on the [.ui]*Security* tab, in the vertical navigation-bar, at the left-hand side of the *Dashboard*:
 +
 [#security-tab-with-hand-cursor]
 image::manage-security/securityTabWithHandCursor.png[,110,align=left]
@@ -26,7 +26,7 @@ image::manage-security/securityViewInitialNoUsers.png[,820,align=left]
 +
 The initial, default view is for [.ui]*Users*.
 
-. To manage client certificate handling, left-click on the *Client Certificate* tab, on the upper, horizontal control bar:
+. To manage client certificate handling, click on the *Client Certificate* tab, on the upper, horizontal control bar:
 +
 [#client-certificate-tab]
 image::manage-security/clientCertificateTab.png[,210,align=left]
@@ -61,14 +61,14 @@ These certificate-configuration options are described in detail in xref:learn:se
 The administrator who configures client-certificate handling on Couchbase Server is expected to anticipate what forms of username-specification are likely to occur in the certificates used by client applications, and to decide how they should be handled.
 +
 To enable Couchbase Server to identify the usernames embedded in client certificates, specify one or more appropriate combinations of *Path*, *Prefix*, and *Delimiter*.
-Add and delete rows as appropriate, by left-clicking on the *+* and *-* buttons.
+Add and delete rows as appropriate, by clicking on the *+* and *-* buttons.
 Note that the default option is *subject.cn*, which indicates that the _Subject Common Name_ within the certificate will be considered a username.
 +
 For an explanation of *Path*, *Prefix*, and *Delimiter* values, see
 xref:learn:security/certificates.adoc#identity-encoding-in-client-certificates[Specifying Usernames for Client-Certificate Authentication].
 Note that *Prefix* and *Delimiter* are optional; and their fields can therefore be left blank.
 
-. Left-click on the *Save* button, to save settings.
+. Click on the *Save* button, to save settings.
 Client certificates will now be handled in accordance with your specification.
 
 [#enable-client-certificate-handling-with-the-cli]

--- a/modules/manage/pages/manage-security/manage-auditing.adoc
+++ b/modules/manage/pages/manage-security/manage-auditing.adoc
@@ -25,7 +25,7 @@ The examples in the subsections below show how to manage auditing using the xref
 
 Proceed as follows.
 
-Access Couchbase Web Console, and left-click on the [.ui]*Security* tab, in the vertical navigation-bar, at the left-hand side of the Dashboard:
+Access Couchbase Web Console, and click on the [.ui]*Security* tab, in the vertical navigation-bar, at the left-hand side of the Dashboard:
 
 [#security-tab-with-hand-cursor]
 image::manage-security/securityTabWithHandCursor.png[,110,align=left]
@@ -36,7 +36,7 @@ This brings up the [.ui]*Security* screen, which appears as follows:
 image::manage-security/securityView.png[,820,align=left]
 
 The initial, default view is for [.ui]*Users*.
-To select auditing, left-click on the [.ui]*Audit* tab, on the horizontal control-bar, near the top:
+To select auditing, click on the [.ui]*Audit* tab, on the horizontal control-bar, near the top:
 
 [#audit-tab]
 image::manage-security/auditTab.png[,120,align=left]
@@ -81,7 +81,7 @@ To understand the difference between these, see xref:learn:security/auditing.ado
 Couchbase Web Console allows the user to enable event-auditing for the node; to enable filterable events per module; to disable filterable events individually, within each module; and to ignore all filterable events for specified local, external, and _internal_ (system) users.
 
 To view all filterable and non-filterable events for (for example) the Data Service, first, ensure that logging is enabled for the node, by checking the *Audit events & write them to a log* checkbox.
-Then, left-click on the right-pointing arrowhead adjacent to *Data Service*.
+Then, click on the right-pointing arrowhead adjacent to *Data Service*.
 The *Data Service* events panel opens, as follows:
 
 [#eventFilteringUIdataServiceInitial]
@@ -135,7 +135,7 @@ Each internal user should be specified in the form `@_internalusername_/couchbas
 For each user specified in the field, all filterable events will be ignored.
 Non-filterable events, however, will continue to be audited.
 
-Left-click on the *Save* button, to save the configuration.
+Click on the *Save* button, to save the configuration.
 
 [#managing-auditing-with-the-cli]
 == Managing Auditing with the CLI

--- a/modules/manage/pages/manage-security/manage-security-settings.adoc
+++ b/modules/manage/pages/manage-security/manage-security-settings.adoc
@@ -40,7 +40,7 @@ This brings up the *Security* screen, which appears as follows:
 [#couchbase-security-view]
 image::manage-security/securityView.png[,800,align=left]
 
-Note the tabs that run from left to right, along the upper, horizontal control-bar. These are *Users*, *Root Certificate*, *Client Certificate*, *Audit*, *Log Redaction*, and *Session*. To display the corresponding screen-content for each, left-click on the tab:
+Note the tabs that run from left to right, along the upper, horizontal control-bar. These are *Users*, *Root Certificate*, *Client Certificate*, *Audit*, *Log Redaction*, and *Session*. To display the corresponding screen-content for each, click on the tab:
 
 [#access-users-panel]
 image::manage-security/accessUsersPanel.png[,150,align=left]

--- a/modules/manage/pages/manage-security/manage-sessions.adoc
+++ b/modules/manage/pages/manage-security/manage-sessions.adoc
@@ -15,7 +15,7 @@ UI and REST API respectively. Sessions cannot be managed with the CLI.
 
 Proceed as follows:
 
-. Access the *Security* screen of Couchbase Web Console, by left-clicking
+. Access the *Security* screen of Couchbase Web Console, by clicking
 on the *Security* tab, in the right-hand navigation bar:
 +
 [#access-security-screen-image]
@@ -26,7 +26,7 @@ This brings up the *Security* screen, which appears as follows:
 [#couchbase-security-view]
 image::manage-security/securityView.png[,800,align=left]
 
-. Access the *Sessions* display, by left-clicking on the *Sessions* tab, on
+. Access the *Sessions* display, by clicking on the *Sessions* tab, on
 the upper, horizontal control-bar:
 +
 [#access-sessions-tab]

--- a/modules/manage/pages/manage-security/manage-users-and-roles.adoc
+++ b/modules/manage/pages/manage-security/manage-users-and-roles.adoc
@@ -19,7 +19,7 @@ For a list of available roles and corresponding privileges, see xref:learn:secur
 [#manage-users-with-the-ui]
 == Manage Users and Groups with the UI
 
-Access the [.ui]*Dashboard* of Couchbase Web Console, and left-click on the [.ui]*Security* tab, on the vertical navigation-bar, at the left.
+Access the [.ui]*Dashboard* of Couchbase Web Console, and click on the [.ui]*Security* tab, on the vertical navigation-bar, at the left.
 This brings up the [.ui]*Security* view, as follows:
 
 [#security_view]
@@ -28,7 +28,7 @@ image::manage-security/securityView.png[,820,align=left]
 [#users-and-groups-panel]
 The *Users & Groups* panel, which is visible by default on the [.ui]*Security* screen, allows _users_ and _groups_ to be defined.
 It also allows _roles_ to be assigned to users and groups.
-If at any time the *Users & Groups* panel is not currently visible, access it by left-clicking on the *Users & Groups* tab, which is located at the left-hand side of the upper, horizontal navigation-bar:
+If at any time the *Users & Groups* panel is not currently visible, access it by clicking on the *Users & Groups* tab, which is located at the left-hand side of the upper, horizontal navigation-bar:
 
 image::manage-security/usersAndGroupsTab.png[,170,align=left]
 
@@ -53,7 +53,7 @@ A _group_ can be defined, and roles assigned to it, by means of Couchbase Web Co
 Users can then be defined, and assigned to each group; each user thus being granted the group's roles.
 Groups may provide the most efficient way of managing role-assignments, when user-numbers are high.
 
-To define a group, left-click on the *Add Group* tab, near the upper right of the *Security* screen:
+To define a group, click on the *Add Group* tab, near the upper right of the *Security* screen:
 
 image::manage-security/addGroupTab2.png[,210,align=left]
 
@@ -75,7 +75,7 @@ The name of an existing LDAP group to which the new Couchbase-Server group is to
 For details, see xref:manage:manage-security/configure-ldap.adoc#map-ldap-groups-to-couchbase-server-roles[Map LDAP Groups to Couchbase Server Roles].
 
 * *Roles*. The roles to be associated with the new Couchbase-Server group.
-The display lists role-categories: to see roles, open each category by left-clicking on its right-pointing arrowhead, and scrolling down as appropriate.
+The display lists role-categories: to see roles, open each category by clicking on its right-pointing arrowhead, and scrolling down as appropriate.
 +
 The first category, which appears at the top of the panel, is for *Administration & Global Roles*: these roles are either administrative, or involve access to cluster-wide features.
 +
@@ -86,7 +86,7 @@ Thus, the new group can be assigned roles that apply either to all buckets defin
 [#all_buckets_checkboxes]
 image::manage-security/allBucketsCheckboxes.png[,280,align=left]
 +
-To display roles at lower levels of the *All Buckets (&#42;)* hierarchy, again, left-click on the right-pointing arrowheads.
+To display roles at lower levels of the *All Buckets (&#42;)* hierarchy, again, click on the right-pointing arrowheads.
 To assign roles to the new group, simply check the appropriate checkboxes.
 (Note that some roles are considered to be _subsets_ of others.
 In such cases, manually checking one checkbox may trigger the automated checking of others — indicating that the corresponding roles are also assigned to the new group.)
@@ -99,12 +99,12 @@ image::manage-security/addNewGroupDialogNoMapping.png[,420,align=left]
 As this indicates, no LDAP group mapping is required to define a group intended for the support only of users who are defined on Couchbase Server as _local_ or _external_.
 For an explanation of LDAP group mappings, see xref:manage:manage-security/configure-ldap.adoc#map-ldap-groups-to-couchbase-server-roles[Map LDAP Groups to Couchbase Server Roles].
 
-Save the group by left-clicking on the *Save* button.
+Save the group by clicking on the *Save* button.
 
 [#add-a-user]
 === Add a User
 
-To add a user, left-click on the [.ui]*Add User* control, at the upper right.
+To add a user, click on the [.ui]*Add User* control, at the upper right.
 
 image::manage-security/addUserTab3.png[,210,align=left]
 
@@ -135,13 +135,13 @@ For example, assign the *Query Curl Access* role:
 
 image::manage-security/addQueryCurlAccessRole.png[,280,align=left]
 
-Now, to add this user, left-click on the *Add User* button, at the lower right of the dialog.
+Now, to add this user, click on the *Add User* button, at the lower right of the dialog.
 Alternatively, continue the user-definition process, by assigning the user to a group.
 
 [#assigning-groups]
 ==== Assign a User to a Group
 
-To assign a user to a group, left-click on the *Groups* tab:
+To assign a user to a group, click on the *Groups* tab:
 
 image::manage-security/rolesAndGroupsToggle.png[,140,align=middle]
 
@@ -154,7 +154,7 @@ To add the user to the group, check the corresponding checkbox:
 
 image::manage-security/checkCllusterAdmin.png[,240,align=middle]
 
-Now left-click on the *Add User* button, at the lower right:
+Now click on the *Add User* button, at the lower right:
 
 image::manage-security/addUserButton.png[,170,align=middle]
 
@@ -169,24 +169,24 @@ Note also that the *auth domain* for the user is *Couchbase*, indicating that th
 ==== Editing Users and Groups
 
 Once created, users and groups can be edited.
-Left-click on the currently defined user's row:
+Click on the currently defined user's row:
 
 image::manage-security/userSecurityRowClicked.png[,800,align=middle]
 
 The row expands vertically, displaying control-buttons at the lower right.
-By left-clicking on [.ui]*Delete*, you delete the user.
-By left-clicking on [.ui]*Edit*, you bring up the [.ui]*Edit <username>* dialog,
+By clicking on [.ui]*Delete*, you delete the user.
+By clicking on [.ui]*Edit*, you bring up the [.ui]*Edit <username>* dialog,
 which provides options for redefining full name, roles, and groups.
 (The content of this dialog is similar to that of the [.ui]*Add New User* dialog, examined above.)
 The *Reset Password* button only appears when the selected user is
-_locally_ defined: left-clicking on this brings up a dialog that allows redefinition of the
+_locally_ defined: clicking on this brings up a dialog that allows redefinition of the
 user's password:
 
 [#reset_password]
 image::manage-security/resetPassword.png[,260,align=left]
 
 Note that the *Users & Groups* panel, subsequent to the definition of a user, displays two buttons towards the upper right, whereby *Users* and *Groups* views can be accessed in turn.
-To inspect and make changes to the currently defined group, left-click on the *Groups* button:
+To inspect and make changes to the currently defined group, click on the *Groups* button:
 
 image::manage-security/accessGroupsButton.png[,150,align=left]
 
@@ -194,8 +194,8 @@ The *Groups* view is now displayed:
 
 image::manage-security/groupSecurityRow.png[,800,align=left]
 
-As with the *Users* view, left-clicking on a group's row displays controls that include *Delete* and *Edit* options.
-Left-click on the *Edit* button to display the *Edit Group <group-name>* dialog, which is similar to the *Add New Group*
+As with the *Users* view, clicking on a group's row displays controls that include *Delete* and *Edit* options.
+Click on the *Edit* button to display the *Edit Group <group-name>* dialog, which is similar to the *Add New Group*
 dialog examined above, and allows all the group's attributes, except the name, to be modified.
 
 [#adding-an-externally-authenticated-user]

--- a/modules/manage/pages/manage-settings/configure-alerts.adoc
+++ b/modules/manage/pages/manage-settings/configure-alerts.adoc
@@ -23,7 +23,7 @@ xref:manage:manage-settings/configure-alerts.adoc#configure-email-alerts-with-re
 [#configure-email-alerts-with-the-ui]
 == Configure Email Alerts with the UI
 
-Access the *Email Alerts* settings screen. First, left-click on the *Settings* tab, in the navigation bar at the left-hand side of Couchbase Web Console:
+Access the *Email Alerts* settings screen. First, click on the *Settings* tab, in the navigation bar at the left-hand side of Couchbase Web Console:
 
 image::manage-settings/settingsTab.png[,120,align=left]
 
@@ -89,15 +89,15 @@ To specify more than one recipient, separate each address by a space, comma (,),
 
 When you have entered appropriate data into the fields, proceed as follows:
 
-. Save the configuration, by left-clicking on the *Save* button, at the bottom of the screen:
+. Save the configuration, by clicking on the *Save* button, at the bottom of the screen:
 +
 image::manage-settings/saveEmailAlertsConfiguration.png[,240,align=left]
 +
-Note that when you left-click on *Save*, the password that you typed into the *Password* field becomes invisible, and the field therefore appears blank.
+Note that when you click on *Save*, the password that you typed into the *Password* field becomes invisible, and the field therefore appears blank.
 This is a security measure imposed by Couchbase Server: the password remains valid, and will be used in authenticating with the email server.
 +
-Alternatively, left-click on *Cancel/Reset*, to remove the configuration.
-. Optionally, left-click on the *Send Test Email* button, to send a test email.
+Alternatively, click on *Cancel/Reset*, to remove the configuration.
+. Optionally, click on the *Send Test Email* button, to send a test email.
 
 [#available-alerts]
 === Available Alerts

--- a/modules/manage/pages/manage-settings/configure-compact-settings.adoc
+++ b/modules/manage/pages/manage-settings/configure-compact-settings.adoc
@@ -19,12 +19,12 @@ Full and Cluster administrators can configure compaction settings with xref:mana
 To access the Auto-Compaction settings:
 
 For a new bucket:{blank}:: Access the [.ui]*Buckets* screen provided by the Couchbase Web Console.
-Left-click on the *Add Bucket* button:
+Click on the *Add Bucket* button:
 +
 [#add-bucket-button]
 image::manage-settings/addBucketButton.png[,100,align=left]
 +
-When the [.ui]*Add Data Bucket* dialog appears, add appropriate data into the initial fields; then left-click on the [.ui]*Advanced bucket settings* tab:
+When the [.ui]*Add Data Bucket* dialog appears, add appropriate data into the initial fields; then click on the [.ui]*Advanced bucket settings* tab:
 +
 [#show_advanced_settings]
 image::manage-settings/show-advanced-settings.png[,360,align=left]
@@ -37,18 +37,18 @@ image::manage-settings/override-default-auto-compaction.png[,370,align=left]
 +
 The dialog expands again, and displays Auto-Compaction settings available for this bucket.
 
-For an existing bucket:{blank}:: Left-click on the information-row for the bucket, on the [.ui]*Buckets* screen of the Couchbase Web Console.
-When the *Edit* button appears, left-click on it:
+For an existing bucket:{blank}:: Click on the information-row for the bucket, on the [.ui]*Buckets* screen of the Couchbase Web Console.
+When the *Edit* button appears, click on it:
 +
 [#edit-bucket-definition-button]
 image::manage-settings/edit-bucket-definition-button.png[,300,align=left]
 +
-This brings up the [.ui]*Edit Bucket Settings* dialog: left-click on the [.ui]*Show advanced bucket settings* tab.
+This brings up the [.ui]*Edit Bucket Settings* dialog: click on the [.ui]*Show advanced bucket settings* tab.
 Access the [.ui]*Auto-Compaction* panel, and check the [.ui]*Override the default auto-compaction settings?* checkbox.
 The dialog expands, thereby showing the available Auto-Compaction settings.
 
-For all buckets for which no override is specified:{blank}:: Left-click on the [.ui]*Settings* tab, in the vertical navigation-bar at the left-hand side.
-When the [.ui]*Settings* screen appears, left-click on the [.ui]*Auto-Compaction* tab, on the horizontal control-bar at the top:
+For all buckets for which no override is specified:{blank}:: Click on the [.ui]*Settings* tab, in the vertical navigation-bar at the left-hand side.
+When the [.ui]*Settings* screen appears, click on the [.ui]*Auto-Compaction* tab, on the horizontal control-bar at the top:
 +
 [#auto_compaction_tab]
 image::manage-settings//auto-compaction-tab.png[,360,align=left]

--- a/modules/manage/pages/manage-settings/general-settings.adoc
+++ b/modules/manage/pages/manage-settings/general-settings.adoc
@@ -152,7 +152,7 @@ In particular, a high number of _writer_ threads on such systems may significant
 Note, however, that a high thread-allocation might _impair_ some aspects of system-performance on less appropriately resourced nodes.
 Consequently, changes to the default thread-allocation should not be made to production systems without prior testing.
 
-Left-clicking on the *Advanced Data Settings* tab displays radio buttons for *Reader Thread Settings* and *Writer Thread Settings*:
+Clicking on the *Advanced Data Settings* tab displays radio buttons for *Reader Thread Settings* and *Writer Thread Settings*:
 
 image::manage-settings/data-settings.png[,540,align=left]
 
@@ -170,7 +170,7 @@ The number of threads allocated is equal to the value selected from the pull-dow
 [#query-settings]
 === Query Settings
 
-Left-clicking on the *Advanced Query Settings* tab displays interactive fields whereby the Query Service can be configured.
+Clicking on the *Advanced Query Settings* tab displays interactive fields whereby the Query Service can be configured.
 The top section of the panel appears as follows:
 
 image::manage-settings/query-settings-top.png[,540,align=left]
@@ -243,11 +243,11 @@ image::manage-settings/xdcr-maximum-processes.png[,540,align=left]
 
 [#saving-settings]
 === Saving Settings
-To save settings, left-click on the *Save* button, at the lower left.
+To save settings, click on the *Save* button, at the lower left.
 
 image::manage-settings/save-or-cancel.png[,220,align=left]
 
-Alternatively, cancel recently entered values, and thereby reset to previous values; by left-clicking on *Cancel/Reset*.
+Alternatively, cancel recently entered values, and thereby reset to previous values; by clicking on *Cancel/Reset*.
 
 [#configure-general-settings-with-the-cli]
 == Configure General Settings with the CLI

--- a/modules/manage/pages/manage-settings/manage-settings.adoc
+++ b/modules/manage/pages/manage-settings/manage-settings.adoc
@@ -6,7 +6,7 @@ Couchbase-Server _settings_ can be established by the administrator.
 [#couchbase-server-settings-overview]
 == Settings Overview
 
-The _settings_ for Couchbase Server can be accessed via Couchbase Web Console. Left-click on the *Settings* tab, in the left-hand navigation menu:
+The _settings_ for Couchbase Server can be accessed via Couchbase Web Console. Click on the *Settings* tab, in the left-hand navigation menu:
 
 image::manage-settings/settingsTab.png[,120,align=left]
 

--- a/modules/manage/pages/manage-statistics/manage-statistics.adoc
+++ b/modules/manage/pages/manage-statistics/manage-statistics.adoc
@@ -15,7 +15,7 @@ Statistics can be viewed by means of xref:manage:manage-statistics/manage-statis
 == Manage Statistics with the UI
 
 Users with the *Full Admin* or *Bucket Admin* role can assemble statistics as _groups_ of _charts_, on the *Dashboard* of Couchbase Web Console.
-This is visible by default after login; and can at any time be displayed by left-clicking on the *Dashboard* tab, in the left-hand navigation bar:
+This is visible by default after login; and can at any time be displayed by clicking on the *Dashboard* tab, in the left-hand navigation bar:
 
 [#access-dashboard]
 image::manage-statistics/DBaccessDB.png[,100,align=left]
@@ -33,8 +33,8 @@ Near the top, a notification is provided, regarding *buckets*:
 image::manage-statistics/DBaddBucketInstruction.png[,560,align=left]
 
 Couchbase Web Console organizes statistics by _bucket_: therefore, until a bucket is added to the cluster, no statistics can be shown.
-To add a bucket, left-click on one of the options provided by the notification.
-Either left-click on xref:manage:manage-buckets/create-bucket.adoc[Buckets], to add a custom bucket; or, left-click on xref:manage:manage-settings/install-sample-buckets.adoc[sample bucket], to install a sample bucket.
+To add a bucket, click on one of the options provided by the notification.
+Either click on xref:manage:manage-buckets/create-bucket.adoc[Buckets], to add a custom bucket; or, click on xref:manage:manage-settings/install-sample-buckets.adoc[sample bucket], to install a sample bucket.
 
 The following examples assume that the `travel-sample` bucket has been installed.
 The dashboard now appears as follows:
@@ -43,7 +43,7 @@ The dashboard now appears as follows:
 image::manage-ui/ClusterOverview.png[,740,align=left]
 
 The *Cluster Overview* thus displays animated charts that provide a variety of information on the status of data-management on the cluster.
-Additional information can be displayed by left-clicking on the *Node Resources* tab.
+Additional information can be displayed by clicking on the *Node Resources* tab.
 
 [#dashboard-access]
 === Dashboard Access
@@ -63,7 +63,7 @@ In the upper part of the screen, the following controls appear:
 image::manage-statistics/dashboardControls.png[,540,align=left]
 
 The control at the left reads *Cluster Overview*.
-When left-clicked on, it displays a pull-down menu, as follows:
+When clicked on, it displays a pull-down menu, as follows:
 
 image::manage-statistics/DashboardToggle.png[,280,align=left]
 
@@ -74,7 +74,7 @@ Currently, the menu provides two dashboards for display.
 
 The second control to the right reads, by default, *minute*.
 This control allows selection of the time-granularity for chart-display.
-Left-click on the control to display a pull-down menu of options:
+Click on the control to display a pull-down menu of options:
 
 [#time-control-three]
 image::manage-statistics/timeGranularityOptions.png[,130,align=left]
@@ -86,7 +86,7 @@ The current option, *travel-sample*, is the only option available, since it is t
 image::manage-statistics/dashboardBucketControl.png[,150,align=left]
 
 The fourth control to the right reads *all server nodes*, and indicates in parentheses the number of nodes currently in the cluster.
-Left-click on the control to display the individual nodes:
+Click on the control to display the individual nodes:
 
 image::manage-statistics/allServerNodesPullDown.png[,280,align=left]
 
@@ -97,12 +97,12 @@ At the far right of the screen, the *Reset* control is displayed:
 
 image::manage-statistics/resetButton.png[,120,align=left]
 
-Left-clicking on this control provides the following notification:
+Clicking on this control provides the following notification:
 
 image::manage-statistics/resetDashboardNotiification.png[,320,align=left]
 
 As this indicates, confirming will delete _all_ previously made customisations.
-Therefore, to keep changes you have made to your dashboard-appearance, left-click on *Cancel*.
+Therefore, to keep changes you have made to your dashboard-appearance, click on *Cancel*.
 
 [#add-a-dashboard]
 === Add a Dashboard
@@ -114,7 +114,7 @@ To define a dashboard, access the *New Dashboard* control, in the pull-down menu
 
 image::manage-statistics/clickToAddDashboardOne.png[,260,align=left]
 
-Left-clicking on the '*+*' symbols displays an extension to the pull-down:
+Clicking on the '*+*' symbols displays an extension to the pull-down:
 
 image::manage-statistics/clickToAddDashboardTwo.png[,260,align=left]
 
@@ -126,7 +126,7 @@ To create a new dashboard named *Test Dashboard* that initially has no content, 
 
 image::manage-statistics/clickToAddDashboardThree.png[,260,align=left]
 
-Left-click on the *Save* button.
+Click on the *Save* button.
 The new dashboard is now displayed, as follows:
 
 image::manage-statistics/testDashboardInitialAppearance.png[,680,align=left]
@@ -142,7 +142,7 @@ image:manage-statistics/pullDownMenuWithNewDashboard.png[,260,align=left]
 [#add-a group]
 === Add a Group
 
-To add a _group_ of charts to the current dashboard, left-click on the *Add Group* button, at the upper right:
+To add a _group_ of charts to the current dashboard, click on the *Add Group* button, at the upper right:
 
 image::manage-statistics/addGroupButton.png[,160,align=left]
 
@@ -150,7 +150,7 @@ This displays the *New Group* dialog:
 
 image::manage-statistics/newGroupDialog.png[,360,align=left]
 
-Add an appropriate name for the group of charts you are creating, and left-click on the *Save* button:
+Add an appropriate name for the group of charts you are creating, and click on the *Save* button:
 
 image::manage-statistics/newGroupDialogFilled.png[,360,align=left]
 
@@ -161,7 +161,7 @@ image::manage-statistics/dashboardWithInitialGroup.png[,680,align=left]
 The newly defined group *Test Group* appears on the dashboard.
 Currently, it contains no charts: however, it displays an interactive '*+*' symbol, which can be used to start the chart-addition process.
 
-Left-click on the '*+*' symbol:
+Click on the '*+*' symbol:
 
 image::manage-statistics/clickOnChartAddition.png[,120,align=left]
 
@@ -180,7 +180,7 @@ This is the default selection.
 This allows easy visual comparisons to be made between different speeds and usage-rates, calculated across all of the nodes.
 
 In the middle of the dialog, interactive tabs appear for *System*, *Data*, *Index*, *Query*, *Search*, *Analytics*, *Eventing*, and *XDCR*.
-By left-clicking on any of these, associated statistics are displayed in the lower section of the dialog.
+By clicking on any of these, associated statistics are displayed in the lower section of the dialog.
 The *System* tab is selected by default: consequently, the associated statistics *CPU*, *Streaming Wakeups*, *HTTP Request Rate*, *Idle Streaming Requests*, *Available RAM*, and *Swap Used* are displayed.
 Each of these statistics is accompanied by a check-box, to permit its selection.
 
@@ -201,7 +201,7 @@ Note that at the upper right, a selector is provided whereby the size of the cha
 
 image::manage-statistics/chartSizeSelector.png[,120,align=left]
 
-Leaving the selection as *S* (for small), left-click on the *Save Chart* button.
+Leaving the selection as *S* (for small), click on the *Save Chart* button.
 The dashboard now appears as follows:
 
 image::manage-statistics/dashboardWithOneChart.png[,680,align=left]
@@ -221,7 +221,7 @@ By hovering the mouse-cursor over the central, data-bearing area of the chart, a
 image::manage-statistics/cpuChartWithPopUpDisplayed.png[,480,align=left]
 
 As this clarifies, the chart's blue and orange lines provide the *CPU* statistic for each of the cluster's two nodes.
-To improve readabiliy further, left-click on the chart, to maximize it.
+To improve readabiliy further, click on the chart, to maximize it.
 The appearance is now as follows:
 
 image::manage-statistics/cpuChartMaximized.png[,620,align=left]
@@ -243,13 +243,13 @@ The maximized chart now appears as follows:
 
 image::manage-statistics/cpuChartMaximizedWithMinuteSelection.png[,620,align=left]
 
-Minimize the chart by left-clicking on the '*X*' icon, at the upper-right:
+Minimize the chart by clicking on the '*X*' icon, at the upper-right:
 
 image::manage-statistics/XiconSelection.png[,50,align=left]
 
 === Creating a Chart of Multiple Statistics, Each Representing the Whole Cluster
 
-Left-click on the dashboard's '*+*' icon.
+Click on the dashboard's '*+*' icon.
 
 When the *Add Chart* dialog appears, select the *combine node data + multiple stats per chart* radio button.
 Accepting the default *System* setting, select the *CPU*, *Available RAM*, and *Swap Used* checkboxes:
@@ -258,12 +258,12 @@ image::manage-statistics/multStatisticChartSelections.png[,580,align=left]
 
 Note that because certain statistics are incompatible with one another, in terms of co-located display, the selection of some may grey-out the others &#8212; as is the case with *Idle Streaming Requests*, *Streaming Wakeups*, and *HTTP Request Rate* here.
 
-Left-click on *Save Chart*, to save.
+Click on *Save Chart*, to save.
 The dashboard now appears as follows:
 
 image::manage-statistics/dashboardWithMultiStatisticChartAdded.png[,680,align=left]
 
-Left-click on the new chart, to maximize:
+Click on the new chart, to maximize:
 
 image::manage-statistics/multiStatisticChartMaximized.png[,680,align=left]
 

--- a/modules/manage/pages/manage-ui/manage-ui.adoc
+++ b/modules/manage/pages/manage-ui/manage-ui.adoc
@@ -59,7 +59,7 @@ Therefore, when port _8091_ is accessed by means of the browser, the following i
 [#console-login-screen]
 image::manage-ui/loginScreen.png[,360,align=left]
 
-Enter username and password, and left-click on the *Sign In* button to access the console.
+Enter username and password, and click on the *Sign In* button to access the console.
 
 Detailed information on authenticating with Couchbase Server is provided in xref:learn:security/authentication-overview.adoc[Authentication].
 
@@ -85,7 +85,7 @@ At the right, it provides information identifying the version of the server that
 In the white horizontal band immediately above the banner, at the right-hand side, three interactive options appear:
 
 * *activity*. When Couchbase Server is engaged in an activity of any considerable duration (such as loading data, or distributing data across multiple nodes), an alert is provided; in the form of an interactive, orange icon.
-Left-click on this, to display the notification.
+click on this, to display the notification.
 For example:
 +
 [#activity-notification]
@@ -110,7 +110,7 @@ After this procedure is followed for the `travel-sample` bucket, the *Dashboard*
 image::manage-ui/ClusterOverview.png[,720,align=left]
 
 The *Cluster Overview* thus displays animated charts that provide a variety of information on the status of data-management on the cluster.
-Additional information can be displayed by left-clicking on the *Node Resources* tab.
+Additional information can be displayed by clicking on the *Node Resources* tab.
 
 The *Cluster Overview* display can be alternated with the *All Services* display, by means of the pull-down menu at the upper left:
 
@@ -129,7 +129,7 @@ On initial console-access, the *Dashboard* tab, at the top, is selected by defau
 Information is provided below on each of the possible selections.
 
 Note that when the mouse cursor is hovered over elements in the navigation bar, a toggle appears at the lower left.
-Left-clicking on this causes the navigation bar to be collapsed, thereby freeing up more horizontal space for the main panel.
+Clicking on this causes the navigation bar to be collapsed, thereby freeing up more horizontal space for the main panel.
 
 [#console-nav-bar-toggle]
 image::manage-ui/navBarToggle.png[,120,align=left]
@@ -159,28 +159,28 @@ For example:
 [#console-notification]
 image::manage-ui/notificationTypes.png[,360,align=left]
 
-Note that red notifications provide a red, interactive `X`, which must be left-clicked on, to dismiss the notification.
+Note that red notifications provide a red, interactive `X`, which must be clicked on, to dismiss the notification.
 Green and orange notifications are self-dismissive.
 
 [#accesing-features]
 == Accessing Features
 
-Couchbase Web Console allows users to access features by left-clicking on _tabs_.
+Couchbase Web Console allows users to access features by clicking on _tabs_.
 Tabs are located:
 
 * _In the left-hand navigation bar_.
-Whenever a tab is left-clicked on, the appearance of the console's _main panel_ changes, to display content for the selected feature.
+Whenever a tab is clicked on, the appearance of the console's _main panel_ changes, to display content for the selected feature.
 
 * _In the upper, horizontal navigation bar_.
 This appears, for _some_ features, immediately above the main panel.
-Whenever a tab is left-clicked on, the appearance of the main panel changes, to display alternative content for the feature selected from the left-hand navigation bar.
+Whenever a tab is clicked on, the appearance of the main panel changes, to display alternative content for the feature selected from the left-hand navigation bar.
 
-The remaining sections on this page describe in turn the features accessed by left-clicking on the tabs provided.
+The remaining sections on this page describe in turn the features accessed by clicking on the tabs provided.
 
 [#console-nav-servers]
 == Servers
 
-Left-click on the *Servers* tab, in the left-hand navigation bar:
+Click on the *Servers* tab, in the left-hand navigation bar:
 
 [#console-servers-tab]
 image::manage-ui/serversTab.png[,100,align=left]
@@ -220,7 +220,7 @@ The active and replica data items currently residing on the node.
 For information on intra-cluster replication, see xref:learn:clusters-and-availability/intra-cluster-replication.adoc[Intra-Cluster Replication].
 
 * *Statistics*
-Left-click on this interactive tab, to display statistics.
+Click on this interactive tab, to display statistics.
 Note that statistics are only available when at least one bucket has been installed.
 
 Above the server-information row, two additional controls are provided:
@@ -230,7 +230,7 @@ To filter the display of servers (when there are multiple servers listed), enter
 Only servers whose names provide a match are then displayed.
 
 * *Rebalance*.
-Left-clicking on this control causes a _rebalance_ to be performed, across the cluster.
+Clicking on this control causes a _rebalance_ to be performed, across the cluster.
 For conceptual information on rebalance, see xref:learn:clusters-and-availability/rebalance.adoc[Rebalance].
 For practical information on performing rebalance, see xref:manage:manage-nodes/add-node-and-rebalance.adoc[Add a Node and Rebalance].
 
@@ -258,7 +258,7 @@ To manage servers, see xref:manage:manage-nodes/node-management-overview.adoc[Ma
 [#console-buckets]
 == Buckets
 
-To access the *Buckets* screen, left-click on the tab in the left-hand navigation bar:
+To access the *Buckets* screen, click on the tab in the left-hand navigation bar:
 
 [#console-buckets-tab]
 image::manage-ui/bucketsTab.png[,100,align=left]
@@ -301,7 +301,7 @@ To the right-hand side of the column, two tabs are provided, whereby additional 
 The *Documents* tab allows the documents within the bucket to be individually read and edited.
 This facility can also be accessed by means of the *Documents* tab, in the left-hand navigation bar; as explained in xref:manage:manage-ui/manage-ui.adoc#console-documents[Documents], below.
 The *Statistics* tab allows statistical information for the bucket to be displayed.
-By left-clicking on this tab, the *Statistics* screen is accessed:
+By clicking on this tab, the *Statistics* screen is accessed:
 
 [#console-buckets-statistics]
 image::manage-ui/statisticsScreen.png[,700,align=left]
@@ -356,7 +356,7 @@ Information on how to manage buckets is provided in xref:manage:manage-buckets/b
 [#console-xdcr]
 == XDCR
 
-To access the *XDCR* screen, left-click on the tab in the left-hand navigation bar:
+To access the *XDCR* screen, click on the tab in the left-hand navigation bar:
 
 [#console-xdcr-tab]
 image::manage-ui/xdcrTab.png[,100,align=left]
@@ -381,7 +381,7 @@ Instructions on setting up and performing XDCR are provided in xref:manage:manag
 [#console-security]
 == Security
 
-To access the *Security* screen, left-click on the tab in the left-hand navigation bar:
+To access the *Security* screen, click on the tab in the left-hand navigation bar:
 
 [#console-security-tab]
 image::manage-ui/securityTab.png[,100,align=left]
@@ -405,7 +405,7 @@ For practical steps towards securing a cluster, see xref:manage:manage-security/
 [#console-settings]
 == Settings
 
-To access the *Settings* screen, left-click on the tab in the left-hand navigation bar:
+To access the *Settings* screen, click on the tab in the left-hand navigation bar:
 
 [#console-settings-tab]
 image::manage-ui/settingsTab.png[,100,align=left]
@@ -427,7 +427,7 @@ Further information is provided in xref:manage:manage-settings/manage-settings.a
 [#console-logs]
 == Logs
 
-To access the *Logs* screen, left-click on the tab in the left-hand navigation bar:
+To access the *Logs* screen, click on the tab in the left-hand navigation bar:
 
 [#console-logs-tab]
 image::manage-ui/logsTab.png[,100,align=left]
@@ -451,7 +451,7 @@ Full details are provided in xref:manage:manage-logging/manage-logging.adoc[Mana
 [#console-documents]
 == Documents
 
-To access the *Documents* screen, left-click on the tab in the left-hand navigation bar:
+To access the *Documents* screen, click on the tab in the left-hand navigation bar:
 
 [#console-documents-tab]
 image::manage-ui/documentsTab.png[,100,align=left]
@@ -485,7 +485,7 @@ For a full explanation of _documents_, and an overview of the Couchbase _data mo
 [#console-query]
 == Query
 
-To access the *Query* screen, left-click on the tab in the left-hand navigation bar:
+To access the *Query* screen, click on the tab in the left-hand navigation bar:
 
 [#console-query-tab]
 image::manage-ui/queryTab.png[,100,align=left]
@@ -514,7 +514,7 @@ For information on N1QL, see the xref:n1ql:n1ql-language-reference/index.adoc[N1
 [#console-search]
 == Search
 
-To access the *Search* screen, left-click on the tab in the left-hand navigation bar:
+To access the *Search* screen, click on the tab in the left-hand navigation bar:
 
 [#console-search-tab]
 image::manage-ui/searchTab.png[,100,align=left]
@@ -537,7 +537,7 @@ For an explanation of the Search Service, and detailed examples of search-index 
 [#console-analytics]
 == Analytics
 
-To access the *Analytics* screen, left-click on the tab in the left-hand navigation bar:
+To access the *Analytics* screen, click on the tab in the left-hand navigation bar:
 
 [#console-analytics-tab]
 image::manage-ui/analyticsTab.png[,100,align=left]
@@ -558,7 +558,7 @@ For an explanation of the Analytics Service, see the xref:analytics:introduction
 [#console-eventing]
 == Eventing
 
-To access the *Eventing* screen, left-click on the tab in the left-hand navigation bar:
+To access the *Eventing* screen, click on the tab in the left-hand navigation bar:
 
 [#console-eventing-tab]
 image::manage-ui/eventingTab.png[,100,align=left]
@@ -578,7 +578,7 @@ For an explanation of the Eventing Service, see xref:eventing:eventing-overview.
 [#console-views]
 == Views
 
-To access the *Views* screen, left-click on the tab in the left-hand navigation bar:
+To access the *Views* screen, click on the tab in the left-hand navigation bar:
 
 [#console-views-tab]
 image::manage-ui/viewsTab.png[,100,align=left]
@@ -598,7 +598,7 @@ For a detailed explanation of Views, see xref:learn:views/views-intro.adoc[Views
 [#console-indexes]
 == Indexes
 
-To access the *Indexes* screen, left-click on the tab in the left-hand navigation bar:
+To access the *Indexes* screen, click on the tab in the left-hand navigation bar:
 
 [#console-indexes-tab]
 image::manage-ui/indexesTab.png[,100,align=left]

--- a/modules/manage/pages/manage-xdcr/create-xdcr-reference.adoc
+++ b/modules/manage/pages/manage-xdcr/create-xdcr-reference.adoc
@@ -55,7 +55,7 @@ For information on listing and creating additional buckets, see xref:manage:mana
 Proceed as follows:
 
 . Access Couchbase Web Console.
-Left-click on the *XDCR* tab, in the left-hand navigation menu.
+Click on the *XDCR* tab, in the left-hand navigation menu.
 +
 [#left_click_on_xdcr_tab]
 image::manage-xdcr/left-click-on-xdcr-tab.png[,100,align=middle]
@@ -68,7 +68,7 @@ image::manage-xdcr/xdcr-replications-screen-initial.png[,840,align=left]
 The upper part of the main panel is entitled *Remote Clusters*.
 The list, which is designed to show the name and IP address or hostname of each registered remote cluster, is currently empty, and so bears the notification `No cluster references defined. Use ADD REMOTE to set one up.`
 
-. Define a reference, by left-clicking on the *ADD REMOTE* button, at the upper right.
+. Define a reference, by clicking on the *ADD REMOTE* button, at the upper right.
 +
 [#xdcr-add-remote-cluster-button]
 image::manage-xdcr/xdcr-add-remote-cluster-button.png[,110,align=middle]
@@ -88,7 +88,7 @@ The complete dialog appears as follows:
 [#xdcr-add-remote-cluster-dialog-complete]
 image::manage-xdcr/xdcr-add-remote-cluster-dialog-complete.png[,400,align=left]
 +
-When you have entered the data, left-click on the *Save* button.
+When you have entered the data, click on the *Save* button.
 +
 The *XDCR Replications* screen is again displayed:
 +
@@ -105,11 +105,11 @@ This concludes reference-definition.
 [#editing-and-deleting-references-with-the-ui]
 == Editing and Deleting References with the UI
 
-By left-clicking on the row for a particular, defined reference, buttons for editing and deleting the reference are displayed:
+By clicking on the row for a particular, defined reference, buttons for editing and deleting the reference are displayed:
 
 image::manage-xdcr/deleteAndEditReferenceButtons.png[,800,align=left]
 
-Now, by left-clicking on the *Edit* and *Delete* buttons themselves, you can respectively edit (by means of the *Edit Remote Cluster* dialog, which is identical to the *Add Remote Cluster* dialog) and delete defined references.
+Now, by clicking on the *Edit* and *Delete* buttons themselves, you can respectively edit (by means of the *Edit Remote Cluster* dialog, which is identical to the *Add Remote Cluster* dialog) and delete defined references.
 Note that if a reference is already associated with a replication, you cannot delete the reference; nor can you modify its target IP address.
 However, you _can_ change the registered name of the target cluster, and you can change the security settings for the replication.
 

--- a/modules/manage/pages/manage-xdcr/create-xdcr-replication.adoc
+++ b/modules/manage/pages/manage-xdcr/create-xdcr-replication.adoc
@@ -49,7 +49,7 @@ These are named after their IP addresses: `10.142.180.101` and `10.142.180.102`.
 Proceed as follows:
 
 . Access Couchbase Web Console.
-Left-click on the *XDCR* tab, in the left-hand navigation menu.
+Click on the *XDCR* tab, in the left-hand navigation menu.
 +
 [#left_click_on_xdcr_tab]
 image::manage-xdcr/left-click-on-xdcr-tab.png[,90,align=left]
@@ -61,7 +61,7 @@ image::manage-xdcr/xdcr-outgoing-replications-initial.png[,800,align=left]
 +
 The list, which is designed to show the name and IP address or hostname of each existing replication, is currently empty, and so bears the notification `There are currently no replications defined. Use ADD REPLICATION to set one up`.
 
-. To start creating a replication, left-click on the
+. To start creating a replication, click on the
 *ADD REPLICATION* button:
 +
 [#left-click-on-add-replication-button]
@@ -84,7 +84,7 @@ The completed dialog now appears as follows.
 image::manage-xdcr/xdcr-add-replication-dialog-complete.png[,400,align=left]
 +
 [#ongoing-replications-with-replication]
-. Left-click on the *Save* button.
+. Click on the *Save* button.
 The *XDCR Replications* screen is now redisplayed, with the appearance of the *Outgoing Replications* panel as follows:
 +
 image::manage-xdcr/xdcr-outgoing-replications-with-replication.png[,800,align=left]
@@ -92,13 +92,13 @@ image::manage-xdcr/xdcr-outgoing-replications-with-replication.png[,800,align=le
 This indicates that a replication is now in progress: from `travel-sample` on `this cluster` to `bucket "travel-sample" on cluster "10.142.180.102"`.
 
 This concludes creation of the replication.
-Note that by left-clicking on the row for the replication, additional controls can be displayed:
+Note that by clicking on the row for the replication, additional controls can be displayed:
 
 image::manage-xdcr/xdcr-outgoing-replications-with-replication-opened.png[,800,align=left]
 
 Use of the *Pause* control is described in xref:manage:manage-xdcr/pause-xdcr-replication.adoc[Pause a Replication]; use of the *Delete* control in xref:manage:manage-xdcr/delete-xdcr-replication.adoc[Delete a Replication]; and use of the *Edit* control in xref:manage:manage-xdcr/filter-xdcr-replication.adoc#editing-filters[Editing Filters].
 
-To see real-time statistics on the current replication, left-click on the *XDCR Stats* tab, at the left:
+To see real-time statistics on the current replication, click on the *XDCR Stats* tab, at the left:
 
 image::manage-xdcr/xdcr-statistics.png[,600,align=left]
 
@@ -108,7 +108,7 @@ For information on how to read the interactive charts now displayed, see xref:ma
 [#xdcr-advanced-filtering-pointer]
 === Advanced Filtering with the UI
 
-*Advanced Filtering* can be enabled by left-clicking on *Replication Filters*.
+*Advanced Filtering* can be enabled by clicking on *Replication Filters*.
 The UI expands to reveal the following field:
 
 [#xdcr-advanced-filtering-initial]
@@ -130,7 +130,7 @@ The practical steps required for establishing filters are explained in xref:mana
 [#xdcr-advanced-settings-pointer]
 === Advanced Replication Settings with the UI
 
-Left-click on the *Advanced Replication Settings* control, on the *Add Replication* dialog.
+Click on the *Advanced Replication Settings* control, on the *Add Replication* dialog.
 The UI expands vertically, to reveal the following:
 
 [#xdcr-advanced-settings-menu]
@@ -146,7 +146,7 @@ If, while a replication is in progress, errors occur, a notification appears adj
 
 image::manage-xdcr/xdcr-error-notification.png[,120,align=left]
 
-Left-click on the orange icon, to display a full account of problems:
+Click on the orange icon, to display a full account of problems:
 
 image::manage-xdcr/xdcr-error-notification-full.png[,400,align=left]
 

--- a/modules/manage/pages/manage-xdcr/delete-xdcr-reference.adoc
+++ b/modules/manage/pages/manage-xdcr/delete-xdcr-reference.adoc
@@ -15,7 +15,7 @@ As their starting-point, the examples assume the scenario that concluded the pag
 Proceed as follows:
 
 . Access Couchbase Web Console.
-Left-click on the *XDCR* tab, in the left-hand navigation menu.
+Click on the *XDCR* tab, in the left-hand navigation menu.
 +
 [#left_click_on_xdcr_tab]
 image::manage-xdcr/left-click-on-xdcr-tab.png[,90,align=middle]
@@ -26,8 +26,8 @@ The upper panel, *Remote Clusters*, features a single reference, as follows:
 [#xdcr-replications-screen-with-reference]
 image::manage-xdcr/xdcr-replications-screen-with-reference.png[,800,align=middle]
 
-. To delete the reference, left-click on the row for the reference.
-When the *Delete* button appears, left-click on it:
+. To delete the reference, click on the row for the reference.
+When the *Delete* button appears, click on it:
 +
 [#left-click-on-delete-reference-tab]
 image::manage-xdcr/left-click-on-delete-replication-tab.png[,120,align=middle]
@@ -37,7 +37,7 @@ The following confirmation dialog is now displayed:
 [#xdcr-confirm-delete]
 image::manage-xdcr/xdcr-confirm-delete-reference.png[,280,align=middle]
 
-. Left-click on *Delete Reference*, to confirm.
+. Click on *Delete Reference*, to confirm.
 The *Remote Clusters* panel now reappears, showing no replications:
 +
 [#xdcr-remote-clusters-panel-no-references]


### PR DESCRIPTION
At 3 places 'left-click' was written which is much more descriptive than required. So changed it to 'click' as it is a web based documentation (not a window tool based) and click is enough I guess and looks more refined.