### PR TITLE
Updated the incorrect Java sdk release notes link

### DIFF
--- a/modules/security/pages/security-certs-auth.adoc
+++ b/modules/security/pages/security-certs-auth.adoc
@@ -163,7 +163,7 @@ Note the following limitations to the feature in the current release:
 
 * X.509 Certificate Based Authentication will only work for data service.
 * For Couchbase Server 5.1, X.509 Certificate-based Authentication support is suported by all SDK Clients.
-However, only the very latest versions support it - check the https://developer.couchbase.com/server/other-products/release-notes-archives/java-sdk[release notes^] for your SDK version.
+However, only the very latest versions support it - check the https://docs.couchbase.com/java-sdk/current/project-docs/sdk-release-notes.html[release notes^] for your SDK version.
 
 == Upgrade
 


### PR DESCRIPTION
Updated the incorrect Java SDK release notes link to https://docs.couchbase.com/java-sdk/current/project-docs/sdk-release-notes.html