### PR TITLE
remove use of counter in block titles and reftext

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/indexing-arrays.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/indexing-arrays.adoc
@@ -265,11 +265,11 @@ They can efficiently index and query recursive trees of arbitrary depth.
 
 The following examples use the {install-sample-buckets}[travel-sample] bucket that is shipped with Couchbase Server.
 
+[[example-1]]
 .Indexing all DISTINCT elements in an array
 ====
-
-.C{counter:example-counter}: Create an index on all schedules
-[[C1,C{example-counter}]]
+.Index: Create an index on all schedules
+[[C1,Index]]
 [source,N1QL]
 ----
 CREATE INDEX idx_sched
@@ -277,8 +277,8 @@ ON `travel-sample`.inventory.route
 ( DISTINCT ARRAY v.flight FOR v IN schedule END );
 ----
 
-.Q{example-counter}: Find the list of scheduled 'UA' flights
-[[Q1,Q{example-counter}]]
+.Query: Find the list of scheduled 'UA' flights
+[[Q1,Query]]
 [source,N1QL]
 ----
 SELECT * FROM `travel-sample`.inventory.route
@@ -286,10 +286,11 @@ WHERE ANY v IN schedule SATISFIES v.flight LIKE 'UA%' END;
 ----
 ====
 
+[[example-2]]
 .Partial index (with WHERE clause) of individual attributes from selected elements (using WHEN clause) of an array
 ====
-.C{counter:example-counter}: Create an index on flights from San Francisco scheduled in the first 4 days of the week
-[[C2,C{example-counter}]]
+.Index: Create an index on flights from San Francisco scheduled in the first 4 days of the week
+[[C2,Index]]
 [source,N1QL]
 ----
 CREATE INDEX idx_flight_sfo
@@ -298,8 +299,8 @@ ON `travel-sample`.inventory.route
 WHERE sourceairport = "SFO";
 ----
 
-.Q{example-counter}: Find the list of scheduled 'UA' flights on day 1
-[[Q2,Q{example-counter}]]
+.Query: Find the list of scheduled 'UA' flights on day 1
+[[Q2,Query]]
 [source,N1QL]
 ----
 SELECT * FROM `travel-sample`.inventory.route
@@ -308,17 +309,18 @@ AND ANY v IN schedule SATISFIES (v.flight LIKE 'UA%') -- <2>
 AND (v.day=1) END; -- <3>
 ----
 
-The index <<C2>> qualifies for the query <<Q2>> because:
+In this example, the <<C2>> qualifies for the <<Q2>> because:
 
 <1> The <<Q2>> predicate `sourceairport = "SFO"` matches that of the partial index WHERE clause.
-<2> The ANY operator uses the index key `v.flight` on which the index <<C2>> is defined.
-<3> The ANY-SATISFIES condition `v.day=1` in <<Q2>> is sargable to that in the index definition WHEN clause `v.day < 4`.
+<2> The ANY operator uses the index key `v.flight` on which the <<C2>> is defined.
+<3> The ANY-SATISFIES condition `v.day=1` in the <<Q2>> is sargable to that in the index definition WHEN clause `v.day < 4`.
 ====
 
+[[example-3]]
 .Compound array index with individual elements of an array and other non-array fields
 ====
-.C{counter:example-counter}: Create an index on scheduled flight IDs and number of stops
-[[C3,C{example-counter}]]
+.Index: Create an index on scheduled flight IDs and number of stops
+[[C3,Index]]
 [source,N1QL]
 ----
 CREATE INDEX idx_flight_stops
@@ -326,8 +328,8 @@ ON `travel-sample`.inventory.route
     ( stops, DISTINCT ARRAY v.flight FOR v IN schedule END );
 ----
 
-.Q{example-counter}: Find the list of scheduled 'FL' flights that have one or more stops
-[[Q3,Q{example-counter}]]
+.Query: Find the list of scheduled 'FL' flights that have one or more stops
+[[Q3,Query]]
 [source,N1QL]
 ----
 SELECT * FROM `travel-sample`.inventory.route
@@ -336,11 +338,13 @@ AND ANY v IN schedule SATISFIES v.flight LIKE 'FL%' END;
 ----
 ====
 
+[[example-4]]
 .Indexing the individual elements of nest arrays
 ====
 Use the DISTINCT ARRAY clause in a nested fashion to index specific attributes of a document when the array contains other arrays or documents that contain arrays.
 For example,
 
+.Update: Create a nested array [.var]`special_flights`
 [source,N1QL]
 ----
 UPDATE `travel-sample`.inventory.route
@@ -351,8 +355,8 @@ SET schedule[0] = {"day" : 7, "special_flights" :
 WHERE destinationairport = "CDG" AND sourceairport = "TLV";
 ----
 
-.C{counter:example-counter}: Create a partial index on a nested array [.var]`special_flights`
-[[C4,C{example-counter}]]
+.Index: Create a partial index on a nested array [.var]`special_flights`
+[[C4,Index]]
 [source,N1QL]
 ----
 CREATE INDEX idx_nested ON `travel-sample`.inventory.route
@@ -364,8 +368,8 @@ CREATE INDEX idx_nested ON `travel-sample`.inventory.route
 
 <1> In this case, the inner ARRAY construct is used as the [.var]`var_expr` for the outer ARRAY construct in the N1QL Syntax above.
 
-.Q{example-counter}: Use nested ANY operator to use the index
-[[Q4,Q{example-counter}]]
+.Query A: Use nested ANY operator to use the index
+[[Q4,Query A]]
 [source,N1QL]
 ----
 SELECT count(*) FROM `travel-sample`.inventory.route
@@ -376,8 +380,8 @@ END;
 
 This query returns 3 results, as there are 3 routes with special flights.
 
-.Q{example-counter}A: Use UNNEST operators to use the index
-[[Q4A,Q{example-counter}A]]
+.Query B: Use UNNEST operators to use the index
+[[Q4A,Query B]]
 [source,N1QL]
 ----
 SELECT count(*) FROM `travel-sample`.inventory.route
@@ -389,18 +393,19 @@ WHERE y.flight IS NOT NULL;
 This query returns 6 results, as there are 3 routes with 2 special flights each.
 ====
 
+[[example-5]]
 .Array Index with multiple elements of an array
 ====
-.C{counter:example-counter}: Create an index on [.var]`flight` and [.var]`day` fields in [.var]`schedule`
-[[C5,C{example-counter}]]
+.Index: Create an index on [.var]`flight` and [.var]`day` fields in [.var]`schedule`
+[[C5,Index]]
 [source,N1QL]
 ----
 CREATE INDEX idx_flight_day ON `travel-sample`.inventory.route
     (DISTINCT ARRAY [v.flight, v.day] FOR v IN schedule END);
 ----
 
-.Q{example-counter}: Find the list of scheduled 'US681' flights on day 2
-[[Q5,Q{example-counter}]]
+.Query: Find the list of scheduled 'US681' flights on day 2
+[[Q5,Query]]
 [source,N1QL]
 ----
 SELECT meta().id FROM `travel-sample`.inventory.route
@@ -408,18 +413,19 @@ WHERE ANY v in schedule SATISFIES [v.flight, v.day] = ["US681", 2] END;
 ----
 ====
 
+[[example-6]]
 .Indexing all elements in an array using simplified syntax
 ====
-.C{counter:example-counter}: Create an index on all schedules using simplified array index syntax
-[[C6,C{example-counter}]]
+.Index: Create an index on all schedules using simplified array index syntax
+[[C6,Index]]
 [source,N1QL]
 ----
 CREATE INDEX idx_sched_simple
 ON `travel-sample`.inventory.route (ALL schedule);
 ----
 
-.Q{example-counter}: Find details of all route documents matching a specific schedule
-[[Q6,Q{example-counter}]]
+.Query A: Find details of all route documents matching a specific schedule
+[[Q6,Query A]]
 [source,N1QL]
 ----
 SELECT * FROM `travel-sample`.inventory.route
@@ -429,8 +435,8 @@ SATISFIES v = {"day":2, "flight": "US681", "utc": "19:20:00"} END; -- <1>
 
 <1> Elements of the schedule array are objects, and hence the right side value of the predicate condition should be a similarly structured object.
 
-.Q{example-counter}A: Find details of all route documents matching a specific schedule
-[[Q6A,Q{example-counter}A]]
+.Query B: Find details of all route documents matching a specific schedule
+[[Q6A,Query B]]
 [source,N1QL]
 ----
 SELECT * FROM `travel-sample`.inventory.route t
@@ -449,12 +455,13 @@ For more details, see {covering-indexes}[Covering Indexes].
 
 Array indexing requires special attention to create covering array indexes.
 In general, the array field itself should be included as one of the index keys in the CREATE INDEX definition.
-For example, the index <<C1>> does not cover the query <<Q1>> because the <<Q1>> projection list includes * which needs to fetch the document from the Data Service.
+For instance, in <<example-1>>, the <<C1>> does not cover the <<Q1>> because the <<Q1>> projection list includes * which needs to fetch the document from the Data Service.
 
+[[example-7]]
 .Covering Array Index
 ====
-.C{counter:example-counter}: Creating a Covering Array Index
-[[C7,C{example-counter}]]
+.Index I: Creating a Covering Array Index
+[[C7,Index I]]
 [source,N1QL]
 ----
 CREATE INDEX idx_sched_cover ON `travel-sample`.inventory.route
@@ -464,11 +471,11 @@ CREATE INDEX idx_sched_cover ON `travel-sample`.inventory.route
 The index keys of an index must be used in the WHERE clause of a DML statement to use the index for that query.
 In the SELECT or DML WHERE clause, Covering Array Indexes can be used by the following operators:
 
-* ANY: As shown in query <<Q7>>.
-* ANY AND EVERY: As shown in query <<Q7A>> (a variant of Example <<Q7>>).
+* ANY: As shown in <<Q7>> below.
+* ANY AND EVERY: As shown in <<Q7A>> (a variant of <<Q7>>) below.
 
-.Q{example-counter}: Covering Array Index using the ANY clause
-[[Q7,Q{example-counter}]]
+.Query A: Covering Array Index using the ANY clause
+[[Q7,Query A]]
 [source,N1QL]
 ----
 EXPLAIN SELECT meta().id FROM `travel-sample`.inventory.route
@@ -476,7 +483,7 @@ USE INDEX (idx_sched_cover) -- <1>
 WHERE ANY v IN schedule SATISFIES v.flight LIKE 'UA%' END;
 ----
 
-<1> The query <<Q7>> needs index <<C7>> to cover it because the query predicate refers to the array `schedule` in the ANY operator.
+<1> In this example, <<Q7>> needs <<C7>> to cover it because the query predicate refers to the array `schedule` in the ANY operator.
 
 [source,JSON]
 .Result
@@ -511,8 +518,8 @@ WHERE ANY v IN schedule SATISFIES v.flight LIKE 'UA%' END;
 ]
 ----
 
-.Q{example-counter}A: Covering Array Index using the ANY AND EVERY clause
-[[Q7A,Q{example-counter}A]]
+.Query B: Covering Array Index using the ANY AND EVERY clause
+[[Q7A,Query B]]
 [source,N1QL]
 ----
 EXPLAIN SELECT meta().id FROM `travel-sample`.inventory.route
@@ -549,8 +556,8 @@ WHERE ANY AND EVERY v IN schedule SATISFIES v.flight LIKE 'UA%' END;
 ]
 ----
 
-.Q{example-counter}B: Covering Array Index using the UNNEST clause and aliasing
-[[Q7B,Q{example-counter}B]]
+.Query C: Covering Array Index using the UNNEST clause and aliasing
+[[Q7B,Query C]]
 [source,N1QL]
 ----
 EXPLAIN SELECT meta(t).id FROM `travel-sample`.inventory.route t
@@ -591,24 +598,24 @@ WHERE v.flight LIKE 'UA%';
 
 [NOTE]
 --
-The <<Q7>> Examples have the following limitation: the collection operator EVERY cannot use array indexes or covering array indexes because the EVERY operator needs to apply the SATISFIES predicate to all elements in the array, including the case where an array has zero elements.
+In this example, <<Q7>> has the following limitation: the collection operator EVERY cannot use array indexes or covering array indexes because the EVERY operator needs to apply the SATISFIES predicate to all elements in the array, including the case where an array has zero elements.
 
 As items cannot be indexed, it is not possible to index MISSING items, so the EVERY operator is evaluated in the N1QL engine and cannot leverage the array index scan.
 
-For example, the following query <<Q7C>> uses the primary index `def_inventory_route_primary` ignoring the {use-index-clause}[USE INDEX hint] to use the array indexes.
-(Note that query <<C7>> defines a DISTINCT array index while <<C7C>> defines an ALL array index, and both are ignored).
+For example, <<Q7C>> below uses the primary index `def_inventory_route_primary` ignoring the {use-index-clause}[USE INDEX hint] to use the array indexes.
+(Note that in this example, <<C7>> defines a DISTINCT array index while <<C7C>> defines an ALL array index, and both are ignored).
 --
 
-.C{counter:example-counter}C: Non-array index with an ALL array index
-[[C7C,C{example-counter}C]]
+.Index II: Non-array index with an ALL array index
+[[C7C,Index II]]
 [source,N1QL]
 ----
 CREATE INDEX idx_sched_cover_all ON `travel-sample`.inventory.route
     (ALL ARRAY v.flight FOR v IN schedule END, schedule);
 ----
 
-.Q{example-counter}C: Non-array index with an ALL array index
-[[Q7C,Q{example-counter}C]]
+.Query D: Non-array index with an ALL array index
+[[Q7C,Query D]]
 [source,N1QL]
 ----
 EXPLAIN SELECT meta().id FROM `travel-sample`.inventory.route
@@ -643,6 +650,7 @@ N1QL supports simplified Implicit Covering Array Index syntax in certain cases w
 This special optimization applies to those queries and DML which have WHERE clause predicates that can be exactly and completely pushed to the indexer during the array index scan.
 For example:
 
+[[example-8]]
 .ANY operator with an =, <, >, and LIKE predicate in the SATISFIES clause
 ====
 Note that the GSI indexes are tree structures that support exact match and range matches.
@@ -650,16 +658,16 @@ And the ANY predicate returns `true` as long as it finds at least one matching i
 Hence, an item found in the index can cover the query.
 Furthermore, this is covered by both ALL and DISTINCT array indexes.
 
-.C{counter:example-counter}: Creating an Implicit Covering Array Index with DISTINCT
-[[C8,C{example-counter}]]
+.Index: Creating an Implicit Covering Array Index with DISTINCT
+[[C8,Index]]
 [source,N1QL]
 ----
 CREATE INDEX idx_sched_cover_simple ON `travel-sample`.inventory.route
     (DISTINCT ARRAY v.flight FOR v IN schedule END);
 ----
 
-.Q{example-counter}: Implicit Covering Array Index using the ANY clause
-[[Q8,Q{example-counter}]]
+.Query: Implicit Covering Array Index using the ANY clause
+[[Q8,Query]]
 [source,N1QL]
 ----
 EXPLAIN SELECT meta().id FROM `travel-sample`.inventory.route
@@ -700,23 +708,24 @@ WHERE ANY v IN schedule SATISFIES v.flight LIKE 'UA%' END;
 ----
 ====
 
+[[example-9]]
 .UNNEST operator with =, <, >, or LIKE predicate in the WHERE clause
 ====
 This applies to only ALL array indexes because, for such index, all array elements are indexed in the array index, and the UNNEST operation needs all the elements to reconstruct the array.
 Note that the array cannot be reconstructed if on DISTINCT elements of the array are indexed.
 
-For example, the following query <<Q8A>> can be covered with the ALL index [.var]`idx_sched_cover_simple_all` in <<C8A>>, but <<Q8B>> is not covered when using the DISTINCT [.var]`index idx_sched_cover_simple` defined in <<C8>>.
+In this example, <<Q8A>> can be covered with the ALL index [.var]`idx_sched_cover_simple_all` defined by the <<C8A>>, but <<Q8B>> is not covered when using the DISTINCT index [.var]`idx_sched_cover_simple` defined by the <<C8>> in <<example-8>>.
 
-.C{counter:example-counter}: UNNEST covered with the ALL index
-[[C8A,C{example-counter}]]
+.Index: UNNEST covered with the ALL index
+[[C8A,Index]]
 [source,N1QL]
 ----
 CREATE INDEX idx_sched_cover_simple_all ON `travel-sample`.inventory.route
     (ALL ARRAY v.flight FOR v IN schedule END);
 ----
 
-.Q{example-counter}A: UNNEST covered with the ALL index
-[[Q8A,Q{example-counter}A]]
+.Query A: UNNEST covered with the ALL index
+[[Q8A,Query A]]
 [source,N1QL]
 ----
 EXPLAIN SELECT meta(t).id FROM `travel-sample`.inventory.route t
@@ -773,8 +782,8 @@ WHERE v.flight LIKE 'UA%';
 ]
 ----
 
-.Q{example-counter}B: UNNEST not covered when using the DISTINCT index
-[[Q8B,Q{example-counter}B]]
+.Query B: UNNEST not covered when using the DISTINCT index
+[[Q8B,Query B]]
 [source,N1QL]
 ----
 EXPLAIN SELECT meta(t).id FROM `travel-sample`.inventory.route t


### PR DESCRIPTION
Reworded so that code listings are no longer referenced using an auto-generated number based on the example number. Examples now have their own IDs. WIthin each example, code listings are referenced using a short title, including a distinguishing letter if necessary, which is hand-generated. References to code listings in other examples include a cross reference to the example.