### PR TITLE
DOC-9648: Separate the definitions of boolean and boolean field queries

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -223,7 +223,7 @@
    **** xref:fts:fts-supported-queries-wildcard.adoc[Wilcard]
   *** xref:fts:fts-supported-queries-compound-query.adoc[Compound Queries]
    **** xref:fts:fts-supported-queries-conjuncts-disjuncts.adoc[Conjuncts and Disjuncts]
-   **** xref:fts:fts-supported-queries-boolean-field-query.adoc[Boolean]
+   **** xref:fts:fts-supported-queries-boolean-query.adoc[Boolean]
   *** xref:fts:fts-supported-queries-range-query.adoc[Range Queries]
    **** xref:fts:fts-supported-queries-numeric-range.adoc[Numeric Range]
    **** xref:fts:fts-supported-queries-date-range.adoc[Date Range]

--- a/modules/fts/pages/fts-introduction.adoc
+++ b/modules/fts/pages/fts-introduction.adoc
@@ -114,8 +114,9 @@ These include:
 
 * xref:fts-supported-queries-match.adoc[Match], xref:fts-supported-queries-match-phrase.adoc[Match Phrase]
 * xref:fts-supported-queries-DocID-query.adoc[DocId Query], and xref:fts-supported-queries-prefix-query.adoc[Prefix Query]
-* xref:fts-supported-queries-conjuncts-disjuncts.adoc[Conjuncts & Disjuncts], and xref:fts-supported-queries-boolean-field-query.adoc[Boolean] 
-* xref:fts-supported-queries-numeric-range.adoc[Numeric Range] and xref:fts-supported-queries-date-range.adoc[Date Range] 
+* xref:fts-supported-queries-boolean-field-query.adoc[Boolean Field Query]
+* xref:fts-supported-queries-conjuncts-disjuncts.adoc[Conjuncts & Disjuncts], and xref:fts-supported-queries-boolean-query.adoc[Boolean]
+* xref:fts-supported-queries-numeric-range.adoc[Numeric Range] and xref:fts-supported-queries-date-range.adoc[Date Range]
 * xref:fts-supported-queries-geo-spatial.adoc[Geospatial] queries
 * xref:fts-supported-queries-query-string-query.adoc[Query String Query] which employ a special syntax to express the details of each query.
 * xref:fts-supported-queries-fuzzy.adoc[Fuzzy]

--- a/modules/fts/pages/fts-query-string-syntax-field-scoping.adoc
+++ b/modules/fts/pages/fts-query-string-syntax-field-scoping.adoc
@@ -8,7 +8,7 @@ The path must use Search syntax rather than xref:n1ql/n1ql-language-reference/in
 
 == Required, Optional, and Exclusion
 
-When a query string includes multiple items, by default these are placed into the SHOULD clause of a xref:fts-supported-queries-boolean-field-query.adoc[boolean query].
+When a query string includes multiple items, by default these are placed into the SHOULD clause of a xref:fts-supported-queries-boolean-query.adoc[Boolean Query].
 You can adjust this by prefixing items with `+` or `-`.
 
 * Prefixing with `+` places that item in the MUST portion of the boolean query.

--- a/modules/fts/pages/fts-supported-queries-boolean-field-query.adoc
+++ b/modules/fts/pages/fts-supported-queries-boolean-field-query.adoc
@@ -1,20 +1,11 @@
-= Boolean Query
+= Boolean Field Query
 
-A _boolean query_ is a combination of conjunction and disjunction queries.
-A boolean query takes three lists of queries:
-
-* `must`: Result documents must satisfy all of these queries.
-* `should`: Result documents should satisfy these queries.
-* `must not`: Result documents must not satisfy any of these queries.
+A _boolean field query_ searches fields that contain boolean true or false values. A boolean field query searches the actual content of the field, and should not be confused with the boolean query.
 
 [source,json]
 ----
 {
- "must": {
-   "conjuncts":[{"field":"reviews.content", "match": "location"}]},
- "must_not": {
-   "disjuncts": [{"field":"free_breakfast", "bool": false}]},
- "should": {
-   "disjuncts": [{"field":"free_breakfast", "bool": true}]}
+  "field": "active",
+  "bool": true
 }
 ----

--- a/modules/fts/pages/fts-supported-queries-boolean-query.adoc
+++ b/modules/fts/pages/fts-supported-queries-boolean-query.adoc
@@ -1,0 +1,20 @@
+= Boolean Query
+
+A _boolean query_ is a combination of conjunction and disjunction queries.
+A boolean query takes three lists of queries:
+
+* `must`: Result documents must satisfy all of these queries.
+* `should`: Result documents should satisfy these queries.
+* `must not`: Result documents must not satisfy any of these queries.
+
+[source,json]
+----
+{
+ "must": {
+   "conjuncts":[{"field":"reviews.content", "match": "location"}]},
+ "must_not": {
+   "disjuncts": [{"field":"free_breakfast", "bool": false}]},
+ "should": {
+   "disjuncts": [{"field":"free_breakfast", "bool": true}]}
+}
+----

--- a/modules/fts/pages/fts-supported-queries-compound-query.adoc
+++ b/modules/fts/pages/fts-supported-queries-compound-query.adoc
@@ -5,4 +5,4 @@ Compound Queries:: Accept multiple queries simultaneously, and return either the
 The following queries are compound queries:
 
 * xref:fts-supported-queries-conjuncts-disjuncts.adoc[Conjuncts & Disjuncts]
-* xref:fts-supported-queries-boolean-field-query.adoc[Boolean]
+* xref:fts-supported-queries-boolean-query.adoc[Boolean]


### PR DESCRIPTION
+ Also fixing the example descriptions and formatting for-
    - boolean query
    - boolean field query