### PR TITLE
DOC-5652 Update 6.0 RN with Amazon Linux deprecation

### DIFF
--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -969,6 +969,7 @@ For more information, refer to xref:install:install-ports.adoc[Network and Firew
 
 Support for the following platforms will be removed in a future release:
 
+* Amazon Linux AMI 2018.03, 2017.09
 * CentOS 6
 * macOS 10.11 (El Capitan)
 * Oracle Linux 6


### PR DESCRIPTION
Support for Amazon Linux AMI 2018.03 and 2017.09 was removed in Couchbase Server 6.0. This change retroactively adds a deprecation notice to the 6.0 release notes.