### PR TITLE
DOC-8060: Update server examples with scopes and collections — settings and tools

### DIFF
--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -1799,7 +1799,7 @@ SELECT callsign from `travel-sample`.inventory.airline LIMIT 3;
 \HELP;
 ----
 
-To execute the commands contained in [.path]_sample.txt_ using the -f option run `$./cbq -f=sample.txt`
+To execute the commands contained in [.path]_sample.txt_ using the -f option, run `$./cbq -f=sample.txt`
 
 .Results
 [source,console]

--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -92,7 +92,7 @@ You can use the [.param]`--script` option to execute a single N1QL query and exi
 
 [source,console]
 ----
-$ cbq -u Administrator -p password -e "http://localhost:8091" \
+$ ./cbq -u Administrator -p password -e "http://localhost:8091" \
 --script="SELECT * FROM \`travel-sample\`.inventory.airline LIMIT 1;"
 ----
 

--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -1203,14 +1203,14 @@ If your keyspace has a password, you can pass the keyspace name and keyspace pas
 
 [source,console]
 ----
-$ ./cbq -engine="http://<keyspacename>:<keyspacepassword>@1localhost:8091/"
+$ ./cbq -engine="http://<keyspacename>:<keyspacepassword>@localhost:8091/"
 ----
 
 For the 'travel-sample' keyspace, if you add a password to it of _w1fg2Uhj89_ (as by default it has none), the command to start [.cmd]`cbq` would look like this:
 
 [source,console]
 ----
-$ ./cbq -engine="http://travel-sample:w1fg2Uhj89@1localhost:8091/"
+$ ./cbq -engine="http://travel-sample:w1fg2Uhj89@localhost:8091/"
 ----
 
 NOTE: These commands execute successfully only if you have loaded sample bucket 'travel-sample' either at install or from the Settings menu in the web UI.
@@ -1219,7 +1219,7 @@ If you want to access all of the keyspaces in the same cbq session, you would pa
 
 [source,console]
 ----
-$ ./cbq -engine="http://Administrator:password@1localhost:8091/"
+$ ./cbq -engine="http://Administrator:password@localhost:8091/"
 ----
 
 [#cbq-single-cred]

--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -1,5 +1,5 @@
 = cbq: The Command Line Shell for N1QL
-:description: pass:q[[.cmd]`cbq` is a comprehensive command line shell for N1QL.]
+:description: cbq is a comprehensive command line shell for N1QL.
 :tabs:
 :page-aliases: n1ql:n1ql-intro/cbq
 
@@ -92,13 +92,18 @@ You can use the [.param]`--script` option to execute a single N1QL query and exi
 
 [source,console]
 ----
-$ ./cbq --script="select \* from \`travel-sample\` LIMIT 1"
+$ cbq -u Administrator -p password -e "http://localhost:8091" \
+--script="SELECT * FROM \`travel-sample\`.inventory.airline LIMIT 1;"
 ----
 
 .Results
 [source,console]
 ----
-Connected to : http://localhost:8091/. Type Ctrl-D to exit.
+Connected to : http://localhost:8091/. Type Ctrl-D or \QUIT to exit.
+
+Path to history file for the shell : ~/.cbq_history
+
+SELECT * FROM `travel-sample`.inventory.airline LIMIT 1;
 {
     ...
 }
@@ -113,9 +118,9 @@ For example:
 
 [source,console]
 ----
-cbq> select *
-> from `travel-sample`
-> LIMIT 1;
+cbq> SELECT *
+   > FROM `travel-sample`.inventory.airline
+   > LIMIT 1;
 ----
 
 When you're done, use a semi-colon `;` to indicate the end of the query, and then press kbd:[Enter] to execute the query.
@@ -128,11 +133,11 @@ No other action is taken.
 
 [source,console]
 ----
-cbq> select *
- > #This is the first comment
- > from `travel-sample`
- > --This is the second comment
- > LIMIT 1;
+cbq> SELECT *
+   > #This is the first comment
+   > FROM `travel-sample`.inventory.airline
+   > --This is the second comment
+   > LIMIT 1;
 ----
 
 However, if a comment exists within a statement, it is considered as part of the N1QL command.
@@ -140,7 +145,7 @@ If the cbq shell encounters a block comment (enclosed between `/{asterisk}` \...
 
 [source,console]
 ----
-cbq> select * from `travel-sample` /* This statement includes a block comment */ LIMIT 1;
+cbq> SELECT * FROM `travel-sample`.inventory.airline /* Block comment */ LIMIT 1;
 ----
 
 === File Based Operations
@@ -157,7 +162,7 @@ You can change the name of the file using the SET command to set the predefined 
 
 [source,console]
 ----
-\SET HISTFILE filename;
+cbq> \SET HISTFILE filename;
 ----
 
 By default, all the commands are stored in the specified file.
@@ -241,6 +246,7 @@ $ ./cbq -e http://[fd63:6f75:6368:1075:816:3c1d:789b:bc4]:8091
 ----
 
 .Result
+[source,console]
 ----
 Connected to : http://localhost:8091/. Type Ctrl-D or \QUIT to exit.
 Path to history file for the shell : /Users/myuser1/.cbq_history
@@ -343,9 +349,10 @@ $ ./cbq --batch
 
 You can also set the batch mode in the interactive session using the <<cbq-set,\SET>> command:
 
+[source,console]
 ----
-\set batch on
-\set batch off
+cbq> \set batch on;
+cbq> \set batch off;
 ----
 
 | [[opt-timeout]]
@@ -430,7 +437,7 @@ none
 .Example
 [source,console]
 ----
-$ ./cbq -e http://localhost:8091 -c=beer-sample:password,Administrator:password
+$ ./cbq -e http://localhost:8091 -c=travel-sample:password,Administrator:password
 ----
 
 | [[opt-version]]
@@ -464,10 +471,9 @@ $ ./cbq --version
 
 .Result
 ----
- SHELL VERSION  : 1.5
+SHELL VERSION  : 2.0
 
-                Use N1QL queries select version();
-                or select min_version(); to display server version.
+Use N1QL queries select version(); or select min_version(); to display server version.
 ----
 
 | [[opt-help]]
@@ -504,31 +510,39 @@ none
 .Examples
 [source,console]
 ----
-$ ./cbq -s="select * from \`travel-sample\` limit 1"
+$ ./cbq -u Administrator -p password -s="SELECT * FROM \`travel-sample\`.inventory.airline LIMIT 1;"
 ----
 
 [source,console]
 ----
-$ ./cbq  -s="\SET v 1" -s="\SET b 2" -s="\PUSH b3" -s="\SET b 5" -s="\SET"  -ne
+$ ./cbq -s="\SET v 1" -s="\SET b 2" -s="\PUSH b3" -s="\SET b 5" -s="\SET" -ne
 ----
 
 .Result
 ----
- Path to history file for the shell : /Users/isha/.cbq_history
+Path to history file for the shell : ~/.cbq_history 
+
+ \SET v 1
+ \SET b 2
  \PUSH b3
- ERROR 139 : Too few input arguments to command.
- Query Parameters :
- Named Parameters :
- User Defined Session Parameters :
- Predefined Session Parameters :
- Parameter name : v
- Value : [1]
- Parameter name : b
- Value : [5]
+ ERROR 139 : Too few input arguments to command. 
+ \SET b 5
+ \SET
+
+ Query Parameters : 
+ Named Parameters : 
+ User Defined Session Parameters : 
+ Predefined Session Parameters : 
  Parameter name : histfile
  Value : [".cbq_history"]
  Parameter name : batch
  Value : ["off"]
+ Parameter name : quiet
+ Value : [false]
+ Parameter name : v
+ Value : [1]
+ Parameter name : b
+ Value : [5]
 ----
 
 | [[opt-file]]
@@ -567,7 +581,7 @@ none
 .Example
 [source,console]
 ----
-$ ./cbq -o="results.txt" -s="select * from `travel-sample` limit 1"
+$ ./cbq -u Administrator -p password -o="results.txt" -s="SELECT * FROM \`travel-sample\`.inventory.airline LIMIT 1;"
 ----
 
 | [[opt-pretty]]
@@ -584,7 +598,7 @@ To specify that the output should _not_ be formatted with line breaks and indent
 .Example
 [source,console]
 ----
-$ ./cbq --pretty=false -s="select * from `travel-sample` limit 1"
+$ ./cbq -u Administrator -p password --pretty=false -s="SELECT * FROM \`travel-sample\`.inventory.airline LIMIT 1;"
 ----
 
 | [[opt-exit-on-error]]
@@ -697,7 +711,7 @@ cbq> \CONNECT http://localhost:8093;
 
 [source,console]
 ----
-cbq> \CONNECT http://[fd63:6f75:6368:1075:816:3c1d:789b:bc4]:8091
+cbq> \CONNECT http://[fd63:6f75:6368:1075:816:3c1d:789b:bc4]:8091;
 ----
 
 | [[cbq-disconnect]]
@@ -826,8 +840,9 @@ a| Pops the top most value from the specified parameter's stack.
 When the [.cmd]`\POP` command is used without any arguments, it pops the top most value of every variable's stack.
 
 .Examples
+[source,console]
 ----
-\POP -args;
+cbq> \POP -args;
 ----
 
 [source,console]
@@ -853,7 +868,7 @@ When the [.cmd]`\ALIAS` command is used without any arguments, it lists all the 
 .Examples
 [source,console]
 ----
-cbq> \ALIAS travel-limit1 select * from `travel-sample` limit 1;
+cbq> \ALIAS travel-limit1 SELECT * FROM `travel-sample`.inventory.airline LIMIT 1;
 ----
 
 [source,console]
@@ -864,7 +879,7 @@ cbq> \ALIAS;
 .Result
 ----
 serverversion  select version()
-travel-limit1  select * from `travel-sample` limit 1
+travel-limit1  SELECT * FROM `travel-sample`.inventory.airline LIMIT 1
 ----
 
 .Execute alias
@@ -877,21 +892,22 @@ cbq> \\serverversion;
 [source,json]
 ----
 {
-    "requestID": "21b0efdb-b1ec-44bc-adab-071831792c03",
+    "requestID": "ef63f01b-f159-437f-a4df-28d6145fa3c2",
     "signature": {
         "$1": "string"
     },
     "results": [
         {
-            "$1": "1.5.0"
+            "$1": "7.0.0-N1QL"
         }
     ],
     "status": "success",
     "metrics": {
-        "elapsedTime": "4.03243ms",
-        "executionTime": "4.001382ms",
+        "elapsedTime": "14.54962ms",
+        "executionTime": "13.164635ms",
         "resultCount": 1,
-        "resultSize": 37
+        "resultSize": 34,
+        "serviceLoad": 12
     }
 }
 ----
@@ -961,7 +977,7 @@ cbq> \VERSION;
 
 .Result
 ----
- SHELL VERSION  : 1.5
+ SHELL VERSION  : 2.0
 ----
 
 | [[cbq-help]]
@@ -1010,10 +1026,9 @@ Command Line Option: <<opt-file,-f>> or <<opt-file,--file>>
 For example, [.path]_sample.txt_ contains the following commands:
 
 ----
-select * from `travel-sample` limit 1;
-\\ECHO this;
+SELECT * FROM `travel-sample`.inventory.airline LIMIT 1;
+\ECHO this;
 #This is a comment;
-EOF
 ----
 
 .Example
@@ -1103,20 +1118,23 @@ If the shell is not connected to any endpoint, an error with a message that the 
 .Examples
 [source,console]
 ----
-$ ./cbq -e=http://localhost:8091;
-Connected to : http://localhost:8091/. Type Ctrl-D to exit.
+$ ./cbq -e http://localhost:8091 -u Administrator -p password
+Connected to : http://localhost:8091/. Type Ctrl-D or \QUIT to exit.
+
+Path to history file for the shell : ~/.cbq_history
 
 cbq> \DISCONNECT;
 Couchbase query shell not connected to any endpoint. Use \CONNECT command to connect.
 
 cbq> \CONNECT http://127.0.0.1:8091;
-Connected to : http://127.0.0.1:8091 . Type Ctrl-D / \exit / \quit to exit.
+Connected to : http://127.0.0.1:8091. Type Ctrl-D or \QUIT to exit.
 
 cbq> \EXIT;
-Exiting the shell.
 
-$ ./cbq -e=http://127.0.0.1:8091;
-Connected to : http://127.0.0.1:8091/. Type Ctrl-D to exit.
+$ ./cbq -e http://127.0.0.1:8091 -u Administrator -p password
+Connected to : http://127.0.0.1:8091/. Type Ctrl-D or \QUIT to exit.
+
+Path to history file for the shell : ~/.cbq_history
 cbq>
 ----
 
@@ -1129,17 +1147,20 @@ After starting cbq without any service, you can connect to a specific endpoint u
 [source,console]
 ----
 $ ./cbq -ne
-cbq> \CONNECT http://127.0.0.1:8091;
-Connected to : http://127.0.0.1:8091 . Type Ctrl-D / \exit / \quit to exit.
+Path to history file for the shell : ~/.cbq_history
+
+cbq> \CONNECT http://Administrator:password@localhost;
+Connected to : http://Administrator:password@localhost:8091. Type Ctrl-D or \QUIT to exit.
 ----
 
 === Exiting the cbq Shell
 
 You can exit the cbq shell by pressing kbd:[Ctrl+D] or by using one of the following commands:
 
+[source,console]
 ----
-\EXIT;
-\QUIT;
+cbq> \EXIT;
+cbq> \QUIT;
 ----
 
 When you run the exit command, the cbq shell first saves the history, closes existing connections, saves the current session in a session file, resets all environment variables, and then closes the shell liner interface.
@@ -1147,32 +1168,32 @@ When you run the exit command, the cbq shell first saves the history, closes exi
 .Example
 [source,console]
 ----
-$ ./cbq
- No Input Credentials. In order to connect to a server with authentication, please provide credentials.
- Connected to : http://localhost:8091/. Type Ctrl-D to exit.
+$ ./cbq -u Administrator -p password
+Connected to : http://localhost:8091/. Type Ctrl-D or \QUIT to exit.
+Path to history file for the shell : ~/.cbq_history
 
-cbq> select name from `travel-sample` WHERE type="airline"  LIMIT 1;
+cbq> SELECT name FROM `travel-sample`.inventory.airline LIMIT 1;
 {
-   "requestID":"3a86dcf2-3bb4-445c-b419-a5eabd327a1d",
-   "signature":{
-      "name":"json"
-   },
-   "results":[
-      {
-         "name":"40-Mile Air"
-      }
-   ],
-   "status":"success",
-   "metrics":{
-      "elapsedTime":"20.564ms",
-      "executionTime":"20.539035ms",
-      "resultCount":1,
-      "resultSize":45
-   }
+    "requestID": "59d1c699-11a2-47c6-b4d0-4a7de1d15a3c",
+    "signature": {
+        "name": "json"
+    },
+    "results": [
+    {
+        "name": "40-Mile Air"
+    }
+    ],
+    "status": "success",
+    "metrics": {
+        "elapsedTime": "13.514441ms",
+        "executionTime": "13.355058ms",
+        "resultCount": 1,
+        "resultSize": 37,
+        "serviceLoad": 12
+    }
 }
 
 cbq> \EXIT;
-Exiting the shell.
 $
 ----
 
@@ -1182,24 +1203,24 @@ If your keyspace has a password, you can pass the keyspace name and keyspace pas
 
 [source,console]
 ----
-$ ./cbq -engine="http://<keyspacename>:<keyspacepassword>@123.45.67.89:8091/"
+$ ./cbq -engine="http://<keyspacename>:<keyspacepassword>@1localhost:8091/"
 ----
 
-For the 'beer-sample' keyspace, if you add a password to it of _w1fg2Uhj89_ (as by default it has none), the command to start [.cmd]`cbq` would look like this:
+For the 'travel-sample' keyspace, if you add a password to it of _w1fg2Uhj89_ (as by default it has none), the command to start [.cmd]`cbq` would look like this:
 
 [source,console]
 ----
-$ ./cbq -engine="http://beer-sample:w1fg2Uhj89@123.45.67.89:8091/"
+$ ./cbq -engine="http://travel-sample:w1fg2Uhj89@1localhost:8091/"
 ----
+
+NOTE: These commands execute successfully only if you have loaded sample bucket 'travel-sample' either at install or from the Settings menu in the web UI.
 
 If you want to access all of the keyspaces in the same cbq session, you would pass in the Administrator username and password instead of the keyspace level.
 
 [source,console]
 ----
-$ ./cbq -engine="http://Administrator:password@123.45.67.89:8091/"
+$ ./cbq -engine="http://Administrator:password@1localhost:8091/"
 ----
-
-NOTE: These commands execute successfully only if you have loaded sample bucket 'beer-sample' either at install or from the Settings menu in the web UI.
 
 [#cbq-single-cred]
 == Providing Single User Credentials
@@ -1226,10 +1247,10 @@ It must be used with the `-u` option to specify the user name that the password 
 ----
 $ ./cbq -u=Administrator
 Enter Password:
-Connected to : http://localhost:8091/. Type Ctrl-D to exit.
+Connected to : http://localhost:8091/. Type Ctrl-D or \QUIT to exit.
 
 $ ./cbq -e http://localhost:8091 -u=Administrator -p=password
-Connected to : http://localhost:8091/. Type Ctrl-D to exit.
+Connected to : http://localhost:8091/. Type Ctrl-D or \QUIT to exit.
 cbq>
 ----
 
@@ -1275,8 +1296,9 @@ To pass authentication credentials per query, set the query parameter to a new v
 You can also switch between users and change credentials during a session.
 To do so, set the [.param]`-creds` query parameter for the session using the following command:
 
+[source,console]
 ----
-\SET -creds travel-sample:b1, session:s1;
+cbq> \SET -creds travel-sample:b1, session:s1;
 ----
 
 [#pass-cred-rest-api]
@@ -1390,8 +1412,9 @@ Each variable has a separate stack associated with it and the [.var]`prefix` [.v
 The SET command always modifies the top value of a variable.
 You can use the SET command to set different kinds of parameters: query parameter, predefined session variables, user-defined session variables and named parameters.
 
+[source,console]
 ----
-\SET <prefix><name> value;
+cbq> \SET <prefix><name> value;
 ----
 
 where [.var]`name` is the name of the parameter, [.var]`value` is the value to be set, and [.var]`prefix` is one of the following depending on the parameter type.
@@ -1541,24 +1564,27 @@ Use the \SET command to define named parameters.
 For each named parameter, prefix the variable name with `-$`.
 The following example creates named parameters `r` and `date` with values 9.5 and "1-1-2016" respectively.
 
+[source,console]
 ----
-\SET -$r 9.5;
-\SET -$date "1-1-2016";
+cbq> \SET -$r 9.5;
+cbq> \SET -$date "1-1-2016";
 ----
 
 === Handling Positional Parameters
 
 Use the SET shell command with the [.param]`-args` query parameter to define positional parameters:
 
+[source,console]
 ----
-\SET -args value;
+cbq> \SET -args value;
 ----
 
 The [.var]`value` contains the different values that correspond to positions within the query.
 For example,
 
+[source,console]
 ----
-\SET -args [ 9.5, "1-1-2016"];
+cbq> \SET -args [ 9.5, "1-1-2016"];
 ----
 
 === Resetting Variable Values
@@ -1568,14 +1594,14 @@ To pop the top of a parameter's stack use:
 
 [source,console]
 ----
-cbq>\POP <prefix><name>;
+cbq> \POP <prefix><name>;
 ----
 
 To pop the top of every parameter's stack once, use the POP command without any arguments:
 
 [source,console]
 ----
-cbq>\POP;
+cbq> \POP;
 ----
 
 To pop all the values of a parameter's stack and then delete the parameter, use:
@@ -1593,8 +1619,9 @@ You can use it to display any input string or command aliases that have been cre
 To display parameters, you must include their prefixes.
 If not, the shell considers the parameters as generic statements and displays the parameter as is.
 
+[source,console]
 ----
-\ECHO input ... ;
+cbq> \ECHO input ... ;
 ----
 
 where [.var]`input` can be a parameter with prefix ([.var]`<prefix><parameter-name>`), an alias ([.var]`\\command-alias`), a N1QL statement, or a string.
@@ -1606,7 +1633,7 @@ cbq> \ECHO hello;
 hello
 
 cbq> \ECHO \\travel-alias1;
-SELECT * from `travel-sample` LIMIT 1
+SELECT * FROM `travel-sample`.inventory.airline LIMIT 1;
 
 cbq> \ECHO -$r;
 9.5
@@ -1619,14 +1646,15 @@ Using the ALIAS shell command, you can define and store aliases for commands.
 This is useful when you have lengthy queries that need to be executed often.
 Run the following command to define an alias:
 
+[source,console]
 ----
-\ALIAS command-alias command
+cbq> \ALIAS command-alias command;
 ----
 
 .Example
 [source,console]
 ----
-cbq> \ALIAS travel-alias1 SELECT * from `travel-sample` LIMIT 1;
+cbq> \ALIAS travel-alias1 SELECT * FROM `travel-sample`.inventory.airline LIMIT 1;
 ----
 
 To run the command alias, use `\\command-alias`.
@@ -1637,22 +1665,22 @@ To run the command alias, use `\\command-alias`.
 cbq> \\travel-alias1;
 
 {
-    "requestID": "01f25f87-bd6c-4686-8852-ab81795290d1",
+    "requestID": "b25c84d6-7b7b-440a-a286-5027e6ecbbb5",
     "signature": {
         "*": "*"
     },
     "results": [
-        {
-            "travel-sample": {
-                "callsign": "MILE-AIR",
-                "country": "United States",
-                "iata": "Q5",
-                "icao": "MLA",
-                "id": 10,
-                "name": "40-Mile Air",
-                "type": "airline"
-            }
+    {
+        "airline": {
+            "callsign": "MILE-AIR",
+            "country": "United States",
+            "iata": "Q5",
+            "icao": "MLA",
+            "id": 10,
+            "name": "40-Mile Air",
+            "type": "airline"
         }
+    }
     ],
     "status": "success",
     ...
@@ -1661,8 +1689,9 @@ cbq> \\travel-alias1;
 
 To list all the existing aliases, use:
 
+[source,console]
 ----
-\ALIAS;
+cbq> \ALIAS;
 ----
 
 .Example
@@ -1670,13 +1699,14 @@ To list all the existing aliases, use:
 ----
 cbq> \ALIAS;
 serverversion  select version()
-travel-alias1  SELECT * from `travel-sample` LIMIT 1
+travel-alias1  SELECT * FROM `travel-sample`.inventory.airline LIMIT 1;
 ----
 
 You can delete a defined alias using the \UNLIAS command.
 
+[source,console]
 ----
-\UNALIAS alias-name ... ;
+cbq> \UNALIAS alias-name ... ;
 ----
 
 [source,console]
@@ -1734,7 +1764,7 @@ An error is thrown if the timeout is invalid.
 $ ./cbq --timeout="2s"
 
 $ ./cbq -q
-cbq> \SET -TIMEOUT 1ms
+cbq> \SET -TIMEOUT 1ms;
 ----
 
 [#cbq-file-based-ops]
@@ -1755,7 +1785,7 @@ The cbq shell executes the commands present in the input file, prints them to st
 * Using a shell command:
 +
 ----
-\SOURCE input-file;
+cbq> \SOURCE input-file;
 ----
 +
 Runs the commands present in the input file and prints the result to stdout.
@@ -1763,36 +1793,38 @@ Runs the commands present in the input file and prints the result to stdout.
 Consider the input file, [.path]_sample.txt_, containing the following commands:
 
 ----
-CREATE PRIMARY INDEX on `beer-sample` USING GSI;
-SELECT * from `beer-sample` LIMIT 2;
-SELECT abv from `beer-sample` LIMIT 3;
+CREATE PRIMARY INDEX ON `travel-sample`.inventory.airline USING GSI;
+SELECT * from `travel-sample`.inventory.airline LIMIT 2;
+SELECT callsign from `travel-sample`.inventory.airline LIMIT 3;
 \HELP;
 ----
 
-To execute the commands contained in [.path]_sample.txt_ using the -f option, run `$./cbq -f=sample.txt`
+To execute the commands contained in [.path]_sample.txt_ using the -f option run `$./cbq -f=sample.txt`
 
 .Results
 [source,console]
 ----
-Connected to : http://localhost:8091/. Type Ctrl-D to exit.
-CREATE PRIMARY INDEX on `beer-sample` USING GSI;
+ Connected to : http://localhost:8091/. Type Ctrl-D or \QUIT to exit.
+
+ Path to history file for the shell : ~/.cbq_history 
+CREATE PRIMARY INDEX ON `travel-sample`.inventory.airline USING GSI;
 { ...
   "results": [ ],
   ...
 }
-SELECT * from `beer-sample` LIMIT 2;
+SELECT * from `travel-sample`.inventory.airline LIMIT 2;
 { ...
   "results": [ ],
   ...
 }
-SELECT abv from `beer-sample` LIMIT 3;
+SELECT callsign from `travel-sample`.inventory.airline LIMIT 3;
 { ...
   "results": [ ],
   ...
 }
 \HELP;
-Help Information for all Shell Commands
-…
+Help information for all shell commands.
+...
 $
 ----
 
@@ -1801,24 +1833,24 @@ To execute the commands contained in [.path]_sample.txt_ using the shell command
 .Results
 [source,console]
 ----
-CREATE PRIMARY INDEX on `beer-sample` USING GSI;
+CREATE PRIMARY INDEX ON `travel-sample`.inventory.airline USING GSI;
 { ...
   "results": [ ],
  ...
 }
-SELECT * from `beer-sample` LIMIT 2;
+SELECT * from `travel-sample`.inventory.airline LIMIT 2;
 { ...
   "results": [ ],
   ...
 }
-SELECT abv from `beer-sample` LIMIT 3;
+SELECT callsign from `travel-sample`.inventory.airline LIMIT 3;
 { ...
   "results": [ ],
   ...
 }
 \HELP;
-Help Information for all Shell Commands
-…
+Help information for all shell commands.
+...
 cbq>
 ----
 
@@ -1850,8 +1882,8 @@ You can append redirected output to an existing file using <<file-append-mode>>.
 [source,console]
 ----
 cbq> \REDIRECT temp_output.txt;
-cbq> CREATE PRIMARY INDEX on `beer-sample` USING GSI;
-cbq> SELECT * from `beer-sample` LIMIT 1;
+cbq> CREATE PRIMARY INDEX ON `travel-sample`.inventory.airline USING GSI;
+cbq> SELECT * FROM `travel-sample`.inventory.airline LIMIT 1;
 cbq> \HELP;
 cbq> \REDIRECT OFF;
 ----
@@ -1870,16 +1902,16 @@ To use file append mode, include a plus sign `+` at the start of the output path
 [source,console]
 ----
 cbq> \REDIRECT +temp_output.txt;
-cbq> SELECT * from `beer-sample` LIMIT 1;
+cbq> SELECT * FROM `travel-sample`.inventory.airline LIMIT 1;
 cbq> \REDIRECT OFF;
 ----
 
 Every time you start appending to the output file, a timestamp is added to the end of the output file, followed by any redirected commands and results.
 
 ----
--- <2020-03-06T03:37:28.484-08:00> : opened in append mode
+-- <2021-07-30T14:48:43.661+01:00> : opened in append mode
 
-SELECT * from `beer-sample` LIMIT 1
+SELECT * FROM `travel-sample`.inventory.airline LIMIT 1
 ...
 ----
 
@@ -1900,17 +1932,21 @@ You can find the version of the client (shell) by using either the command line 
 [source,console]
 ----
 $ ./cbq -v
-SHELL VERSION : 1.0
+SHELL VERSION  : 2.0
+
+Use N1QL queries select version(); or select min_version(); to display server version.
 
 $ ./cbq --version
-SHELL VERSION : 1.0
+SHELL VERSION  : 2.0
+
+Use N1QL queries select version(); or select min_version(); to display server version.
 ----
 
 .Example Using the Shell Command
 [source,console]
 ----
 cbq> \VERSION;
-SHELL VERSION : 1.0
+SHELL VERSION : 2.0
 ----
 
 To display the version of the query service, use the N1QL commands `SELECT version();` and `SELECT min_version();`.
@@ -1922,12 +1958,13 @@ You can view the copyright, attributions, and distribution terms of the command 
 [source,console]
 ----
 cbq> \COPYRIGHT;
-Copyright (c) 2015 Couchbase, Inc. Licensed under the Apache License, Version 2.0 (the "License");
+Copyright (c) 2016 Couchbase, Inc. Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy of the
 License at http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software distributed under the
 License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
 either express or implied. See the License for the specific language governing permissions
+and limitations under the License.
 cbq>
 ----
 


### PR DESCRIPTION
- Update cbq examples to use scopes and collections
- Update example results
- Make source highlighting and prompts consistent

Pending DOC-6706, I have not updated information on authentication with SASL buckets, other than to replace beer-sample with travel-sample where possible.

Docs issue: [DOC-8060](https://issues.couchbase.com/browse/DOC-8060)