### PR TITLE
DOC-8946: mistake in docs for boolean logic table

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/booleanlogic.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/booleanlogic.adoc
@@ -38,7 +38,7 @@ The following table describes how these values relate to the logical operators:
 
 | MISSING
 | MISSING
-| FALSE
+| TRUE
 
 .4+| FALSE
 | TRUE

--- a/modules/n1ql/pages/n1ql-language-reference/booleanlogic.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/booleanlogic.adoc
@@ -52,7 +52,7 @@ The following table describes how these values relate to the logical operators:
 
 | NULL
 | FALSE
-| FALSE
+| NULL
 
 | MISSING
 | FALSE


### PR DESCRIPTION
Backport of #2437 to release/7.0

Docs issue: [DOC-8946](https://issues.couchbase.com/browse/DOC-8946)

To verify these changes: [booleanlogic.n1ql](https://gist.github.com/simon-dew/2dffadc79aea29b003df9d71bc19d145)
Result: [booleanlogic.json](https://gist.github.com/simon-dew/611ea96a320825b5e9854fb4c6f882e0)