### PR TITLE
Update relnotes-v5.0.x.adoc

### DIFF
--- a/modules/release-notes/pages/relnotes-v5.0.x.adoc
+++ b/modules/release-notes/pages/relnotes-v5.0.x.adoc
@@ -239,7 +239,7 @@ Regardless of needing new features, it is always advised to upgrade to the newes
 
 ! Node.js
 ! 2.4.0
-! https://developer.couchbase.com/server/other-products/release-notes-archives/nodejs-sdk[Release notes^]
+! https://docs.couchbase.com/nodejs-sdk/current/project-docs/sdk-release-notes.html[Release notes^]
 
 ! Python
 ! 2.2.6


### PR DESCRIPTION
Updated the incorrect Node.js Release notes link on the page

Updated the incorrect link (https://developer.couchbase.com/server/other-products/release-notes-archives/nodejs-sdk) to https://docs.couchbase.com/nodejs-sdk/current/project-docs/sdk-release-notes.html

Can you please check and confirm the link?