### PR TITLE
Correct the abrupt statement

### DIFF
--- a/modules/sdk/pages/development-intro.adoc
+++ b/modules/sdk/pages/development-intro.adoc
@@ -3,7 +3,7 @@
 == Using Couchbase
 
 Once you've xref:install:install-intro.adoc[installed the server], and xref:clustersetup:create-bucket.adoc[created a test bucket], you can start storing, retrieving, and querying documents with Couchbase.
-You can start with an SDK, the command-line cbc tool, or the web browser.
+You can start with an SDK, the command-line [cbc tool](https://docs.couchbase.com/c-sdk/current/hello-world/cbc.html), or the Web Console.
 
 Every item in a database goes through the basic _CRUD_ cycle, which is typical of an application’s use of data.
 CRUD stands for create, read, update, and delete:


### PR DESCRIPTION
1. The **cbc tool** here is really unexpected, I can't find it in current doc and also in the **CLI Reference list**, so add a reference here. but the problem is, the ref is cross repo and branches, I don't know your best practice, just use the doc URL in that place.
2. It's better to add [cbc reference](https://docs.couchbase.com/sdk-api/couchbase-c-client/md_doc_cbc.html) in the [CLI Reference list](https://docs.couchbase.com/server/5.0/cli/cli-intro.html)
3. The **web browser** here is not specific, you use Web Console/Web UI  in pre-section, just to align.
4. This suggested fix is cross version 5.0 still to 7.0. so I made this change in the initial version.