### PR TITLE
Updated the Java SDK release notes link present on the page

### DIFF
--- a/modules/security/pages/security-certs-auth.adoc
+++ b/modules/security/pages/security-certs-auth.adoc
@@ -167,7 +167,7 @@ For information on assigning roles to users, see xref:security-rbac-for-admins-a
 Note the following limitations to the feature in the current release:
 
 * For Couchbase Server 5.5, X.509 Certificate-based Authentication is supported by all SDK Clients.
-However, only the very latest versions support it - check the https://developer.couchbase.com/server/other-products/release-notes-archives/java-sdk[release notes^] for your SDK version.
+However, only the very latest versions support it - check the https://docs.couchbase.com/java-sdk/current/project-docs/sdk-release-notes.html[release notes^] for your SDK version.
 
 == Upgrade
 

--- a/modules/security/pages/security-certs-auth.adoc
+++ b/modules/security/pages/security-certs-auth.adoc
@@ -167,7 +167,7 @@ For information on assigning roles to users, see xref:security-rbac-for-admins-a
 Note the following limitations to the feature in the current release:
 
 * For Couchbase Server 5.5, X.509 Certificate-based Authentication is supported by all SDK Clients.
-However, only the very latest versions support it - check the https://docs.couchbase.com/java-sdk/current/project-docs/sdk-release-notes.html[release notes^] for your SDK version.
+However, only the very latest versions support it -- check the xref:2.7@java-sdk::sdk-release-notes.adoc[release notes] for your SDK version.
 
 == Upgrade
 


### PR DESCRIPTION
Updated the existing Java SDK release notes link: https://developer.couchbase.com/server/other-products/release-notes-archives/java-sdk

to https://docs.couchbase.com/java-sdk/current/project-docs/sdk-release-notes.html.

Can you please check and approve the change request?

Thank you