### PR TITLE
Remove subqueries from description of JOIN how-to guide

### DIFF
--- a/modules/guides/pages/join.adoc
+++ b/modules/guides/pages/join.adoc
@@ -5,7 +5,7 @@
 :imagesdir: ../assets/images
 :clauses: Joins
 :tabs:
-:description: How to join data sources for a N1QL selection query, and how to use subqueries.
+:description: How to join data sources for a N1QL selection query.
 
 [abstract]
 {description}


### PR DESCRIPTION
How-to guides don't cover subqueries yet