### PR TITLE
DOC-7264 Mark 'cbdocloader' as deprecated

### DIFF
--- a/modules/cli/pages/cbdocloader-tool.adoc
+++ b/modules/cli/pages/cbdocloader-tool.adoc
@@ -2,9 +2,13 @@
 :page-topic-type: reference
 
 [abstract]
-The [.cmd]`cbdocloader` tool loads Couchbase sample datasets into Couchbase Server.
+(Deprecated) The [.cmd]`cbdocloader` tool loads Couchbase sample datasets into
+Couchbase Server.
 
 == Description
+
+[.cmd]`cbdocloader` has been deprecated, please use [.cmd]`cbimport` with the
+`--format sample` flag instead.
 
 The [.cmd]`cbdocloader` tool loads Couchbase sample datasets into Couchbase Server.
 Sample datasets are zip files, provided by Couchbase, which contain documents and index definitions.


### PR DESCRIPTION
We are deprecating 'cbdocloader' in 7.0.0, users will be able to use the
'cbimport' tool with the '--format sample' flag. The 'cbimport' tool
provides an equivalent feature set with the added benefit of being
collection aware.