### PR TITLE
DOC-9444: Release notes showing Debian 11.x support

### DIFF
--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -379,7 +379,7 @@ Couchbase Server comes in two editions: Enterprise Edition and Community Edition
 
 This release adds support for the following platforms:
 
-* Debian 11.x
+* macOS Big Sur for development only
 
 See xref:install:install-platforms.adoc[Supported Platforms] for the complete list of supported platforms.
 


### PR DESCRIPTION
Reverted changed line. We're not supporting Debian 11.x until 7.1