### PR TITLE
DOC-7926: Memory quota for query needs update

### DIFF
--- a/modules/n1ql/pages/n1ql-rest-api/index.adoc
+++ b/modules/n1ql/pages/n1ql-rest-api/index.adoc
@@ -1,7 +1,9 @@
 = N1QL REST API
 :page-topic-type: concept
+:request-parameters: xref:settings:query-settings.adoc#section_nnj_sjk_k1b
 
-[abstract]
+== Overview
+
 N1QL provides a REST API to enable clients to execute N1QL statements.
 The REST API runs synchronously, so once execution of the statement in the request is started, results are streamed back to the client, terminating when execution of the statement finishes.
 In this section, you will find information about the REST endpoints, request and response parameters, and examples.
@@ -15,7 +17,7 @@ where [.var]`node` is the host name or IP address of a computer running the N1QL
 
 The N1QL REST API query service allows you to execute a N1QL statement.
 
-See  xref:n1ql-rest-api/examplesrest.adoc[Examples] for REST API samples.
+See xref:n1ql-rest-api/examplesrest.adoc[Examples] for REST API samples.
 
 == Request specification
 
@@ -35,8 +37,8 @@ POST /query/service
 
 === Request parameters
 
-For a table of request parameters that can be passed in a request to the /query/service endpoint with examples, see
-xref:settings:query-settings.adoc#section_nnj_sjk_k1b[Request-Level Parameters].
+For a table of request parameters that can be passed in a request to the `/query/service` endpoint with examples, see
+{request-parameters}[Request-Level Parameters].
 
 === Named parameters
 
@@ -215,16 +217,14 @@ For URL-encoded parameters, the format is consistent with the syntax for variabl
 
 == Response
 
-This section has two subsections: Response HTTP Status Codes and Response Body.
+This section describes the response HTTP status codes.
 
-=== Response HTTP status code
-
-==== Normal status code
+=== Normal status code
 
 200 OK:: The request completed with or without errors.
 Any errors or warnings that occurred during the request will be in the response body.
 
-==== Possible error codes
+=== Possible error codes
 
 400 Bad Request:: The request cannot be processed for one of the following reasons:
 +
@@ -252,184 +252,208 @@ Previously made requests are being completed, but no new requests are being acce
 
 503 Service Unavailable:: There is an issue (that is possibly temporary) preventing the request being processed; the request queue is full or the data store is not accessible.
 
+== Definitions
+
+This section describes the properties returned by this REST API.
+
+[[response-body]]
 === Response body
 
 The response body has the following structure:
 
-[source,json]
-----
-{
-"requestID": UUID,
-"clientContextID": string,
-"signature":
-{
-	*.* |
-	( field_name:    field_type,
-	...
-	)
-	},
-
-"results":
-	[
-	json_value,
-	...
-	],
-"errors":
-	[
-	{ "code": int, "msg":  string }, ...
-	],
-"warnings":
-	[
-	{ "code": int, "msg": string }, …
-	],
-"status":  "success",
-"metrics":
-	{
-	"elapsedTime": string,
-	"executionTime": string,
-	"resultCount": unsigned int,
-	"resultSize": unsigned int,
-	"mutationCount": unsigned int,
-	"sortCount": unsigned int,
-	"errorCount": unsigned int,
-	"warningCount": unsigned int
-	}
-}
-----
-
-[cols="35,20,45"]
+[options="header", cols=".<3a,.<11a,.<4a"]
 |===
-| `requestID`
-| UUID
+|Name|Description|Schema
+
+| **requestID**
 | A unique identifier for the response.
+| string (UUID)
 
-| `clientContextID`
+| **clientContextID** +
+__Optional__
+| The client context ID of the request, if one was supplied -- see `client_context_id` in {request-parameters}[Request parameters].
 | string
-| The clientContextID of the request, if one was supplied (see client_context _id in Request Parameters).
 
-| `signature`
-| object
+| **signature** +
+__Optional__
 | The schema of the results.
 Present only when the query completes successfully.
 
-| `results`
-| list
-| A list of all the objects returned by the query.
-An object can be any JSON value.
-
-| `status`
-| enum
-| The status of the request.
-Possible values are: success, running, errors, completed, stopped, timeout, fatal.
-
-| `errors`
-| list
-| A list of 0 or more error objects.
-If an error occurred during processing of the request, it will be represented by an error object in this list.
-
-| `error.code`
-| int
-| A number that identifies the error.
-
-| `error.msg`
-| string
-| A message describing the error in detail.
-
-| `warnings`
-| list
-| A list of 0 or more warning objects.
-If a warning occurred during processing of the request, it is represented by a warning object in this list.
-
-| `warning.code`
-| int
-| A number that identifies the warning.
-
-| `warning.msg`
-| string
-| A message describing the warning in full.
-
-| `metrics`
+.Examples
+`{asterisk}.{asterisk}` +
+`field_name: field_type, ...`
 | object
+
+| **results**
+| An array of all the objects returned by the query.
+An object can be any JSON value.
+| [ object ] array
+
+| **status**
+| The status of the request.
+| enum (success, running, errors, completed, stopped, timeout, fatal)
+
+| **errors** +
+__Optional__
+| An array of 0 or more error objects.
+If an error occurred during processing of the request, it will be represented by an error object in this list.
+| [ <<request-error-and-warning-format>> ] array
+
+| **warnings** +
+__Optional__
+| An array of 0 or more warning objects.
+If a warning occurred during processing of the request, it is represented by a warning object in this list.
+| [ <<request-error-and-warning-format>> ] array
+
+| **metrics**
 | An object containing metrics about the request.
+| <<metrics>>
 
-| `metrics.elapsedTime`
-| string
-| The total time taken for the request, that is the time from when the request was received until the results were returned.
-
-| `metrics.executionTime`
-| string
-| The time taken for the execution of the request, that is the time from when query execution started until the results were returned.
-
-| `metrics.resultCount`
-| unsigned int
-| The total number of objects in the results.
-
-| `metrics.resultSize`
-| unsigned int
-| The total number of bytes in the results.
-
-| `metrics.mutationCount`
-| unsigned int
-| The number of mutations that were made during the request.
-
-| `metrics.sortCount`
-| unsigned int
-| The number of objects that were sorted.
-Present only if the request includes ORDER BY.
-
-If a query includes ORDER BY, LIMIT, or OFFSET clauses, an application can use the `sortCount` value to give the overall number of results in a message such as "[.out]``page 1 of N``".
-
-| `metrics.errorCount`
-| unsigned int
-| The number of errors that occurred during the request.
-
-| `metrics.warningCount`
-| unsigned int
-| The number of warnings that occurred during the request.
+| **controls** +
+__Optional__
+| An object containing runtime information provided along with the request.
+Present only if `controls` was set to true in the {request-parameters}[Request parameters].
+| <<controls>>
 |===
 
-== Request error and warning format
+[[request-error-and-warning-format]]
+=== Conditions
 
 Errors and warnings have the following format:
 
-[source,json]
-----
-{
-	"code" : int,
-	"msg" : string,
-	"name": string,
-	"sev" : int,
-	"temp" : bool
-}
-----
+[options="header", cols=".<3a,.<11a,.<4a"]
+|===
+|Name|Description|Schema
 
-code:: A unique number for the error or warning.
+| **code** +
+__Required__
+| A unique number that identifies the error or warning.
 The code ranges are partitioned by component.
 The codes can also include parts that indicate severity and transience.
-*code* is always present in every condition returned in the Query REST API or captured in a log.
+This property is always present in every condition returned in the Query REST API or captured in a log.
+| integer
 
-msg:: A detailed description of the condition.
-*msg* is always present in every condition returned in the Query REST API or captured in a log.
+| **msg** +
+__Required__
+| A message describing the error or warning in detail.
+This property is always present in every condition returned in the Query REST API or captured in a log.
+| string
 
-The following elements are optional and can be present in a condition returned in the Query REST API or captured in a log.
-Additional elements not listed here might also be present.
-Clients and consumers of the REST API or the logs must accommodate any additional elements.
-
-name:: Unique name that has a 1:1 mapping to the *code*.
+| **name** +
+__Optional__
+| Unique name that has a 1:1 mapping to the *code*.
 Uniquely identifies the condition.
-*name* is helpful for pattern matching and can have meaning making it more memorable than the code).
+This property is helpful for pattern matching and can have meaning, making it more memorable than the code.
 The name should be fully qualified.
-Here are some examples:
-+
-* `indexing.scan.io_failure`
-* `query.execute.index_not_found`
 
-sev:: One of the following N1QL severity levels (listed in order of severity):
-+
+.Examples
+`indexing.scan.io_failure` +
+`query.execute.index_not_found`
+| string
+
+| **sev** +
+__Optional__
+| One of the following N1QL severity levels, listed in order of severity:
+
 . Severe
 . Error
 . Warn
 . Info
+| integer
 
-temp:: Indicates if the condition is transient (for example, the queue is full).
+| **temp** +
+__Optional__
+| Indicates if the condition is transient -- for example, the queue is full.
 If the value is *false*, it tells clients and users that a retry without modification produces the same condition.
+| boolean
+|===
+
+Additional elements not listed here might also be present.
+Clients and consumers of the REST API or the logs must accommodate any additional elements.
+
+[[metrics]]
+=== Metrics
+
+[options="header", cols=".<3a,.<11a,.<4a"]
+|===
+|Name|Description|Schema
+
+| **elapsedTime**
+| The total time taken for the request, that is the time from when the request was received until the results were returned.
+| string
+
+| **executionTime**
+| The time taken for the execution of the request, that is the time from when query execution started until the results were returned.
+| string
+
+| **resultCount**
+| The total number of objects in the results.
+| integer (unsigned)
+
+| **resultSize**
+| The total number of bytes in the results.
+| integer (unsigned)
+
+| **mutationCount** +
+__Optional__
+| The number of mutations that were made during the request.
+| integer (unsigned)
+
+| **sortCount** +
+__Optional__
+| The number of objects that were sorted.
+Present only if the request includes ORDER BY.
+
+If a query includes ORDER BY, LIMIT, or OFFSET clauses, an application can use the `sortCount` value to give the overall number of results in a message such as "[.out]``page 1 of N``".
+| integer (unsigned)
+
+| **usedMemory** +
+__Optional__
+| The amount of document memory used to execute the request.
+This property is only returned if a memory quota was set for the query.
+| integer (unsigned)
+
+| **errorCount** +
+__Optional__
+| The number of errors that occurred during the request.
+| integer (unsigned)
+
+| **warningCount** +
+__Optional__
+| The number of warnings that occurred during the request.
+| integer (unsigned)
+|===
+
+Additional elements not listed here might also be present.
+Clients and consumers of the REST API or the logs must accommodate any additional elements.
+
+[[controls]]
+=== Controls
+
+[options="header", cols=".<3a,.<11a,.<4a"]
+|===
+|Name|Description|Schema
+
+| **scan_consistency**
+| The value of the query setting Scan Consistency used for the query.
+| string
+
+| **use_cbo**
+| Whether the cost-based optimizer was enabled for the query.
+| boolean
+
+| **memoryQuota**
+| The memory quota for the request, in MB.
+This property is only returned if a memory quota was set for the query.
+| integer (unsigned)
+
+| **stmtType**
+| The type of query statement.
+
+.Example
+`SELECT`
+| string
+|===
+
+Additional elements not listed here might also be present.
+Clients and consumers of the REST API or the logs must accommodate any additional elements.

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -705,9 +705,10 @@ $ curl http://localhost:8093/query/service -u user:pword -d 'statement=select * 
 | [[memory_quota_req]]
 **memory_quota** +
 __Optional__
-| Specifies the maximum document memory consumption for the query, in MB.
+| Specifies the maximum amount of memory the request may use, in MB.
 
-Specify `0` (the default value) to disable. When disabled, there is no quota.
+Specify `0` (the default value) to disable.
+When disabled, there is no quota.
 
 Within a transaction, this parameter enforces the memory quota for the transaction.
 The transaction memory quota tracks only the delta table and the transaction log (approximately).


### PR DESCRIPTION
The following draft documentation is ready for review:

* Settings and Parameters — Improve explanation of [queryMemoryQuota][1], [memory-quota][2] and [memory_quota][3]
* Explain [servicers][4] default and the overall node memory
* [Query Service API][6] — add `metrics.usedMemory`, `controls.memoryQuota` and `controls.use_cbo` to response body
* [Query Admin API][7] — Add `usedMemory`, `memoryQuota` and `useCBO` to Request reponses

Docs issue: [DOC-7926](https://issues.couchbase.com/browse/DOC-7926)

[1]: https://docs-staging.couchbase.com/server/7.0/settings/query-settings.html#queryMemoryQuota
[2]: https://docs-staging.couchbase.com/server/7.0/settings/query-settings.html#memory-quota-srv
[3]: https://docs-staging.couchbase.com/server/7.0/settings/query-settings.html#memory_quota_req
[4]: https://docs-staging.couchbase.com/server/7.0/settings/query-settings.html#servicers
[6]: https://docs-staging.couchbase.com/server/7.0/n1ql/n1ql-rest-api/index.html#definitions
[7]: https://docs-staging.couchbase.com/server/7.0/n1ql/n1ql-rest-api/admin.html#_requests
