### PR TITLE
Update relnotes-v5.0.x.adoc

### DIFF
--- a/modules/release-notes/pages/relnotes-v5.0.x.adoc
+++ b/modules/release-notes/pages/relnotes-v5.0.x.adoc
@@ -231,31 +231,31 @@ Regardless of needing new features, it is always advised to upgrade to the newes
 
 ! Java
 ! 2.5.1
-! https://developer.couchbase.com/server/other-products/release-notes-archives/java-sdk[Release notes^]
+! xref:3.0@java-sdk:project-docs:sdk-release-notes.adoc#older-releases[Release notes^]
 
 ! .NET
 ! 2.5.0
-! https://developer.couchbase.com/server/other-products/release-notes-archives/dotnet-sdk#2.4.5[Release notes^]
+! xref:3.0@dotnet-sdk:project-docs:sdk-release-notes.adoc#older-releases[Release notes^]
 
 ! Node.js
 ! 2.4.0
-! https://developer.couchbase.com/server/other-products/release-notes-archives/nodejs-sdk[Release notes^]
+! xref:3.0@nodejs-sdk:project-docs:sdk-release-notes.adoc#older-releases[Release notes^]
 
 ! Python
 ! 2.2.6
-! https://developer.couchbase.com/server/other-products/release-notes-archives/python-sdk[Release notes^]
+! xref:3.0@python-sdk:project-docs:sdk-release-notes.adoc#older-releases[Release notes^]
 
 ! PHP
 ! 2.4.0
-! https://developer.couchbase.com/server/other-products/release-notes-archives/php-sdk[Release notes^]
+! xref:3.0@php-sdk:project-docs:sdk-release-notes.adoc#older-releases[Release notes^]
 
 ! Go
 ! 1.2.5
-! https://docs.couchbase.com/go-sdk/current/project-docs/sdk-release-notes.html[Release notes^]
+! xref:2.1@go-sdk:project-docs:sdk-release-notes.adoc#older-releases[Release notes^]
 
 ! C
 ! 2.8.0
-! https://developer.couchbase.com/server/other-products/release-notes-archives/c-sdk[Release notes^]
+! xref:3.0@c-sdk:project-docs:sdk-release-notes.adoc#older-releases[Release notes^]
 !===
 |===
 

--- a/modules/release-notes/pages/relnotes-v5.0.x.adoc
+++ b/modules/release-notes/pages/relnotes-v5.0.x.adoc
@@ -251,7 +251,7 @@ Regardless of needing new features, it is always advised to upgrade to the newes
 
 ! Go
 ! 1.2.5
-! https://developer.couchbase.com/server/other-products/release-notes-archives/go-sdk[Release notes^]
+! https://docs.couchbase.com/go-sdk/current/project-docs/sdk-release-notes.html[Release notes^]
 
 ! C
 ! 2.8.0


### PR DESCRIPTION
Updated the Go SDK release notes link on the page.

Updated the incorrect link(https://developer.couchbase.com/server/other-products/release-notes-archives/go-sdk) to (https://docs.couchbase.com/go-sdk/current/project-docs/sdk-release-notes.html).

Can you please confirm and approve the change?