### PR TITLE
Document /api/v1/functions/test/{pause,resume,undeploy,deploy} for 6.5+

### DIFF
--- a/modules/eventing/pages/eventing-api.adoc
+++ b/modules/eventing/pages/eventing-api.adoc
@@ -4,22 +4,83 @@
 [abstract]
 The Eventing REST API, available by default at port 8096, provides the methods available to work with Couchbase Eventing Functions.
 
-NOTE: The Functions REST API endpoints on this page are supported, as long as the content of the handler body is not created or modified externally (as the internal format of the body is not yet standardized).
+NOTE: The Eventing Functions REST API endpoints on this page are supported, as long as the content of the handler body is not created or modified externally (as the internal format of the body is not yet standardized).
 
-.Eventing Functions API
+
+.Eventing Functions API (basic activation/deactivation)
+[cols="2,3,6"]
+|===
+| HTTP Method | *URI Path* | *Description*
+
+| POST
+| [.path]_/pi/v1/functions/[sample_name]/deploy_
+a|
+Deploys an undeployed Function. Since 6.5.0 this is the preferred invocation.
+A deploy CURL example is provided for reference.
+
+Sample API:
+
+[source,console]
+----
+curl -XPOST http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/deploy
+----
+
+| POST
+| [.path]_/api/v1/functions/[sample_name]/undeploy_
+a|
+Undeploys a Function. Since 6.5.0 this is the preferred invocation.
+An undeploy CURL example is provided for reference.
+
+Sample API:
+
+[source,console]
+----
+curl -XPOST http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/undeploy
+----
+
+| POST
+| [.path]_/api/v1/functions/[sample_name]/pause_
+a|
+Pauses a Function and creates a DCP checkpoint such that on a subsequent resume no mutations will be lost. Since 6.5.0 this is the preferred invocation.
+A pause CURL example is provided for reference.
+
+Sample API:
+
+[source,console]
+----
+curl -XPOST http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/pause
+----
+
+| POST
+| [.path]_/api/v1/functions/[sample_name]/resume_
+a|
+Resumes a paused function from its paused DCP checkpoint. Since 6.5.0 this is the preferred invocation.
+A resume CURL example is provided for reference.
+
+Sample API:
+
+[source,console]
+----
+curl -XPOST http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/resume
+----
+
+|===
+
+
+.Eventing Functions API (advanced)
 [cols="2,3,6"]
 |===
 | HTTP Method | *URI Path* | *Description*
 
 | POST
 | [.path]_/api/v1/functions/[function_name]_
-| Create a single Function.
+| Import or create a single Function.
 The Function name in the body must match that on the URL.
 Function definition includes current settings.
 
 | POST
 | [.path]_/api/v1/functions/_
-| Creates multiple Functions.
+| Imports or creates multiple Functions.
 Function names must be unique.
 When multiple Functions have the same name, an error is reported.
 
@@ -59,52 +120,20 @@ The response indicates whether the Eventing service must be restarted for the ne
 | GET
 | [.path]_/api/v1/functions/[function_name]/settings_
 a|
-Returns the information for one function Functions in the cluster.
+Export or return the full definition for one Eventing Function in the cluster.  The definition can be subseqently imported.  However any changes to the function definition made outside the UI are not supported.
 
-Sample API:
+Sample API (to standard out):
 
+[source,console]
 ----
-curl 
-http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
-----
-
-| POST
-| [.path]_/api/v1/functions/[function_name]/settings_
-a|
-Deploys an undeployed Function or resumes a paused function from its paused DCP checkpoint.
-A deploy/resume CURL example is provided for reference.
-
-Sample API:
-
-----
-curl -XPOST -d '{"deployment_status":true,"processing_status":true}'
-http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
+curl http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
 ----
 
-| POST
-| [.path]_/api/v1/functions/[function_name]/settings_
-a|
-Undeploys a Function.
-An undeploy CURL example is provided for reference.
+Sample API (to file):
 
-Sample API:
-
+[source,console]
 ----
-curl -XPOST -d '{"deployment_status":false,"processing_status":false}'
-http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
-----
-
-| POST
-| [.path]_/api/v1/functions/[function_name]/settings_
-a|
-Pauses a Function and creates a DCP checkpoint such that on a subsequent resume no mutations will be lost.
-A pause CURL example is provided for reference.
-
-Sample API:
-
-----
-curl -XPOST -d '{"deployment_status":true,"processing_status":false}'
-http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
+curl http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings -o [sample_name.json]
 ----
 
 | POST
@@ -115,9 +144,9 @@ Note you must always specify deployment_status (deployed/undeployed) and process
 
 Sample API (alter worker_count):
 
+[source,console]
 ----
-curl -XPOST -d '{"deployment_status":false,"processing_status":false,"worker_count":6}'
-http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
+curl -XPOST -d '{"deployment_status":false,"processing_status":false,"worker_count":6}' http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
 ----
 
 | POST
@@ -128,9 +157,63 @@ Note you must always specify deployment_status (deployed/undeployed) and process
 
 Sample API (alter app_log_max_files and app_log_max_size):
 
+[source,console]
 ----
-curl -XPOST -d '{"deployment_status":false,"processing_status":false,"app_log_max_files":5,"app_log_max_size":10485760}'
-http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
+curl -XPOST -d '{"deployment_status":false,"processing_status":false,"app_log_max_files":5,"app_log_max_size":10485760}' http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
+----
+
+Sample API (alter timer_context_size):
+
+[source,console]
+----
+curl -XPOST -d '{"deployment_status":false,"processing_status":false,"timer_context_size":2048}' http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
+----
+
+|===
+
+
+.Eventing Functions API (depricated activation/deactivation)
+[cols="2,3,6"]
+|===
+| HTTP Method | *URI Path* | *Description*
+
+| POST
+| [.path]_/api/v1/functions/[function_name]/settings_
+a|
+Deploys an undeployed Function or resumes a paused function from its paused DCP checkpoint.  Depricated, see (basic activation/deactivation) for prefereed invocation.
+A deploy/resume CURL example is provided for reference.
+
+Sample API:
+
+[source,console]
+----
+curl -XPOST -d '{"deployment_status":true,"processing_status":true}' http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
+----
+
+| POST
+| [.path]_/api/v1/functions/[function_name]/settings_
+a|
+Undeploys a Function. Depricated, see (basic activation/deactivation) for prefereed invocation.
+An undeploy CURL example is provided for reference.
+
+Sample API:
+
+[source,console]
+----
+curl -XPOST -d '{"deployment_status":false,"processing_status":false}' http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
+----
+
+| POST
+| [.path]_/api/v1/functions/[function_name]/settings_
+a|
+Pauses a Function and creates a DCP checkpoint such that on a subsequent resume no mutations will be lost. Depricated, see (basic activation/deactivation) for prefereed invocation.
+A pause CURL example is provided for reference.
+
+Sample API:
+
+[source,console]
+----
+curl -XPOST -d '{"deployment_status":true,"processing_status":false}' http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
 ----
 
 |===


### PR DESCRIPTION
For 6.5.0+ we should also make the preferred method to change a function's state to /api/v1/functions/test/{pause,resume,undeploy,deploy}
This update can be BP to 6.5 doc set.
In addition other updates that should have been backported were verified form 6.6 and added, such that 6.5 and 6.6 doc sets are the same.