### PR TITLE
DOC-9515 "Couchbase Client Deployment Strategies" link goes to the generic SDK intro.

### DIFF
--- a/modules/install/pages/install-production-deployment.adoc
+++ b/modules/install/pages/install-production-deployment.adoc
@@ -35,9 +35,9 @@ You need to set the swappiness setting to 0, or at most 1, for optimal Couchbase
 xref:install-swap-space.adoc[Swap Space and Kernel Swappiness]
 
 | *Couchbase client deployment*
-| When you deploy Couchbase Server, you need to plan how clients will access and interact with the cluster.
+| Deploy client applications that incorporate Couchbase SDKs to enable interaction with Couchbase clusters.
 
-xref:install-client-server.adoc[Couchbase Client Deployment Strategies]
+xref:sdk:overview.adoc[]
 
 | *Security*
 | Couchbase Server provides security features that allow administrators to implement various security controls to ensure secure deployment.

--- a/modules/install/pages/install-production-deployment.adoc
+++ b/modules/install/pages/install-production-deployment.adoc
@@ -37,7 +37,7 @@ xref:install-swap-space.adoc[Swap Space and Kernel Swappiness]
 | *Couchbase client deployment*
 | Deploy client applications that incorporate Couchbase SDKs to enable interaction with Couchbase clusters.
 
-xref:sdk:overview.adoc[]
+xref:home:sdk.adoc[]
 
 | *Security*
 | Couchbase Server provides security features that allow administrators to implement various security controls to ensure secure deployment.


### PR DESCRIPTION
The client-server installation page has been removed, so the deployment guide has been reworded to reflect the new location.