### PR TITLE
DOC-8377 Update getting-started image to 6.6.0

### DIFF
--- a/modules/getting-started/pages/do-a-quick-install.adoc
+++ b/modules/getting-started/pages/do-a-quick-install.adoc
@@ -24,7 +24,7 @@ NOTE: You may need administrative or root privileges on your computer to complet
 Open a console window on your computer and enter the following command:
 
 ----
-docker run -t --name db -p 8091-8094:8091-8094 -p 11210:11210 couchbase/server-sandbox:6.5.0
+docker run -t --name db -p 8091-8094:8091-8094 -p 11210:11210 couchbase/server-sandbox:6.6.0
 ----
 
 When you run the command, Docker downloads, installs, and configures Couchbase Server.


### PR DESCRIPTION
[DOC-8377](https://issues.couchbase.com/browse/DOC-8377) Updates the Docker sandbox image used in the Getting Started section to version 6.6.0.