### PR TITLE
DOC-8644: correction for Standard GSI

### DIFF
--- a/modules/learn/pages/services-and-indexes/services/index-service.adoc
+++ b/modules/learn/pages/services-and-indexes/services/index-service.adoc
@@ -38,11 +38,17 @@ Each index is created on one keyspace (collection) only; but multiple indexes ma
 The Index Service can be configured to use either _standard_ or _memory-optimized_ storage:
 
 Standard::
+
 The supervisor process persists to disk all changes made to individual indexes.
-Each index gets a dedicated file.
+
 * In Couchbase Server Community Edition, writes can either be _append-only_ or _write with circular reuse_, depending on the write mode selected for global secondary indexes.
+Each index gets a dedicated file.
+
 * In Couchbase Server Enterprise Edition, compaction is handled automatically.
+As of Couchbase Server 7.0, multiple indexes are stored in a given file.
+
 Memory-Optimized::
+
 Only available in Couchbase Server Enterprise Edition.
 Indexes are saved in-memory.
 This provides increased efficiency for maintenance, scanning, and mutation.


### PR DESCRIPTION
The following draft documentation is ready for review:

* [Index Service › Saving Indexes](https://docs-staging.couchbase.com/server/7.0/learn/services-and-indexes/services/index-service.html#saving-indexes) — In EE 7.0 standard GSI stores multiple indexes in a given file

Docs issue: [DOC-8644](https://issues.couchbase.com/browse/DOC-8644)