### PR TITLE
DOC-8992: Add fixed issues to 7.0 release notes now that 6.6.3 is GA

### DIFF
--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -555,7 +555,7 @@ This section lists common vulnerabilities and exposures that are fixed in this r
 
 See https://www.couchbase.com/alerts[Couchbase Alerts] for the complete list of common vulnerabilities and exposures.
 
-* CVE-2021-35943
+* https://nvd.nist.gov/vuln/detail/CVE-2021-35943[CVE-2021-35943]
 * https://nvd.nist.gov/vuln/detail/CVE-2021-23840[CVE-2021-23840]
 * https://nvd.nist.gov/vuln/detail/CVE-2019-10768[CVE-2019-10768]
 * https://nvd.nist.gov/vuln/detail/CVE-2021-3450[CVE-2021-3450]


### PR DESCRIPTION
Follow-up to [couchbase/docs-server#2142](https://github.com/couchbase/docs-server/pull/2142)

* Added link for CVE-2021-35943 (published on 09/29/2021)

Docs issue: [DOC-8992](https://issues.couchbase.com/browse/DOC-8992)