### PR TITLE
DOC-8946: mistake in docs for boolean logic table

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/booleanlogic.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/booleanlogic.adoc
@@ -37,7 +37,7 @@ The following table describes how these values relate to the logical operators:
 
 | MISSING
 | MISSING
-| FALSE
+| TRUE
 
 .4+| FALSE
 | TRUE

--- a/modules/n1ql/pages/n1ql-language-reference/booleanlogic.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/booleanlogic.adoc
@@ -51,7 +51,7 @@ The following table describes how these values relate to the logical operators:
 
 | NULL
 | FALSE
-| FALSE
+| NULL
 
 | MISSING
 | FALSE


### PR DESCRIPTION
Backport of #2437 to release/6.0

Docs issue: [DOC-8946](https://issues.couchbase.com/browse/DOC-8946)