### PR TITLE
Re-Purpose for New Developers -  createindex.adoc

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -1,6 +1,6 @@
 = CREATE INDEX
-:description: pass:q[The `CREATE INDEX` statement allows you to create a secondary index. \
-Secondary indexes contain a filtered or a full set of keys in a given keyspace.]
+:description: pass:q[The `CREATE INDEX` statement creates a secondary index. \
+Secondary indexes increase query efficiency by creating a filtered or a full set of keys in a given keyspace.]
 :page-topic-type: concept
 :imagesdir: ../../assets/images
 :keywords: secondary, index, placement
@@ -23,49 +23,22 @@ Secondary indexes contain a filtered or a full set of keys in a given keyspace.]
 :querying-indexes: {sysinfo}#querying-indexes
 
 {description}
-Secondary indexes are optional but increase query efficiency on a keyspace.
 
-In Couchbase Server 7.0 and later, `CREATE INDEX` allows you to make multiple concurrent index creation requests.
-The command starts a task to create the index definition in the background.
-If there is an index creation task already running, the Index Service queues the incoming index creation request.
-`CREATE INDEX` returns as soon as the index creation phase is complete.
 
-By default, when the index creation phase is complete, the Index Service triggers the index build phase.
-If you lose connectivity, the index build operation continues in the background.
-You can also defer the index build phase using the `defer_build` clause.
-In deferred build mode, `CREATE INDEX` creates the index definition, but does not trigger the index build phase.
-You can then build the index using the {build-index}[BUILD INDEX] command.
+`CREATE INDEX` creates an index definition and builds that index for a given keyspace.
+You can also defer the index build phase by using the `defer_build` clause.
+Then build the index using the {build-index}[BUILD INDEX] command.
 
-Index metadata provides a state field.
-The index state may be `scheduled for creation`, `deferred`, `building`, `pending`, `online`, `offline`, or `abridged`.
+The state of an index may be `scheduled for creation`, `deferred`, `building`, `pending`, `online`, `offline`, or `abridged`.
 This state field and other index metadata can be queried using {querying-indexes}[system:indexes].
 You can also monitor the index state using the Couchbase Web Console.
-
-[IMPORTANT]
-====
-If you kick off multiple index creation operations concurrently, you may sometimes see transient errors similar to the following.
-If this error occurs, the Index Service tries to run the failed operation again in the background until it succeeds, up to a maximum of 1000 retries.
-
-[source,json]
-----
-include::example$n1ql-language-reference/build-idx-error.jsonc[]
-----
-
-If the Index Service still cannot create the index after the maximum number of retries, the index state is marked as `offline`.
-You must drop the failed index using the `DROP INDEX` command.
-====
-
-You can create multiple identical secondary indexes on a keyspace and place them on separate nodes for better index availability.
-In Couchbase Server Enterprise Edition, the recommended way to do this is using the `num_replicas` option.
-In Couchbase Server Community Edition, you need to create multiple identical indexes and place them using the `nodes` option.
-Refer to <<index-with,WITH Clause>> below for more details.
 
 == Prerequisites
 
 [discrete]
 ===== RBAC Privileges
 
-User executing the CREATE INDEX statement must have the _Query Manage Index_ privilege granted on the keyspace.
+The user executing the CREATE INDEX statement must have the _Query Manage Index_ privilege granted on the keyspace.
 For more details about user roles, see
 {authorization-overview}[Authorization].
 


### PR DESCRIPTION
CREATE INDEX is logically one of the first pages a new developer will see. With no intro to Couchbase, that user would be confused by this page. Too much complicated stuff right at the top. Too many warnings and caveats. This developer needs the basics first; then more details. I removed a LOT of content from the top of the page and made the language more consistent and succinct.