### PR TITLE
DOC-7808: Couchbase Transaction parameters

### DIFF
--- a/modules/manage/pages/manage-settings/general-settings.adoc
+++ b/modules/manage/pages/manage-settings/general-settings.adoc
@@ -643,26 +643,16 @@ To set the directory for temporary query data, and establish its size-limit, use
 
 [source,shell]
 ----
-curl -v -X POST -u Administrator:password \
-http://10.143.192.101:8091/settings/querySettings \
--d queryTmpSpaceDir=%2Fopt%2Fcouchbase%2Fvar%2Flib%2Fcouchbase%2Ftmp \
--d queryTmpSpaceSize=5120
+include::rest-api:example$query-settings-post-settings.sh[]
 ----
 
-This specifies that the directory for temporary query data should be `/opt/couchbase/var/lib/couchbase/tmp`; and that the maximum size should be 5120 megabytes.
+This specifies that the directory for temporary query data should be `/tmp`; and that the maximum size should be 2048 megabytes.
 
 If successful, this call returns a JSON document featuring all the current query-related settings, including access-control:
 
 [source,json]
 ----
-{
-  "queryTmpSpaceDir": "/opt/couchbase/var/lib/couchbase/tmp",
-  "queryTmpSpaceSize":5120,
-  ...
-  "queryCurlWhitelist": {
-    "all_access": false
-  }
-}
+include::rest-api:example$query-settings-post-settings.jsonc[tags=tmpSpace;ellipsis;access]
 ----
 
 The document's values indicate that the specified values for directory and size have been established; and that the current setting for access-control restricts access to all, with no exceptions.
@@ -671,9 +661,7 @@ To specify particular URLs as allowed and disallowed, use the `/settings/querySe
 
 [source,shell]
 ----
-curl -v -X POST -u Administrator:password \
-http://10.143.192.101:8091/settings/querySettings/curlWhitelist \
--d '{"all_access":false,"allowed_urls":["https://company1.com"],"disallowed_urls":["https://company2.com"]}'
+include::rest-api:example$query-settings-post-access.sh[]
 ----
 
 A JSON document is specified as the payload for the method.
@@ -683,15 +671,7 @@ If successful, the call returns a JSON document that confirms the modified setti
 
 [source,json]
 ----
-{
-  "all_access": false,
-  "allowed_urls": [
-    "https://company1.com"
-  ],
-  "disallowed_urls": [
-    "https://company2.com"
-  ]
-}
+include::rest-api:example$query-settings-post-access.jsonc[]
 ----
 
 For additional information, refer to xref:rest-api:rest-cluster-query-settings.adoc[Cluster Query Settings API].

--- a/modules/n1ql/pages/n1ql-rest-api/admin.adoc
+++ b/modules/n1ql/pages/n1ql-rest-api/admin.adoc
@@ -1,6 +1,9 @@
 = Admin REST API
 
 // Cluster-level settings from node-level
+:queryCleanupClientAttempts: xref:rest-api:rest-cluster-query-settings.adoc#queryCleanupClientAttempts
+:queryCleanupLostAttempts: xref:rest-api:rest-cluster-query-settings.adoc#queryCleanupLostAttempts
+:queryCleanupWindow: xref:rest-api:rest-cluster-query-settings.adoc#queryCleanupWindow
 :queryCompletedLimit: xref:rest-api:rest-cluster-query-settings.adoc#queryCompletedLimit
 :queryCompletedThreshold: xref:rest-api:rest-cluster-query-settings.adoc#queryCompletedThreshold
 :queryLogLevel: xref:rest-api:rest-cluster-query-settings.adoc#queryLogLevel
@@ -8,29 +11,35 @@
 :queryPreparedLimit: xref:rest-api:rest-cluster-query-settings.adoc#queryPreparedLimit
 
 // Request-level parameters from node-level
+:atrcollection_req: xref:settings:query-settings.adoc#atrcollection_req
 :controls_req: xref:settings:query-settings.adoc#controls_req
-:memory_quota_req: xref:settings:query-settings.adoc#memory_quota_req
 :pretty_req: xref:settings:query-settings.adoc#pretty_req
 :profile_req: xref:settings:query-settings.adoc#profile_req
-:txtimeout_req: xref:settings:query-settings.adoc#txtimeout_req
-:use_cbo_req: xref:settings:query-settings.adoc#use_cbo_req
 //
 :tximplicit: xref:settings:query-settings.adoc#tximplicit
 :client_context_id: xref:settings:query-settings.adoc#client_context_id
 
 // Cluster-level settings from node-level and request-level
 :queryMaxParallelism: xref:rest-api:rest-cluster-query-settings.adoc#queryMaxParallelism
+:queryMemoryQuota: xref:rest-api:rest-cluster-query-settings.adoc#queryMemoryQuota
+:queryNumAtrs: xref:rest-api:rest-cluster-query-settings.adoc#queryNumAtrs
 :queryPipelineBatch: xref:rest-api:rest-cluster-query-settings.adoc#queryPipelineBatch
 :queryPipelineCap: xref:rest-api:rest-cluster-query-settings.adoc#queryPipelineCap
 :queryScanCap: xref:rest-api:rest-cluster-query-settings.adoc#queryScanCap
 :queryTimeout: xref:rest-api:rest-cluster-query-settings.adoc#queryTimeout
+:queryTxTimeout: xref:rest-api:rest-cluster-query-settings.adoc#queryTxTimeout
+:queryUseCBO: xref:rest-api:rest-cluster-query-settings.adoc#queryUseCBO
 
 // Request-level parameters from node-level and cluster-level
 :max_parallelism_req: xref:settings:query-settings.adoc#max_parallelism_req
+:memory_quota_req: xref:settings:query-settings.adoc#memory_quota_req
+:numatrs_req: xref:settings:query-settings.adoc#numatrs_req
 :pipeline_batch_req: xref:settings:query-settings.adoc#pipeline_batch_req
 :pipeline_cap_req: xref:settings:query-settings.adoc#pipeline_cap_req
 :scan_cap_req: xref:settings:query-settings.adoc#scan_cap_req
 :timeout_req: xref:settings:query-settings.adoc#timeout_req
+:txtimeout_req: xref:settings:query-settings.adoc#txtimeout_req
+:use_cbo_req: xref:settings:query-settings.adoc#use_cbo_req
 
 // Node-level parameters (internal)
 :completed-threshold-srv: xref:completed-threshold

--- a/modules/rest-api/pages/rest-cluster-query-settings.adoc
+++ b/modules/rest-api/pages/rest-cluster-query-settings.adoc
@@ -1,6 +1,9 @@
 = Cluster Query Settings API
 
 // Node-level settings from cluster-level
+:cleanupclientattempts: xref:n1ql:n1ql-rest-api/admin.adoc#cleanupclientattempts
+:cleanuplostattempts: xref:n1ql:n1ql-rest-api/admin.adoc#cleanuplostattempts
+:cleanupwindow: xref:n1ql:n1ql-rest-api/admin.adoc#cleanupwindow
 :completed-limit-srv: xref:n1ql:n1ql-rest-api/admin.adoc#completed-limit
 :completed-threshold-srv: xref:n1ql:n1ql-rest-api/admin.adoc#completed-threshold
 :loglevel-srv: xref:n1ql:n1ql-rest-api/admin.adoc#loglevel
@@ -9,17 +12,27 @@
 
 // Node-level settings from cluster-level and request-level
 :max-parallelism-srv: xref:n1ql:n1ql-rest-api/admin.adoc#max-parallelism-srv
+:memory-quota-srv: xref:n1ql:n1ql-rest-api/admin.adoc#memory-quota-srv
+:numatrs-srv: xref:n1ql:n1ql-rest-api/admin.adoc#numatrs-srv
 :pipeline-batch-srv: xref:n1ql:n1ql-rest-api/admin.adoc#pipeline-batch-srv
 :pipeline-cap-srv: xref:n1ql:n1ql-rest-api/admin.adoc#pipeline-cap-srv
 :scan-cap-srv: xref:n1ql:n1ql-rest-api/admin.adoc#scan-cap-srv
 :timeout-srv: xref:n1ql:n1ql-rest-api/admin.adoc#timeout-srv
+:txtimeout-srv: xref:n1ql:n1ql-rest-api/admin.adoc#txtimeout-srv
+:use-cbo-srv: xref:n1ql:n1ql-rest-api/admin.adoc#use-cbo-srv
 
 // Request-level parameters from node-level and cluster-level
 :max_parallelism_req: xref:settings:query-settings.adoc#max_parallelism_req
+:memory_quota_req: xref:settings:query-settings.adoc#memory_quota_req
+:numatrs_req: xref:settings:query-settings.adoc#numatrs_req
 :pipeline_batch_req: xref:settings:query-settings.adoc#pipeline_batch_req
 :pipeline_cap_req: xref:settings:query-settings.adoc#pipeline_cap_req
 :scan_cap_req: xref:settings:query-settings.adoc#scan_cap_req
 :timeout_req: xref:settings:query-settings.adoc#timeout_req
+:txtimeout_req: xref:settings:query-settings.adoc#txtimeout_req
+:use_cbo_req: xref:settings:query-settings.adoc#use_cbo_req
+//
+:tximplicit: xref:settings:query-settings.adoc#tximplicit
 
 include::partial$query-settings/overview.adoc[tag=body]
 include::partial$query-settings/paths.adoc[]

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -399,7 +399,7 @@ This will output the entire list of node-level query settings:
 
 [source,json]
 ----
-{"auto-prepare":false,"completed":{"aborted":null,"threshold":1000},"completed-limit":4000,"completed-threshold":1000,"controls":false,"cpuprofile":"","debug":false,"functions-limit":16384,"keep-alive-length":16384,"loglevel":"INFO","max-index-api":4,"max-parallelism":1,"memprofile":"","mutexprofile":false,"n1ql-feat-ctrl":12,"pipeline-batch":16,"pipeline-cap":512,"prepared-limit":16384,"pretty":false,"profile":"off","request-size-cap":67108864,"scan-cap":512,"servicers":4,"timeout":0}
+{"atrcollection":"","auto-prepare":false,"cleanupclientattempts":true,"cleanuplostattempts":true,"cleanupwindow":"1m0s","completed":{"aborted":null,"threshold":1000},"completed-limit":4000,"completed-threshold":1000,"controls":false,"cpuprofile":"","debug":false,"functions-limit":16384,"keep-alive-length":16384,"loglevel":"INFO","max-index-api":4,"max-parallelism":1,"memory-quota":0,"memprofile":"","mutexprofile":false,"n1ql-feat-ctrl":76,"numatrs":1024,"pipeline-batch":16,"pipeline-cap":512,"plus-servicers":16,"prepared-limit":16384,"pretty":false,"profile":"off","request-size-cap":67108864,"scan-cap":512,"servicers":4,"timeout":0,"txtimeout":"0s","use-cbo":true}
 ----
 
 To output to a file for editing multiple settings at a single time, add the [.var]`-o filename` option.

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -1115,17 +1115,7 @@ NOTE: If both `prepared` and `statement` are present and non-empty, an error is 
 __Optional__
 | Maximum time to spend on the request before timing out.
 
-Specify a duration of `0` or a negative duration to disable.
-When disabled, no timeout is applied and the request runs for however long it takes.
-
-The {timeout-srv}[node-level] `timeout` setting specifies the default for this parameter for a single node.
-The request-level parameter overrides the node-level setting.
-However, if the node-level setting is greater than 0, the timeout for the query is limited to the node-level setting.
-
-In addition, the {queryTimeout}[cluster-level] `queryTimeout` setting specifies the default for this parameter for the whole cluster.
-When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
-
-The request-level `timeout` parameter is a string.
+The value for this parameter is a string.
 Its format includes an amount and a mandatory unit, e.g. `10ms` (10 milliseconds) or `0.5s` (half a second).
 Valid units are:
 
@@ -1136,8 +1126,18 @@ Valid units are:
 * `m` (minutes)
 * `h` (hours)
 
+Specify a duration of `0` or a negative duration to disable.
+When disabled, no timeout is applied and the request runs for however long it takes.
+
 If {txid}[txid] or {tximplicit}[tximplicit] is set, this parameter is ignored.
 The request inherits the remaining time of the transaction as timeout.
+
+The {timeout-srv}[node-level] `timeout` setting specifies the default for this parameter for a single node.
+The request-level parameter overrides the node-level setting.
+However, if the node-level setting is greater than 0, the timeout for the query is limited to the node-level setting.
+
+In addition, the {queryTimeout}[cluster-level] `queryTimeout` setting specifies the default for this parameter for the whole cluster.
+When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
 
 .Example
 [source,shell]
@@ -1253,17 +1253,7 @@ Within a transaction, the request-level {timeout_req}[timeout] parameter is igno
 The transaction timeout clock starts when the `BEGIN WORK` statement is successful.
 Once the transaction timeout is reached, no statement is allowed to continue in the transaction.
 
-Specify a duration of `0` to disable.
-When disabled, the request-level timeout is set to the default.
-
-The {txtimeout-srv}[node-level] `txtimeout` setting specifies the default for this parameter for a single node.
-The request-level parameter overrides the node-level setting.
-However, if the node-level setting is greater than 0, the transaction timeout for the query is limited to the node-level setting.
-
-In addition, the {queryTxTimeout}[cluster-level] `queryTxTimeout` setting specifies the default for this parameter for the whole cluster.
-When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
-
-The request-level `txtimeout` parameter is a string.
+The value for this parameter is a string.
 Its format includes an amount and a mandatory unit, e.g. `10ms` (10 milliseconds) or `0.5s` (half a second).
 Valid units are:
 
@@ -1273,6 +1263,16 @@ Valid units are:
 * `s` (seconds)
 * `m` (minutes)
 * `h` (hours)
+
+Specify a duration of `0` to disable.
+When disabled, the request-level timeout is set to the default.
+
+The {txtimeout-srv}[node-level] `txtimeout` setting specifies the default for this parameter for a single node.
+The request-level parameter overrides the node-level setting.
+However, if the node-level setting is greater than 0, the transaction timeout for the query is limited to the node-level setting.
+
+In addition, the {queryTxTimeout}[cluster-level] `queryTxTimeout` setting specifies the default for this parameter for the whole cluster.
+When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
 
 .Default
 `"2m"`

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -483,7 +483,7 @@ If not specified, the ATR is stored in the default collection in the default sco
 The value must be a string in the form `"bucket.scope.collection"` or `"namespace:bucket.scope.collection"`.
 If any part of the path contains a special character, that part of the path must be delimited in backticks `pass:c[``]`.
 
-The {atrcollections-srv}[node-level] `atrcollections` setting specifies the default for this parameter for a single node.
+The {atrcollection-srv}[node-level] `atrcollection` setting specifies the default for this parameter for a single node.
 The request-level parameter overrides the node-level setting.
 
 .Example

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -58,6 +58,18 @@
 // Request-level parameters (internal)
 :txid: xref:txid
 
+// External cross-references
+:rest-cluster-query-settings: xref:rest-api:rest-cluster-query-settings.adoc
+:general-settings-query-settings: xref:manage:manage-settings/general-settings.adoc#query-settings
+:couchbase-cli-setting-query: xref:cli:cbcli/couchbase-cli-setting-query.adoc
+:n1ql-rest-api-admin: xref:n1ql:n1ql-rest-api/admin.adoc
+:n1ql-rest-api-index: xref:n1ql:n1ql-rest-api/index.adoc
+:cbq-shell: xref:tools:cbq-shell.adoc
+:transactions-understanding-transactions: xref:learn:data/transactions.adoc#understanding-transactions
+:prepare-auto-execute: xref:n1ql:n1ql-language-reference/prepare.adoc#auto-execute
+:flex-indexes: xref:n1ql:n1ql-language-reference/flex-indexes.adoc
+:rest-intro: xref:rest-api:rest-intro.adoc
+
 // Pass through HTML table styles for this page
 
 ifdef::basebackend-html[]
@@ -340,8 +352,8 @@ a| <<max_parallelism_req,max_parallelism>>
 [[cluster-level-query-settings]]
 == Cluster-Level Query Settings
 
-To set a cluster-level query setting, use the xref:rest-api:rest-cluster-query-settings.adoc[Query Settings REST API] (`/settings/querySettings` endpoint) with a cURL statement, or the xref:manage:manage-settings/general-settings.adoc#query-settings[Advanced Query Settings] in the Couchbase Web Console.
-You can also set all of the cluster-level query settings, except for the CURL() access list settings, using the xref:cli:cbcli/couchbase-cli-setting-query.adoc[setting-query] command.
+To set a cluster-level query setting, use the {rest-cluster-query-settings}[Query Settings REST API] (`/settings/querySettings` endpoint) with a cURL statement, or the {general-settings-query-settings}[Advanced Query Settings] in the Couchbase Web Console.
+You can also set all of the cluster-level query settings, except for the CURL() access list settings, using the {couchbase-cli-setting-query}[setting-query] command.
 
 The table below contains details of all cluster-level query settings.
 
@@ -355,7 +367,7 @@ include::rest-api:partial$query-settings/definitions.adoc[tag=access]
 [[service-level-query-settings]]
 == Node-Level Query Settings
 
-To set a node-level query setting, use the xref:n1ql:n1ql-rest-api/admin.adoc[Admin REST API] (`/admin/settings` endpoint) with a cURL statement.
+To set a node-level query setting, use the {n1ql-rest-api-admin}[Admin REST API] (`/admin/settings` endpoint) with a cURL statement.
 
 NOTE: These settings cannot be set by `cbq`.
 
@@ -392,7 +404,7 @@ include::n1ql:partial$n1ql-rest-api/admin/definitions.adoc[tag=settings]
 [#section_nnj_sjk_k1b]
 == Request-Level Parameters
 
-To set a request-level parameter, use the xref:n1ql:n1ql-rest-api/index.adoc[N1QL REST API] (`/query/service` endpoint) with a cURL statement, or the xref:tools:cbq-shell.adoc[cbq] command, or a client program.
+To set a request-level parameter, use the {n1ql-rest-api-index}[N1QL REST API] (`/query/service` endpoint) with a cURL statement, or the {cbq-shell}[cbq] command, or a client program.
 
 While `cbq` is a sandbox to test code on your local machine, your production query settings are set with the cURL commands on your server.
 
@@ -444,7 +456,7 @@ __Optional__
 | Specifies that prepared statements should be executed automatically as soon as they are created.
 This saves you from having to make two separate requests in cases where you want to prepare a statement and execute it immediately.
 
-Refer to xref:n1ql:n1ql-language-reference/prepare.adoc#auto-execute[Auto-Execute] for more information.
+Refer to {prepare-auto-execute}[Auto-Execute] for more information.
 
 .Default
 `false`
@@ -1252,7 +1264,7 @@ If the query does not contain a `USING FTS` hint, and this parameter is set to t
 If a qualified full-text index is available, it is selected for the query.
 If none of the available full-text indexes are qualified, the available GSI indexes are considered instead.
 
-Refer to xref:n1ql:n1ql-language-reference/flex-indexes.adoc[Flex Indexes] for more information.
+Refer to {flex-indexes}[Flex Indexes] for more information.
 
 .Default
 `false`
@@ -1324,10 +1336,10 @@ NOTE: Positional Parameters can also be specified in a statement using *?* as an
 
 == Related Links
 
-For more details about the N1QL REST API, refer to  xref:n1ql:n1ql-rest-api/index.adoc[N1QL REST API].
+For more details about the N1QL REST API, refer to {n1ql-rest-api-index}[N1QL REST API].
 
-For more details about the Admin REST API, refer to xref:n1ql:n1ql-rest-api/admin.adoc[Admin REST API].
+For more details about the Admin REST API, refer to {n1ql-rest-api-admin}[Admin REST API].
 
-For more details about the Query Settings API, refer to xref:rest-api:rest-cluster-query-settings.adoc[Cluster Query Settings API].
+For more details about the Query Settings API, refer to {rest-cluster-query-settings}[Cluster Query Settings API].
 
-For more details about API content and settings, refer to xref:rest-api:rest-intro.adoc[REST API reference].
+For more details about API content and settings, refer to {rest-intro}[REST API reference].

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -18,16 +18,14 @@
 :completed-limit-srv: xref:completed-limit
 :completed-threshold-srv: xref:completed-threshold
 :loglevel-srv: xref:loglevel
-:prepared-limit-srv: xref:prepared-limit
 :n1ql-feat-ctrl: xref:n1ql-feat-ctrl
+:prepared-limit-srv: xref:prepared-limit
 
 // Node-level settings from request-level
+:atrcollection-srv: xref:atrcollection-srv
 :controls-srv: xref:controls-srv
-:memory-quota-srv: xref:memory-quota-srv
 :pretty-srv: xref:pretty-srv
 :profile-srv: xref:profile-srv
-:txtimeout-srv: xref:txtimeout-srv
-:use-cbo-srv: xref:use-cbo-srv
 
 // Request-level parameters from node-level
 :atrcollection_req: xref:atrcollection_req
@@ -476,12 +474,15 @@ cbq> \set -args ["LAX", 6];
 __Optional__
 | [.edition]#{enterprise}#
 
-For Couchbase transactions, specifies the collection where the {transactions-understanding-transactions}[active transaction record] (ATR) is stored.
+Specifies the collection where the {transactions-understanding-transactions}[active transaction record] (ATR) is stored.
 The collection must be present.
 If not specified, the ATR is stored in the default collection in the default scope in the bucket containing the first mutated document within the transaction.
 
 The value must be a string in the form `"bucket.scope.collection"` or `"namespace:bucket.scope.collection"`.
 If any part of the path contains a special character, that part of the path must be delimited in backticks `pass:c[``]`.
+
+The {atrcollections-srv}[node-level] `atrcollections` setting specifies the default for this parameter for a single node.
+The request-level parameter overrides the node-level setting.
 
 .Example
 [source,shell]
@@ -712,6 +713,9 @@ The {memory-quota-srv}[node-level] `memory-quota` setting specifies the ceiling 
 If the node-level setting is zero (the default), the request-level parameter overrides the node-level setting.
 If the node-level setting is greater than zero, the request-level parameter is capped by the node-level setting.
 
+In addition, the {queryUseCBO}[cluster-level] `queryUseCBO` setting specifies the default for this parameter for the whole cluster.
+When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
+
 .Default
 `0`
 
@@ -758,9 +762,14 @@ cbq> \set -namespace default;
 __Optional__
 | [.edition]#{enterprise}#
 
-For Couchbase transactions.
 Specifies the total number of {transactions-understanding-transactions}[active transaction records].
 Must be a positive integer.
+
+The {numatrs-srv}[node-level] `numatrs` setting specifies the default for this parameter for a single node.
+The request-level parameter overrides the node-level setting.
+
+In addition, the {queryNumAtrs}[cluster-level] `queryNumAtrs` setting specifies the default for this parameter for the whole cluster.
+When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
 
 .Default
 [source,shell]
@@ -1251,6 +1260,9 @@ The {txtimeout-srv}[node-level] `txtimeout` setting specifies the default for th
 The request-level parameter overrides the node-level setting.
 However, if the node-level setting is greater than 0, the transaction timeout for the query is limited to the node-level setting.
 
+In addition, the {queryTxTimeout}[cluster-level] `queryTxTimeout` setting specifies the default for this parameter for the whole cluster.
+When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
+
 The request-level `txtimeout` parameter is a string.
 Its format includes an amount and a mandatory unit, e.g. `10ms` (10 milliseconds) or `0.5s` (half a second).
 Valid units are:
@@ -1281,6 +1293,9 @@ __Optional__
 
 The {use-cbo-srv}[node-level] `use-cbo` setting specifies the default for this parameter for a single node.
 The request-level parameter overrides the node-level setting.
+
+In addition, the {queryMemoryQuota}[cluster-level] `queryMemoryQuota` setting specifies the default for this parameter for the whole cluster.
+When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
 
 .Example
 [source,shell]

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -814,10 +814,7 @@ In addition, the {queryNumAtrs}[cluster-level] `queryNumAtrs` setting specifies 
 When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
 
 .Default
-[source,shell]
-----
-1024
-----
+`1024`
 
 .Example
 [source,shell]
@@ -1317,7 +1314,8 @@ In addition, the {queryTxTimeout}[cluster-level] `queryTxTimeout` setting specif
 When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
 
 .Default
-`"2m"`
+`"15s"` for cbq files or scripts +
+`"2m"` for interactive cbq sessions or redirected input
 
 .Example
 [source,shell]

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -748,11 +748,14 @@ __Optional__
 
 Specify `0` (the default value) to disable. When disabled, there is no quota.
 
+Within a transaction, this parameter enforces the memory quota for the transaction.
+The transaction memory quota tracks only the delta table and the transaction log (approximately).
+
 The {memory-quota-srv}[node-level] `memory-quota` setting specifies the ceiling for this parameter for a single node.
 If the node-level setting is zero (the default), the request-level parameter overrides the node-level setting.
 If the node-level setting is greater than zero, the request-level parameter is capped by the node-level setting.
 
-In addition, the {queryUseCBO}[cluster-level] `queryUseCBO` setting specifies the default for this parameter for the whole cluster.
+In addition, the {queryMemoryQuota}[cluster-level] `queryMemoryQuota` setting specifies the ceiling for this parameter for the whole cluster.
 When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
 
 .Default
@@ -1333,7 +1336,7 @@ __Optional__
 The {use-cbo-srv}[node-level] `use-cbo` setting specifies the default for this parameter for a single node.
 The request-level parameter overrides the node-level setting.
 
-In addition, the {queryMemoryQuota}[cluster-level] `queryMemoryQuota` setting specifies the default for this parameter for the whole cluster.
+In addition, the {queryUseCBO}[cluster-level] `queryUseCBO` setting specifies the default for this parameter for the whole cluster.
 When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
 
 .Example

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -210,8 +210,6 @@ a| <<auto-prepare,auto-prepare>>
 
 a| <<args,args>>
 
-<<atrcollection,atrcollection>>
-
 <<auto_execute,auto_execute>>
 
 <<batch_args,batch_args>>
@@ -235,8 +233,6 @@ a| <<args,args>>
 <<metrics,metrics>>
 
 <<namespace,namespace>>
-
-<<numatrs,numatrs>>
 
 <<prepared,prepared>>
 
@@ -274,17 +270,29 @@ a| <<args,args>>
 |===
 | Cluster-Level Name | Node-Level Name | Request-Level Name
 
-a| <<queryCompletedLimit,queryCompletedLimit>>
+a| <<queryCleanupClientAttempts,queryCleanupClientAttempts>>
+
+<<queryCleanupLostAttempts,queryCleanupLostAttempts>>
+
+<<queryCleanupWindow,queryCleanupWindow>>
+
+<<queryCompletedLimit,queryCompletedLimit>>
 
 <<queryCompletedThreshold,queryCompletedThreshold>>
 
 <<queryLogLevel,queryLogLevel>>
 
-<<queryN1QLFeatCtrl,queryN1QLFeatCtrl>>
+<<queryN1qlFeatCtrl,queryN1qlFeatCtrl>>
 
 <<queryPreparedLimit,queryPreparedLimit>>
 
-a| <<completed-limit,completed-limit>>
+a| <<cleanupclientattempts,cleanupclientattempts>>
+
+<<cleanuplostattempts,cleanuplostattempts>>
+
+<<cleanupwindow,cleanupwindow>>
+
+<<completed-limit,completed-limit>>
 
 <<completed-threshold,completed-threshold>>
 
@@ -304,29 +312,21 @@ a| N/A
 
 a| N/A
 
-a| <<controls-srv,controls>>
+a| <<atrcollection-srv,atrcollection>>
 
-<<memory-quota-srv,memory-quota>>
+<<controls-srv,controls>>
 
 <<pretty-srv,pretty>>
 
 <<profile-srv,profile>>
 
-<<txtimeout-srv,txtimeout>>
+a| <<atrcollection_req,atrcollection>>
 
-<<use-cbo-srv,use-cbo>>
-
-a| <<controls_req,controls>>
-
-<<memory_quota_req,memory_quota>>
+<<controls_req,controls>>
 
 <<pretty_req,pretty>>
 
 <<profile_req,profile>>
-
-<<txtimeout_req,txtimeout>>
-
-<<use_cbo_req,use_cbo>>
 |===
 
 .Settings for Cluster-Level, Node-Level, and Request-Level
@@ -336,6 +336,10 @@ a| <<controls_req,controls>>
 
 a| <<queryMaxParallelism,queryMaxParallelism>>
 
+<<queryMemoryQuota,queryMemoryQuota>>
+
+<<queryNumAtrs,queryNumAtrs>>
+
 <<queryPipelineBatch,queryPipelineBatch>>
 
 <<queryPipelineCap,queryPipelineCap>>
@@ -344,7 +348,15 @@ a| <<queryMaxParallelism,queryMaxParallelism>>
 
 <<queryTimeout,queryTimeout>>
 
+<<queryTxTimeout,queryTxTimeout>>
+
+<<queryUseCBO,queryUseCBO>>
+
 a| <<max-parallelism-srv,max-parallelism>>
+
+<<memory-quota-srv,memory-quota>>
+
+<<numatrs-srv,numatrs>>
 
 <<pipeline-batch-srv,pipeline-batch>>
 
@@ -354,7 +366,15 @@ a| <<max-parallelism-srv,max-parallelism>>
 
 <<timeout-srv,timeout>>
 
+<<txtimeout-srv,txtimeout>>
+
+<<use-cbo-srv,use-cbo>>
+
 a| <<max_parallelism_req,max_parallelism>>
+
+<<memory_quota_req,memory_quota>>
+
+<<numatrs_req,numatrs>>
 
 <<pipeline_batch_req,pipeline_batch>>
 
@@ -363,6 +383,10 @@ a| <<max_parallelism_req,max_parallelism>>
 <<scan_cap_req,scan_cap>>
 
 <<timeout_req,timeout>>
+
+<<txtimeout_req,txtimeout>>
+
+<<use_cbo_req,use_cbo>>
 |===
 
 [[cluster-level-query-settings]]
@@ -447,7 +471,7 @@ cbq> \set -args ["LAX", 6];
 ----
 | array
 
-| [[atrcollection]]
+| [[atrcollection_req]]
 **atrcollection** +
 __Optional__
 | [.edition]#{enterprise}#
@@ -729,7 +753,7 @@ cbq> \set -namespace default;
 ----
 | string
 
-| [[numatrs]]
+| [[numatrs_req]]
 **numatrs** +
 __Optional__
 | [.edition]#{enterprise}#

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -2,6 +2,9 @@
 :page-aliases: manage:manage-settings/query-settings
 
 // Cluster-level settings from node-level
+:queryCleanupClientAttempts: xref:queryCleanupClientAttempts
+:queryCleanupLostAttempts: xref:queryCleanupLostAttempts
+:queryCleanupWindow: xref:queryCleanupWindow
 :queryCompletedLimit: xref:queryCompletedLimit
 :queryCompletedThreshold: xref:queryCompletedThreshold
 :queryLogLevel: xref:queryLogLevel
@@ -9,6 +12,9 @@
 :queryPreparedLimit: xref:queryPreparedLimit
 
 // Node-level settings from cluster-level
+:cleanupclientattempts: xref:cleanupclientattempts
+:cleanuplostattempts: xref:cleanuplostattempts
+:cleanupwindow: xref:cleanupwindow
 :completed-limit-srv: xref:completed-limit
 :completed-threshold-srv: xref:completed-threshold
 :loglevel-srv: xref:loglevel
@@ -24,36 +30,46 @@
 :use-cbo-srv: xref:use-cbo-srv
 
 // Request-level parameters from node-level
+:atrcollection_req: xref:atrcollection_req
 :controls_req: xref:controls_req
-:memory_quota_req: xref:memory_quota_req
 :pretty_req: xref:pretty_req
 :profile_req: xref:profile_req
-:txtimeout_req: xref:txtimeout_req
-:use_cbo_req: xref:use_cbo_req
 //
 :tximplicit: xref:tximplicit
 :client_context_id: xref:client_context_id
 
 // Cluster-level settings from node-level and request-level
 :queryMaxParallelism: xref:queryMaxParallelism
+:queryMemoryQuota: xref:queryMemoryQuota
+:queryNumAtrs: xref:queryNumAtrs
 :queryPipelineBatch: xref:queryPipelineBatch
 :queryPipelineCap: xref:queryPipelineCap
 :queryScanCap: xref:queryScanCap
 :queryTimeout: xref:queryTimeout
+:queryTxTimeout: xref:queryTxTimeout
+:queryUseCBO: xref:queryUseCBO
 
 // Node-level settings from cluster-level and request-level
 :max-parallelism-srv: xref:max-parallelism-srv
+:memory-quota-srv: xref:memory-quota-srv
+:numatrs-srv: xref:numatrs-srv
 :pipeline-batch-srv: xref:pipeline-batch-srv
 :pipeline-cap-srv: xref:pipeline-cap-srv
 :scan-cap-srv: xref:scan-cap-srv
 :timeout-srv: xref:timeout-srv
+:txtimeout-srv: xref:txtimeout-srv
+:use-cbo-srv: xref:use-cbo-srv
 
 // Request-level parameters from node-level and cluster-level
 :max_parallelism_req: xref:max_parallelism_req
+:memory_quota_req: xref:memory_quota_req
+:numatrs_req: xref:numatrs_req
 :pipeline_batch_req: xref:pipeline_batch_req
 :pipeline_cap_req: xref:pipeline_cap_req
 :scan_cap_req: xref:scan_cap_req
 :timeout_req: xref:timeout_req
+:txtimeout_req: xref:txtimeout_req
+:use_cbo_req: xref:use_cbo_req
 
 // Request-level parameters (internal)
 :txid: xref:txid

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -208,6 +208,8 @@ a| <<args,args>>
 
 <<namespace,namespace>>
 
+<<numatrs,numatrs>>
+
 <<prepared,prepared>>
 
 <<query_context,query_context>>
@@ -698,6 +700,28 @@ __Optional__
 cbq> \set -namespace default;
 ----
 | string
+
+| [[numatrs]]
+**numatrs** +
+__Optional__
+| [.edition]#{enterprise}#
+
+For Couchbase transactions.
+Specifies the total number of {transactions-understanding-transactions}[active transaction records].
+Must be a positive integer.
+
+.Default
+[source,shell]
+----
+1024
+----
+
+.Example
+[source,shell]
+----
+cbq> \set -numatrs 512;
+----
+| integer (int32)
 
 | [[pipeline_batch_req]]
 **pipeline_batch** +

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -1419,7 +1419,7 @@ If you specify a scan consistency of `not_bounded` for a statement within the tr
 When you specify a scan consistency of `request_plus`, `statement_plus`, or `at_plus` for a statement within the transaction, the scan consistency for the statement is set to `request_plus`.
 
 However, `request_plus` consistency is not supported for statements using a full-text index.
-If any statements within the transaction use a full-text index, by means of the SEARCH function or the Flex Index feature, the scan consistency is set to `not_bounded` for the duration of the full-text search.
+If any statement within the transaction uses a full-text index, by means of the SEARCH function or the Flex Index feature, the scan consistency is set to `not_bounded` for the duration of the full-text search.
 
 .Overriding the transactional scan consistency
 [%header, cols="2"]

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -1355,10 +1355,10 @@ Refer to <<section_srh_tlm_n1b,Named Parameters VS. Positional Parameters>> for 
 ===== Transactional Scan Consistency
 
 If the request contains a `BEGIN TRANSACTION` statement, or a DML statement with the {tximplicit}[tximplicit] parameter set to `true`, then the <<scan_consistency,scan_consistency>> parameter sets the [def]__transactional scan consistency__.
-If you specify a transactional scan consistency of `request_plus`, `status_plus`, or `at_plus`, or if you specify no transactional scan consistency, the transactional scan consistency is set to `request_plus`; otherwise, the transactional scan consistency is set as specified.
+If you specify a transactional scan consistency of `request_plus`, `statement_plus`, or `at_plus`, or if you specify no transactional scan consistency, the transactional scan consistency is set to `request_plus`; otherwise, the transactional scan consistency is set as specified.
 
 Any DML statements within the transaction that have no scan consistency set will inherit from the transactional scan consistency.
-When you specify a scan consistency of `request_plus` or `status_plus` for a statement within the transaction, the scan consistency for the statement is set to `request_plus`.
+When you specify a scan consistency of `request_plus` or `statement_plus` for a statement within the transaction, the scan consistency for the statement is set to `request_plus`.
 If you specify a scan consistency of `not_bounded` or `at_plus` for a statement within the transaction, the scan consistency for the statement is set as specified.
 
 

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -873,7 +873,7 @@ NOTE: If both `prepared` and `statement` are present and non-empty, an error is 
 .Example
 Prepare the query result of the most expensive hotel:
 [source,shell]
-$ curl -v http://localhost:8093/query/service -d 'statement=PREPARE pricy_hotel FROM SELECT MAX(price) FROM `travel-sample` WHERE type="hotel";'
+$ curl -v http://localhost:8093/query/service -d 'statement=PREPARE pricy_hotel FROM SELECT MAX(price) FROM `travel-sample`.inventory.hotel;'
 
 Response:
 [source,json]
@@ -960,9 +960,9 @@ If the namespace name is omitted, the default namespace in the current session i
 .Example
 [source,shell]
 ----
-cbq> \set -query_context "default:travel-sample.places";
+cbq> \set -query_context "default:travel-sample.inventory";
 
-cbq> \set -query_context "travel-sample.places";
+cbq> \set -query_context "travel-sample.inventory";
 ----
 | string
 

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -423,7 +423,44 @@ This will output the entire list of node-level query settings:
 
 [source,json]
 ----
-{"atrcollection":"","auto-prepare":false,"cleanupclientattempts":true,"cleanuplostattempts":true,"cleanupwindow":"1m0s","completed":{"aborted":null,"threshold":1000},"completed-limit":4000,"completed-threshold":1000,"controls":false,"cpuprofile":"","debug":false,"functions-limit":16384,"keep-alive-length":16384,"loglevel":"INFO","max-index-api":4,"max-parallelism":1,"memory-quota":0,"memprofile":"","mutexprofile":false,"n1ql-feat-ctrl":76,"numatrs":1024,"pipeline-batch":16,"pipeline-cap":512,"plus-servicers":16,"prepared-limit":16384,"pretty":false,"profile":"off","request-size-cap":67108864,"scan-cap":512,"servicers":4,"timeout":0,"txtimeout":"0s","use-cbo":true}
+{
+  "atrcollection": "",
+  "auto-prepare": false,
+  "cleanupclientattempts": true,
+  "cleanuplostattempts": true,
+  "cleanupwindow": "1m0s",
+  "completed": {
+    "aborted": null,
+    "threshold": 1000
+  },
+  "completed-limit": 4000,
+  "completed-threshold": 1000,
+  "controls": false,
+  "cpuprofile": "",
+  "debug": false,
+  "functions-limit": 16384,
+  "keep-alive-length": 16384,
+  "loglevel": "INFO",
+  "max-index-api": 4,
+  "max-parallelism": 1,
+  "memory-quota": 0,
+  "memprofile": "",
+  "mutexprofile": false,
+  "n1ql-feat-ctrl": 76,
+  "numatrs": 1024,
+  "pipeline-batch": 16,
+  "pipeline-cap": 512,
+  "plus-servicers": 16,
+  "prepared-limit": 16384,
+  "pretty": false,
+  "profile": "off",
+  "request-size-cap": 67108864,
+  "scan-cap": 512,
+  "servicers": 4,
+  "timeout": 0,
+  "txtimeout": "0s",
+  "use-cbo": true
+}
 ----
 
 To output to a file for editing multiple settings at a single time, add the [.var]`-o filename` option.

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -202,6 +202,8 @@ a| <<auto-prepare,auto-prepare>>
 
 <<mutexprofile,mutexprofile>>
 
+<<plus-servicers,plus-servicers>>
+
 <<request-size-cap,request-size-cap>>
 
 <<servicers,servicers>>

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -129,7 +129,7 @@ You can also specify parameters for individual requests.
 Cluster-level query settings, node-level query settings, and request-level parameters must be set and used in different ways.
 
 .Comparison of Query Settings and Parameters
-[cols="216h,145,145,145,230"]
+[cols="216s,145,145,145,230"]
 |===
 | | Setting Per | Set By | Set On | Set Via
 
@@ -1395,10 +1395,51 @@ Refer to <<section_srh_tlm_n1b,Named Parameters VS. Positional Parameters>> for 
 If the request contains a `BEGIN TRANSACTION` statement, or a DML statement with the {tximplicit}[tximplicit] parameter set to `true`, then the <<scan_consistency,scan_consistency>> parameter sets the [def]__transactional scan consistency__.
 If you specify a transactional scan consistency of `request_plus`, `statement_plus`, or `at_plus`, or if you specify no transactional scan consistency, the transactional scan consistency is set to `request_plus`; otherwise, the transactional scan consistency is set as specified.
 
-Any DML statements within the transaction that have no scan consistency set will inherit from the transactional scan consistency.
-When you specify a scan consistency of `request_plus` or `statement_plus` for a statement within the transaction, the scan consistency for the statement is set to `request_plus`.
-If you specify a scan consistency of `not_bounded` or `at_plus` for a statement within the transaction, the scan consistency for the statement is set as specified.
+.Transactional scan consistency
+[%header, cols="2"]
+|===
+| Scan consistency at start of transaction
+| Transactional scan consistency
 
+| Not set
+| `request_plus`
+
+| `not_bounded`
+| `not_bounded`
+
+| `request_plus` +
+  `statement_plus` +
+  `at_plus`
+| `request_plus`
+|===
+
+Any DML statements within the transaction that have no scan consistency set will inherit from the transactional scan consistency.
+Individual DML statements within the transaction may override the transactional scan consistency.
+If you specify a scan consistency of `not_bounded` for a statement within the transaction, the scan consistency for the statement is set as specified.
+When you specify a scan consistency of `request_plus`, `statement_plus`, or `at_plus` for a statement within the transaction, the scan consistency for the statement is set to `request_plus`.
+
+However, `request_plus` consistency is not supported for statements using a full-text index.
+If any statements within the transaction use a full-text index, by means of the SEARCH function or the Flex Index feature, the scan consistency is set to `not_bounded` for the duration of the full-text search.
+
+.Overriding the transactional scan consistency
+[%header, cols="2"]
+|===
+| Scan consistency for statement within transaction
+| Inherited scan consistency
+
+| Not set
+| Transactional scan consistency +
+ (`not_bounded` for full-text search)
+
+| `not_bounded`
+| `not_bounded`
+
+| `request_plus` +
+  `statement_plus` +
+  `at_plus`
+| `request_plus` +
+ (`not_bounded` for full-text search)
+|===
 
 [#section_srh_tlm_n1b]
 == Named Parameters VS. Positional Parameters
@@ -1407,7 +1448,7 @@ Named Parameters use a variable name to refer to each one, while Positional Para
 As summarized in the below table, these two types of requests should contain the following parameters:
 
 .Named Parameters VS. Positional Parameters
-[cols="2h,5,2"]
+[cols="2s,5,2"]
 |===
 | | Statement | Args
 

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -182,6 +182,8 @@ a| <<auto-prepare,auto-prepare>>
 
 a| <<args,args>>
 
+<<atrcollection,atrcollection>>
+
 <<auto_execute,auto_execute>>
 
 <<batch_args,batch_args>>
@@ -414,6 +416,25 @@ Refer to <<section_srh_tlm_n1b,Named Parameters VS. Positional Parameters>> for 
 cbq> \set -args ["LAX", 6];
 ----
 | array
+
+| [[atrcollection]]
+**atrcollection** +
+__Optional__
+| [.edition]#{enterprise}#
+
+For Couchbase transactions, specifies the collection where the {transactions-understanding-transactions}[active transaction record] (ATR) is stored.
+The collection must be present.
+If not specified, the ATR is stored in the default collection in the default scope in the bucket containing the first mutated document within the transaction.
+
+The value must be a string in the form `"bucket.scope.collection"` or `"namespace:bucket.scope.collection"`.
+If any part of the path contains a special character, that part of the path must be delimited in backticks `pass:c[``]`.
+
+.Example
+[source,shell]
+----
+cbq> \set -atrcollection "default:`travel-sample`.transaction.test";
+----
+| string
 
 | [[auto_execute]]
 **auto_execute** +


### PR DESCRIPTION
The following documentation is ready for review:

* [Settings and Parameters](https://docs-staging.couchbase.com/server/7.0/settings/query-settings.html)
  - New cluster-level settings: `queryMemoryQuota`, `queryNumAtrs`, `queryTxTimeout`, `queryUseCBO`, `queryCleanupClientAttempts`, `queryCleanupLostAttempts`, `queryCleanupWindow`
  - New node-level settings: `atrcollection`, `numatrs`, `cleanupclientattempts`, `cleanuplostattempts`, `cleanupwindow`, `plus-servicers`
  - New request-level parameters: `atrcollection`, `numatrs`
  - Update defaults for `txtimeout`
  - Use of `memory_quota` to control memory use by transactions
* [Cluster Query Settings API](https://docs-staging.couchbase.com/server/7.0/rest-api/rest-cluster-query-settings.html)
  - Copy of cluster-level settings for REST API reference
* [Admin REST API › Resources › Settings](https://docs-staging.couchbase.com/server/7.0/n1ql/n1ql-rest-api/admin.html#_settings_resource)
  - Copy of node-level settings for REST API reference

Docs issue: [DOC-7808](https://issues.couchbase.com/browse/DOC-7808)