### PR TITLE
Document /api/v1/functions/test/{pause,resume,undeploy,deploy} for 6.5+

### DIFF
--- a/modules/eventing/pages/eventing-api.adoc
+++ b/modules/eventing/pages/eventing-api.adoc
@@ -15,7 +15,7 @@ NOTE: The Eventing Functions REST API endpoints on this page are supported, as l
 | POST
 | [.path]_/pi/v1/functions/[sample_name]/deploy_
 a|
-Deploys an undeployed Function. Since 6.5.0 this is the preferred invocation.
+Deploys an undeployed Function. Starting version 6.5.0, this is the preferred invocation.
 A deploy CURL example is provided for reference.
 
 Sample API:
@@ -28,7 +28,7 @@ curl -XPOST http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sam
 | POST
 | [.path]_/api/v1/functions/[sample_name]/undeploy_
 a|
-Undeploys a Function. Since 6.5.0 this is the preferred invocation.
+Undeploys a Function. Starting version 6.5.0, this is the preferred invocation.
 An undeploy CURL example is provided for reference.
 
 Sample API:
@@ -41,7 +41,7 @@ curl -XPOST http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sam
 | POST
 | [.path]_/api/v1/functions/[sample_name]/pause_
 a|
-Pauses a Function and creates a DCP checkpoint such that on a subsequent resume no mutations will be lost. Since 6.5.0 this is the preferred invocation.
+Pauses a Function and creates a DCP checkpoint such that on a subsequent resume no mutations will be lost. Starting version 6.5.0, this is the preferred invocation.
 A pause CURL example is provided for reference.
 
 Sample API:
@@ -54,7 +54,7 @@ curl -XPOST http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sam
 | POST
 | [.path]_/api/v1/functions/[sample_name]/resume_
 a|
-Resumes a paused function from its paused DCP checkpoint. Since 6.5.0 this is the preferred invocation.
+Resumes a paused function from its paused DCP checkpoint. Starting version 6.5.0, this is the preferred invocation.
 A resume CURL example is provided for reference.
 
 Sample API:
@@ -139,8 +139,8 @@ curl http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_nam
 | POST
 | [.path]_/api/v1/functions/[function_name]/settings_
 a| 
-Updates an undeployed a Function with the provided setting. Do not update settings for a deployed or paused function.
-Note you must always specify deployment_status (deployed/undeployed) and processing_status (paused/not-paused) when using this REST endpoint to update any option(s).
+Updates an undeployed Function with the provided setting. Do not update settings for a deployed or paused function.
+Note that you must always specify deployment_status (deployed/undeployed) and processing_status (paused/not-paused) when using this REST endpoint to update any option(s).
 
 Sample API (alter worker_count):
 
@@ -152,8 +152,8 @@ curl -XPOST -d '{"deployment_status":false,"processing_status":false,"worker_cou
 | POST
 | [.path]_/api/v1/functions/[function_name]/settings_
 a| 
-Updates an undeployed a Function with the provided settings. Do not update settings for a deployed or paused function.
-Note you must always specify deployment_status (deployed/undeployed) and processing_status (paused/not-paused) when using this REST endpoint to update any option(s).
+Updates an undeployed Function with the provided settings. Do not update settings for a deployed or paused function.
+Note that you must always specify deployment_status (deployed/undeployed) and processing_status (paused/not-paused) when using this REST endpoint to update any option(s).
 
 Sample API (alter app_log_max_files and app_log_max_size):
 
@@ -184,7 +184,7 @@ curl -XGET http://Administrator:password@192.168.1.5:8096/api/v1/status
 |===
 
 
-.Eventing Functions API (depricated activation/deactivation)
+.Eventing Functions API (deprecated activation/deactivation)
 [cols="2,3,6"]
 |===
 | HTTP Method | *URI Path* | *Description*
@@ -192,7 +192,7 @@ curl -XGET http://Administrator:password@192.168.1.5:8096/api/v1/status
 | POST
 | [.path]_/api/v1/functions/[function_name]/settings_
 a|
-Deploys an undeployed Function or resumes a paused function from its paused DCP checkpoint.  Depricated, see (basic activation/deactivation) for preferred invocation.
+Deploys an undeployed Function or resumes a paused function from its paused DCP checkpoint.  Deprecated, see (basic activation/deactivation) for preferred invocation.
 A deploy/resume CURL example is provided for reference.
 
 Sample API:
@@ -205,7 +205,7 @@ curl -XPOST -d '{"deployment_status":true,"processing_status":true}' http://Admi
 | POST
 | [.path]_/api/v1/functions/[function_name]/settings_
 a|
-Undeploys a Function. Depricated, see (basic activation/deactivation) for prefereed invocation.
+Undeploys a Function. Deprecated, see (basic activation/deactivation) for preferred invocation.
 An undeploy CURL example is provided for reference.
 
 Sample API:
@@ -218,7 +218,7 @@ curl -XPOST -d '{"deployment_status":false,"processing_status":false}' http://Ad
 | POST
 | [.path]_/api/v1/functions/[function_name]/settings_
 a|
-Pauses a Function and creates a DCP checkpoint such that on a subsequent resume no mutations will be lost. Depricated, see (basic activation/deactivation) for prefereed invocation.
+Pauses a Function and creates a DCP checkpoint such that on a subsequent resume no mutations will be lost. Deprecated, see (basic activation/deactivation) for preferred invocation.
 A pause CURL example is provided for reference.
 
 Sample API:

--- a/modules/eventing/pages/eventing-api.adoc
+++ b/modules/eventing/pages/eventing-api.adoc
@@ -6,7 +6,68 @@ The Eventing REST API, available by default at port 8096, provides the methods a
 
 NOTE: The Eventing Functions REST API endpoints on this page are supported, as long as the content of the handler body is not created or modified externally (as the internal format of the body is not yet standardized).
 
-.Eventing Functions API
+
+.Eventing Functions API (basic activation/deactivation)
+[cols="2,3,6"]
+|===
+| HTTP Method | *URI Path* | *Description*
+
+| POST
+| [.path]_/pi/v1/functions/[sample_name]/deploy_
+a|
+Deploys an undeployed Function. Since 6.5.0 this is the preferred invocation.
+A deploy CURL example is provided for reference.
+
+Sample API:
+
+[source,console]
+----
+curl -XPOST http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/deploy
+----
+
+| POST
+| [.path]_/api/v1/functions/[sample_name]/undeploy_
+a|
+Undeploys a Function. Since 6.5.0 this is the preferred invocation.
+An undeploy CURL example is provided for reference.
+
+Sample API:
+
+[source,console]
+----
+curl -XPOST http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/undeploy
+----
+
+| POST
+| [.path]_/api/v1/functions/[sample_name]/pause_
+a|
+Pauses a Function and creates a DCP checkpoint such that on a subsequent resume no mutations will be lost. Since 6.5.0 this is the preferred invocation.
+A pause CURL example is provided for reference.
+
+Sample API:
+
+[source,console]
+----
+curl -XPOST http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/pause
+----
+
+| POST
+| [.path]_/api/v1/functions/[sample_name]/resume_
+a|
+Resumes a paused function from its paused DCP checkpoint. Since 6.5.0 this is the preferred invocation.
+A resume CURL example is provided for reference.
+
+Sample API:
+
+[source,console]
+----
+curl -XPOST http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/resume
+----
+
+|===
+
+
+.Eventing Functions API (advanced)
 [cols="2,3,6"]
 |===
 | HTTP Method | *URI Path* | *Description*
@@ -77,45 +138,6 @@ curl http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_nam
 
 | POST
 | [.path]_/api/v1/functions/[function_name]/settings_
-a|
-Deploys an undeployed Function or resumes a paused function from its paused DCP checkpoint.
-A deploy/resume CURL example is provided for reference.
-
-Sample API:
-
-[source,console]
-----
-curl -XPOST -d '{"deployment_status":true,"processing_status":true}' http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
-----
-
-| POST
-| [.path]_/api/v1/functions/[function_name]/settings_
-a|
-Undeploys a Function.
-An undeploy CURL example is provided for reference.
-
-Sample API:
-
-[source,console]
-----
-curl -XPOST -d '{"deployment_status":false,"processing_status":false}' http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
-----
-
-| POST
-| [.path]_/api/v1/functions/[function_name]/settings_
-a|
-Pauses a Function and creates a DCP checkpoint such that on a subsequent resume no mutations will be lost.
-A pause CURL example is provided for reference.
-
-Sample API:
-
-[source,console]
-----
-curl -XPOST -d '{"deployment_status":true,"processing_status":false}' http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
-----
-
-| POST
-| [.path]_/api/v1/functions/[function_name]/settings_
 a| 
 Updates an undeployed a Function with the provided setting. Do not update settings for a deployed or paused function.
 Note you must always specify deployment_status (deployed/undeployed) and processing_status (paused/not-paused) when using this REST endpoint to update any option(s).
@@ -145,6 +167,53 @@ Sample API (alter timer_context_size):
 [source,console]
 ----
 curl -XPOST -d '{"deployment_status":false,"processing_status":false,"timer_context_size":2048}' http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
+----
+
+|===
+
+
+.Eventing Functions API (depricated activation/deactivation)
+[cols="2,3,6"]
+|===
+| HTTP Method | *URI Path* | *Description*
+
+| POST
+| [.path]_/api/v1/functions/[function_name]/settings_
+a|
+Deploys an undeployed Function or resumes a paused function from its paused DCP checkpoint.  Depricated, see (basic activation/deactivation) for prefereed invocation.
+A deploy/resume CURL example is provided for reference.
+
+Sample API:
+
+[source,console]
+----
+curl -XPOST -d '{"deployment_status":true,"processing_status":true}' http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
+----
+
+| POST
+| [.path]_/api/v1/functions/[function_name]/settings_
+a|
+Undeploys a Function. Depricated, see (basic activation/deactivation) for prefereed invocation.
+An undeploy CURL example is provided for reference.
+
+Sample API:
+
+[source,console]
+----
+curl -XPOST -d '{"deployment_status":false,"processing_status":false}' http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
+----
+
+| POST
+| [.path]_/api/v1/functions/[function_name]/settings_
+a|
+Pauses a Function and creates a DCP checkpoint such that on a subsequent resume no mutations will be lost. Depricated, see (basic activation/deactivation) for prefereed invocation.
+A pause CURL example is provided for reference.
+
+Sample API:
+
+[source,console]
+----
+curl -XPOST -d '{"deployment_status":true,"processing_status":false}' http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
 ----
 
 |===

--- a/modules/eventing/pages/eventing-api.adoc
+++ b/modules/eventing/pages/eventing-api.adoc
@@ -169,6 +169,18 @@ Sample API (alter timer_context_size):
 curl -XPOST -d '{"deployment_status":false,"processing_status":false,"timer_context_size":2048}' http://Administrator:password@192.168.1.5:8096/api/v1/functions/[sample_name]/settings
 ----
 
+| GET
+| [.path]_/api/v1/status
+a| 
+Returns a list (arrary) of all Eventing Functions showing their corresponding *composite_status*. It can have one of the following values - _undeployed_, _deploying_, _deployed_, _undeploying_, _paused_, and '_pausing_.  Note, there is no value of _resuming_ when resuming a paused Eventing Function the *composite_status* will return _deploying_ until it reaches the _deployed_ state.
+
+Sample API (status):
+
+[source,console]
+----
+curl -XGET http://Administrator:password@192.168.1.5:8096/api/v1/status
+----
+
 |===
 
 
@@ -180,7 +192,7 @@ curl -XPOST -d '{"deployment_status":false,"processing_status":false,"timer_cont
 | POST
 | [.path]_/api/v1/functions/[function_name]/settings_
 a|
-Deploys an undeployed Function or resumes a paused function from its paused DCP checkpoint.  Depricated, see (basic activation/deactivation) for prefereed invocation.
+Deploys an undeployed Function or resumes a paused function from its paused DCP checkpoint.  Depricated, see (basic activation/deactivation) for preferred invocation.
 A deploy/resume CURL example is provided for reference.
 
 Sample API:


### PR DESCRIPTION
For 6.5.0+ we should also make the preferred method to change a function's state to /api/v1/functions/test/{pause,resume,undeploy,deploy}

This update can be BP to 6.5 doc set.