### PR TITLE
Correcting cbq shell login command

### DIFF
--- a/modules/install/pages/getting-started-docker.adoc
+++ b/modules/install/pages/getting-started-docker.adoc
@@ -59,10 +59,10 @@ bash -c "clear && docker exec -it db sh"
 # cd /opt/couchbase/bin
 ----
 
-. Run the [.cmd]`cbq` command line tool:
+. Run the [.cmd]`cbq` command line tool providing accessing query engine at port 8093 using credentials:
 +
 ----
-# ./cbq
+# ./cbq -u username -p password -engine=http://127.0.0.1:8093/
 ----
 
 . Execute a N1QL query on the `beer-sample` bucket:


### PR DESCRIPTION
If only '**./cbq'** command is executed inside container then below error is coming :

```
root@8867902b6f91:/opt/couchbase/bin# ./cbq
 No input credentials. In order to connect to a server with authentication, please provide credentials.
 ERROR 100 : N1QL: Connection failure Requested resource not found.

 Path to history file for the shell : /root/.cbq_history
cbq> SELECT name FROM `beer-sample` WHERE  brewery_id ="mishawaka_brewing";
 ERROR 107 : Not connected to any cluster. Use \CONNECT command.
```


**To fix this used below command to login query service** : 
./cbq -u username -p password -engine=http://127.0.0.1:8093/

**When using above command, able to query successfully** : 
```
cbq> root@8867902b6f91:/opt/couchbase/bin# ./cbq -u arpit -p pass1234 -engine=http://127.0.0.1:8093/
 Connected to : http://127.0.0.1:8093/. Type Ctrl-D or \QUIT to exit.

 Path to history file for the shell : /root/.cbq_history
cbq> SELECT name FROM `beer-sample` WHERE  brewery_id ="mishawaka_brewing";
{
    "requestID": "3d6e69f0-f365-4273-a6c7-5e7a9c219ed9",
    "signature": {
        "name": "json"
    },
    "results": [
    {
        "name": "Four Horsemen Ale"
    },
    {
        "name": "INDIAna Pale Ale"
    },
    {
        "name": "Kolsch"
    },
    {
        "name": "Lake Effect Pale Ale"
    },
    {
        "name": "Raspberry Wheat Ale"
    },
    {
        "name": "Wall Street Wheat Ale"
    }
    ],
    "status": "success",
    "metrics": {
        "elapsedTime": "398.087893ms",
        "executionTime": "397.962056ms",
        "resultCount": 6,
        "resultSize": 255
    }
}
cbq>
```