### PR TITLE
[DOC-9520] Internal document is given as external link on release notes page

### DIFF
--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -364,7 +364,8 @@ When a Data Service request cannot be completed immediately, this enhancement en
 
 * The Internet Engineering Task Force (IETF) have formally deprecated both the TLS 1.0 and 1.1 protocols along with a wider industry movement to use newer, more secure standards. Keeping in line with these changes, we strongly recommend that clients which use TLS encryption use TLS 1.2 or higher, and have updated the default minimum TLS version for all Couchbase Server 7.0 clusters to TLS 1.2.  Currently supported SDKs already support the TLS 1.2 standard, so in most cases no application changes are required.
 +
-If you do need to configure the minimum TLS to a lower version (not recommended), follow the instructions provided in https://docs.couchbase.com/server/current/manage/manage-security/manage-tls.html#set-the-minimum-tls-version.
+If you do need to configure the minimum TLS to a lower version (not recommended), follow the instructions provided in xref:manage:manage-security/manage-tls.adoc[].
+The minimum TLS can be configured through the xref:manage:manage-security/manage-tls.adoc#set-the-minimum-tls-version-with-the-cli[CLI] or through the xref:manage:manage-security/manage-tls.adoc#set-the-minimum-tls-version-with-the-rest-api[REST-API].
 
 * Updated license for Community Edition
 +


### PR DESCRIPTION
See https://issues.couchbase.com/browse/DOC-9520

Corrected link on a page that was:

1.  Pointing to a non-existent ID.
1. Was given as a full link to the global docs site rather than pointing to an external document.
