### PR TITLE
[DOC-9190] Scopes and collection name length incorrect

### DIFF
--- a/modules/learn/pages/data/scopes-and-collections.adoc
+++ b/modules/learn/pages/data/scopes-and-collections.adoc
@@ -53,7 +53,7 @@ The benefits of scopes and collections include:
 User-defined scopes and collections must be assigned user-defined names.
 Such names:
 
-* Must be between 1 and 30 characters in length.
+* Must be between 1 and 251 characters in length.
 * Can only contain the characters `A-Z`, `a-z`, `0-9`, and the symbols `&#95;`, `-`, and `%`.
 Note that scope and collection names are _case sensitive_.
 * Cannot start with `&#95;` or `%`.


### PR DESCRIPTION
Changed the maximum length of the scope/collection name to 251 characters.