### PR TITLE
DOC-9463: Grammar mistake

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -28,7 +28,7 @@ Secondary indexes are optional but increase query efficiency on a keyspace.
 In Couchbase Server 7.0 and later, `CREATE INDEX` allows you to make multiple concurrent index creation requests.
 The command starts a task to create the index definition in the background.
 If there is an index creation task already running, the Index Service queues the incoming index creation request.
-`CREATE INDEX` returns as soon as the when the index creation phase is complete.
+`CREATE INDEX` returns as soon as the index creation phase is complete.
 
 By default, when the index creation phase is complete, the Index Service triggers the index build phase.
 If you lose connectivity, the index build operation continues in the background.


### PR DESCRIPTION
Corrected "as soon as the when the index creation phase is complete" to "as soon as the index creation phase is complete" using the same terminology as the CREATE PRIMARY INDEX page.

Docs issue: [DOC-9463](https://issues.couchbase.com/browse/DOC-9463)