### PR TITLE
Added listing for more clarity

### DIFF
--- a/modules/clustersetup/pages/logging.adoc
+++ b/modules/clustersetup/pages/logging.adoc
@@ -13,7 +13,11 @@ This may appear as follows:
 [#welcome]
 image::loggingScreenBasic.png[,720,align=left]
 
-By default, on Linux systems, log files are saved to `/opt/couchbase/var/lib/couchbase/logs`; on MacOS, to `/Users/`_username_`/Library/Application Support/Couchbase/var/lib/couchbase/logs`; and on Windows, to `C:\Program Files\Couchbase\Server\var\lib\couchbase\logs`.
+By default, log files are saved in the following directories:
+
+* *On Linux systems*: `/opt/couchbase/var/lib/couchbase/logs`.
+* *On MacOSP*: `/Users/username/Library/Application Support/Couchbase/var/lib/couchbase/logs`.
+* *On Windows*: `C:\Program Files\Couchbase\Server\var\lib\couchbase\logs`.
 
 [#collecting_information]
 == Collecting Information


### PR DESCRIPTION
Default log storage was mention in a line which was a little confusing.
Changed it to a list form for more clarity.