### PR TITLE
Add example of named parameters

### DIFF
--- a/modules/eventing/pages/eventing-handler-basicN1qlPreparedSelectStmt.adoc
+++ b/modules/eventing/pages/eventing-handler-basicN1qlPreparedSelectStmt.adoc
@@ -6,12 +6,15 @@
 
 * This function *basicN1qlPreparedSelectStmt* demonstrates how use a prepared N1QL SELECT statement with a passed parameter. 
 * Typically, this is done for greater performance, the cluster will typically not prepare a statement if it is already prepared.
-* We have just one positional parameter $1 for "doc.iata", if we had a second parameter we would use the placeholder $2, and so on.
+* We have just one positional parameter $1 for "doc.iata", if we had a second parameter we would use 
+the placeholder $2, and so on. Note positional parameters are passed in an array.
+* A _commented out_ example of using named parameters is also shown. Note named parameters are passed and an object.
 * Requires the "travel-sample" sample dataset to be loaded.
 * Requires a metadata bucket, a source bucket of "travel-sample".
 * Deploy the Function with a Feed Boundary "From now" (Note you will log 187 lines if you use "Everything").
 * Assuming you deployed "From now" mutate any document in "travel-sample" to generate a log line.
-* For more detail refer to xref:eventing-language-constructs.adoc#added-lang-features[N1QL Statements].
+* For more detail refer to xref:eventing-language-constructs.adoc#added-lang-features[N1QL Statements] and
+xref:eventing-language-constructs.adoc#n1ql_call[The N1QL() function call]
 
 [{tabs}] 
 ====
@@ -26,11 +29,24 @@ function OnUpdate(doc, meta) {
     if (doc.type !== 'airline') return;
     
     var route_cnt = 0;       // we want to get the total routes per iata
+    
+    // positional prameter(s)
     var results = N1QL("SELECT COUNT(*) AS cnt " +
         "FROM `travel-sample` " +
         "WHERE type = \"route\" AND airline = $1",
         [doc.iata], { isPrepared: true }
-      );      
+    );      
+      
+    /*    
+    // named parameter(s)
+    var max_dist = 120;
+    var results = N1QL("SELECT COUNT(*) AS cnt " +
+        "FROM `travel-sample` WHERE type = $mytype " +
+        "AND airline = $myairline AND distance <= $mydistance",
+        { '$mytype': 'route', '$mydistance': max_dist, '$myairline': doc.iata },         
+        { 'consistency': 'none', isPrepared: true }
+    );
+    */
         
     for (var item of results) {   // Stream results using 'for' iterator.
         route_cnt = item.cnt;

--- a/modules/eventing/pages/eventing-handler-basicN1qlPreparedSelectStmt.adoc
+++ b/modules/eventing/pages/eventing-handler-basicN1qlPreparedSelectStmt.adoc
@@ -13,7 +13,7 @@ the placeholder $2, and so on. Note positional parameters are passed in an array
 * Requires a metadata bucket, a source bucket of "travel-sample".
 * Deploy the Function with a Feed Boundary "From now" (Note you will log 187 lines if you use "Everything").
 * Assuming you deployed "From now" mutate any document in "travel-sample" to generate a log line.
-* For more detail refer to xref:eventing-language-constructs.adoc#added-lang-features[N1QL Statements] and
+* For additional details refer to xref:eventing-language-constructs.adoc#added-lang-features[N1QL Statements] and
 xref:eventing-language-constructs.adoc#n1ql_call[The N1QL() function call]
 
 [{tabs}] 


### PR DESCRIPTION
We already show how to use positional parameters 
We want to also show example of named parameters it is commented out but makes it easy to test if needed.
Also link to the "The N1QL() function call" section.