### PR TITLE
[DOC-9533] Spelling mistake in tutorial

### DIFF
--- a/modules/tutorials/partials/retrieve-documents-using-query-bench-section.adoc
+++ b/modules/tutorials/partials/retrieve-documents-using-query-bench-section.adoc
@@ -50,7 +50,7 @@ create primary index course_idx on `course-record-collection`
 
 This will create a single index (`course_idx`) on your `course-record-collection`.
 
-TIP: The error message returned from the search statement provides an example command for creating the primary index. You can copy the example command and run it in the query editor to create yoour primary index.
+TIP: The error message returned from the search statement provides an example command for creating the primary index. You can copy the example command and run it in the query editor to create your primary index.
 
 Okay, now if you run the `select` query again …
 


### PR DESCRIPTION
Dropped an extra 'o' into 'your'. This PR fixes it.