### PR TITLE
DOC-8378: Primary index doesn't include transactional documents

### DIFF
--- a/modules/learn/pages/services-and-indexes/indexes/indexing-and-query-perf.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/indexing-and-query-perf.adoc
@@ -2,6 +2,12 @@
 :description: This topic provides an overview of the indexing options for JSON in Couchbase, which in turn would help query for data efficiently and improve query performance.
 :page-aliases: performance:indexing-and-query-perf
 
+// Cross-references
+:install-sample-buckets: xref:manage:manage-settings/install-sample-buckets.adoc
+:aggregatefun: xref:n1ql:n1ql-language-reference/aggregatefun.adoc
+:bucket-analyzer: xref:tools:query-workbench.adoc#bucket-analyzer
+:additional-storage-use: xref:learn:data/transactions.adoc#additional-storage-use
+
 {description}
 Creating the right index -- with the right keys, in the right order, and using the right expressions -- is critical to query performance in any database system.
 This is true for Couchbase as well.
@@ -16,7 +22,7 @@ For more details, refer to xref:learn:services-and-indexes/indexes/storage-modes
 
 The examples in this topic use the travel-sample dataset which is shipped with Couchbase Server.
 Ensure that you've installed the travel-sample bucket.
-For instructions on how to install the sample bucket, see xref:manage:manage-settings/install-sample-buckets.adoc[Sample Buckets].
+For instructions on how to install the sample bucket, see {install-sample-buckets}[Sample Buckets].
 
 Couchbase Server is a distributed database that supports flexible data model using JSON.
 Each document in a keyspace has a user-generated unique document key and this uniqueness is enforced when inserting data into the keyspace.
@@ -67,6 +73,10 @@ CREATE PRIMARY INDEX ON `travel-sample`.inventory.airline;
 The Couchbase data layer enforces the uniqueness constraint on the document key.
 The primary index, like every other index, is maintained asynchronously.
 Use the primary index for full keyspace scans (primary scans) when the query does not have any filters (predicates) or when no other index or access path can be used.
+
+NOTE: A primary index does not index any {additional-storage-use}[transaction records] that may be stored in a keyspace.
+This means that if you are counting the number of documents in a keyspace, you may see slightly different results, depending on whether you are using a primary index or not.
+Refer to {aggregatefun}[Aggregate Functions] and {bucket-analyzer}[Viewing the Data Insights].
 
 .Metadata for Primary Index
 ====

--- a/modules/learn/pages/services-and-indexes/indexes/indexing-and-query-perf.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/indexing-and-query-perf.adoc
@@ -8,9 +8,9 @@
 :bucket-analyzer: xref:tools:query-workbench.adoc#bucket-analyzer
 :additional-storage-use: xref:learn:data/transactions.adoc#additional-storage-use
 
-{description}
 Creating the right index -- with the right keys, in the right order, and using the right expressions -- is critical to query performance in any database system.
 This is true for Couchbase as well.
+{description}
 
 There are two types of index storage available:
 

--- a/modules/n1ql/pages/n1ql-language-reference/aggregatefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/aggregatefun.adoc
@@ -6,6 +6,15 @@
 :window-definition: {window}#window-definition
 :groupby: xref:n1ql-language-reference/groupby.adoc
 :windowfun: xref:n1ql-language-reference/windowfun.adoc
+:additional-storage-use: xref:learn:data/transactions.adoc#additional-storage-use
+
+// Footnotes
+:doc-count: When counting all the documents within a collection, this function usually relies on the collection statistics, which include any {additional-storage-use}[transaction records] that may be stored in that collection. \
+However, if the query performs an index scan using the primary index on that collection, counting all documents does not include any transaction records.
+ifeval::["{asciidoctor-version}" < "2.0.0"]
+:doc-count: When counting all the documents within a collection, this function usually relies on the collection statistics, which include any {additional-storage-use}[transaction records\] that may be stored in that collection. \
+However, if the query performs an index scan using the primary index on that collection, counting all documents does not include any transaction records.
+endif::[]
 
 Aggregate functions take multiple values from documents, perform calculations, and return a single value as the result.
 The function names are case insensitive.
@@ -183,7 +192,7 @@ SELECT AVG(DISTINCT stops) FROM `travel-sample`.inventory.route; <2>
 == COUNT(*)
 
 === Return Value
-Returns count of all the input rows for the group, regardless of value.
+Returns count of all the input rows for the group, regardless of value. footnote:count[{doc-count}]
 
 === Example
 ====
@@ -209,7 +218,7 @@ SELECT COUNT(*) AS CountAll FROM `travel-sample`.inventory.landmark;
 == [[count_distinct]]COUNT( {startsb} ALL | DISTINCT {endsb} `expression`)
 
 === Return Value
-With the `ALL` quantifier, or no quantifier, returns count of all the non-NULL and non-MISSING values in the group.
+With the `ALL` quantifier, or no quantifier, returns count of all the non-NULL and non-MISSING values in the group. footnote:count[]
 
 With the `DISTINCT` quantifier, returns count of all the distinct non-NULL and non-MISSING values in the group.
 
@@ -258,7 +267,7 @@ SELECT COUNT(DISTINCT stops) AS CountOfDistinctStops FROM `travel-sample`.invent
 == COUNTN( {startsb} ALL {vbar} DISTINCT {endsb} `expression` )
 
 === Return Value
-With the `ALL` quantifier, or no quantifier, returns a count of all the numeric values in the group.
+With the `ALL` quantifier, or no quantifier, returns a count of all the numeric values in the group. footnote:count[]
 
 With the `DISTINCT` quantifier, returns a count of all the distinct numeric values in the group.
 

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -79,7 +79,7 @@
 :n1ql-rest-api-admin: xref:n1ql:n1ql-rest-api/admin.adoc
 :n1ql-rest-api-index: xref:n1ql:n1ql-rest-api/index.adoc
 :cbq-shell: xref:tools:cbq-shell.adoc
-:transactions-understanding-transactions: xref:learn:data/transactions.adoc#understanding-transactions
+:transactions-understanding-transactions: xref:learn:data/transactions.adoc#additional-storage-use
 :prepare-auto-execute: xref:n1ql:n1ql-language-reference/prepare.adoc#auto-execute
 :flex-indexes: xref:n1ql:n1ql-language-reference/flex-indexes.adoc
 :rest-intro: xref:rest-api:rest-intro.adoc

--- a/modules/tools/pages/query-workbench.adoc
+++ b/modules/tools/pages/query-workbench.adoc
@@ -1,5 +1,5 @@
 = Query Workbench
-:description: pass:q[The [.ui]*Query Workbench* provides a rich graphical user interface to perform query development.]
+:description: The Query Workbench provides a rich graphical user interface to perform query development.
 :page-aliases: developer-guide:query-workbench-intro
 :imagesdir: ../assets/images
 
@@ -22,6 +22,15 @@
 :timeout_req: xref:settings:query-settings.adoc#timeout_req
 :txtimeout_req: xref:settings:query-settings.adoc#txtimeout_req
 :query_context: xref:settings:query-settings.adoc#query_context
+:additional-storage-use: xref:learn:data/transactions.adoc#additional-storage-use
+
+// Footnotes
+:doc-count: If there is no primary index on a collection, the count of documents within the collection includes any {additional-storage-use}[transaction records] that may be stored in that collection. \
+However, if there is a primary index on the collection, the count of documents does not include transaction records.
+ifeval::["{asciidoctor-version}" < "2.0.0"]
+:doc-count: f there is no primary index on a collection, the count of documents within the collection includes any {additional-storage-use}[transaction records\] that may be stored in that collection. \
+However, if there is a primary index on the collection, the count of documents does not include transaction records.
+endif::[]
 
 [abstract]
 {description}
@@ -310,7 +319,7 @@ Similarly, when you expand a scope, the collections within that scope are displa
 
 The number of collections within the bucket is displayed to the right of the bucket heading.
 Similarly, the number of documents within a collection is displayed to the right of the collection heading.
-You may need to refresh the [.ui]*Data Insights* area to see these figures.
+You may need to refresh the [.ui]*Data Insights* area to see these figures. footnote:[{doc-count}]
 
 image::query-workbench-insights-keyspaces.png["Hierarchy of bucket, scopes, and collections in the Data Insights area"]
 

--- a/modules/tools/pages/query-workbench.adoc
+++ b/modules/tools/pages/query-workbench.adoc
@@ -28,7 +28,7 @@
 :doc-count: If there is no primary index on a collection, the count of documents within the collection includes any {additional-storage-use}[transaction records] that may be stored in that collection. \
 However, if there is a primary index on the collection, the count of documents does not include transaction records.
 ifeval::["{asciidoctor-version}" < "2.0.0"]
-:doc-count: f there is no primary index on a collection, the count of documents within the collection includes any {additional-storage-use}[transaction records\] that may be stored in that collection. \
+:doc-count: If there is no primary index on a collection, the count of documents within the collection includes any {additional-storage-use}[transaction records\] that may be stored in that collection. \
 However, if there is a primary index on the collection, the count of documents does not include transaction records.
 endif::[]
 


### PR DESCRIPTION
The following draft documentation is ready for review:

* [Indexing and Query Performance › Primary Index][1] — added note about transactional records
* [Query Workbench › Viewing the Data Insights][2] — added footnote about transactional records
* [Aggregate Functions › COUNT(*)][3], [COUNT()][4], and [COUNTN()][5] — added footnote about transactional records

Docs issue: [DOC-8378](https://issues.couchbase.com/browse/DOC-8378)

[1]: https://docs-staging.couchbase.com/server/7.0/learn/services-and-indexes/indexes/indexing-and-query-perf.html#primary-index
[2]: https://docs-staging.couchbase.com/server/7.0/tools/query-workbench.html#bucket-analyzer
[3]: https://docs-staging.couchbase.com/server/7.0/n1ql/n1ql-language-reference/aggregatefun.html#count_all
[4]: https://docs-staging.couchbase.com/server/7.0/n1ql/n1ql-language-reference/aggregatefun.html#count
[5]: https://docs-staging.couchbase.com/server/7.0/n1ql/n1ql-language-reference/aggregatefun.html#countn