### PR TITLE
Add missing Log access REST API for Eventing

### DIFF
--- a/modules/eventing/pages/eventing-api.adoc
+++ b/modules/eventing/pages/eventing-api.adoc
@@ -454,6 +454,49 @@ curl -XGET http://Administrator:password@192.168.1.5:8096/api/v1/status/[sample_
 |===
 
 
+.Eventing Log API (advanced)
+[cols="2,10,18"]
+|===
+| HTTP Method | *URI Path* | *Description*
+
+| GET
+| [.path]_/getAppLog?name=[sample_name]_
+a|
+Returns the most recent application log messages for a specific Eventing Function.  
+
+This API by default accesses a single Eventing node but can access all Eventing nodes by setting the optional parameter *aggregate=true*. 
+
+By default the amount of logging information returned is approximately 40960 bytes unless you specify the optional size parameter *size=#* where # is in bytes.  Note when specifying the *size* parameter and fetching from more than one Eventing node only *size/#nodes* bytes are returned from each node.
+
+|
+2+a|
+Sample API (fetch recent Application log info from one Eventing node):
+
+[source,console]
+----
+curl -XGET http://Administrator:password@192.168.1.5:8096/getAppLog?name=[sample_name]
+----
+
+|
+2+a|
+Sample API (fetch recent Application log info from all Eventing nodes):
+
+[source,console]
+----
+curl -XGET http://Administrator:password@192.168.1.5:8096/getAppLog?name=[sample_name]&aggregate=true
+----
+
+|
+2+a|
+Sample API (fetch recent Application log info from all Eventing nodes but limited to 2048 bytes):
+
+[source,console]
+----
+curl -XGET http://Administrator:password@192.168.1.5:8096/getAppLog?name=[sample_name]&aggregate=true&size=2048
+----
+
+|===
+
 .Eventing List API (advanced)
 [cols="2,10,18"]
 |===


### PR DESCRIPTION
Eventing Log API was not documented, 

Customers were using the wrong URL which is for the internal UI (found by inspecting the UI's JavaScript):

`/_p/event/getAppLog?name=[sample_name]
`

The correct URL (which is documented in this PR) is:

`/getAppLog?name=[sample_name]`