### PR TITLE
Update eventing-handler-docControlledSelfExpiry.adoc

### DIFF
--- a/modules/eventing/pages/eventing-handler-docControlledSelfExpiry.adoc
+++ b/modules/eventing/pages/eventing-handler-docControlledSelfExpiry.adoc
@@ -33,7 +33,7 @@ WARNING: You must use the function _N1QL(...)_ with great caution when updating 
 docControlledSelfExpiry::
 +
 --
-Two variants of this function are available a 6.6 version (*this Function*) that relies on N1QL and a 6.6.1 version that directly sets the expiration.  
+Two variants of this function are available: a 6.6 version (*this Function*) that relies on N1QL, and a 6.6.1 version that directly sets the expiration.  
 Using _N1QL(...)_ is much slower than using _couchbase.replace(bucket_binding, meta, doc)_ in the advancedDocControlledSelfExpiry variant.
 
 * <<docControlledSelfExpiry,docControlledSelfExpiry (indirect TTL via N1QL)>>


### PR DESCRIPTION
add colon and comma in "two variants" sentence