### PR TITLE
FTS Documentation Updates for pagination

### DIFF
--- a/modules/fts/pages/fts-queries.adoc
+++ b/modules/fts/pages/fts-queries.adoc
@@ -27,6 +27,93 @@ For information on how to execute queries, see xref:fts-performing-searches.adoc
 The results returned from a Full Text Search can be _sorted_: by *id*, *score*, *field*, and more.
 Details are provided in xref:fts-sorting.adoc[Sorting Query Results].
 
+[#pagination]
+== Pagination
+
+The number of results obtained for a Full Text Search request can be large at times. Pagination of these results becomes essential for sorting and displaying a subset of these results.
+There's multiple ways to achieve pagination with settings within a search request. Pagination will fetch a deterministic set of results when the results are sorted in a certain fashion.
+
+`size/limit, from/offset`::
+
+These settings can be used to obtain a subset of results and works deterministically when combined with a certain sort order.
+The default sort order is based on _score_ (relevance) where the results are ordered from the highest to the lowest score.
+
+Here's an example query that fetches results from the 11th onwards to the 15th that have been ordered by _score_ ..
+
+----
+{
+  "query": {
+      "match": "California",
+      "field": "state"
+  },
+  "size": 5,
+  "from": 10
+}
+----
+
+`search_after, search_before`::
+
+Using `size/limit` and `offset/from` would fetch at least `size + from` ordered results from a partition and then return the `size` number of results starting at offset `from`.
+Deep pagination can therefore get pretty expensive when using `size + from` on a sharded index due to each shard having to possibly return large results sets (at least `size + from`) over the network for merging at the coordinating node before returning the `size` number of results starting at offset `from`.
+
+For more efficient pagination - the `search_after/search_before` settings can be leveraged.
+`search_after` is designed to fetch the `size` number of results after the key specified and `search_before` is designed to fetch the `size` number of results before the key specified.
+These settings allow for the client to maintain state while paginating - the sort key of the last result (for search_after) or the first result (for search_before) in the current page.
+
+Note that both the attributes accept an array of strings (sort keys) - the length of this array will need to be the same length of the "sort" array within the search request.
+Both `search_after` and `search_before` CANNOT be used witin the same search request.
+
+Here're a couple of examples using `search_after/search_before` over sort key "_id" (an internal field that carries the document ID) ..
+
+----
+{
+  "query": {
+      "match": "California",
+      "field": "state"
+  },
+  "sort": ["_id"],
+  "search_after": ["hotel_10180"],
+  "size": 3
+}
+----
+
+----
+{
+  "query": {
+      "match": "California",
+      "field": "state"
+  },
+  "sort": ["_id"],
+  "search_before": ["hotel_17595"],
+  "size": 4
+}
+----
+
+Note: A Full Text Search request that doesn't carry any pagination settings will return the first 10 results (`"size: 10", "from": 0`) ordered by _score_ sequentially from the highest to lowest.
+
+[#scoring]
+== Scoring
+
+Search result scoring occurs at query time. The results for a search request are ordered by *score* (relevance) with the sort order being descending, unless explicitly set not to do so.
+Couchbase (via bleve) uses a slightly modified version of the standard *tf-idf* algorithm. This deviation is to normalize the score by various relevant factors.
+
+By setting `explain` to `true` within the search request, you will obtain the explanation of how the score was calculated for a result alongside it.
+
+Scores for result document hits are calculated by default, whether the score is used for ordering or not. This means calculation of various frequency and normalization information for the search terms at query time.
+Scoring can be disabled by setting `score` to `none` in the search request. This may be desirable in the situation when scoring (document relevancy) isn't needed by the application.
+Note that using `"score": "none"` is expected to boost query performance in certain situations. Here's an example search request ..
+
+----
+{
+  "query": {
+      "match": "California",
+      "field": "state"
+  },
+  "score": "none",
+  "size": 100
+}
+----
+
 [#query-response-objects]
 == Query Response Objects
 

--- a/modules/fts/pages/fts-sorting.adoc
+++ b/modules/fts/pages/fts-sorting.adoc
@@ -71,7 +71,7 @@ Used only if `field` has been specified as the value for the `by` field; otherwi
 The value of `missing` can be `first`, in which case results with missing values appear _before_ other results; or `last` (the default), in which case they appear _after_.
 
 * `mode`: Specifies the search-order for index-fields that contain multiple values (in consequence of arrays or multi-token analyzer-output).
-The `default` order is undefined but deterministic, allowing the paging of results from `from (`_offset_`)`, with reliable ordering.
+The `default` order is undefined but deterministic, allowing the paging of results from `from (_offset_)`, with reliable ordering.
 To sort using the minimum or maximum value, the value of `mode` should be set to either `min` or `max`.
 
 * `type`: Specifies the type of the search-order field value. 

--- a/modules/fts/pages/fts-troubleshooting.adoc
+++ b/modules/fts/pages/fts-troubleshooting.adoc
@@ -175,15 +175,14 @@ Invoking the commands above with --help will highlight more information and furt
 
 *Q: How does the Search service (FTS) score documents?*
 
-FTS's internal text indexing library(bleve) uses a slightly modified version of standard tf-idf scoring. This improvisation is done to normalise the score by various relevant factors. The search scoring happens at query time.
+FTS's internal text indexing library (bleve) uses a slightly modified version of standard tf-idf scoring. This improvisation is done to normalize the score by various relevant factors. The search scoring happens at query time.
 
 When bleve scores a document - it sort of sums a set of sub scores to reach the final score. Scores across different searches are not directly comparable as the search query is also an input factor to the scoring function. The more conjuncts/disjuncts/sub clauses your query has, the more it will influence the scoring.
 The score of a particular hit is not absolute, meaning that it can only be used as a comparison to the highest score from the same search result. There isn't a pre-defined range for valid scores. 
 
 Below is the summary of the scoring function in Search service,
 
-Given a document which has a field  `f`  over which a given  match query `q`  is applied, 
-then the  `scoreFn`  for that document is defined as:
+Given a document which has a field  `f`  over which a given  match query `q`  is applied, then the  `scoreFn`  for that document is defined as:
 
 ----
 scoreFn(q, f) = coord(q, f) * SUM(tw(t0, q, f), tw(t1, q, f), tw(t2, q, f)..., tw(tn, q, f))
@@ -207,7 +206,7 @@ where SQROOT, SUM, and LN denote standard mathematical functions. Auxiliary func
 * *queryNorm(q)*  — is used to normalize each query term’s contribution. It uses the https://en.wikipedia.org/wiki/Norm_(mathematics)#Euclidean_norm[Euclidean distance] as the normalization factor.
 * *fieldWeight(f, ti)*  — is a normalized product of  *ti* ’s idf and the square root of its frequency.
 * *FREQ(ti, f)*  — is the frequency of  *ti*  in the given field  *f* .
-* *fieldNorm(f)*  — normalises each (in  *f* ) term’s contribution to the score. The normalisation factor is the square root of the number of distinct terms in  *f.*  (Note that  *f* ’s terms may and may not be part of  *q.* )
+* *fieldNorm(f)*  — normalizes each (in  *f* ) term’s contribution to the score. The normalisation factor is the square root of the number of distinct terms in  *f.*  (Note that  *f* ’s terms may and may not be part of  *q.* )
 * *idf(f, ti)*  — a dampening factor that favours terms that have high frequency in a small set of field, but not across the whole indexed (document) set.
 * *FREQ(ti, FIELDNAME(f), Docs)*  —frequency of  *ti*  across all documents’ fields that have the same ID/Name as  *f* .
 
@@ -216,7 +215,7 @@ Bleve's tf-idf scoring variant differs with the standard  *textbook*  functions 
 1. Term frequency is augmented with the square root function.
 2. The idf function is “ *inverse document frequency smooth* ” (due to the (1+) factor). Note that it is present in both the query weight and the field weight.
 3. The normalization factors are different for the field weight (a variant of the  *byte size*  normalization) and the query weight ( *Euclidean* ).
-4. The coordination factor, which is often not present by default, can have an impact on scores for small queries. 
+4. The coordination factor, which is often not present by default, can have an impact on scores for small queries.
 
 You have an option to explore the score computations during any search in FTS by enabling the "Explain" field in the searchRequest to retrieve the score deriving details for the hits.
 


### PR DESCRIPTION
+ This change includes documentation (DOC-7405):
    - size/limit, from/offset
    - search_after
    - search_before
+ Additionally some content on scoring and on the
  "score": "none" optimization.