### PR TITLE
DOC-7842: Request Level Parameters section doesn't remain within the central section of the page

### DIFF
--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -58,6 +58,11 @@ ifdef::basebackend-html[]
     max-width: none !important;
   }
 
+  /* Wrap code listings in table cells */
+  td .listingblock .content pre code {
+    white-space: pre-wrap !important;
+  }
+
   /* Ignore fixed column widths */
   table:not(.fixed-width) col{
     width: auto !important;


### PR DESCRIPTION
Draft build for review: [Query Settings › Request-Level Settings](https://simon-dew.github.io/docs-site/DOC-7842/server/6.6/settings/query-settings.html#section_nnj_sjk_k1b)

Docs issue: [DOC-7842](https://issues.couchbase.com/browse/DOC-7842)