### PR TITLE
Scriptlet has Typo's in the buckets names needed

### DIFF
--- a/modules/eventing/pages/eventing-handler-shippingNotifier.adoc
+++ b/modules/eventing/pages/eventing-handler-shippingNotifier.adoc
@@ -7,9 +7,9 @@
 * This function *shippingNotifier* demonstrates a shipping workflow.
 * Requires four buckets metadata, active (the source), archive, and a notify.
 ** bucket "metadata", common Eventing scratchpad across all handlers.
-** bucket "active",  binding alias "act_bck" in mode read+write, active shipping items.
-** bucket "archive", binding alias "arc_bck" in mode read+write, archived or complete shipments.
-** bucket "notify",  binding alias "snd_bck" in mode read+write, bucket to integrate with SDK or Kafka to send notifications.
+** bucket "active",  binding alias "act_bkt" in mode read+write, active shipping items.
+** bucket "archive", binding alias "arc_bkt" in mode read+write, archived or complete shipments.
+** bucket "notify",  binding alias "snd_bkt" in mode read+write, bucket to integrate with SDK or Kafka to send notifications.
 * Will operate on any doc with type === "ship".
 * Will update the source document with key information on each notify.
 * Delivered the shipping recored is archived.


### PR DESCRIPTION
The bindings for the bucket names are defined as act_bck, arc_bck and snd_bck. In the function code you are using act_bkt, arc_bkt and snd_bkt.
(as per find by Pavel Novokshonov)