### PR TITLE
DOC-5388: Change “RedHat” to “Red Hat”

### DIFF
--- a/modules/manage/pages/manage-security/configure-pam.adoc
+++ b/modules/manage/pages/manage-security/configure-pam.adoc
@@ -29,7 +29,7 @@ Proceed as follows:
 
 . Bring up a terminal, and install the `saslauthd` library for your Linux distribution:
 
-** *Centos/RHEL*
+** *CentOS/RHEL*
 +
 [source,bash]
 ----
@@ -65,7 +65,7 @@ usermod -aG sasl couchbase
 
 . In the `saslauthd` configuration file, verify that `saslauthd` is set up to use PAM, by using the `grep` command, and examining the output, using one of the following procedures:
 
-** *Centos/RHEL*
+** *CentOS/RHEL*
 +
 [source,bash]
 ----
@@ -163,7 +163,7 @@ The user you created is now logged into Couchbase Server, as an administrator.
 
 If login does not succeed, bring up the file `/etc/default/saslauthd` in an editor, and ensure it contains the line `START=yes`.
 If the line reads `START=no`, change it to `START=yes`.
-Also confirm that the `MECH` (for RedHat/Centos) or `MECHANISM` (for Ubuntu/Debian) parameter is set to `pam`.
+Also confirm that the `MECH` (for CentOS/RHEL) or `MECHANISM` (for Ubuntu/Debian) parameter is set to `pam`.
 Save the file, and exit.
 Then, restart both `saslauthd` and `couchbase-server`, as described above.
 Finally, re-attempt login.

--- a/modules/manage/pages/manage-security/manage-connections-and-disks.adoc
+++ b/modules/manage/pages/manage-security/manage-connections-and-disks.adoc
@@ -51,7 +51,7 @@ For guidance, consult the following online information-resources:
 === Controlling Access to Files
 
 To restrict user-access to files and directories, traditional file-permissions can be used.
-Additionally, RedHat Linux provides the following options:
+Additionally, Red Hat Enterprise Linux (RHEL) provides the following options:
 
 * https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Security-Enhanced_Linux/[Security Enhanced Linux^]
 * https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Storage_Administration_Guide/ch-acls.html[Access Control Lists^].

--- a/modules/manage/pages/troubleshoot/core-files.adoc
+++ b/modules/manage/pages/troubleshoot/core-files.adoc
@@ -72,7 +72,7 @@ kernel.core_pattern=/opt/couchbase/data/tmp/core-%e-%s-%u-%g-%p-%t
 service procps start
 ----
 
-*RedHat*
+*Red Hat Enterprise Linux (RHEL)*
 
 On RHEL 6, run the following command and then reboot the system.
 
@@ -80,7 +80,7 @@ On RHEL 6, run the following command and then reboot the system.
 echo "DAEMON_COREFILE_LIMIT='unlimited'" >> /etc/sysconfig/init
 ----
 
-Earlier RedHat derivative operating systems such as RHEL4, RHEL5, F7, and CentOS, need a modification to their startup scripts.
+Earlier RHEL derivative operating systems such as RHEL 4, RHEL 5, F7, and CentOS, need a modification to their startup scripts.
 By default, these operating systems hard set the core size to zero in the [.path]_/etc/profile_ file.
 To fix this, edit the following line in the file [.path]_/etc/profile_ from `ulimit -S -c 0 > /dev/null 2>&1` to `ulimit -S -c unlimited > /dev/null 2>&1`.
 Then reboot the system.


### PR DESCRIPTION
Corrected a few instances where Red Hat is spelled as a single word (RedHat).