### PR TITLE
[NO ISSUE] Fix keyspace in GROUP BY example

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/groupby.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/groupby.adoc
@@ -14,7 +14,8 @@ This `GROUP BY` clause follows the `WHERE` clause and precedes the optional `LET
 
 [subs="normal"]
 ----
-group-by-clause ::= GROUP BY <<group-term>> [ ',' <<group-term>> ]* [ <<letting-clause>> ] [ <<having-clause>> ] | <<letting-clause>>
+group-by-clause ::= GROUP BY <<group-term>> [ ',' <<group-term>> ]* [ <<letting-clause>> ] [ <<having-clause>> ] |
+                    <<letting-clause>>
 ----
 
 image::n1ql-language-reference/group-by-clause.png["'GROUP' 'BY' group-term ( ',' group-term )* letting-clause? having-clause? | letting-clause"]
@@ -96,8 +97,7 @@ For more details, refer to xref:n1ql:n1ql-language-reference/selectintro.adoc#in
 [source,n1ql]
 ----
 SELECT city City, COUNT(DISTINCT name) LandmarkCount
-FROM `travel-sample`
-WHERE type = "landmark"
+FROM `travel-sample`.inventory.landmark
 GROUP BY city
 ORDER BY LandmarkCount DESC
 LIMIT 4;


### PR DESCRIPTION
* Fix keyspace in example 1 to use scopes and collections
* While I'm at it, wrap the listing for the syntax diagram