### PR TITLE
node-to-node encryption and eventing storage

### DIFF
--- a/modules/eventing/pages/eventing-Terminologies.adoc
+++ b/modules/eventing/pages/eventing-Terminologies.adoc
@@ -102,7 +102,7 @@ The Eventing Storage (or Metadata) collection, stores artifacts (or configuratio
 
 When you are creating an Eventing Function, ensure that a separate collection is designated as an Eventing metadata and reserved solely for the internal use of the Eventing Service. You can use a common Eventing metadata collection across multiple Eventing Functions for the same tenant.  
 
-NOTE: The Eventing Storage keyspace must be in a Bucket of type Couchbase.  If this keyspace is not persistent the Data Service, or KV, will evict timer and checkpoint documents on hitting quota and Eventing can lose track of both timers and mutations processed. Furthermore at any point, refrain from deleting the Eventing metadata collection. Also, ensure that your handler code or other services do not perform a write or delete operation on the Eventing metadata collection.
+NOTE: The Eventing Storage keyspace must be in a Bucket of type Couchbase.  If this keyspace is not persistent the Data Service, or KV, will evict timer and checkpoint documents on hitting quota and Eventing can lose track of both timers and mutations processed. Furthermore at any point, refrain from deleting the Eventing metadata collection. Also, ensure that your Eventing Function's JavaScript code or other services do not perform a write or delete operation on the Eventing metadata collection.
 
 If an Eventing metadata collection gets accidentally deleted, then all deployed functions are undeployed and associated indexes and constructs get dropped.
 

--- a/modules/eventing/pages/eventing-Terminologies.adoc
+++ b/modules/eventing/pages/eventing-Terminologies.adoc
@@ -102,7 +102,7 @@ The Eventing Storage (or Metadata) collection, stores artifacts (or configuratio
 
 When you are creating an Eventing Function, ensure that a separate collection is designated as an Eventing metadata and reserved solely for the internal use of the Eventing Service. You can use a common Eventing metadata collection across multiple Eventing Functions for the same tenant.  
 
-NOTE: At any point, refrain from deleting the Eventing metadata collection. Also, ensure that your handler code or other services do not perform a write or delete operation on the Eventing metadata collection.
+NOTE: The Eventing Storage keyspace must be in a Bucket of type Couchbase.  If this keyspace is not persistent the Data Service, or KV, will evict timer and checkpoint documents on hitting quota and Eventing can lose track of both timers and mutations processed. Furthermore at any point, refrain from deleting the Eventing metadata collection. Also, ensure that your handler code or other services do not perform a write or delete operation on the Eventing metadata collection.
 
 If an Eventing metadata collection gets accidentally deleted, then all deployed functions are undeployed and associated indexes and constructs get dropped.
 

--- a/modules/eventing/pages/eventing-faq.adoc
+++ b/modules/eventing/pages/eventing-faq.adoc
@@ -319,3 +319,11 @@ that you may need to raise the Memory Quota for Eventing).
 However keep in mind that sometimes the Function is limited by both the number of cores in the Eventing instance the overall 
 performance of the Data Service.  In these cases it is appropriate to either scale compute power of the Eventing node, scale the 
 Eventing service, or scale the Data service.
+
+* Does Eventing support node-to-node encryption ?
++
+Yes, node-to-node encryption is  available in the Couchbase Server for the Eventing Service in the 7.X train starting with version 7.0.2 and the 6.X train starting with version 6.6.5.
+Therefore, on earlier versions (in either train), when _all_ is specified, the data passed to and from all other Couchbase Services is passed in encrypted form, whereas the data passed to and from the Eventing Service continues to be passed in _unencrypted_ form.
++
+When node-to-node encryption is enabled or disabled any deployed Eventing Functions needs to be temporarily paused and can be resumed after the necessary changes have been made to prevents the potential loss of mutations during the encryption change.
+

--- a/modules/eventing/pages/eventing-faq.adoc
+++ b/modules/eventing/pages/eventing-faq.adoc
@@ -325,5 +325,5 @@ Eventing service, or scale the Data service.
 Yes, node-to-node encryption is  available in the Couchbase Server for the Eventing Service in the 7.X train starting with version 7.0.2 and the 6.X train starting with version 6.6.5.
 Therefore, on earlier versions (in either train), when _all_ is specified, the data passed to and from all other Couchbase Services is passed in encrypted form, whereas the data passed to and from the Eventing Service continues to be passed in _unencrypted_ form.
 +
-When node-to-node encryption is enabled or disabled any deployed Eventing Functions needs to be temporarily paused and can be resumed after the necessary changes have been made to prevents the potential loss of mutations during the encryption change.
+When node-to-node encryption is enabled or disabled all deployed Eventing Function needs to be temporarily paused and can be resumed after the necessary changes have been made (to prevents the potential loss of mutations during the encryption change.)
 

--- a/modules/eventing/pages/troubleshooting-best-practices.adoc
+++ b/modules/eventing/pages/troubleshooting-best-practices.adoc
@@ -1,5 +1,6 @@
 = Troubleshooting and Best Practices
 :page-edition: Enterprise Edition
+
 == Why do similar functions that I write seem to run slower in 7.0.0 than 6.6.2?
 
 The default number of workers per function was three (3) in 6.X and is now one (1) in 7.0.0. You can simply raise the number of workers to 3 to get back the expected performance.  

--- a/modules/eventing/pages/troubleshooting-best-practices.adoc
+++ b/modules/eventing/pages/troubleshooting-best-practices.adoc
@@ -160,7 +160,7 @@ Yes, Ephemeral are fine for user data but not for the Eventing Storage (metadata
 
 The source bucket and any bucket (or keyspace) bindings of your Eventing Function can be Ephemeral.  However, the Eventing Storage keyspace (metadata collection) should always be persistent.
 
-NOTE: If the Eventing Storage keyspace is not persistent, the Data Service, or KV, will evict timer and checkpoint documents on hitting quota and Eventing can lose track of both timers and mutations processed.
+NOTE: The Eventing Storage keyspace must be in a Bucket of type Couchbase.  If this keyspace is not persistent the Data Service, or KV, will evict timer and checkpoint documents on hitting quota and Eventing can lose track of both timers and mutations processed. Furthermore at any point, refrain from deleting the Eventing metadata collection. Also, ensure that your handler code or other services do not perform a write or delete operation on the Eventing metadata collection.
 
 == Eventing worked fine when application was first deployed but now I am getting LCB_ETMPFAIL failures.
 

--- a/modules/eventing/pages/troubleshooting-best-practices.adoc
+++ b/modules/eventing/pages/troubleshooting-best-practices.adoc
@@ -1,6 +1,5 @@
 = Troubleshooting and Best Practices
 :page-edition: Enterprise Edition
-
 == Why do similar functions that I write seem to run slower in 7.0.0 than 6.6.2?
 
 The default number of workers per function was three (3) in 6.X and is now one (1) in 7.0.0. You can simply raise the number of workers to 3 to get back the expected performance.  
@@ -153,13 +152,15 @@ If the collection you chose to hold your meta data spills over to disk access is
 
 Always make sure that the memory quota on your metadata Eventing Storage keyspace (metadata collection) is sufficiently large to ensure a residency ratio of 100%. Additionally avoid using an Ephemeral bucket for your Eventing Storage keyspace (refer to next question for details). 
 
+You should only use Buckets of type Couchbase for data persistence of the Eventing Storage or metadata (for details refer to next question).
+
 == Can I use Ephemeral Buckets with Eventing?
 
-Yes, but not for the Eventing Storage keyspace. 
+Yes, Ephemeral are fine for user data but not for the Eventing Storage (metadata collection). 
 
-The source bucket and any bucket (or keyspace) bindings of your Eventing Function can be Ephemeral.  
+The source bucket and any bucket (or keyspace) bindings of your Eventing Function can be Ephemeral.  However, the Eventing Storage keyspace (metadata collection) should always be persistent.
 
-However, the Eventing Storage keyspace (metadata collection) should always be persistent. If the Eventing Storage keyspace is not persistent, the Data Service, or KV, will evict timer and checkpoint documents on hitting quota and Eventing can lose track of both timers and mutations processed.
+NOTE: If the Eventing Storage keyspace is not persistent, the Data Service, or KV, will evict timer and checkpoint documents on hitting quota and Eventing can lose track of both timers and mutations processed.
 
 == Eventing worked fine when application was first deployed but now I am getting LCB_ETMPFAIL failures.
 

--- a/modules/eventing/pages/troubleshooting-best-practices.adoc
+++ b/modules/eventing/pages/troubleshooting-best-practices.adoc
@@ -161,7 +161,7 @@ Yes, Ephemeral are fine for user data but not for the Eventing Storage (metadata
 
 The source bucket and any bucket (or keyspace) bindings of your Eventing Function can be Ephemeral.  However, the Eventing Storage keyspace (metadata collection) should always be persistent.
 
-NOTE: The Eventing Storage keyspace must be in a Bucket of type Couchbase.  If this keyspace is not persistent the Data Service, or KV, will evict timer and checkpoint documents on hitting quota and Eventing can lose track of both timers and mutations processed. Furthermore at any point, refrain from deleting the Eventing metadata collection. Also, ensure that your handler code or other services do not perform a write or delete operation on the Eventing metadata collection.
+NOTE: The Eventing Storage keyspace must be in a Bucket of type Couchbase.  If this keyspace is not persistent the Data Service, or KV, will evict timer and checkpoint documents on hitting quota and Eventing can lose track of both timers and mutations processed. Furthermore at any point, refrain from deleting the Eventing metadata collection. Also, ensure that your Eventing Function's JavaScript code or other services do not perform a write or delete operation on the Eventing metadata collection.
 
 == Eventing worked fine when application was first deployed but now I am getting LCB_ETMPFAIL failures.
 


### PR DESCRIPTION
For node-to-node encryption (attempt mirror recent updates to DOC-8818 WRT Eventing)

For eventing storage clarify that we must have a persistent Couchbase bucket.