### PR TITLE
DOC-9650 Note on eviction is in the wrong place.

### DIFF
--- a/modules/manage/pages/manage-buckets/create-bucket.adoc
+++ b/modules/manage/pages/manage-buckets/create-bucket.adoc
@@ -99,6 +99,8 @@ If [.ui]*Value-only* is selected, only data is ejected.
 Generally, Value-only ejection favors performance at the expense of memory; and Full ejection vice versa.
 See xref:learn:buckets-memory-and-storage/memory.adoc#ejection[Ejection], for more information.
 Note that _ejection_ in the context of a Couchbase bucket means removal from memory, with continued persistence on disk.
++
+include::learn:partial$full-eviction-note.adoc[]
 
 [#bucket-priority]
 * [.ui]*Bucket Priority*: Allows you to specify the priority of the current Couchbase bucket's background tasks, relative to the background tasks of other buckets on the cluster.
@@ -165,9 +167,7 @@ The following settings are different for Ephemeral buckets:
 If [.ui]*No ejection* is selected, no ejection of existing data occurs, and attempts to cache new data fail.
 If [.ui]*NRU ejection* is selected, existing data is ejected, with _Not Recently Used_ documents being those removed.
 Note that _ejection_ when applied to an Ephemeral bucket means removal of bucket-data from memory without persistence (since ephemeral buckets have no presence on disk).
-+
-include::learn:partial$full-eviction-note.adoc[]
-{nbsp}
+
 * [.ui]*Metadata Purge Interval*: This setting, here provided at the top level of the user interface for Ephemeral buckets, was made visible for Couchbase buckets only by checking the [.ui]*Auto-Compaction* checkbox.
 Note that other auto-compaction settings do not apply to Ephemeral buckets, since such settings are for data that reside on disk: however, the Metadata Purge Interval applies both to Couchbase _and_ to Ephemeral buckets.
 * *Durability Level*: Only the *None* and *Majority* settings are available (since persistence is not supported by Ephemeral buckets).


### PR DESCRIPTION
Fixed (I think)

@shivaniguptacb, @stevewatanabe  <-- I just want someone to take a quick look at this. We seem to have  `ejection` and `eviction` used here. Are they the same thing?