### PR TITLE
DOC-6649: CE vs EE needs to be clarified for index storage mode

### DIFF
--- a/modules/learn/pages/services-and-indexes/indexes/indexing-and-query-perf.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/indexing-and-query-perf.adoc
@@ -3,22 +3,16 @@
 :page-aliases: performance:indexing-and-query-perf
 
 {description}
-Creating the right index -- with the right keys, in the right order, and using the right expressions -- is critical to query performance in any database system.This is true for Couchbase as well.
+Creating the right index -- with the right keys, in the right order, and using the right expressions -- is critical to query performance in any database system.
+This is true for Couchbase as well.
 
-There are two types of indexes available:
+There are two types of index storage available:
 
 * Standard global secondary index
 * Memory-optimized global secondary index
 
-The standard global secondary index stores uses the ForestDB storage engine to store the B-Tree index and keeps the optimal working set of data in the buffer.
-This means, the total size of the index can be much bigger than the amount of memory available in each index node.
-
-A memory-optimized index uses a lock-free skiplist to maintain the index and keeps all the index data in memory.
-A memory-optimized index has better latency for index scans and processes the mutations of the data much faster.
-
-Both standard and memory-optimized indexes implement multi-version concurrency control (MVCC) to provide consistent index scan results and high throughput.
-
-During cluster installation, you can choose the type of index you'd like to use in the cluster.
+During cluster installation, you can choose the type of index storage you'd like to use in the cluster.
+For more details, refer to xref:learn:services-and-indexes/indexes/storage-modes.adoc[Index Storage Settings].
 
 The examples in this topic use the travel-sample dataset which is shipped with Couchbase Server.
 Ensure that you've installed the travel-sample bucket.

--- a/modules/learn/pages/services-and-indexes/indexes/storage-modes.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/storage-modes.adoc
@@ -52,7 +52,7 @@ _Standard_ is the default storage-setting for Secondary Indexes: the indexes are
 The performance of standard index storage depends on overall I/O performance.
 
 The standard global secondary index uses a B-Tree index and keeps the optimal working set of data in the buffer.
-This means, the total size of the index can be much bigger than the amount of memory available in each index node.
+This means the total size of the index can be much bigger than the amount of memory available in each index node.
 
 ****
 [.edition]#{enterprise}#

--- a/modules/learn/pages/services-and-indexes/indexes/storage-modes.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/storage-modes.adoc
@@ -5,6 +5,8 @@
 [abstract]
 {description}
 
+Both standard and memory-optimized indexes implement multi-version concurrency control (MVCC) to provide consistent index scan results and high throughput.
+
 [#memory-optimized-index-storage]
 == Memory-Optimized Index Storage
 
@@ -12,6 +14,9 @@
 [.edition]#{enterprise}#
 
 Memory-optimized index-storage is supported by the _Nitro_ storage engine, and is only available in Couchbase Server Enterprise Edition.
+
+A memory-optimized index uses a lock-free skiplist to maintain the index and keeps all the index data in memory.
+A memory-optimized index has better latency for index scans and processes the mutations of the data much faster.
 
 Memory-optimized index-storage allows high-speed maintenance and scanning; since the index is kept fully in memory at all times.
 A snapshot of the index is maintained on disk, to permit rapid recovery if node-failures are experienced.
@@ -45,6 +50,9 @@ For information on these settings, see xref:services-and-indexes/indexes/index-r
 
 _Standard_ is the default storage-setting for Secondary Indexes: the indexes are saved on disk; in a disk-optimized format that uses both memory and disk for index-update and scanning.
 The performance of standard index storage depends on overall I/O performance.
+
+The standard global secondary index uses a B-Tree index and keeps the optimal working set of data in the buffer.
+This means, the total size of the index can be much bigger than the amount of memory available in each index node.
 
 ****
 [.edition]#{enterprise}#


### PR DESCRIPTION
The following draft documentation is ready for review:

* [Indexing and Query Performance](https://github.com/couchbase/docs-server/blob/f63524b0396cfa8ea09b444c65c34926bb2fbb63/modules/learn/pages/services-and-indexes/indexes/indexing-and-query-perf.adoc) — removed misleading information on index storage
* [Storage Settings](https://github.com/couchbase/docs-server/blob/f63524b0396cfa8ea09b444c65c34926bb2fbb63/modules/learn/pages/services-and-indexes/indexes/storage-modes.adoc) — added information on b-tree, skiplist, and multi-version concurrency control

Docs issue: [DOC-6649](https://issues.couchbase.com/browse/DOC-6649)