### PR TITLE
Document positional and named iterators also isPrepared option

### DIFF
--- a/modules/eventing/pages/eventing-language-constructs.adoc
+++ b/modules/eventing/pages/eventing-language-constructs.adoc
@@ -215,10 +215,52 @@ This is the identified N1QL statement. This will be passed to N1QL via SDK to ru
 * _params_
 +
 This can be either a JavaScript array (for positional parameters) or a JavaScript map. When the N1QL statement utilizes positional parameters (i.e., $1, $2 ...), then params is expected to be a JavaScript array corresponding to the values to be bound to these positional parameters. When the N1QL statement utilizes named parameters (i.e., $name), then params is expected to be a JavaScript map object providing the name-value pairs corresponding to the variables used by the N1QL statement. Positional and named value parameters cannot be mixed.
++
+_iterator using a positional params array_
++
+[source,javascript]
+----
+    // Using `travel-sample` demonstrate positional params.
+    // a) Positional param 1 is field 'iata' from the input doc
+    // b) Positional param 2 from a Handler variable: max_dist
+    // c) Will also prepare the statement for better performance
+    
+    var max_dist = 120;
+    var results = N1QL(
+        "SELECT COUNT(*) AS cnt " +
+        "FROM `travel-sample` WHERE type = \"route\" " +
+        "AND airline = $1 AND distance <= $2",
+        [doc.iata,max_dist], 
+        { 'isPrepared': true }
+    );
+----
++
+_iterator using a named params object_
++
+[source,javascript]
+----
+    // Using `travel-sample` demonstrate named params.
+    // a) Named param 1 '$mytype' is a hardcode
+    // b) Named param 2 '$myairline' is field 'iata' from the input doc
+    // c) Named param 3 '$mydistance' if from a Handler variable max_dist
+    // d) Set the consistancy in the options to none
+    
+    var max_dist = 120;
+    var results = N1QL("SELECT COUNT(*) AS cnt " +
+        "FROM `travel-sample` WHERE type = $mytype " +
+        "AND airline = $myairline AND distance <= $mydistance",
+        { '$mytype': 'route', '$mydistance': max_dist, '$myairline': doc.iata },         
+        { 'consistency': 'none' }
+    );
+----
 
 * _options_
 +
 This is a JSON object having various query runtime options as keys. Currently, the following settings are recognized:
+
+** _isPrepared_
++
+This controls the if statement will be prepared. Normally, this defaults to _false_ but can be set on a per statement basis to _true_ for any N1QL query that needs increased performance.
 
 ** _consistency_
 +


### PR DESCRIPTION
Document both positional and named iterators - users have a HARD time figuring them out I know I did.
Also add isPrepared as a supported option.
Update docs as per https://issues.couchbase.com/browse/MB-39461
Can also BP this to block of text to 6.5