### PR TITLE
Updated the Scala SDK link on the page to avoid redirect chain error

### DIFF
--- a/modules/introduction/pages/whats-new.adoc
+++ b/modules/introduction/pages/whats-new.adoc
@@ -32,7 +32,7 @@ Couchbase SDKs are bringing in major new features and updating to the latest int
 
 For more information, see the SDK 3 documentation.
 
-https://docs.couchbase.com/c-sdk/3.0/hello-world/start-using-sdk.html[C SDK] | https://docs.couchbase.com/go-sdk/2.0/hello-world/start-using-sdk.html[Go SDK] | https://docs.couchbase.com/dotnet-sdk/3.0/hello-world/start-using-sdk.html[.NET SDK] | https://docs.couchbase.com/java-sdk/3.0/hello-world/start-using-sdk.html[Java SDK] | https://docs.couchbase.com/nodejs-sdk/3.0/hello-world/start-using-sdk.html[Node.js SDK] | https://docs.couchbase.com/php-sdk/3.0/hello-world/start-using-sdk.html[PHP SDK] | https://docs.couchbase.com/python-sdk/3.0/hello-world/start-using-sdk.html[Python SDK] | https://docs.couchbase.com/scala-sdk/1.0/start-using-sdk.html[Scala SDK]
+https://docs.couchbase.com/c-sdk/3.0/hello-world/start-using-sdk.html[C SDK] | https://docs.couchbase.com/go-sdk/2.0/hello-world/start-using-sdk.html[Go SDK] | https://docs.couchbase.com/dotnet-sdk/3.0/hello-world/start-using-sdk.html[.NET SDK] | https://docs.couchbase.com/java-sdk/3.0/hello-world/start-using-sdk.html[Java SDK] | https://docs.couchbase.com/nodejs-sdk/3.0/hello-world/start-using-sdk.html[Node.js SDK] | https://docs.couchbase.com/php-sdk/3.0/hello-world/start-using-sdk.html[PHP SDK] | https://docs.couchbase.com/python-sdk/3.0/hello-world/start-using-sdk.html[Python SDK] | https://docs.couchbase.com/scala-sdk/current/hello-world/start-using-sdk.html[Scala SDK]
 
 
 ==== Query Enhancements


### PR DESCRIPTION
Updated the Scala SDK link to https://docs.couchbase.com/scala-sdk/current/hello-world/start-using-sdk.html to avoid SEO redirect chain error.

It will be great if you can approve the change.

Thank you