### PR TITLE
Fix broken scriptlet due to discontinued URL

### DIFF
--- a/modules/eventing/pages/eventing-handler-curl-get.adoc
+++ b/modules/eventing/pages/eventing-handler-curl-get.adoc
@@ -9,11 +9,12 @@
 * Requires a metadata bucket and a source bucket.
 * Needs a Binding of type URL Alias (as documented in the Scriptlet).
 * Will operate on any mutation of the KEY "make_curl_request::1".
-* The actual cURL request from the Eventing Function will be equivalent to:
+* The actual cURL request from the Eventing Function will be equivalent to either of the following (but test to make sure the service is live):
 +
 [source,shell]
 ----
-curl -q https://api.ratesapi.io/api/latest
+curl -q -X GET 'https://api.frankfurter.app/latest'
+curl -q -X GET 'https://api.ratesapi.io/api/latest'
 ----
 * Only logs the REST response JSON payload to the Application log file.
 * For a more complete example using this public REST endpoint, refer to xref:eventing:eventing-examples-rest-via-curl-get.adoc[External REST via cURL GET].
@@ -28,7 +29,7 @@ basicCurlGet::
 // To run need a Binding in this Function's Settings to apublic API as follows: 
 // 1. URL Alias
 // 2. exchangeRateApi
-// 3. https://api.ratesapi.io/api/
+// 3. https://api.frankfurter.app/
 // 4. "no auth"
 
 function OnUpdate(doc, meta) {


### PR DESCRIPTION
Discontinued URL
https://api.ratesapi.io hasn't been live for a while