### PR TITLE
DOC-7754: Transactions are EE and CE in Cheshire Cat

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/begin-transaction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/begin-transaction.adoc
@@ -172,4 +172,4 @@ This is equivalent to the request in <<ex-3>>.
 * To set a savepoint, refer to {savepoint}[SAVEPOINT].
 * To rollback a transaction, refer to {rollback-transaction}[ROLLBACK TRANSACTION].
 * To commit a transaction, refer to {commit-transaction}[COMMIT TRANSACTION].
-* Blog post: https://blog.couchbase.com/transactions-n1ql-couchbase-distributed-nosql/[N1QL Transactions^].
+* Blog post: https://blog.couchbase.com/transactions-n1ql-couchbase-distributed-nosql/[N1QL Support for Couchbase Transactions^].

--- a/modules/n1ql/pages/n1ql-language-reference/begin-transaction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/begin-transaction.adoc
@@ -1,7 +1,6 @@
 = BEGIN TRANSACTION
 :page-topic-type: concept
 :page-status: Couchbase Server 7.0
-:page-edition: Enterprise Edition
 :imagesdir: ../../assets/images
 
 // Cross-references

--- a/modules/n1ql/pages/n1ql-language-reference/commit-transaction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/commit-transaction.adoc
@@ -1,7 +1,6 @@
 = COMMIT TRANSACTION
 :page-topic-type: concept
 :page-status: Couchbase Server 7.0
-:page-edition: Enterprise Edition
 :imagesdir: ../../assets/images
 
 // Cross-references

--- a/modules/n1ql/pages/n1ql-language-reference/commit-transaction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/commit-transaction.adoc
@@ -76,4 +76,4 @@ $ curl http://localhost:8093/query/service \
 * To specify transaction settings, refer to {set-transaction}[SET TRANSACTION].
 * To set a savepoint, refer to {savepoint}[SAVEPOINT].
 * To rollback a transaction, refer to {rollback-transaction}[ROLLBACK TRANSACTION].
-* Blog post: https://blog.couchbase.com/transactions-n1ql-couchbase-distributed-nosql/[N1QL Transactions^].
+* Blog post: https://blog.couchbase.com/transactions-n1ql-couchbase-distributed-nosql/[N1QL Support for Couchbase Transactions^].

--- a/modules/n1ql/pages/n1ql-language-reference/rollback-transaction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/rollback-transaction.adoc
@@ -88,4 +88,4 @@ $ curl http://localhost:8093/query/service \
 * To specify transaction settings, refer to {set-transaction}[SET TRANSACTION].
 * To set a savepoint, refer to {savepoint}[SAVEPOINT].
 * To commit a transaction, refer to {commit-transaction}[COMMIT TRANSACTION].
-* Blog post: https://blog.couchbase.com/transactions-n1ql-couchbase-distributed-nosql/[N1QL Transactions^].
+* Blog post: https://blog.couchbase.com/transactions-n1ql-couchbase-distributed-nosql/[N1QL Support for Couchbase Transactions^].

--- a/modules/n1ql/pages/n1ql-language-reference/rollback-transaction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/rollback-transaction.adoc
@@ -1,7 +1,6 @@
 = ROLLBACK TRANSACTION
 :page-topic-type: concept
 :page-status: Couchbase Server 7.0
-:page-edition: Enterprise Edition
 :imagesdir: ../../assets/images
 
 // Cross-references

--- a/modules/n1ql/pages/n1ql-language-reference/savepoint.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/savepoint.adoc
@@ -76,4 +76,4 @@ $ curl http://localhost:8093/query/service \
 * To specify transaction settings, refer to {set-transaction}[SET TRANSACTION].
 * To rollback a transaction, refer to {rollback-transaction}[ROLLBACK TRANSACTION].
 * To commit a transaction, refer to {commit-transaction}[COMMIT TRANSACTION].
-* Blog post: https://blog.couchbase.com/transactions-n1ql-couchbase-distributed-nosql/[N1QL Transactions^].
+* Blog post: https://blog.couchbase.com/transactions-n1ql-couchbase-distributed-nosql/[N1QL Support for Couchbase Transactions^].

--- a/modules/n1ql/pages/n1ql-language-reference/savepoint.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/savepoint.adoc
@@ -1,7 +1,6 @@
 = SAVEPOINT
 :page-topic-type: concept
 :page-status: Couchbase Server 7.0
-:page-edition: Enterprise Edition
 :imagesdir: ../../assets/images
 
 // Cross-references

--- a/modules/n1ql/pages/n1ql-language-reference/set-transaction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/set-transaction.adoc
@@ -1,7 +1,6 @@
 = SET TRANSACTION
 :page-topic-type: concept
 :page-status: Couchbase Server 7.0
-:page-edition: Enterprise Edition
 :imagesdir: ../../assets/images
 
 // Cross-references

--- a/modules/n1ql/pages/n1ql-language-reference/set-transaction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/set-transaction.adoc
@@ -86,4 +86,4 @@ $ curl http://localhost:8093/query/service \
 * To set a savepoint, refer to {savepoint}[SAVEPOINT].
 * To rollback a transaction, refer to {rollback-transaction}[ROLLBACK TRANSACTION].
 * To commit a transaction, refer to {commit-transaction}[COMMIT TRANSACTION].
-* Blog post: https://blog.couchbase.com/transactions-n1ql-couchbase-distributed-nosql/[N1QL Transactions^].
+* Blog post: https://blog.couchbase.com/transactions-n1ql-couchbase-distributed-nosql/[N1QL Support for Couchbase Transactions^].

--- a/modules/n1ql/pages/n1ql-language-reference/transactions.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/transactions.adoc
@@ -22,6 +22,7 @@
 :txid: xref:settings:query-settings.adoc#txid
 :tximplicit: xref:settings:query-settings.adoc#tximplicit
 :txstmtnum: xref:settings:query-settings.adoc#txstmtnum
+:kvtimeout: xref:settings:query-settings.adoc#kvtimeout
 :txtimeout_req: xref:settings:query-settings.adoc#txtimeout_req
 :txtimeout-srv: xref:settings:query-settings.adoc#txtimeout-srv
 :queryTxTimeout: xref:settings:query-settings.adoc#queryTxTimeout
@@ -75,6 +76,8 @@ Refer to the documentation for each parameter for more information and examples.
 * The {tximplicit}[tximplicit] request-level parameter specifies that a statement is a single transaction.
 
 * The {txstmtnum}[txstmtnum] request-level parameter specifies the transaction statement number.
+
+* The {kvtimeout}[kvtimeout] request-level parameter specifies the maximum time to spend on a KV operation within a transaction before timing out.
 
 * The {txtimeout_req}[txtimeout] request-level parameter, {txtimeout-srv}[txtimeout] node-level setting, and {queryTxTimeout}[queryTxTimeout] cluster-level setting specify the maximum time to spend on a transaction before timing out.
 

--- a/modules/n1ql/pages/n1ql-language-reference/transactions.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/transactions.adoc
@@ -1,7 +1,6 @@
 = N1QL Support for Couchbase Transactions
 :page-topic-type: tutorial
 :page-status: Couchbase Server 7.0
-:page-edition: Enterprise Edition
 :imagesdir: ../../assets/images
 :description: N1QL offers full support for Couchbase ACID transactions.
 

--- a/modules/n1ql/pages/n1ql-language-reference/transactions.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/transactions.adoc
@@ -322,4 +322,4 @@ cbq> \quit;
 
 == Related Links
 
-* Blog post: https://blog.couchbase.com/transactions-n1ql-couchbase-distributed-nosql/[N1QL Transactions^].
+* Blog post: https://blog.couchbase.com/transactions-n1ql-couchbase-distributed-nosql/[N1QL Support for Couchbase Transactions^].

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -474,9 +474,7 @@ cbq> \set -args ["LAX", 6];
 | [[atrcollection_req]]
 **atrcollection** +
 __Optional__
-| [.edition]#{enterprise}#
-
-Specifies the collection where the {transactions-understanding-transactions}[active transaction record] (ATR) is stored.
+| Specifies the collection where the {transactions-understanding-transactions}[active transaction record] (ATR) is stored.
 The collection must be present.
 If not specified, the ATR is stored in the default collection in the default scope in the bucket containing the first mutated document within the transaction.
 
@@ -620,9 +618,7 @@ cbq> \set -creds travel-sample user:pword, beer-sample user:pword;
 | [[durability_level]]
 **durability_level** +
 __Optional__
-| [.edition]#{enterprise}#
-
-The level of durability for mutations produced by the request.
+| The level of durability for mutations produced by the request.
 
 If the request contains a `BEGIN TRANSACTION` statement, or a DML statement with the {tximplicit}[tximplicit] parameter set to `true`, the durability level is specified for all mutations within that transaction.
 For all other statements it is ignored.
@@ -765,9 +761,7 @@ cbq> \set -namespace default;
 | [[numatrs_req]]
 **numatrs** +
 __Optional__
-| [.edition]#{enterprise}#
-
-Specifies the total number of {transactions-understanding-transactions}[active transaction records].
+| Specifies the total number of {transactions-understanding-transactions}[active transaction records].
 Must be a positive integer.
 
 The {numatrs-srv}[node-level] `numatrs` setting specifies the default for this parameter for a single node.
@@ -1153,18 +1147,14 @@ $ curl http://localhost:8093/query/service -u user:pword -d 'statement=select * 
 | [[txdata]]
 **txdata** +
 __Optional__
-| [.edition]#{enterprise}#
-
-Transaction data.
+| Transaction data.
 For internal use only.
 | object
 
 | [[txid]]
 **txid** +
 __Required__ for statements within a transaction
-| [.edition]#{enterprise}#
-
-Transaction ID.
+| Transaction ID.
 Specifies the transaction to which a statement belongs.
 For use with DML statements within a transaction, rollbacks, and commits.
 
@@ -1189,9 +1179,7 @@ $ curl http://localhost:8093/query/service \
 | [[tximplicit]]
 **tximplicit** +
 __Optional__
-| [.edition]#{enterprise}#
-
-Specifies that a DML statement is a singleton transaction.
+| Specifies that a DML statement is a singleton transaction.
 
 When this parameter is true, the Query service starts a transaction and executes the statement.
 If execution is successful, the Query service commits the transaction; otherwise the transaction is rolled back.
@@ -1220,9 +1208,7 @@ $ curl http://localhost:8093/query/service \
 | [[txstmtnum]]
 **txstmtnum** +
 __Optional__
-| [.edition]#{enterprise}#
-
-Transaction statement number.
+| Transaction statement number.
 The transaction statement number must be a positive integer, and must be higher than any previous transaction statement numbers in the transaction.
 If the transaction statement number is lower than the transaction statement number for any previous statement, an error is generated.
 
@@ -1245,9 +1231,7 @@ $ curl http://localhost:8093/query/service \
 | [[txtimeout_req]]
 **txtimeout** +
 __Optional__
-| [.edition]#{enterprise}#
-
-Maximum time to spend on a transaction before timing out.
+| Maximum time to spend on a transaction before timing out.
 Only applies to `BEGIN TRANSACTION` statements, or DML statements for which {tximplicit}[tximplicit] is set.
 For other statements, it is ignored.
 

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -230,6 +230,8 @@ a| <<args,args>>
 
 <<format,format>>
 
+<<kvtimeout,kvtimeout>>
+
 <<metrics,metrics>>
 
 <<namespace,namespace>>
@@ -728,6 +730,38 @@ cbq> \set -memory_quota 4;
 $ curl http://localhost:8093/query/service -u user:pword -d 'statement=select * from default&memory_quota=4'
 ----
 | integer (int32)
+
+| [[kvtimeout]]
+**kvtimeout** +
+__Optional__
+| The maximum time to wait for a KV operation before timing out.
+Only applies to statements within a transaction.
+
+The value for this parameter is a string.
+Its format includes an amount and a mandatory unit, e.g. `10ms` (10 milliseconds) or `0.5s` (half a second).
+Valid units are:
+
+* `ns` (nanoseconds)
+* `us` (microseconds)
+* `ms` (milliseconds)
+* `s` (seconds)
+* `m` (minutes)
+* `h` (hours)
+
+Specify a duration of `0` or a negative duration to disable.
+When disabled, no timeout is applied and the KV operation runs for however long it takes.
+
+.Default
+`"2.5s"`
+
+.Example
+[source,shell]
+----
+cbq> \set -kvtimeout "10ms";
+
+$ curl http://localhost:8093/query/service -u user:pword -d 'statement=select * from default&kvtimeout=10ms'
+----
+| string
 
 | [[metrics]]
 **metrics** +


### PR DESCRIPTION
The following draft documentation is ready for review:

* [Settings and Parameters](https://simon-dew.github.io/docs-site/DOC-7754/server/7.0/settings/query-settings.html#kvtimeout) — added **kvtimeout**
* Removed Enterprise Edition labels from Couchbase transaction features throughout
* Checked for correct usage — "N1Ql Support for Couchbase Transactions"

Docs issue: [DOC-7754](https://issues.couchbase.com/browse/DOC-7754)