### PR TITLE
[ray offiah] fixing the prometheus installation instructions

### DIFF
--- a/modules/manage/pages/monitor/set-up-prometheus-for-monitoring.adoc
+++ b/modules/manage/pages/monitor/set-up-prometheus-for-monitoring.adoc
@@ -79,7 +79,7 @@ The directory should contain the following files.
 
 ----
 
-NOTE: The cluster configuration file will have a different name to the one shown here
+NOTE: The cluster configuration file will have a different name to the one shown here.
 
 == Install Prometheus
 

--- a/modules/manage/pages/monitor/set-up-prometheus-for-monitoring.adoc
+++ b/modules/manage/pages/monitor/set-up-prometheus-for-monitoring.adoc
@@ -101,7 +101,7 @@ docker run \
 <.> This is the mapping of the Prometheus configuration directory to the host machine configuration.
 `~/prometheus` will be mapped on to the Prometheus instance configuration directory inside the Docker container.
 
-== Test the configuration.
+== Test the configuration
 Once the Docker container has started up, visit `http://localhost:9090/targets` to ensure that Prometheus is accessing the cluster correctly:
 
 image::monitor/prometheus-alert.png[]

--- a/modules/manage/pages/monitor/set-up-prometheus-for-monitoring.adoc
+++ b/modules/manage/pages/monitor/set-up-prometheus-for-monitoring.adoc
@@ -1,4 +1,4 @@
-= Using Your Own Prometheus Server to Consume Couchbase Metrics
+= Set up Prometheus to Consume Couchbase Metrics
 
 :description: This page will demonstrate how to enable a Prometheus server to read from Couchbase's Prometheus-ready endpoints.
 
@@ -8,15 +8,13 @@ With Couchbase 7.x, it's not necessary to write a custom Prometheus Exporter.
 
 == Prerequisites
 
-In this tutorial, we're going to use a https://www.docker.com/get-started[Docker] instance of https://prometheus.io/[Prometheus] to build our consumer. 
-Make sure that you have Docker installed and running on your machine. 
+Make sure that you have https://www.docker.com/get-started[Docker] installed and running on your machine. 
 You should also have an available Couchbase cluster with at least one running node.
-
 
 :sectnums:
 
 == Prepare the target configuration file
-You need to create a file that contains a list of the cluster's node targets. 
+Create a file that contains a list of the cluster's node targets. 
 This is done by issuing a request to the server from the command line:
 
 [source, console]
@@ -26,8 +24,9 @@ wget --content-disposition \
     --http-user Administrator --http-password password
 ----
 
-This will generate a configuration file containing the target addresses of the servers in your node. 
-The name of your file will depend on the name of your cluster, but the file suffix will be `yml`.
+This will generate a configuration file containing the target addresses of the nodes in your cluster. 
+
+NOTE: The name and contents of the file will depend on the configuration of the cluster:
 
 .couchbase_sd_config_my-cluster.yml
 [source, yaml]
@@ -37,7 +36,7 @@ The name of your file will depend on the name of your cluster, but the file suff
     - '10.144.220.102:8091'
 ----
 
-Now, create a new directory on your system and copy the file to the new directory:
+Create a new directory on your system and copy the file to the new directory:
 
 [source, console]
 ----
@@ -63,12 +62,13 @@ scrape_configs:
         refresh_interval: 15s
 ----
 
-<.> This is the name that Prometheus will assign to the process retrieving data from your target nodes.
-<.> The username the process can use to log into your cluster.
-<.> The password the process will use to log into your cluster.
-<.> The name of target file from which the process can read address of the cluster nodes.
+<.> This is the name that Prometheus will assign to the process retrieving data from the target nodes.
+<.> The username the process can use to log into the cluster.
+<.> The password the process will use to log into the cluster.
+<.> The name of target file. 
+The process will use this to read th addresses of the target nodes.
 
-Now you should have a directory containing two configuration files:
+The directory should contain the following files.
 
 [source, text]
 ----
@@ -78,6 +78,8 @@ Now you should have a directory containing two configuration files:
     📄 couchbase_sd_config_my-cluster.yml
 
 ----
+
+NOTE: The cluster configuration file will have a different name to the one shown here
 
 == Install Prometheus
 
@@ -96,10 +98,10 @@ docker run \
 *host-port*:: The port of the host machine used to access the Prometheus service.
 *container-port*:: This is the port used internally by the container. The host port maps on to this.
 
-<.> This is the mapping of the Prometheus configuration directory to the host machine configuration that you just created.
+<.> This is the mapping of the Prometheus configuration directory to the host machine configuration.
 `~/prometheus` will be mapped on to the Prometheus instance configuration directory inside the Docker container.
 
-== Test your configuration.
-Once the Docker container has started up, visit `http://localhost:9090/targets` to ensure that Prometheus is accessing your cluster correctly:
+== Test the configuration.
+Once the Docker container has started up, visit `http://localhost:9090/targets` to ensure that Prometheus is accessing the cluster correctly:
 
 image::monitor/prometheus-alert.png[]


### PR DESCRIPTION
The instructions didn't fit well with the rest of the section, so they've been adjusted to be more of a how-to-guide than a tutorial.

This mainly involved taking out the word 'tutorial'.