### PR TITLE
Update eventing-handler-advanced-docControlledSelfExpiry.adoc

### DIFF
--- a/modules/eventing/pages/eventing-handler-advanced-docControlledSelfExpiry.adoc
+++ b/modules/eventing/pages/eventing-handler-advanced-docControlledSelfExpiry.adoc
@@ -6,7 +6,7 @@
 
 *Goal*: {description}
 
-* This function *advancedDocControlledSelfExpiry* demonstrates self-expiry of a document for example a user trial.
+* This function *advancedDocControlledSelfExpiry* demonstrates self-expiry of a document; for example, a user trial.
 * Requires a metadata bucket and a source bucket.
 * The source bucket must be named "source" and the Function needs a bucket alias of "src_bkt" in mode read+write.
 * When documents are created, they will have no expiration value. This function processes the initial mutation to calculate and set the proper TTL.


### PR DESCRIPTION
Fixed grammatically awkward "for example" part of sentence