### PR TITLE
Update description of using cbstats collections

### DIFF
--- a/modules/manage/pages/manage-scopes-and-collections/manage-scopes-and-collections.adoc
+++ b/modules/manage/pages/manage-scopes-and-collections/manage-scopes-and-collections.adoc
@@ -360,7 +360,21 @@ Statistics are displayed as follows:
 manifest_uid:                 4
 ----
 +
-Note that the output identifies the collection `my_collection_in_my_scope_1` collection as `0x8`, and indicates that this contains 2 items: these correspond to the two documents previously created with `cbc create`.
+The output identifies all data associated with each collection using a pair of hexadecimal prefixes, these are the scope and collection unique identifiers. For example `0x8:0x9:name:` is the name of the collection with id `0x8` in the scope with id `0x9`.
++
+The identifier or name (with scope) of a collection can be used to return data about a single collection. Here `cbstats` can also select collections in the default scope using a single `.`.
++
+----
+/opt/couchbase/bin/cbstats -u Administrator -p password -b testBucket \
+localhost:11210 collections my_scope.my_collection_in_my_scope_2
+
+/opt/couchbase/bin/cbstats -u Administrator -p password -b testBucket \
+localhost:11210 collections id 0x9
+
+/opt/couchbase/bin/cbstats -u Administrator -p password -b testBucket \
+localhost:11210 collections .my_collection_in_default_scope
+----
++
 
 . Again display statistics on existing collections using the `cbstats` command, this time specifying the `collections-details` parameter.
 +


### PR DESCRIPTION
Commit more fully describes the pair of prefixes seen in the output
of cbstats collections. Further examples are also provided to show
how the name or id can be used to select individual collections.