### PR TITLE
Updated the incorrect .NET SDK release notes link

### DIFF
--- a/modules/introduction/pages/whats-new.adoc
+++ b/modules/introduction/pages/whats-new.adoc
@@ -181,7 +181,7 @@ The latest SDK update supports many new critical features including:
 * Querying the new Full Text Search (FTS) Service
 * Querying the Analytics Service
 
-There are many other language-specific improvements worth reviewing, see the release notes of https://docs.couchbase.com/dotnet-sdk/current/project-docs/sdk-release-notes.html[each language^] for more about bug fixes and new features.
+There are many other language-specific improvements worth reviewing, see the release notes of xref:2.7@dotnet-sdk::sdk-release-notes.adoc[each language^] for more about bug fixes and new features.
 
 Support for different development environments also continues with, for example, improved Spring Data integration and https://blog.couchbase.com/introducing-couchbase-net-2-4-0-net-core-ga/[.NET Core^] support for cross-platform development.
 

--- a/modules/introduction/pages/whats-new.adoc
+++ b/modules/introduction/pages/whats-new.adoc
@@ -181,7 +181,7 @@ The latest SDK update supports many new critical features including:
 * Querying the new Full Text Search (FTS) Service
 * Querying the Analytics Service
 
-There are many other language-specific improvements worth reviewing, see the release notes of https://developer.couchbase.com/server/other-products/release-notes-archives/dotnet-sdk[each language^] for more about bug fixes and new features.
+There are many other language-specific improvements worth reviewing, see the release notes of https://docs.couchbase.com/dotnet-sdk/current/project-docs/sdk-release-notes.html[each language^] for more about bug fixes and new features.
 
 Support for different development environments also continues with, for example, improved Spring Data integration and https://blog.couchbase.com/introducing-couchbase-net-2-4-0-net-core-ga/[.NET Core^] support for cross-platform development.
 

--- a/modules/introduction/pages/whats-new.adoc
+++ b/modules/introduction/pages/whats-new.adoc
@@ -181,7 +181,7 @@ The latest SDK update supports many new critical features including:
 * Querying the new Full Text Search (FTS) Service
 * Querying the Analytics Service
 
-There are many other language-specific improvements worth reviewing, see the release notes of xref:2.7@dotnet-sdk::sdk-release-notes.adoc[each language^] for more about bug fixes and new features.
+There are many other language-specific improvements worth reviewing, see the release notes of xref:2.7@dotnet-sdk::sdk-release-notes.adoc[each language] for more about bug fixes and new features.
 
 Support for different development environments also continues with, for example, improved Spring Data integration and https://blog.couchbase.com/introducing-couchbase-net-2-4-0-net-core-ga/[.NET Core^] support for cross-platform development.
 


### PR DESCRIPTION
Updated the incorrect .NET SDK release notes link(https://developer.couchbase.com/server/other-products/release-notes-archives/dotnet-sdk) to https://docs.couchbase.com/dotnet-sdk/current/project-docs/sdk-release-notes.html

Can you please confirm the link and approve the change request?

Thank you