### PR TITLE
DOC-8628: Update Cheshire Cat Index issues after QE

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
@@ -27,12 +27,14 @@ Benefits of a partitioned index include:
 
 For example, the following statement creates an index partitioned by the document ID:
 
+====
 [source,n1ql]
 ----
 CREATE INDEX idx ON `travel-sample`.inventory.airline
 (country, name, id)
  PARTITION BY HASH(META().id);
 ----
+====
 
 Partitioned indexes are displayed in the Couchbase Web Console with a `partitioned` indicator:
 
@@ -44,10 +46,12 @@ For further details, refer to xref:manage:manage-indexes/manage-indexes.adoc[Man
 
 [subs="normal"]
 ----
-create-index ::= CREATE INDEX __index-name__ ON <<keyspace-ref>> '(' <<index-key>> [ <<index-order>> ] [ ',' <<index-key>> [ <<index-order>> ] ]* ')' [ <<index-partition>> ] [ <<where-clause>> ] [ <<index-using>> ] [ <<index-with>> ]
+create-index ::= CREATE INDEX __index-name__ ON <<keyspace-ref>>
+                 '(' <<index-key>> [ <<index-order>> ] [ ',' <<index-key>> [ <<index-order>> ] ]* ')'
+                 [ <<index-partition>> ] [ <<where-clause>> ] [ <<index-using>> ] [ <<index-with>> ]
 ----
 
-image::n1ql-language-reference/create-partitioned-index-syntax.png["'CREATE' 'INDEX' index-name 'ON' keyspace-ref '(' index-key index-order? ( ',' index-key index-order? )* ')' index-partition? where-clause? index-using? index-with?"]
+image::n1ql-language-reference/create-partitioned-index-syntax.png["'CREATE' 'INDEX' index-name 'ON' keyspace-ref '(' index-key index-order? ( ',' index-key index-order? )* ')' index-partition? where-clause? index-using? index-with?",align=left]
 
 _index-name_::
 {identifiers}[Identifier] representing the name of your index.
@@ -61,21 +65,21 @@ The partitioned index name must be unique within a keyspace or bucket.
 keyspace-ref ::= <<keyspace-path>> | <<keyspace-partial>>
 ----
 
-image::n1ql-language-reference/keyspace-ref.png["keyspace-path | keyspace-partial"]
+image::n1ql-language-reference/keyspace-ref.png["keyspace-path | keyspace-partial",align=left]
 
 [#keyspace-path,reftext="keyspace-path",subs="normal"]
 ----
 keyspace-path ::= [ {logical-hierarchy}[namespace] ':' ] {logical-hierarchy}[bucket] [ '.' {logical-hierarchy}[scope] '.' {logical-hierarchy}[collection] ]
 ----
 
-image::n1ql-language-reference/keyspace-path.png["( namespace ':' )? bucket ( '.' scope '.' collection )?"]
+image::n1ql-language-reference/keyspace-path.png["( namespace ':' )? bucket ( '.' scope '.' collection )?",align=left]
 
 [#keyspace-partial,reftext="keyspace-partial",subs="normal"]
 ----
 keyspace-partial ::= {logical-hierarchy}[collection]
 ----
 
-image::n1ql-language-reference/keyspace-partial.png["collection"]
+image::n1ql-language-reference/keyspace-partial.png["collection",align=left]
 
 The simple name or fully-qualified name of the keyspace on which to create the index.
 Refer to the {keyspace-ref}[CREATE INDEX] statement for details of the syntax.
@@ -88,7 +92,7 @@ Refer to the {keyspace-ref}[CREATE INDEX] statement for details of the syntax.
 index-key ::= __expr__
 ----
 
-image::n1ql-language-reference/cond.png["expr"]
+image::n1ql-language-reference/cond.png["expr",align=left]
 
 _expr_::
 A {expression}[N1QL expression] over any fields in the document.
@@ -101,7 +105,7 @@ A {expression}[N1QL expression] over any fields in the document.
 index-order ::= ASC | DESC
 ----
 
-image::n1ql-language-reference/index-order.png["'ASC' | 'DESC'"]
+image::n1ql-language-reference/index-order.png["'ASC' | 'DESC'",align=left]
 
 Specifies the sort order of the index key.
 
@@ -121,7 +125,7 @@ This clause is optional; if omitted, the default is `ASC`.
 index-partition ::= PARTITION BY HASH '(' __partition-key-expr__ [ ',' __partition-key-expr__ ] * ')'
 ----
 
-image::n1ql-language-reference/index-partition.png["'PARTITION' 'BY' 'HASH' '(' partition-key-expr ( ',' partition-key-expr )* ')'"]
+image::n1ql-language-reference/index-partition.png["'PARTITION' 'BY' 'HASH' '(' partition-key-expr ( ',' partition-key-expr )* ')'",align=left]
 
 _partition-key-expr_::
 A field or an expression over a field representing a partition key.
@@ -135,7 +139,7 @@ For details and examples, refer to <<partition-keys>>.
 where-clause ::= WHERE _cond_
 ----
 
-image::n1ql-language-reference/where-clause.png["'WHERE' cond"]
+image::n1ql-language-reference/where-clause.png["'WHERE' cond",align=left]
 
 _cond_::
 Specifies WHERE clause predicates to qualify the subset of documents to include in the index.
@@ -148,7 +152,7 @@ Specifies WHERE clause predicates to qualify the subset of documents to include 
 index-using ::= USING GSI
 ----
 
-image::n1ql-language-reference/index-using.png["'USING' 'GSI'"]
+image::n1ql-language-reference/index-using.png["'USING' 'GSI'",align=left]
 
 The index type for a partitioned index must be Global Secondary Index (GSI).
 The `USING GSI` keywords are optional and may be omitted.
@@ -161,7 +165,7 @@ The `USING GSI` keywords are optional and may be omitted.
 index-with ::= WITH __expr__
 ----
 
-image::n1ql-language-reference/index-with.png["'WITH' expr"]
+image::n1ql-language-reference/index-with.png["'WITH' expr",align=left]
 
 Use the WITH clause to specify additional options.
 
@@ -667,7 +671,7 @@ Any new query requests requiring the lost partition are then serviced by the par
 
 When new index nodes are added or removed from the cluster, the rebalance operation attempts to move the index partitions across available index nodes in order to balance resource consumptions.
 At the time of rebalancing, the rebalance operation gathers statistics from each index.
-These statistics are fed to an optimization algorithm to  determine the possible placement of each partition in order to minimize the variation of resource consumption across index nodes.
+These statistics are fed to an optimization algorithm to determine the possible placement of each partition in order to minimize the variation of resource consumption across index nodes.
 
 The rebalancer will only attempt to balance resource consumption on a best try basis.
 There are situations where the resource consumption cannot be fully balanced.

--- a/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
@@ -25,6 +25,21 @@ Benefits of a partitioned index include:
 * Provides a low-latency range query while allowing indexes to be scaled out as needed.
 --
 
+For example, the following statement creates an index partitioned by the document ID:
+
+[source,n1ql]
+----
+CREATE INDEX idx ON `travel-sample`.inventory.airline
+(country, name, id)
+ PARTITION BY HASH(META().id);
+----
+
+Partitioned indexes are displayed in the Couchbase Web Console with a `partitioned` indicator:
+
+image::manage:manage-indexes/index-indicators.png[]
+
+For further details, refer to xref:manage:manage-indexes/manage-indexes.adoc[Manage Indexes].
+
 == Syntax
 
 [subs="normal"]

--- a/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
@@ -1,6 +1,7 @@
 = Index Partitioning
 :page-edition: Enterprise Edition
 :imagesdir: ../../assets/images
+:description: Index Partitioning enables you to increase aggregate query performance by dividing and spreading a large index of documents across multiple nodes, horizontally scaling out an index as needed.
 
 :expression: xref:n1ql-language-reference/index.adoc
 :logical-hierarchy: xref:n1ql-intro/sysinfo.adoc#logical-hierarchy
@@ -11,8 +12,7 @@
 :index-with: {createindex}#index-with
 :rebalancing-the-index-service: xref:learn:clusters-and-availability/rebalance.adoc#rebalancing-the-index-service
 
-[abstract]
-Index Partitioning enables you to increase aggregate query performance by dividing and spreading a large index of documents across multiple nodes, horizontally scaling out an index as needed.
+{description}
 The system partitions the index across a number of index nodes using a hash partitioning strategy in a way that is transparent to queries.
 
 [#idx-partition-intro]


### PR DESCRIPTION
The following draft documentation is ready for review:

* [Index Partitioning][1] — added initial example

Docs issue: [DOC-8628](https://issues.couchbase.com/browse/DOC-8628)

[1]: https://docs-staging.couchbase.com/server/7.0/n1ql/n1ql-language-reference/index-partitioning.html