### PR TITLE
Add performance numbers to Eventign Scriptlet

### DIFF
--- a/modules/eventing/pages/eventing-handler-ConvertBucketToCollections.adoc
+++ b/modules/eventing/pages/eventing-handler-ConvertBucketToCollections.adoc
@@ -17,6 +17,11 @@
 ** remove all type` = "brewery" from upgrade COLLECTION `beer-sample`.`_default`.`_default` 
 ** remove all type` = "beer" from upgrade COLLECTION `beer-sample`.`_default`.`_default`
 * The function should have higher throughput as you add more workers up to the # of vCPUs.
+* Example of performance using this technique:
+** Test cluster a symmetric 3 x AWS r5.2xlarge (64 GiB of memory, 8 vCPUs, 64-bit platform) 
+** Will process 93K ops/sec. in a steady state.
+** 250M small documents: time 44 minutes to reorganize a bucket with 80 types into a new bucket with 80 collections.
+** 1B small documents: time 3 hours to reorganize a bucket with 80 types into a new bucket with 80 collections.
 
 [{tabs}] 
 ====

--- a/modules/eventing/pages/eventing-handler-ConvertBucketToCollections.adoc
+++ b/modules/eventing/pages/eventing-handler-ConvertBucketToCollections.adoc
@@ -7,7 +7,7 @@
 
 * This function *ConvertBucketToCollections* demonstrates a simple technique to reorganize into buckets.
 * Requires Eventing Storage (or metadata collection) and a "source" collection listing to the sample "beer-sample".
-* The sample "beer-sample" is equivalent to an upgraded bucket all data resides in `beer-sample`.`_default`.`_default`.
+* The sample "beer-sample" is equivalent to an upgraded bucket where all data resides in `beer-sample`.`_default`.`_default`.
 * Needs Bindings of type "Constant alias" (as documented in the Scriptlet).
 * Needs Bindings of type "bucket alias" (as documented in the Scriptlet).
 * If "Constant alias" *DO_COPY* is true
@@ -18,10 +18,10 @@
 ** remove all type` = "beer" from upgrade COLLECTION `beer-sample`.`_default`.`_default`
 * The function should have higher throughput as you add more workers up to the # of vCPUs.
 * Example of performance using this technique:
-** Test cluster a symmetric 3 x AWS r5.2xlarge (64 GiB of memory, 8 vCPUs, 64-bit platform) 
-** Will process 93K ops/sec. in a steady state.
-** 250M small documents: time 44 minutes to reorganize a bucket with 80 types into a new bucket with 80 collections.
-** 1B small documents: time 3 hours to reorganize a bucket with 80 types into a new bucket with 80 collections.
+** Test cluster is a symmetric 3 x AWS r5.2xlarge (64 GiB of memory, 8 vCPUs, 64-bit platform). 
+** Will process 93K ops/sec in a steady state.
+** 250M small documents: takes 44 minutes to reorganize a bucket with 80 types into a new bucket with 80 collections.
+** 1B small documents: takes 3 hours to reorganize a bucket with 80 types into a new bucket with 80 collections.
 
 [{tabs}] 
 ====


### PR DESCRIPTION
Work done for CONNECT 2021 exposed some real performance (and capabilities) of this technique to reorganize.
Makes sense to add to the example on a low-mid range cluster.

Details are in https://github.com/jon-strabala/cb-buckets-to-collections