### PR TITLE
DOC-5322: Note about FTS auto-upgrade to Scorch

### DIFF
--- a/modules/install/pages/upgrade-strategy-for-features.adoc
+++ b/modules/install/pages/upgrade-strategy-for-features.adoc
@@ -4,7 +4,7 @@ Upgrading to the latest version of Couchbase Server allows you to leverage the l
 The following table summarizes the new features in this release, and describes what parts of the cluster need to be upgraded to enable them.
 
 .Couchbase Server 6.0 Feature Upgrade Matrix
-[cols="1,1,1,1,1,1"]
+[cols="1,1,1,1,1,2"]
 |===
 | Feature | Upgrade Level | xref:upgrade-strategies.adoc[Upgrade Type] | xref:upgrade.adoc#supported-upgrade-paths[Upgrade Path] | Mixed Mode<<feature-mixed-mode,†>> | Dependencies
 
@@ -24,15 +24,18 @@ If you plan to use the production release of Couchbase Analytics in version 6.0,
 | No
 | All Eventing nodes must be running version 6.0 to enable this feature.
 
-| Scorch indexing system (Full Text Search)
+| Scorch indexing system (Search Service)
 | Cluster
 | Offline/Online
 | Direct
 | Yes*
-| * FTS nodes running version 6.0 use the Scorch indexing system by default for new indexes.
-You can continue to use previous indexes in version 6.0, but they will not use Scorch.
+a| *After upgrading to Couchbase Server 6.0, existing Full Text Indexes will continue to use the Moss xref:fts:fts-creating-indexes.adoc#index-type[index type], while _new_ Full Text Indexes will use the Scorch index type by default.
+These Moss indexes can be upgraded to Scorch by updating their respective definitions with the new index type.
 
-To upgrade previous indexes to use Scorch, simply xref:fts:fts-creating-indexes.adoc[recreate] them using the new index type option.
+Note that existing indexes that do not have `indexType` explicitly specified in the index definition are considered to use the default index type.
+These indexes will continue to use the Moss index type after upgrading to Couchbase Server 6.0.
+However, any further updates to the index definition will result in the index being upgraded to Scorch.
+Indexes created through the Couchbase Web Console automatically include the index type, therefore this issue only applies to indexes that were created using the command line.
 |===
 
 [[feature-mixed-mode]]† _Mixed Mode in this context refers to only the nodes that are running the indicated service.

--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -949,10 +949,15 @@ When upgrading from Couchbase Server 5.5 to Couchbase Server 6.0 or later, any e
 
 The following changes have been made to the Full-Text Search Service:
 
-* Search nodes running Couchbase Server 6.0 now use the Scorch indexing system by default for new indexes.
-You can continue to use previous indexes in version 6.0, but they will not use Scorch.
+* Scorch is now the default xref:fts:fts-creating-indexes.adoc#index-type[index type] for all new Full Text Indexes.
 +
-To upgrade previous indexes to use Scorch, simply xref:fts:fts-creating-indexes.adoc[recreate] them using the new index type option.
+After upgrading to Couchbase Server 6.0, existing Full Text Indexes will continue to use the Moss index type, while _new_ Full Text Indexes will use the Scorch index type by default.
+These Moss indexes can be upgraded to Scorch by updating their respective definitions with the new index type.
++
+NOTE: Existing indexes that do not have `indexType` explicitly specified in the index definition are considered to use the default index type.
+These indexes will continue to use the Moss index type after upgrading to Couchbase Server 6.0.
+However, any further updates to the index definition will result in the index being upgraded to Scorch.
+Indexes created through the Couchbase Web Console automatically include the index type, therefore this issue only applies to indexes that were created using the command line.
 
 * In Couchbase Server 6.0 Enterprise Edition, the Search Service explicitly requires encrypted port 18094 (`fts_ssl_port`) for scatter-gather operations between nodes that are running the Search Service (even if you're still using unencrypted port 8094 for client-to-node traffic).
 The node-to-node traffic uses the HTTP/2 protocol and is encrypted with either the auto-generated certificate from installation, or with a xref:learn:security/certificates.adoc[custom node certificate] if one has been specified.


### PR DESCRIPTION
This PR seeks to update the 6.0 release notes and upgrade docs to clarify an edge case where indexes can be automatically upgraded to Scorch.