### PR TITLE
DOC-9491: Ports 11280, 9123 and 9124 missing from install docs

### DIFF
--- a/modules/install/pages/install-ports.adoc
+++ b/modules/install/pages/install-ports.adoc
@@ -310,6 +310,20 @@ The following table contains a detailed description of each port used by Couchba
 | No
 | No
 
+| `prometheus_http_port`
+| 9123
+| Analytics service
+| No
+| Yes
+| No
+
+| `backup_grpc_port`
+| 9124
+| Backup Service gRPC
+| Yes
+| No
+| No
+
 | `fts_grpc_port` / `fts_grpc_ssl_port`
 | 9130 / 19130
 a| Search Service gRPC port used for xref:learn:services-and-indexes/services/search-service.adoc[scatter-gather] operations between FTS nodes
@@ -322,13 +336,6 @@ a| Search Service gRPC port used for xref:learn:services-and-indexes/services/se
 | Eventing Service Debugger
 | No
 | Yes
-| No
-
-| `backup_grpc_port`
-| 9124
-| Backup Service gRPC
-| Yes
-| No
 | No
 
 | `xdcr_rest_port`
@@ -360,6 +367,13 @@ a| Search Service gRPC port used for xref:learn:services-and-indexes/services/se
 | Yes
 | Yes
 | Version 2
+
+| `memcached_prometheus`
+| 11280
+| Data Service
+| No
+| Yes
+| No
 
 | Cluster Management Exchange
 | 21100 / 21150


### PR DESCRIPTION
Add missing points 11280 and 9123. Move note on port 9124 to the right location.