### PR TITLE
Remove repeated information about bucket

### DIFF
--- a/modules/getting-started/pages/look-at-the-results.adoc
+++ b/modules/getting-started/pages/look-at-the-results.adoc
@@ -42,8 +42,7 @@ Taking a closer look at this bucket will give you some idea of how Couchbase sto
 
 Click [.ui]*Buckets* in the left-hand navigation bar to bring up the [.ui]*Buckets* screen.
 
-The [.ui]*Buckets* screen shows that you have a single active bucket on the system (_bucket_ meaning a logical group of data-items).
-Taking a closer look at this bucket will give you some idea of how Couchbase stores data, and prepare you to make your first data-queries:
+The [.ui]*Buckets* screen shows that you have a single active bucket on the system:
 
 [#travel_sample_bucket_screen_initial]
 image::travelSampleBucketScreenInitial.png[,720,align=left]


### PR DESCRIPTION
The removed information appears just in the paragraph above it, so it's redundant to repeat it