### PR TITLE
DOC-8077: example of collection creation is wrong

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/createcollection.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createcollection.adoc
@@ -58,7 +58,7 @@ It is assumed that the `places` scope already exists.
 
 [source,n1ql]
 ----
-CREATE SCOPE `travel-sample`.places.cities
+CREATE COLLECTION `travel-sample`.places.cities
 ----
 ====
 

--- a/modules/n1ql/pages/n1ql-language-reference/createcollection.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createcollection.adoc
@@ -6,7 +6,7 @@
 
 :identifier: xref:n1ql-language-reference/identifiers.adoc
 :logical-hierarchy: xref:n1ql-intro/sysinfo.adoc#logical-hierarchy
-:naming-for-scopes-and-collection: xref:learn:data/scopes-and-collections.adoc#naming-for-scopes-and-collection
+:naming-for-scopes-and-collections: xref:learn:data/scopes-and-collections.adoc#naming-for-scopes-and-collections
 :query-context: xref:n1ql:n1ql-intro/sysinfo.adoc#query-context
 :scopes-and-collections: xref:learn:data/scopes-and-collections.adoc
 :manage-scopes-and-collections: xref:manage:manage-scopes-and-collections/manage-scopes-and-collections.adoc
@@ -38,7 +38,7 @@ scope::
 
 collection::
 (Required) An {identifier}[identifier] that refers to the name of the collection that you want to create.
-Refer to {naming-for-scopes-and-collection}[Naming for Scopes and Collections] for restrictions on collection names.
+Refer to {naming-for-scopes-and-collections}[Naming for Scopes and Collections] for restrictions on collection names.
 
 NOTE: If there is a hyphen (-) inside the bucket name, the scope name, or the collection name, you must wrap that part of the path in backticks ({backtick} {backtick}).
 For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.

--- a/modules/n1ql/pages/n1ql-language-reference/createcollection.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createcollection.adoc
@@ -4,6 +4,15 @@
 :imagesdir: ../../assets/images
 :page-partial:
 
+:identifier: xref:n1ql-language-reference/identifiers.adoc
+:logical-hierarchy: xref:n1ql-intro/sysinfo.adoc#logical-hierarchy
+:naming-for-scopes-and-collection: xref:learn:data/scopes-and-collections.adoc#naming-for-scopes-and-collection
+:query-context: xref:n1ql:n1ql-intro/sysinfo.adoc#query-context
+:scopes-and-collections: xref:learn:data/scopes-and-collections.adoc
+:manage-scopes-and-collections: xref:manage:manage-scopes-and-collections/manage-scopes-and-collections.adoc
+:scopes-and-collections-api: xref:rest-api:scopes-and-collections-api.adoc
+:couchbase-cli-collection-manage: xref:cli:cbcli/couchbase-cli-collection-manage.adoc
+
 [abstract]
 The `CREATE COLLECTION` statement enables you to create a named collection within a scope.
 
@@ -17,19 +26,19 @@ create-collection ::= CREATE COLLECTION [ [ _namespace_ ':' ] _bucket_ '.' _scop
 image::n1ql-language-reference/create-collection.png["'CREATE' 'COLLECTION' ( ( namespace ':' )? bucket '.' scope '.' )? collection"]
 
 namespace::
-(Optional) An xref:n1ql-language-reference/identifiers.adoc[identifier] that refers to the xref:n1ql-intro/sysinfo.adoc#logical-hierarchy[namespace] of the bucket in which you want to create the collection.
+(Optional) An {identifier}[identifier] that refers to the {logical-hierarchy}[namespace] of the bucket in which you want to create the collection.
 Currently, only the `default` namespace is available.
 If the namespace name is omitted, the default namespace in the current session is used.
 
 bucket::
-(Optional) An xref:n1ql-language-reference/identifiers.adoc[identifier] that refers to the bucket in which you want to create the collection.
+(Optional) An {identifier}[identifier] that refers to the bucket in which you want to create the collection.
 
 scope::
-(Optional) An xref:n1ql-language-reference/identifiers.adoc[identifier] that refers to the scope in which you want to create the collection.
+(Optional) An {identifier}[identifier] that refers to the scope in which you want to create the collection.
 
 collection::
-(Required) An xref:n1ql-language-reference/identifiers.adoc[identifier] that refers to the name of the collection that you want to create.
-Refer to xref:learn:data/scopes-and-collections.adoc#naming-for-scopes-and-collection[Naming for Scopes and Collections] for restrictions on collection names.
+(Required) An {identifier}[identifier] that refers to the name of the collection that you want to create.
+Refer to {naming-for-scopes-and-collection}[Naming for Scopes and Collections] for restrictions on collection names.
 
 NOTE: If there is a hyphen (-) inside the bucket name, the scope name, or the collection name, you must wrap that part of the path in backticks ({backtick} {backtick}).
 For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.
@@ -42,7 +51,7 @@ To specify the collection, you may do one of the following:
 * Include a [def]_relative path_, containing just the bucket and scope, followed by the connection name;
 * Specify just the collection name without a path.
 
-When you specify a collection name without a path, you must set the xref:n1ql:n1ql-intro/sysinfo.adoc#query-context[query context] to indicate the required namespace, bucket, and scope.
+When you specify a collection name without a path, you must set the {query-context}[query context] to indicate the required namespace, bucket, and scope.
 If you specify a collection name by itself without setting a valid query context, an error is generated.
 
 It is important to note that the scope must exist before you can create the collection, whether the scope is specified in the statement itself or implied by the query context.
@@ -53,41 +62,53 @@ You cannot create the scope and the collection in a single statement.
 
 .Create collection with full path
 ====
-This statement creates a collection called `cities` in the `places` scope within the `travel-sample` bucket.
-It is assumed that the `places` scope already exists.
+This statement creates a collection called `city` in the `inventory` scope within the `travel-sample` bucket.
 
 [source,n1ql]
 ----
-CREATE COLLECTION `travel-sample`.places.cities
+CREATE COLLECTION `travel-sample`.inventory.city
 ----
+====
+
+[discrete]
+===== Query Context
+
+For the following example, you must first set the {query-context}[query context] to `{backtick}travel-sample{backtick}.inventory`, using the Query Workbench or the cbq shell.
+
+[{tabs}]
+====
+Query Workbench::
++
+--
+image::tools:query-workbench-context.png["The query context drop-down menu, with 'travel-sample.inventory' selected"]
+--
+
+CBQ Shell::
++
+--
+[source,shell]
+----
+cbq> \SET -query_context 'travel-sample.inventory';
+----
+--
 ====
 
 .Create collection with query context
 ====
-This statement creates a collection called `countries` in the `places` scope within the `travel-sample` bucket.
-It is assumed that the `places` scope already exists.
+Assuming that the query context is set, this statement creates a collection called `country` in the `inventory` scope within the `travel-sample` bucket.
 
-This example uses the cbq shell, but you can also set the query context and create the collection using the Query Workbench.
-
-.Set the query context
-[source,shell]
+[source,n1ql]
 ----
-cbq> \SET -query_context "travel-sample.places";
-----
-
-.Create the collection
-[source,shell]
-----
-cbq> CREATE COLLECTION countries;
+CREATE COLLECTION country;
 ----
 ====
 
 == Related Links
 
-* An overview of scopes and collections is provided in xref:learn:data/scopes-and-collections.adoc[Scopes and Collections].
+* An overview of scopes and collections is provided in {scopes-and-collections}[Scopes and Collections].
 
-* Step-by-step procedures for management are provided in xref:manage:manage-scopes-and-collections/manage-scopes-and-collections.adoc[Manage Scopes and Collections].
+* Step-by-step procedures for management are provided in {manage-scopes-and-collections}[Manage Scopes and Collections].
 
-* Refer to xref:rest-api:scopes-and-collections-api.adoc[Scopes and Collections API] to manage scopes and collections with the REST API.
+* Refer to {scopes-and-collections-api}[Scopes and Collections API] to manage scopes and collections with the REST API.
 
-* Refer to the reference page for the xref:cli:cbcli/couchbase-cli-collection-manage.adoc[collection-manage] command to manage scopes and collections with the CLI.
+* Refer to the reference page for the {couchbase-cli-collection-manage}[collection-manage] command to manage scopes and collections with the CLI.

--- a/modules/n1ql/pages/n1ql-language-reference/createscope.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createscope.adoc
@@ -4,6 +4,14 @@
 :imagesdir: ../../assets/images
 :page-partial:
 
+:identifier: xref:n1ql-language-reference/identifiers.adoc
+:logical-hierarchy: xref:n1ql-intro/sysinfo.adoc#logical-hierarchy
+:naming-for-scopes-and-collection: xref:learn:data/scopes-and-collections.adoc#naming-for-scopes-and-collection
+:scopes-and-collections: xref:learn:data/scopes-and-collections.adoc
+:manage-scopes-and-collections: xref:manage:manage-scopes-and-collections/manage-scopes-and-collections.adoc
+:scopes-and-collections-api: xref:rest-api:scopes-and-collections-api.adoc
+:couchbase-cli-collection-manage: xref:cli:cbcli/couchbase-cli-collection-manage.adoc
+
 [abstract]
 The `CREATE SCOPE` statement enables you to create a scope.
 
@@ -17,16 +25,16 @@ create-scope ::= CREATE SCOPE [ _namespace_ ':' ] _bucket_ '.' _scope_
 image::n1ql-language-reference/create-scope.png["create-scope ::= 'CREATE' 'SCOPE' ( namespace ':' )? bucket '.' scope"]
 
 namespace::
-(Optional) An xref:n1ql-language-reference/identifiers.adoc[identifier] that refers to the xref:n1ql-intro/sysinfo.adoc#logical-hierarchy[namespace] of the bucket in which you want to create the scope.
+(Optional) An {identifier}[identifier] that refers to the {logical-hierarchy}[namespace] of the bucket in which you want to create the scope.
 Currently, only the `default` namespace is available.
 If the namespace name is omitted, the default namespace in the current session is used.
 
 bucket::
-(Required) An xref:n1ql-language-reference/identifiers.adoc[identifier] that refers to the bucket in which you want to create the scope.
+(Required) An {identifier}[identifier] that refers to the bucket in which you want to create the scope.
 
 scope::
-(Required) An xref:n1ql-language-reference/identifiers.adoc[identifier] that refers to the name of the scope that you want to create.
-Refer to xref:learn:data/scopes-and-collections.adoc#naming-for-scopes-and-collection[Naming for Scopes and Collections] for restrictions on scope names.
+(Required) An {identifier}[identifier] that refers to the name of the scope that you want to create.
+Refer to {naming-for-scopes-and-collection}[Naming for Scopes and Collections] for restrictions on scope names.
 
 NOTE: If there is a hyphen (-) inside the bucket name or the scope name, you must wrap that part of the path in backticks ({backtick} {backtick}).
 For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.
@@ -34,20 +42,20 @@ For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-s
 == Example
 
 ====
-This statement creates a scope called `places` in the `travel-sample` bucket.
+This statement creates a scope called `events` in the `travel-sample` bucket.
 
 [source,n1ql]
 ----
-CREATE SCOPE `travel-sample`.places
+CREATE SCOPE `travel-sample`.events
 ----
 ====
 
 == Related Links
 
-* An overview of scopes and collections is provided in xref:learn:data/scopes-and-collections.adoc[Scopes and Collections].
+* An overview of scopes and collections is provided in {scopes-and-collections}[Scopes and Collections].
 
-* Step-by-step procedures for management are provided in xref:manage:manage-scopes-and-collections/manage-scopes-and-collections.adoc[Manage Scopes and Collections].
+* Step-by-step procedures for management are provided in {manage-scopes-and-collections}[Manage Scopes and Collections].
 
-* Refer to xref:rest-api:scopes-and-collections-api.adoc[Scopes and Collections API] to manage scopes and collections with the REST API.
+* Refer to {scopes-and-collections-api}[Scopes and Collections API] to manage scopes and collections with the REST API.
 
-* Refer to the reference page for the xref:cli:cbcli/couchbase-cli-collection-manage.adoc[collection-manage] command to manage scopes and collections with the CLI.
+* Refer to the reference page for the {couchbase-cli-collection-manage}[collection-manage] command to manage scopes and collections with the CLI.

--- a/modules/n1ql/pages/n1ql-language-reference/createscope.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createscope.adoc
@@ -6,7 +6,7 @@
 
 :identifier: xref:n1ql-language-reference/identifiers.adoc
 :logical-hierarchy: xref:n1ql-intro/sysinfo.adoc#logical-hierarchy
-:naming-for-scopes-and-collection: xref:learn:data/scopes-and-collections.adoc#naming-for-scopes-and-collection
+:naming-for-scopes-and-collections: xref:learn:data/scopes-and-collections.adoc#naming-for-scopes-and-collections
 :scopes-and-collections: xref:learn:data/scopes-and-collections.adoc
 :manage-scopes-and-collections: xref:manage:manage-scopes-and-collections/manage-scopes-and-collections.adoc
 :scopes-and-collections-api: xref:rest-api:scopes-and-collections-api.adoc
@@ -34,7 +34,7 @@ bucket::
 
 scope::
 (Required) An {identifier}[identifier] that refers to the name of the scope that you want to create.
-Refer to {naming-for-scopes-and-collection}[Naming for Scopes and Collections] for restrictions on scope names.
+Refer to {naming-for-scopes-and-collections}[Naming for Scopes and Collections] for restrictions on scope names.
 
 NOTE: If there is a hyphen (-) inside the bucket name or the scope name, you must wrap that part of the path in backticks ({backtick} {backtick}).
 For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.

--- a/modules/n1ql/pages/n1ql-language-reference/dropcollection.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropcollection.adoc
@@ -4,6 +4,14 @@
 :imagesdir: ../../assets/images
 :page-partial:
 
+:identifier: xref:n1ql-language-reference/identifiers.adoc
+:logical-hierarchy: xref:n1ql-intro/sysinfo.adoc#logical-hierarchy
+:query-context: xref:n1ql:n1ql-intro/sysinfo.adoc#query-context
+:scopes-and-collections: xref:learn:data/scopes-and-collections.adoc
+:manage-scopes-and-collections: xref:manage:manage-scopes-and-collections/manage-scopes-and-collections.adoc
+:scopes-and-collections-api: xref:rest-api:scopes-and-collections-api.adoc
+:couchbase-cli-collection-manage: xref:cli:cbcli/couchbase-cli-collection-manage.adoc
+
 [abstract]
 The `DROP COLLECTION` statement enables you to delete a named collection from a scope.
 
@@ -17,18 +25,18 @@ drop-collection ::= DROP COLLECTION [ [ _namespace_ ':' ] _bucket_ '.' _scope_ '
 image::n1ql-language-reference/drop-collection.png["'DROP' 'COLLECTION' ( ( namespace ':' )? bucket '.' scope '.' )? collection"]
 
 namespace::
-(Optional) An xref:n1ql-language-reference/identifiers.adoc[identifier] that refers to the xref:n1ql-intro/sysinfo.adoc#logical-hierarchy[namespace] of the bucket which contains the collection you want to delete.
+(Optional) An {identifier}[identifier] that refers to the {logical-hierarchy}[namespace] of the bucket which contains the collection you want to delete.
 Currently, only the `default` namespace is available.
 If the namespace name is omitted, the default namespace in the current session is used.
 
 bucket::
-(Optional) An xref:n1ql-language-reference/identifiers.adoc[identifier] that refers to the bucket which contains the collection you want to delete.
+(Optional) An {identifier}[identifier] that refers to the bucket which contains the collection you want to delete.
 
 scope::
-(Optional) An xref:n1ql-language-reference/identifiers.adoc[identifier] that refers to the scope which contains the collection you want to delete.
+(Optional) An {identifier}[identifier] that refers to the scope which contains the collection you want to delete.
 
 collection::
-(Required) An xref:n1ql-language-reference/identifiers.adoc[identifier] that refers to the name of the collection that you want to delete.
+(Required) An {identifier}[identifier] that refers to the name of the collection that you want to delete.
 
 NOTE: If there is a hyphen (-) inside the bucket name, the scope name, or the collection name, you must wrap that part of the path in backticks ({backtick} {backtick}).
 For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.
@@ -41,46 +49,60 @@ To specify the collection, you may do one of the following:
 * Include a [def]_relative path_, containing just the bucket and scope, followed by the connection name;
 * Specify just the collection name without a path.
 
-When you specify a collection name without a path, you must set the xref:n1ql:n1ql-intro/sysinfo.adoc#query-context[query context] to indicate the required namespace, bucket, and scope.
+When you specify a collection name without a path, you must set the {query-context}[query context] to indicate the required namespace, bucket, and scope.
 If you specify a collection name by itself without setting a valid query context, an error is generated.
 
 == Examples
 
 .Delete collection with full path
 ====
-This statement deletes a collection called `cities` in the `places` scope within the `travel-sample` bucket.
+This statement deletes a collection called `city` in the `inventory` scope within the `travel-sample` bucket.
 
 [source,n1ql]
 ----
-DROP COLLECTION `travel-sample`.places.cities
+DROP COLLECTION `travel-sample`.inventory.city
 ----
+====
+
+[discrete]
+===== Query Context
+
+For the following example, you must first set the {query-context}[query context] to `{backtick}travel-sample{backtick}.inventory`, using the Query Workbench or the cbq shell.
+
+[{tabs}]
+====
+Query Workbench::
++
+--
+image::tools:query-workbench-context.png["The query context drop-down menu, with 'travel-sample.inventory' selected"]
+--
+
+CBQ Shell::
++
+--
+[source,shell]
+----
+cbq> \SET -query_context 'travel-sample.inventory';
+----
+--
 ====
 
 .Delete collection with query context
 ====
-This statement deletes a collection called `countries` in the `places` scope within the `travel-sample` bucket.
+Assuming that the query context is set, this statement deletes a collection called `country` in the `inventory` scope within the `travel-sample` bucket.
 
-This example uses the cbq shell, but you can also set the query context and delete the collection using the Query Workbench.
-
-.Set the query context
-[source,shell]
+[source,n1ql]
 ----
-cbq> \SET -query_context "travel-sample.places";
-----
-
-.Delete the collection
-[source,shell]
-----
-cbq> DROP COLLECTION countries;
+DROP COLLECTION country;
 ----
 ====
 
 == Related Links
 
-* An overview of scopes and collections is provided in xref:learn:data/scopes-and-collections.adoc[Scopes and Collections].
+* An overview of scopes and collections is provided in {scopes-and-collections}[Scopes and Collections].
 
-* Step-by-step procedures for management are provided in xref:manage:manage-scopes-and-collections/manage-scopes-and-collections.adoc[Manage Scopes and Collections].
+* Step-by-step procedures for management are provided in {manage-scopes-and-collections}[Manage Scopes and Collections].
 
-* Refer to xref:rest-api:scopes-and-collections-api.adoc[Scopes and Collections API] to manage scopes and collections with the REST API.
+* Refer to {scopes-and-collections-api}[Scopes and Collections API] to manage scopes and collections with the REST API.
 
-* Refer to the reference page for the xref:cli:cbcli/couchbase-cli-collection-manage.adoc[collection-manage] command to manage scopes and collections with the CLI.
+* Refer to the reference page for the {couchbase-cli-collection-manage}[collection-manage] command to manage scopes and collections with the CLI.

--- a/modules/n1ql/pages/n1ql-language-reference/dropscope.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropscope.adoc
@@ -4,6 +4,13 @@
 :imagesdir: ../../assets/images
 :page-partial:
 
+:identifier: xref:n1ql-language-reference/identifiers.adoc
+:logical-hierarchy: xref:n1ql-intro/sysinfo.adoc#logical-hierarchy
+:scopes-and-collections: xref:learn:data/scopes-and-collections.adoc
+:manage-scopes-and-collections: xref:manage:manage-scopes-and-collections/manage-scopes-and-collections.adoc
+:scopes-and-collections-api: xref:rest-api:scopes-and-collections-api.adoc
+:couchbase-cli-collection-manage: xref:cli:cbcli/couchbase-cli-collection-manage.adoc
+
 [abstract]
 The `DROP SCOPE` statement enables you to delete a scope.
 
@@ -17,15 +24,15 @@ drop-scope ::= DROP SCOPE [ _namespace_ ':' ] _bucket_ '.' _scope_
 image::n1ql-language-reference/drop-scope.png["drop-scope ::= 'DROP' 'SCOPE' ( namespace ':' )? bucket '.' scope"]
 
 namespace::
-(Optional) An xref:n1ql-language-reference/identifiers.adoc[identifier] that refers to the xref:n1ql-intro/sysinfo.adoc#logical-hierarchy[namespace] of the bucket which contains the scope you want to delete.
+(Optional) An {identifier}[identifier] that refers to the {logical-hierarchy}[namespace] of the bucket which contains the scope you want to delete.
 Currently, only the `default` namespace is available.
 If the namespace name is omitted, the default namespace in the current session is used.
 
 bucket::
-(Required) An xref:n1ql-language-reference/identifiers.adoc[identifier] that refers to the bucket which contains the scope you want to delete.
+(Required) An {identifier}[identifier] that refers to the bucket which contains the scope you want to delete.
 
 scope::
-(Required) An xref:n1ql-language-reference/identifiers.adoc[identifier] that refers to the name of the scope that you want to delete.
+(Required) An {identifier}[identifier] that refers to the name of the scope that you want to delete.
 
 NOTE: If there is a hyphen (-) inside the bucket name or the scope name, you must wrap that part of the path in backticks ({backtick} {backtick}).
 For example, `default:{backtick}travel-sample{backtick}` indicates the `travel-sample` keyspace in the `default` namespace.
@@ -37,20 +44,20 @@ When you delete a scope, any collections within that scope are deleted also.
 == Example
 
 ====
-This statement deletes a scope called `places` in the `travel-sample` bucket.
+This statement deletes a scope called `events` in the `travel-sample` bucket.
 
 [source,n1ql]
 ----
-DROP SCOPE `travel-sample`.places
+DROP SCOPE `travel-sample`.events
 ----
 ====
 
 == Related Links
 
-* An overview of scopes and collections is provided in xref:learn:data/scopes-and-collections.adoc[Scopes and Collections].
+* An overview of scopes and collections is provided in {scopes-and-collections}[Scopes and Collections].
 
-* Step-by-step procedures for management are provided in xref:manage:manage-scopes-and-collections/manage-scopes-and-collections.adoc[Manage Scopes and Collections].
+* Step-by-step procedures for management are provided in {manage-scopes-and-collections}[Manage Scopes and Collections].
 
-* Refer to xref:rest-api:scopes-and-collections-api.adoc[Scopes and Collections API] to manage scopes and collections with the REST API.
+* Refer to {scopes-and-collections-api}[Scopes and Collections API] to manage scopes and collections with the REST API.
 
-* Refer to the reference page for the xref:cli:cbcli/couchbase-cli-collection-manage.adoc[collection-manage] command to manage scopes and collections with the CLI.
+* Refer to the reference page for the {couchbase-cli-collection-manage}[collection-manage] command to manage scopes and collections with the CLI.


### PR DESCRIPTION
1. Fixed typo
2. Updated examples for CREATE SCOPE, CREATE COLLECTION, DROP SCOPE and DROP COLLECTION to use the `inventory` scope where possible, instead of the made-up scopes I used before `inventory` was available
3. Updated links to use attributes
4. Updated examples to include the query context dropdown in the Query Workbench UI

Docs issue: [DOC-8077](https://issues.couchbase.com/browse/DOC-8077)