### PR TITLE
Eventing 6.5.1 expiry improvement

### DIFF
--- a/modules/eventing/pages/eventing-examples-docexpiry.adoc
+++ b/modules/eventing/pages/eventing-examples-docexpiry.adoc
@@ -29,6 +29,19 @@ There are several methods to make a test document with an expiration set. The ea
 +
 [{tabs}] 
 ====
+N1QL UPDATE::
++
+--
+Using the Query Workbench [.status]#Couchbase Server 6.5.1#::
+[source,N1QL]
+----
+UPSERT INTO source (KEY, VALUE) VALUES ("SampleDocument2", {"a_key":"a_value"}, {"expiration":600});
+----
+Issue the above command in the Query Workbench of the UI.
+
+For information on setting document expiration times via N1QL, refer to xref:n1ql:n1ql-language-reference/insert.adoc#insert-document-with-expiration[Insert a document with expiration]
+--
+
 The cbc binary, or KV client::
 +
 --

--- a/modules/n1ql/pages/n1ql-language-reference/insert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/insert.adoc
@@ -348,6 +348,7 @@ INSERT INTO `travel-sample` (KEY, VALUE)
 ----
 ====
 
+[#insert-document-with-expiration]
 [[example-7a]]
 .Insert a document with expiration
 ====


### PR DESCRIPTION
Couchbase Server 6.5.1 supports setting the expiry or TTL via N1QL inserts and updates.
Here we use the UPDATE command but only INSERT (in the N1QL) has a full example thus we link to it.

Thus the Example is updated in Eventing docs.
and an anchor is added to the N1QL docs.

The above is a subset in my pending update for 6.6 (to support 6.6.1 advanced bucket ops) but this small subset important to add to the 6.5 documents.