### PR TITLE
Update cluster-manager.adoc

### DIFF
--- a/modules/learn/pages/clusters-and-availability/cluster-manager.adoc
+++ b/modules/learn/pages/clusters-and-availability/cluster-manager.adoc
@@ -102,13 +102,13 @@ xref:manage:manage-nodes/fail-nodes-over.adoc[Fail a Node over and Rebalance].
 [#vbucket-distribution]
 == vBucket Distribution
 
-Couchbase Server buckets physically contain 1024 master and 0 or more replica vBuckets.
+Couchbase Server buckets physically contain 1024 active and 0 or more replica vBuckets.
 The _Master Services_ govern the placement of these vBuckets, to maximize availability to and rebalance performance.
 The vBucket map is recalculated whenever the cluster topology changes, by means of the following rules:
 
-* Master and replica vBuckets are placed on separate nodes.
+* Active and replica vBuckets are placed on separate nodes.
 * If a bucket is configured with more than one replica, each additional replica vBucket is placed on a separate node.
-* If _Server Groups_ are defined for master vBuckets, the replica vBuckets are placed in a separate groups.
+* If _Server Groups_ are defined for active vBuckets, the replica vBuckets are placed in a separate groups.
 See xref:clusters-and-availability/groups.adoc[Server Group Awareness], for more information.
 
 == Centralized Management, Statistics, and Logging


### PR DESCRIPTION
In the documentation to this time, vBuckets were named as active and replica vBuckets; suddenly, in this page the active vBucket was referred to as "Master" vBucket thereby reducing readability and adding cognitive load to the reader. Hence changed the Master vBuckets to be called as active vBuckets to be consistent across all documentations.