### PR TITLE
DOC-9521 Inconsistency between Table 1 and Table 2 sections

### DIFF
--- a/modules/install/pages/install-ports.adoc
+++ b/modules/install/pages/install-ports.adoc
@@ -79,7 +79,7 @@ The following table lists all port numbers, grouped by category of communication
 *Encrypted*: 9999, 11206, 11207, 18091-18094, 19102, 19130, 21150
 
 | _Client-to-node_
-| *Unencrypted*: 8091-8097, 9140 {fn-eventing-debug-port}, 11210, 11211
+| *Unencrypted*: 8091-8097, 9140 {fn-eventing-debug-port}, 11210
 
 *Encrypted*: 11207, 18091-18095, 18096, 18097
 
@@ -143,7 +143,7 @@ The following table contains a detailed description of each port used by Couchba
 | `fts_http_port` / `fts_ssl_port`
 | 8094 / 18094
 | Search Service REST/HTTP traffic
-| No
+| Yes
 | Yes
 | No
 


### PR DESCRIPTION
Corrected inconsistencies. Note that the port 11211 is no longer in use:
https://issues.couchbase.com/browse/DOC-4141

Related:

https://github.com/couchbase/docs-server/pull/2318
