### PR TITLE
DOC-7649: support access to DNS SRV in cbq

### DIFF
--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -571,7 +571,7 @@ $ ./cbq --exit-on-error -f="sample.txt"
 `--cacert`
 | string (path)
 | none
-a| Only applicable when using an encrypted protocol scheme -- either _https://_ or _couchbase://_.
+a| Only applicable when using an encrypted protocol scheme -- either _https://_ or _couchbases://_.
 
 Specifies the path to the root CA certificate to verify the identity of the server.
 
@@ -585,7 +585,7 @@ $ ./cbq --cacert ./root/ca.pem
 `--cert`
 | string (path)
 | none
-a| Only applicable when using an encrypted protocol scheme -- either _https://_ or _couchbase://_.
+a| Only applicable when using an encrypted protocol scheme -- either _https://_ or _couchbases://_.
 
 Specifies the path to the chain certificate.
 
@@ -599,7 +599,7 @@ $ ./cbq --cert ./client/client/chain.pem
 `--key`
 | string (path)
 | none
-a| Only applicable when using an encrypted protocol scheme -- either _https://_ or _couchbase://_.
+a| Only applicable when using an encrypted protocol scheme -- either _https://_ or _couchbases://_.
 
 Specifies the path to the client key file. 
 
@@ -615,7 +615,7 @@ $ ./cbq --key ./client/client/client.key
 `-skip-verify`
 | boolean footnote:boolean[]
 | `false`
-a| Only applicable when using an encrypted protocol scheme -- either _https://_ or _couchbase://_.
+a| Only applicable when using an encrypted protocol scheme -- either _https://_ or _couchbases://_.
 
 When specified, the cbq shell can skip the verification of certificates.
 
@@ -1301,7 +1301,7 @@ Parameter name : histfile Value  [".cbq_history"]
 [#cbq-encrypted]
 == Using an Encrypted Connection
 
-You can connect to the cluster or node with an encrypted protocol scheme -- that is, either _https://_ or _couchbase://_.
+You can connect to the cluster or node with an encrypted protocol scheme -- that is, either _https://_ or _couchbases://_.
 To do this, you can provide the root CA certificate, the chain certificate, and the client key file using the <<opt-cacert,--cacert>>, <<opt-cert,--cert>>, and <<opt-key,--key>> options.
 You can use the <<opt-skip-verify,--no-ssl-verify>> option to skip the verification of certificates.
 

--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -1322,6 +1322,9 @@ You can use the <<opt-skip-verify,--no-ssl-verify>> option to skip the verificat
 When connecting to a cluster or node with an encrypted protocol scheme, the default ports are 18091 and 18093.
 You need not specify the port when connecting to the cluster.
 
+In Couchbase Server 6.6.1 and later, you can use the encrypted _couchbases://_ protocol scheme with a domain name to connect to a node or cluster deployed in Couchbase Cloud.
+For more details, refer to <<cbq-connect-to-cluster>>.
+
 [#cbq-parameter-manipulation]
 == Parameter Manipulation
 

--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -638,12 +638,9 @@ $ ./cbq -skip-verify https://127.0.0.1:18091
 | [.var]`url`
 a| Connects cbq shell to the specified query engine or Couchbase cluster.
 
-The connection string consists of a protocol scheme followed by a host, including a port number to connect to the query service (8093) or the Couchbase cluster (8091).
+The connection string consists of a protocol scheme, followed by a host, and optionally a port number to connect to the query service (8093) or the Couchbase cluster (8091).
 
-The cbq shell supports [.path]_http://_, [.path]_https://_, [.path]_couchbase://_ and [.path]_couchbases://_ protocol schemes.
-When using the [.path]_couchbase://_ or [.path]_couchbases://_ protocol schemes, you need not specify the port when connecting to the Couchbase cluster.
-
-The cbq shell supports both IPV4 and IPV6 addresses.
+For more details, refer to <<cbq-connect-to-cluster>>.
 
 Command Line Option: <<opt-engine,-e>> or <<opt-engine,--engine>>
 

--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -200,21 +200,23 @@ cbq> \HELP;
 == Available Command Line Options and Shell Commands
 
 .Command Line Options for cbq Shell
-[#table_a3h_rhz_dw,cols="1,1,1,5"]
+[#table_a3h_rhz_dw,cols="~,~,55"]
 |===
-| Option | Arguments | Default | Description and Examples
+| Option | Arguments | Description and Examples
 
 | [[opt-engine]]
 `-e`
 
 `--engine`
 | string (url)
-| `+http://localhost:8091+`
 a| The connection string consists of a protocol scheme, followed by a host, and optionally a port number to connect to the query service (8093) or the Couchbase cluster (8091).
 
 For more details, refer to <<cbq-connect-to-cluster>>.
 
 Shell command: <<cbq-connect,\CONNECT>>
+
+.Default
+`+http://localhost:8091+`
 
 .Examples
 [source,console]
@@ -249,9 +251,11 @@ cbq>
 
 `--no-engine`
 | boolean footnote:boolean[Invoking a boolean option with no value sets the value to `true`.]
-| `false`
 a| When specified, the cbq shell does not connect to any query service.
 You must explicitly connect to a query service using the <<cbq-connect,\CONNECT>> shell command.
+
+.Default
+`false`
 
 .Example
 [source,console]
@@ -264,12 +268,14 @@ $ ./cbq --no-engine
 
 `--networkconfig`
 | string (`auto`, `default`, `external`)
-| `auto`
 a| Specifies whether to connect to a node's principal or alternate address.
 
 * `auto` -- Select the principal address or alternate address automatically, depending on the input IP.
 * `default` -- Use the principal address.
 * `external` -- Use the alternate addresses.
+
+.Default
+`auto`
 
 .Example
 [source,console]
@@ -282,8 +288,10 @@ $ ./cbq -ncfg default -e http://localhost:8091
 
 `--quiet`
 | boolean footnote:boolean[]
-| `false`
 a| When specified, disables the startup connection message for the cbq shell.
+
+.Default
+`false`
 
 .Example
 [source,console]
@@ -302,11 +310,14 @@ cbq>
 
 `--analytics`
 | boolean footnote:boolean[]
-| `false`
 a| Only applicable when connecting to the Analytics Service.
 When specified, if you are connecting to a cluster, cbq automatically discovers and connects to an Analytics node.
 This option also switches on <<opt-batch,batch mode>>.
 
+.Default
+`false`
+
+.Example
 [source,console]
 ----
 $ ./cbq --analytics
@@ -317,10 +328,13 @@ $ ./cbq --analytics
 
 `--batch`
 | string (`on`, `off`)  footnote:[Invoking this option with no value sets the value to `on`.]
-| `off`
 a| This option is available only with the Analytics Service.
 When specified, cbq sends the queries to server only when you hit EOF or \ to indicate the end of the batch input.
 
+.Default
+`off`
+
+.Examples
 [source,console]
 ----
 $ ./cbq --batch
@@ -338,8 +352,10 @@ You can also set the batch mode in the interactive session using the <<cbq-set,\
 
 `--timeout`
 | string (duration)
-| `0ms`
 a| Sets the query timeout parameter.
+
+.Default
+`0ms`
 
 .Example
 [source,console]
@@ -352,13 +368,15 @@ $ ./cbq -e http://localhost:8091 --timeout="1s"
 
 `--user`
 | string
-| none
 a| Specifies a single user name to log in to Couchbase.
 When used by itself, without the `-p` option to specify the password, you will be prompted for the password.
 
 This option requires administration credentials and you cannot switch the credentials during a session.
 
 Couchbase recommends using the `-u` and `-p` option if your password contains special characters such as #, $, %, &, (,), or '.
+
+.Default
+none
 
 .Example
 [source,console]
@@ -376,7 +394,6 @@ Enter Password:
 
 `--password`
 | string
-| none
 a| Specifies the password for the given user name.
 You cannot use this option by itself.
 It must be used with the -u option to specify the user name.
@@ -384,6 +401,9 @@ It must be used with the -u option to specify the user name.
 This option requires administration credentials and you cannot switch the credentials during a session.
 
 Couchbase recommends using the `-u` and `-p` option if your password contains special characters such as #, $, %, &, (,), or '.
+
+.Default
+none
 
 .Example
 [source,console]
@@ -396,13 +416,15 @@ $ ./cbq -e http://localhost:8091 -u=Administrator -p=password
 
 `--credentials`
 | string
-| none
 a| Specify the login credentials in the form of [.var]`username`:[.var]``password``.
 You can specify credentials for different buckets by separating them with a comma.
 
 Shell command: <<cbq-set,\SET>> `-creds`
 
 REST API: `-creds` parameter
+
+.Default
+none
 
 .Example
 [source,console]
@@ -415,7 +437,6 @@ $ ./cbq -e http://localhost:8091 -c=beer-sample:password,Administrator:password
 
 `--version`
 | boolean footnote:boolean[]
-| `false`
 a| When specified, provides the version of the cbq shell.
 To display the query engine version of Couchbase Server (this is not the same as the version of Couchbase Server itself), use one of the following N1QL queries:
 
@@ -430,6 +451,9 @@ select min_version();
 ----
 
 Shell command: <<cbq-version,\VERSION>>
+
+.Default
+`false`
 
 .Example
 [source,console]
@@ -450,10 +474,12 @@ $ ./cbq --version
 
 `--help`
 | none
-| none
 a| Provides help for the command line options.
 
 Shell command: <<cbq-help,\HELP>>
+
+.Default
+none
 
 .Example
 [source,console]
@@ -466,11 +492,13 @@ $ ./cbq --help
 
 `-script`
 | string
-| none
 a| Provides a single command mode to execute a query from the command line.
 
 You can also use multiple `-s` options on the command line.
 If one of the commands is incorrect, an error is displayed for that command and cbq continues to execute the remaining commands.
+
+.Default
+none
 
 .Examples
 [source,console]
@@ -507,10 +535,12 @@ $ ./cbq  -s="\SET v 1" -s="\SET b 2" -s="\PUSH b3" -s="\SET b 5" -s="\SET"  -ne
 
 `--file`
 | string (path)
-| none
 a| Provides an input file which contains all the commands to be run.
 
 Shell command: <<cbq-source,\SOURCE>>
+
+.Default
+none
 
 .Example
 [source,console]
@@ -523,13 +553,15 @@ $ ./cbq --file="sample.txt"
 
 `--output`
 | string (path)
-| none
 a| Specifies an output file where the commands and their results are to be written.
 
 If the file doesn't exist, it is created.
 If the file already exists, it is overwritten.
 
 Shell command: <<cbq-redirect,\REDIRECT>>
+
+.Default
+none
 
 .Example
 [source,console]
@@ -540,11 +572,13 @@ $ ./cbq -o="results.txt" -s="select * from `travel-sample` limit 1"
 | [[opt-pretty]]
 `--pretty`
 | boolean footnote:boolean[]
-| `true`
 a| Specifies whether the output should be formatted with line breaks and indents.
 
 This option is set to `true` by default.
 To specify that the output should _not_ be formatted with line breaks and indents, you must explicitly set this option to `false`.
+
+.Default
+`true`
 
 .Example
 [source,console]
@@ -555,8 +589,10 @@ $ ./cbq --pretty=false -s="select * from `travel-sample` limit 1"
 | [[opt-exit-on-error]]
 `--exit-on-error`
 | boolean footnote:boolean[]
-| `false`
 a| When specified, the cbq shell must exit when it encounters the first error.
+
+.Default
+`false`
 
 .Example
 [source,console]
@@ -567,10 +603,12 @@ $ ./cbq --exit-on-error -f="sample.txt"
 | [[opt-cacert]]
 `--cacert`
 | string (path)
-| none
 a| Only applicable when using an encrypted protocol scheme -- either _https://_ or _couchbases://_.
 
 Specifies the path to the root CA certificate to verify the identity of the server.
+
+.Default
+none
 
 .Example
 [source,console]
@@ -581,10 +619,12 @@ $ ./cbq --cacert ./root/ca.pem
 | [[opt-cert]]
 `--cert`
 | string (path)
-| none
 a| Only applicable when using an encrypted protocol scheme -- either _https://_ or _couchbases://_.
 
 Specifies the path to the chain certificate.
+
+.Default
+none
 
 .Example
 [source,console]
@@ -595,10 +635,12 @@ $ ./cbq --cert ./client/client/chain.pem
 | [[opt-key]]
 `--key`
 | string (path)
-| none
 a| Only applicable when using an encrypted protocol scheme -- either _https://_ or _couchbases://_.
 
 Specifies the path to the client key file. 
+
+.Default
+none
 
 .Examples
 [source,console]
@@ -611,10 +653,12 @@ $ ./cbq --key ./client/client/client.key
 
 `-skip-verify`
 | boolean footnote:boolean[]
-| `false`
 a| Only applicable when using an encrypted protocol scheme -- either _https://_ or _couchbases://_.
 
 When specified, the cbq shell can skip the verification of certificates.
+
+.Default
+`false`
 
 .Examples
 [source,console]
@@ -629,7 +673,7 @@ $ ./cbq -skip-verify https://127.0.0.1:18091
 |===
 
 .cbq Shell Commands
-[#table_htk_hgc_fw,cols="1,2,4"]
+[#table_htk_hgc_fw,cols="~,~,55"]
 |===
 | Shell Command | Arguments | Description and Examples
 
@@ -694,7 +738,7 @@ cbq> \QUIT;
 [.cmd]`\SET`
 | [.var]`parameter` [.var]`value`
 
-[.var]`parameter`=[.var]`prefix`:[.var]``variable name``
+[.var]`parameter` = [.var]`prefix` : [.var]`variable name`
 a| Sets the top most value of the stack for the given variable with the specified value.
 
 Variables can be of the following types:
@@ -719,7 +763,7 @@ cbq> \SET -args [6,7];
 
 | [[cbq-push]]
 [.cmd]`\PUSH`
-| [.var]`parameter value`
+| [.var]`parameter` [.var]`value`
 a| Pushes the specified value on to the given parameter stack.
 
 When the [.cmd]`\PUSH` command is used without any arguments, it copies the top element of every variable's stack, and then pushes that copy to the top of the respective variable's stack.

--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -1034,19 +1034,33 @@ There are two ways to establish a connection:
 cbq> \CONNECT url;
 ----
 
-The [.var]`url` is made up of two components: the URL and a port number.
-The URL can be the IP address or URL of any node in the cluster, as cbq will automatically discover the query nodes.
+The [.var]`url` may contain up to three components: the protocol scheme, the host, and a port number.
 The URL is optional and if it is not specified, the default URL `+http://localhost:8091+` is used.
 An error is thrown if the URL is invalid.
 
-The port number to connect to the query service is 8093 and to the Couchbase cluster is 8091.
+The cbq shell supports the [.path]_http://_, [.path]_https://_, [.path]_couchbase://_ and [.path]_couchbases://_ protocol schemes.
+The [.path]_https://_ and [.path]_couchbases://_ protocol schemes are encrypted.
+For more details, refer to <<cbq-encrypted>>.
 
-The cbq shell supports [.path]_http://_, [.path]_https://_, [.path]_couchbase://_ and [.path]_couchbases://_ protocol schemes.
-When using the [.path]_couchbase://_ or [.path]_couchbases://_ protocol schemes, you need not specify the port when connecting to the Couchbase cluster.
+The host may be the IP address or hostname of any node in the cluster, as cbq will automatically discover the query nodes.
+The cbq shell supports both IPV4 and IPV6 addresses.
 
-When connecting to the query service, use the query port 8093.
+****
+[.status]#Couchbase Server 6.6.1#
+
+In Couchbase Server 6.6.1 and later, the [.path]_couchbase://_ and [.path]_couchbases://_ protocol schemes support the domain name service (DNS).
+When using one of these protocol schemes, the host may be a domain name which is resolved using DNS.
+For example, this enables you to connect to a cluster or node over the internet.
+
+Note that you must use the encrypted [.path]_couchbases://_ protocol scheme to connect to a cluster or node deployed in Couchbase Cloud.
+****
+
+You may optionally specify the port when using the [.path]_http://_ or [.path]_https://_ protocol schemes.
+When connecting to the query service, use the query port 8093, or 18093 for an encrypted connection.
 When connecting to the cluster, you don't need to specify the port as the connection uses round robin to find a query service to connect to.
-If you want to specify a port, use the admin port 8091.
+If you want to specify a port, use the admin port 8091, or 18091 for an encrypted connection.
+
+You cannot specify the port when using the [.path]_couchbase://_ or [.path]_couchbases://_ protocol schemes.
 
 You can close the connection with an existing node or cluster without exiting the shell at any given time during the session using the [.cmd]`\DISCONNECT;` command.
 If the shell is not connected to any endpoint, an error with a message that the shell is not connected to any instance is thrown.

--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -210,12 +210,9 @@ cbq> \HELP;
 `--engine`
 | string (url)
 | `+http://localhost:8091+`
-a| The connection string consists of a protocol scheme followed by a host, including a port number to connect to the query service (8093) or the Couchbase cluster (8091).
+a| The connection string consists of a protocol scheme, followed by a host, and optionally a port number to connect to the query service (8093) or the Couchbase cluster (8091).
 
-The cbq shell supports [.path]_http://_, [.path]_https://_, [.path]_couchbase://_ and [.path]_couchbases://_ protocol schemes.
-When using the [.path]_couchbase://_ or [.path]_couchbases://_ protocol schemes, you need not specify the port when connecting to the Couchbase cluster.
-
-The cbq shell supports both IPV4 and IPV6 addresses.
+For more details, refer to <<cbq-connect-to-cluster>>.
 
 Shell command: <<cbq-connect,\CONNECT>>
 


### PR DESCRIPTION
The following draft documentation is ready for review:

* [cbq: The Command Line Shell for N1QL › Connecting to the Cluster or Query Node](https://simon-dew.github.io/docs-site/DOC-7649/server/6.6/tools/cbq-shell.html#cbq-connect-to-cluster)

Added sidebar for Couchbase Server 6.6.1 about connecting to host using DNS server; other minor changes throughout

Docs issue: [DOC-7649](https://issues.couchbase.com/browse/DOC-7649)