### PR TITLE
DOC-7842: Request Level Parameters section doesn't remain within the central section of the page

### DIFF
--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -58,6 +58,11 @@ ifdef::basebackend-html[]
     max-width: none !important;
   }
 
+  /* Wrap code listings in table cells */
+  td .listingblock .content pre code {
+    white-space: pre-wrap !important;
+  }
+
   /* Ignore fixed column widths */
   table:not(.fixed-width) col{
     width: auto !important;


### PR DESCRIPTION
Backport of #1776 to release/6.5