### PR TITLE
[DOC-9627] FTS geo distance is not always in miles

### DIFF
--- a/modules/fts/pages/fts-supported-queries-geo-spatial.adoc
+++ b/modules/fts/pages/fts-supported-queries-geo-spatial.adoc
@@ -9,7 +9,7 @@ Areas and locations are represented by  _latitude_-_longitude_ coordinate pairs.
 
 The location data provided by a geospatial query can be any of the following:
 
-* A location, is specified as a longitude-latitude coordinate pair; and a distance, in miles.
+* A location, is specified as a longitude-latitude coordinate pair; and a distance.
 The location determines the center of a circle whose radius-length is the specified distance.
 Documents are returned if they reference a location within the circle. For details of the units and formats in which distances can be specified, see xref:fts:fts-supported-queries-geo-spatial.adoc#specifying-distances[Specifying Distances].
 
@@ -37,7 +37,7 @@ Latitude-longitude coordinate pairs can be specified in multiple ways, including
 The `travel-sample` bucket, provided for test and development, contains multiple documents that specify locations.
 For example, those that represent airports, such as `airport_1254`:
 
-[source,javascript]
+[source, json]
 ----
 {
   "airportname": "Calais Dunkerque",
@@ -78,7 +78,7 @@ Each latitude-longitude coordinate can be expressed by means of any of the follo
 An individual latitude-longitude coordinate can be expressed by means of an object containing two key-value pairs.
 For example, the central location for a radius-based area can be expressed as follows:
 
-[source,javascript]
+[source, json]
 ----
 "location": {
        "lon": -2.235143,
@@ -88,7 +88,7 @@ For example, the central location for a radius-based area can be expressed as fo
 
 Where multiple coordinates are required, for the specifying of a polygon, an array of such objects can be specified, as follows:
 
-[source,javascript]
+[source, json]
 ----
 "polygon_points": [
   { “lat”: 37.79393211306212, “lon”: -122.44234633404847 },
@@ -106,14 +106,14 @@ Where multiple coordinates are required, for the specifying of a polygon, an arr
 An individual latitude-longitude coordinate can be expressed as a string containing two floating-point numbers &#8212; the first signifying latitude, the second longitude.
 For example, the center of a circle can be specified as follows:
 
-[source,javascript]
+[source, json]
 ----
 "location": "53.482358,-2.235143"
 ----
 
 Where multiple coordinates are required, for the specifying of a polygon, an array of such strings can be specified, as follows:
 
-[source,javascript]
+[source, json]
 ----
 "polygon_points": [
   "37.79393211306212,-122.44234633404847",
@@ -138,7 +138,7 @@ For example, the top left corner of a rectangle can be specified as follows:
 
 Where multiple coordinates are required, for the specifying of a polygon, an array of such arrays can be specified, as follows:
 
-[source,javascript]
+[source, json]
 ----
 "polygon_points": [
   [ -122.44234633404847, 37.79393211306212 ],
@@ -156,14 +156,14 @@ Where multiple coordinates are required, for the specifying of a polygon, an arr
 A latitude-longitude coordinate can be expressed by means of a single https://en.wikipedia.org/wiki/Geohash[Geohash] encoding.
 For example, the bottom right corner of a rectangle can be specified as follows:
 
-[source,javascript]
+[source, json]
 ----
 "bottom_right": "gcw2m0hmm6hs"
 ----
 
 Where multiple coordinates are required, for the specifying of a polygon, an array of geohashes can be specified, as follows:
 
-[source,javascript]
+[source, json]
 ----
 "polygon_points": [
   “9q8zjbkp”,
@@ -245,7 +245,7 @@ Note that more detailed information on performing queries with the Couchbase RES
 The following query-body specifies a longitude of `-2.235143` and a latitude of `53.482358`.
 The target-field `geo` is specified, as is a `distance` of `100` miles: this is the radius within which target-locations must reside for their documents to be returned.
 
-[source,javascript]
+[source, json]
 ----
 {
   "from": 0,
@@ -276,11 +276,8 @@ The query contains a `sort` object, which specifies that the returned documents 
 
 A subset of formatted console output might appear as follows:
 
-[source,javascript]
+[source, json]
 ----
-            .
-            .
-            .
 "hits": [
   {
     "index": "geoIndex_61d8c796ef7f4360_acbbef99",
@@ -313,10 +310,8 @@ A subset of formatted console output might appear as follows:
     "sort": [
       " \u0001?U]S\\.e\u0002_"
    ]
-  },
-            .
-            .
-            .
+  }
+]
 ----
 
 [#creating_geospatial_rest_query_bounding_box_based]
@@ -326,7 +321,7 @@ In the following query-body, the `top_left` of a rectangle is expressed by means
 The `bottom_right` is expressed by means of key-value pairs, specifying a longitude of `28.955043` and a latitude of `40.991862`.
 The results are specified to be sorted on `name` alone.
 
-[source,javascript]
+[source, json]
 ----
 {
   "from": 0,
@@ -347,11 +342,8 @@ The results are specified to be sorted on `name` alone.
 
 A subset of formatted output might appear as follows:
 
-[source,javascript]
+[source, json]
 ----
-          .
-          .
-          .
 "hits": [
   {
     "index": "geoIndex_61d8c796ef7f4360_acbbef99",
@@ -384,10 +376,8 @@ A subset of formatted output might appear as follows:
     "sort": [
       " \u0001?U]S\\.e\u0002_"
     ]
-  },
-          .
-          .
-          .
+  }
+ ]
 ----
 
 [#creating_geospatial_rest_query_polygon_based]
@@ -402,7 +392,7 @@ However, specifying an explicit closure in this way is optional: closure will be
 If a target data-location falls within the box, its document is returned.
 The results are specified to be sorted on `name` alone.
 
-[source,javascript]
+[source, json]
 ----
 {
   "query": {
@@ -424,11 +414,8 @@ The results are specified to be sorted on `name` alone.
 
 A subset of formatted output might appear as follows:
 
-[source,javascript]
+[source,json]
 ----
-    .
-    .
-    .
     "hits": [
       {
         "index": "geoIndex_661ef3af66ee41b5_54820232",
@@ -453,9 +440,7 @@ A subset of formatted output might appear as follows:
         "sort": [
           "atherton"
         ]
-      },
-        .
-        .
-        .
+      }
+    ]
 ----
 


### PR DESCRIPTION
Removed the 'in miles' reference.
Tidied up some JSON blocks.