### PR TITLE
DOC-7481: Allow concurrent CREATE INDEX

### DIFF
--- a/modules/learn/pages/services-and-indexes/indexes/global-secondary-indexes.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/global-secondary-indexes.adoc
@@ -1,10 +1,11 @@
 = Global Secondary Indexes
-:description: pass:q[A _Global Secondary Index_ (GSI) supports queries made by the _Query Service_ on attributes within documents. \
-Extensive filtering is supported.]
 :page-aliases: indexes:indexing-overview,understanding-couchbase:services-and-indexes/indexes/global-secondary-indexes,indexes:gsi-for-n1ql,architecture:global-secondary-indexes,architecture:gsi-versus-views
+:description: A Global Secondary Index (GSI) supports queries made by the Query Service on attributes within documents. \
+Extensive filtering is supported.
 
 [abstract]
-{description}
+A _Global Secondary Index_ (GSI) supports queries made by the _Query Service_ on attributes within documents.
+Extensive filtering is supported.
 
 Global Secondary Indexes provide the following:
 
@@ -18,6 +19,11 @@ Each index can have its own partition key, so each can be partitioned independen
 As new requirements arise, the application will also be able to create a new index with a new partition key, without affecting performance of existing queries.
 
 == Creating Global Secondary Indexes
+
+Index creation happens in two phases: the [def]_creation phase_ and the [def]_build phase_.
+During the creation phase, the Index Service validates the user input, decides the host node for the index, and creates the index metadata on the host node.
+During the build phase, the Index Service reads the documents from the Data Service and builds the index.
+The build phase cannot start until the creation phase is complete.
 
 Both Primary and Secondary indexes can be created by means of the N1QL query-language; using the CREATE INDEX statement and the USING GSI clause.
 For more information, see xref:n1ql:n1ql-language-reference/createindex.adoc[CREATE INDEX].

--- a/modules/n1ql/examples/n1ql-language-reference/build-idx-error.jsonc
+++ b/modules/n1ql/examples/n1ql-language-reference/build-idx-error.jsonc
@@ -1,7 +1,7 @@
 [
   {
     "code": 5000,
-    "msg": "BuildIndexes - cause: Build index fails.  Some index will be retried building in the background.  For more details, please check index status.\n",
-    "query_from_user": "BUILD INDEX ON ..."
+    "msg": "GSI CreateIndex() - cause: Encountered transient error.  Index creation will be retried in background.  Error: Index ... will retry building in the background for reason: Build Already In Progress. Keyspace ...",
+    "query": "..."
   }
 ]

--- a/modules/n1ql/pages/n1ql-language-reference/alterindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/alterindex.adoc
@@ -295,6 +295,8 @@ replicaId;;
 
 == Usage
 
+If you attempt to alter an index which is still scheduled for background creation, the request fails.
+
 === Moving an Index or Index Replicas
 
 When moving an index or index replicas, the number of destination nodes must be the same as the number of nodes on which the index and any replicas are currently placed.

--- a/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
@@ -8,20 +8,23 @@
 :selectclause: xref:n1ql-language-reference/selectclause.adoc
 :subqueries: xref:n1ql-language-reference/subqueries.adoc
 :logical-hierarchy: xref:n1ql-intro/sysinfo.adoc#logical-hierarchy
+:querying-indexes: xref:n1ql-intro/sysinfo.adoc#querying-indexes
 :keyspace-ref: xref:n1ql-language-reference/createindex.adoc#keyspace-ref
 
 [abstract]
 The BUILD INDEX statement enables you to build one or more GSI indexes that are marked for deferred building all at once.
 
-By default, CREATE INDEX statement starts building the created index.
-However for more efficient building of multiple indexes, CREATE INDEX command can mark indexes for deferred building using the `defer_build:true` option.
-BUILD INDEX is capable of building multiple indexes at once, and can utilize a single scan of documents in the bucket to feed many index build operations.
+By default, CREATE INDEX starts building the created index after the creation stage is complete.
+However for more efficient building of multiple indexes, CREATE INDEX can mark indexes for deferred building using the `defer_build:true` option.
+BUILD INDEX is capable of building multiple indexes at once, and can utilize a single scan of documents in the keyspace to feed many index build operations.
 
 BUILD INDEX is an asynchronous operation.
 BUILD INDEX creates a task to build the primary or secondary GSI indexes and returns as soon as the task is queued for execution.
-The full index creation operation happens in the background.
-Indexes of type GSI provide a status field and mark index status pending while the index build operation is in progress.
-This status field and other index metadata can be queried using `system:indexes`.
+The full index build operation happens in the background.
+
+Index metadata provides a state field.
+The index state may be `scheduled for creation`, `deferred`, `building`, `pending`, `online`, `offline`, or `abridged`.
+This state field and other index metadata can be queried using {querying-indexes}[system:indexes].
 
 BUILD INDEX is also idempotent.
 On execution, the statement only builds indexes which have not already been built.
@@ -34,22 +37,21 @@ When building an index which has automatic index replicas, all of the replicas a
 [discrete]
 ===== RBAC Privileges
 
-User executing the BUILD INDEX statement must have the _Query Manage Index_ privilege granted on the keyspace/bucket.
+User executing the BUILD INDEX statement must have the _Query Manage Index_ privilege granted on the keyspace.
 For more details about user roles, see
 {authorization-overview}[Authorization].
 
 [IMPORTANT]
-.Known Issue
 ====
-If multiple index building operations are kicked off without waiting for all indexes to get to the online state, index building for some indexes might fail.
-In this case, `system:indexes` output might report an error similar to the following:
+If you kick off multiple index build operations concurrently, then you may sometimes see transient errors similar to the following.
+If this error occurs, the Index Service tries to run the build operation again in the background.
 
 [source,json]
 ----
 include::example$n1ql-language-reference/build-idx-error.jsonc[]
 ----
 
-To work around this issue, wait for index building to complete (that is, for all indexes to get to the online state), then issue the BUILD INDEX command again.
+If the Index Service still cannot build the index after retrying, the index is marked as failed in the Couchbase Web Console, so that you can drop the index.
 ====
 
 == Syntax
@@ -211,7 +213,7 @@ include::example$n1ql-language-reference/check-idx-defer.jsonc[]
 ----
 ====
 
-<1> The index is in the pending state (deferred).
+<1> The index is in the deferred state.
 
 [[ex-build-idx-single]]
 .Build a named index

--- a/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
@@ -25,11 +25,14 @@ The full index build operation happens in the background.
 Index metadata provides a state field.
 The index state may be `scheduled for creation`, `deferred`, `building`, `pending`, `online`, `offline`, or `abridged`.
 This state field and other index metadata can be queried using {querying-indexes}[system:indexes].
+You can also monitor the index state using the Couchbase Web Console.
+
+If you attempt to build an index which is still scheduled for background creation, the request fails.
 
 [IMPORTANT]
 ====
 If you kick off multiple index build operations concurrently, then you may sometimes see transient errors similar to the following.
-If this error occurs, the Index Service tries to run the build operation again in the background.
+If this error occurs, the Index Service tries to run the failed operation again in the background.
 
 [source,json]
 ----

--- a/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
@@ -32,14 +32,13 @@ If you attempt to build an index which is still scheduled for background creatio
 [IMPORTANT]
 ====
 If you kick off multiple index build operations concurrently, then you may sometimes see transient errors similar to the following.
-If this error occurs, the Index Service tries to run the failed operation again in the background.
 
 [source,json]
 ----
 include::example$n1ql-language-reference/build-idx-error.jsonc[]
 ----
 
-If the Index Service still cannot build the index after retrying, the index is marked as failed in the Couchbase Web Console, so that you can drop the index.
+To work around this issue, wait for index building to complete (that is, for all indexes to get to the online state), then issue the BUILD INDEX command again.
 ====
 
 BUILD INDEX is also idempotent.

--- a/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
@@ -235,6 +235,8 @@ Alternatively, kick off all deferred builds in the keyspace, using a subquery to
 ----
 include::example$n1ql-language-reference/build-idx-all.n1ql[]
 ----
+
+Note that it is only possible to kick off all deferred builds in a single collection -- it is not possible to kick off all deferred builds in all collections in all scopes within a bucket.
 ====
 
 <1> One set of parentheses delimits the whole group of index terms, and another set of parentheses delimits the subquery.

--- a/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
@@ -26,6 +26,19 @@ Index metadata provides a state field.
 The index state may be `scheduled for creation`, `deferred`, `building`, `pending`, `online`, `offline`, or `abridged`.
 This state field and other index metadata can be queried using {querying-indexes}[system:indexes].
 
+[IMPORTANT]
+====
+If you kick off multiple index build operations concurrently, then you may sometimes see transient errors similar to the following.
+If this error occurs, the Index Service tries to run the build operation again in the background.
+
+[source,json]
+----
+include::example$n1ql-language-reference/build-idx-error.jsonc[]
+----
+
+If the Index Service still cannot build the index after retrying, the index is marked as failed in the Couchbase Web Console, so that you can drop the index.
+====
+
 BUILD INDEX is also idempotent.
 On execution, the statement only builds indexes which have not already been built.
 If any of the indexes specified by BUILD INDEX have already been built, BUILD INDEX skips those indexes.
@@ -40,19 +53,6 @@ When building an index which has automatic index replicas, all of the replicas a
 User executing the BUILD INDEX statement must have the _Query Manage Index_ privilege granted on the keyspace.
 For more details about user roles, see
 {authorization-overview}[Authorization].
-
-[IMPORTANT]
-====
-If you kick off multiple index build operations concurrently, then you may sometimes see transient errors similar to the following.
-If this error occurs, the Index Service tries to run the build operation again in the background.
-
-[source,json]
-----
-include::example$n1ql-language-reference/build-idx-error.jsonc[]
-----
-
-If the Index Service still cannot build the index after retrying, the index is marked as failed in the Couchbase Web Console, so that you can drop the index.
-====
 
 == Syntax
 

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -24,30 +24,34 @@ The `CREATE INDEX` statement allows you to create a secondary index.
 Secondary indexes contain a filtered or a full set of keys in a given keyspace.
 Secondary indexes are optional but increase query efficiency on a keyspace.
 
-In Couchbase Server 7.0 and later, `CREATE INDEX` allows you to make concurrent index creation requests.
-If there is an index creation task already running, the Index Service queues the incoming index creation request, and schedules the index creation phase to run in the background.
+In Couchbase Server 7.0 and later, `CREATE INDEX` allows you to make multiple concurrent index creation requests.
+The command starts a task to create the index definition in the background.
+If there is an index creation task already running, the Index Service queues the incoming index creation request.
+`CREATE INDEX` returns as soon as the when the index creation phase is complete.
 
-By default, when the index creation phase is complete, the Index Service then triggers the index build phase.
+By default, when the index creation phase is complete, the Index Service triggers the index build phase.
 If you lose connectivity, the index build operation continues in the background.
 You can also defer the index build phase using the `defer_build` clause.
-In deferred build mode, `CREATE INDEX` starts a task to create the index definition, and returns as soon as the task finishes.
+In deferred build mode, `CREATE INDEX` creates the index definition, but does not trigger the index build phase.
 You can then build the index using the {build-index}[BUILD INDEX] command.
 
 Index metadata provides a state field.
 The index state may be `scheduled for creation`, `deferred`, `building`, `pending`, `online`, `offline`, or `abridged`.
 This state field and other index metadata can be queried using {querying-indexes}[system:indexes].
+You can also monitor the index state using the Couchbase Web Console.
 
 [IMPORTANT]
 ====
-If you kick off multiple index creation operations concurrently, and the build phase is not deferred, then you may sometimes see transient errors during the build phase similar to the following.
-If this error occurs, the Index Service tries to run the build operation again in the background.
+If you kick off multiple index creation operations concurrently, you may sometimes see transient errors similar to the following.
+If this error occurs, the Index Service tries to run the failed operation again in the background until it succeeds, up to a maximum of 1000 retries.
 
 [source,json]
 ----
 include::example$n1ql-language-reference/build-idx-error.jsonc[]
 ----
 
-If the Index Service still cannot build the index after retrying, the index is marked as failed in the Couchbase Web Console, so that you can drop the index.
+If the Index Service still cannot create the index after the maximum number of retries, the index state is marked as `offline`.
+You must drop the failed index using the `DROP INDEX` command.
 ====
 
 You can create multiple identical secondary indexes on a keyspace and place them on separate nodes for better index availability.

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -55,12 +55,6 @@ In Couchbase Server Enterprise Edition, the recommended way to do this is using 
 In Couchbase Server Community Edition, you need to create multiple identical indexes and place them using the `nodes` option.
 Refer to <<index-with,WITH Clause>> below for more details.
 
-[NOTE]
-====
-You cannot run multiple `CREATE INDEX` statements in parallel, even when you specify that the indexes should be created on different nodes.
-This is to avoid the possibility of duplicate index names.
-====
-
 == Prerequisites
 
 [discrete]

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -21,33 +21,36 @@
 :querying-indexes: {sysinfo}#querying-indexes
 
 The `CREATE INDEX` statement allows you to create a secondary index.
-Secondary indexes contain a filtered or a full set of keys in a given bucket.
-Secondary indexes are optional but increase query efficiency on a bucket.
+Secondary indexes contain a filtered or a full set of keys in a given keyspace.
+Secondary indexes are optional but increase query efficiency on a keyspace.
 
-`CREATE INDEX` is by default a synchronous operation,
-which means that every `CREATE INDEX` statement blocks until the operation finishes.
-Index building starts by creating a task that is queued for index build.
-After this phase, if you lose connectivity, the index build operation continues in the background.
-You can also run index creation asynchronously using the `defer_build` clause.
-In the asynchronous mode, `CREATE INDEX` starts a task to create the index definition, and returns as soon as the task finishes.
+In Couchbase Server 7.0 and later, `CREATE INDEX` allows you to make concurrent index creation requests.
+If there is an index creation task already running, the Index Service queues the incoming index creation request, and schedules the index creation phase to run in the background.
+
+By default, when the index creation phase is complete, the Index Service then triggers the index build phase.
+If you lose connectivity, the index build operation continues in the background.
+You can also defer the index build phase using the `defer_build` clause.
+In deferred build mode, `CREATE INDEX` starts a task to create the index definition, and returns as soon as the task finishes.
 You can then build the index using the {build-index}[BUILD INDEX] command.
 
-GSI indexes provide a status field and mark index status pending.
-With GSI indexer, index status continues to report "pending".
-This status field and other index metadata can be queried using `system:indexes`.
+Index metadata provides a state field.
+The index state may be `scheduled for creation`, `deferred`, `building`, `pending`, `online`, `offline`, or `abridged`.
+This state field and other index metadata can be queried using {querying-indexes}[system:indexes].
 
 [IMPORTANT]
 ====
-Indexes cannot be built concurrently on a given bucket unless the `defer_build` option of the CREATE INDEX statement is used in combination with BUILD INDEX statement.
-The following error is reported if a second index build operation is kicked off before the completion of the ongoing index build.
+If you kick off multiple index creation operations concurrently, and the build phase is not deferred, then you may sometimes see transient errors during the build phase similar to the following.
+If this error occurs, the Index Service tries to run the build operation again in the background.
 
 [source,json]
 ----
 include::example$n1ql-language-reference/build-idx-error.jsonc[]
 ----
+
+If the Index Service still cannot build the index after retrying, the index is marked as failed in the Couchbase Web Console, so that you can drop the index.
 ====
 
-You can create multiple identical secondary indexes on a bucket and place them on separate nodes for better index availability.
+You can create multiple identical secondary indexes on a keyspace and place them on separate nodes for better index availability.
 In Couchbase Server Enterprise Edition, the recommended way to do this is using the `num_replicas` option.
 In Couchbase Server Community Edition, you need to create multiple identical indexes and place them using the `nodes` option.
 Refer to <<index-with,WITH Clause>> below for more details.
@@ -63,7 +66,7 @@ This is to avoid the possibility of duplicate index names.
 [discrete]
 ===== RBAC Privileges
 
-User executing the CREATE INDEX statement must have the _Query Manage Index_ privilege granted on the keyspace/bucket.
+User executing the CREATE INDEX statement must have the _Query Manage Index_ privilege granted on the keyspace.
 For more details about user roles, see
 {authorization-overview}[Authorization].
 
@@ -459,7 +462,7 @@ include::example$n1ql-language-reference/check-idx-defer.n1ql[]
 include::example$n1ql-language-reference/check-idx-defer.jsonc[]
 ----
 
-<1> The index is in the pending state (deferred).
+<1> The index is in the deferred state.
 ====
 
 [[ex-build-idx-defer]]

--- a/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
@@ -17,28 +17,34 @@ The `CREATE PRIMARY INDEX` statement allows you to create a primary index.
 Primary indexes contain a full set of keys in a given keyspace.
 Primary indexes are optional and are only required for running ad hoc queries on a keyspace that is not supported by a secondary index.
 
-In Couchbase Server 7.0 and later, `CREATE PRIMARY INDEX` allows you to make concurrent index creation requests.
-If there is an index creation task already running, the Index Service queues the incoming index creation request, and schedules the index creation phase to run in the background.
+In Couchbase Server 7.0 and later, `CREATE PRIMARY INDEX` allows you to make multiple concurrent index creation requests.
+The command starts a task to create the primary index definition in the background.
+If there is an index creation task already running, the Index Service queues the incoming index creation request.
+`CREATE PRIMARY INDEX` returns as soon as the index creation phase is complete.
 
-By default, when the index creation phase is complete, the Index Service then triggers the index build phase.
+By default, when the index creation phase is complete, the Index Service triggers the index build phase.
 If you lose connectivity, the index build operation continues in the background.
 You can also defer the index build phase using the `defer_build` clause.
-In deferred build mode, `CREATE PRIMARY INDEX` starts a task to create the primary index definition, and returns as soon as the task finishes.
+In deferred build mode, `CREATE PRIMARY INDEX` creates the index definition, but does not trigger the index build phase.
 You can then build the index using the {build-index}[BUILD INDEX] command.
 
 Index metadata provides a state field.
 The index state may be `scheduled for creation`, `deferred`, `building`, `pending`, `online`, `offline`, or `abridged`.
 This state field and other index metadata can be queried using {querying-indexes}[system:indexes].
+You can also monitor the index state using the Couchbase Web Console.
 
 [IMPORTANT]
 ====
-If you kick off multiple index creation operations concurrently, and the build phase is not deferred, then you may sometimes see transient errors during the build phase similar to the following.
-If this error occurs, the Index Service tries to run the build operation again in the background.
+If you kick off multiple index creation operations concurrently, you may sometimes see transient errors similar to the following.
+If this error occurs, the Index Service tries to run the failed operation again in the background until it succeeds, up to a maximum of 1000 retries.
+
+[source,json]
 ----
 include::example$n1ql-language-reference/build-idx-error.jsonc[]
 ----
 
-If the Index Service still cannot build the index after retrying, the index is marked as failed in the Couchbase Web Console, so that you can drop the index.
+If the Index Service still cannot create the index after the maximum number of retries, the index state is marked as `offline`.
+You must drop the failed index using the `DROP INDEX` command.
 ====
 
 You can create multiple identical primary indexes on a keyspace and place them on separate nodes for better index availability.

--- a/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
@@ -6,9 +6,10 @@
 
 :authorization-overview: xref:learn:security/authorization-overview.adoc
 :build-index: xref:n1ql-language-reference/build-index.adoc
-:query-context: xref:n1ql:n1ql-intro/sysinfo.adoc#query-context
 :identifiers: xref:n1ql-language-reference/identifiers.adoc
+:query-context: xref:n1ql:n1ql-intro/sysinfo.adoc#query-context
 :logical-hierarchy: xref:n1ql-intro/sysinfo.adoc#logical-hierarchy
+:querying-indexes: xref:n1ql-intro/sysinfo.adoc#querying-indexes
 :index-replication: xref:learn:services-and-indexes/indexes/index-replication.adoc#index-replication
 :query-settings: xref:manage:manage-settings/query-settings.adoc
 
@@ -16,29 +17,31 @@ The `CREATE PRIMARY INDEX` statement allows you to create a primary index.
 Primary indexes contain a full set of keys in a given keyspace.
 Primary indexes are optional and are only required for running ad hoc queries on a keyspace that is not supported by a secondary index.
 
-`CREATE PRIMARY INDEX` is by default a synchronous operation,
-which means that every `CREATE PRIMARY INDEX` statement blocks until the operation finishes.
-Index building starts by creating a task that is queued for index build.
-After this phase, if you lose connectivity, the index build operation continues in the background.
-You can also run index creation asynchronously by using the `defer_build` clause.
-In the asynchronous mode, `CREATE PRIMARY INDEX` starts a task to create the primary index definition, and returns as soon as the task finishes.
+In Couchbase Server 7.0 and later, `CREATE PRIMARY INDEX` allows you to make concurrent index creation requests.
+If there is an index creation task already running, the Index Service queues the incoming index creation request, and schedules the index creation phase to run in the background.
+
+By default, when the index creation phase is complete, the Index Service then triggers the index build phase.
+If you lose connectivity, the index build operation continues in the background.
+You can also defer the index build phase using the `defer_build` clause.
+In deferred build mode, `CREATE PRIMARY INDEX` starts a task to create the primary index definition, and returns as soon as the task finishes.
 You can then build the index using the {build-index}[BUILD INDEX] command.
 
-GSI indexers provide a status field and mark index status pending.
-With the GSI indexer, index status continues to report `pending`.
-This status field and other index metadata can be queried using `system:indexes`.
+Index metadata provides a state field.
+The index state may be `scheduled for creation`, `deferred`, `building`, `pending`, `online`, `offline`, or `abridged`.
+This state field and other index metadata can be queried using {querying-indexes}[system:indexes].
 
 [IMPORTANT]
 ====
-Indexes cannot be built concurrently on a given keyspace unless the `defer_build` option in the `CREATE PRIMARY INDEX` statement is used in combination with the `BUILD INDEX` statement.
-The following error is reported if a second index creation operation is kicked off before the completion of the ongoing index creation.
-
+If you kick off multiple index creation operations concurrently, and the build phase is not deferred, then you may sometimes see transient errors during the build phase similar to the following.
+If this error occurs, the Index Service tries to run the build operation again in the background.
 ----
 include::example$n1ql-language-reference/build-idx-error.jsonc[]
 ----
+
+If the Index Service still cannot build the index after retrying, the index is marked as failed in the Couchbase Web Console, so that you can drop the index.
 ====
 
-You can create multiple identical secondary indexes on a bucket and place them on separate nodes for better index availability.
+You can create multiple identical primary indexes on a keyspace and place them on separate nodes for better index availability.
 In Couchbase Server Enterprise Edition, the recommended way to do this is using the `num_replicas` option.
 In Couchbase Server Community Edition, you need to create multiple identical indexes and place them using the `nodes` option.
 Refer to <<index-with,WITH Clause>> below for more details.
@@ -339,7 +342,7 @@ Query `system:indexes` for the status of the index.
 SELECT * FROM system:indexes WHERE name="idx_hotel_primary";
 ----
 
-The output from `system:indexes` shows the `idx_hotel_primary` in the pending state (`"state": "deferred"`).
+The output from `system:indexes` shows the `idx_hotel_primary` in the deferred state.
 ====
 
 .Build a deferred primary index

--- a/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
@@ -219,6 +219,8 @@ If the failed-over index node is recovered, then the orphan replica will be drop
 
 If you drop an index with replicas when one of the index nodes is unavailable but not failed over, the drop index operation may fail.
 
+If you drop an index which is scheduled for background creation, a warning message is generated, but the drop index operation succeeds.
+
 [caption=Attention]
 IMPORTANT: We recommend that you do not drop (or create) secondary indexes when any node with a secondary index role is down as this may result in duplicate index names.
 

--- a/modules/n1ql/pages/n1ql-language-reference/hints.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/hints.adoc
@@ -153,6 +153,8 @@ The query engine attempts to use a specified index if the index is applicable fo
 In Couchbase Server 6.6 and later, you can omit the index name and just specify the index type.
 In this case, the query service considers all the available indexes of the specified type.
 
+If you attempt to use an index which is still scheduled for background creation, the request fails.
+
 === Syntax
 
 [subs="normal"]


### PR DESCRIPTION
The following draft documentation is ready for review:

* [Global Secondary Indexes › Creating Global Secondary Indexes](https://docs-staging.couchbase.com/server/7.0/learn/services-and-indexes/indexes/global-secondary-indexes.html#creating-global-secondary-indexes) — described create phase and build phase
* [CREATE INDEX](https://docs-staging.couchbase.com/server/7.0/n1ql/n1ql-language-reference/createindex.html) — added info about concurrent create operations, updated 5000 error
* [CREATE PRIMARY INDEX](https://docs-staging.couchbase.com/server/7.0/n1ql/n1ql-language-reference/createprimaryindex.html) — added info about concurrent create operations, updated 5000 error
* [BUILD INDEX](https://docs-staging.couchbase.com/server/7.0/n1ql/n1ql-language-reference/build-index.html) — updated 5000 error, added note about building all indexes in a collection

Docs issue: [DOC-7481](https://issues.couchbase.com/browse/DOC-7481)