### PR TITLE
DOC-9631 Overly complicated Windows installation instructions.

### DIFF
--- a/modules/install/pages/install-package-windows.adoc
+++ b/modules/install/pages/install-package-windows.adoc
@@ -42,33 +42,8 @@ Proceed as follows:
 . Download the appropriate package from the Couchbase https://www.couchbase.com/downloads[downloads page^].
 Note that Couchbase Server for Windows is packaged in a standard MSI file.
 
-. In the *Type here to search* field, which is to the immediate right of the *Start* button, at the lower left of the screen, type `cmd`:
-+
-image::typeCmd.png[,280,align=left]
 
-. When the *Command Prompt* icon appears in the search results, right-click on it, to display the pull-down menu; then, select *Run as administrator*:
-+
-image::runAsAdmin.png[,280,align=left]
-+
-Next, a dialog appears, asking whether you wish to allow the *Windows Command Processor* to make changes to your system.
-Click *Yes*, on the dialog.
-
-. The *Command Prompt* now appears.
-Against the prompt, change directory to *Downloads*, by entering the following command.
-+
-[source,shell]
-----
-cd C:\Users\customer\Downloads
-----
-
-. Start the Couchbase-Server install wizard; by using the `call` command, and specifying the `.msi` file that you have downloaded:
-+
-[source,shell]
-----
-call couchbase-server-enterprise_7.0.2-windows_amd64.msi
-----
-+
-The install wizard now appears:
+. Start the Couchbase-Server install wizard; by double-clicking on the `.msi` file you have just downloaded.
 +
 image::wizardScreen.png[,440,align=left]
 


### PR DESCRIPTION
Removed instructions that directed reader to use the command line.