### PR TITLE
Update relnotes-v5.0.x.adoc

### DIFF
--- a/modules/release-notes/pages/relnotes-v5.0.x.adoc
+++ b/modules/release-notes/pages/relnotes-v5.0.x.adoc
@@ -243,7 +243,7 @@ Regardless of needing new features, it is always advised to upgrade to the newes
 
 ! Python
 ! 2.2.6
-! https://developer.couchbase.com/server/other-products/release-notes-archives/python-sdk[Release notes^]
+! https://docs.couchbase.com/python-sdk/current/project-docs/sdk-release-notes.html[Release notes^]
 
 ! PHP
 ! 2.4.0


### PR DESCRIPTION
Updated the incorrect link for Python SDK release notes on the page
Updated the incorrect link(https://developer.couchbase.com/server/other-products/release-notes-archives/python-sdk) to (https://docs.couchbase.com/python-sdk/current/project-docs/sdk-release-notes.html)

Can you please confirm and approve the change?