### PR TITLE
DOC-9374 Direct upgrade from 6.0.x to 7.1.x is not supported

### DIFF
--- a/modules/install/pages/upgrade.adoc
+++ b/modules/install/pages/upgrade.adoc
@@ -33,14 +33,14 @@ All supported upgrades can be performed with the cluster either _offline_ or _on
 | Starting Version |  Path to Current Version
 
 | 5.0.x
-| 5.0.x and 5.1.x -> 6.0.4+ -> 6.6 -> 7.0
+| 5.0.x and 5.1.x -> 6.0.4+ -> 6.6 -> 7.0 -> 7.1x
 
-5.0.x and 5.1.x -> 6.6 -> 7.0
+5.0.x and 5.1.x -> 6.6 -> 7.0 -> 7.1x
 
-5.5.0+ -> 6.6 -> 7.0
+5.5.0+ -> 6.6 -> 7.0 -> 7.1x
 
 | 6.x
-| 6.x -> 7.0
+| 6.x -> 7.0 -> 7.1x
 
 |===
 
@@ -52,10 +52,10 @@ All supported upgrades can be performed with the cluster either _offline_ or _on
 | Starting Version | Path to Current Version
 
 | 5.x
-| 5.x -> 6.0 -> 6.5 -> 6.6 -> 7.0
+| 5.x -> 6.0 -> 6.5 -> 6.6 -> 7.0 -> 7.1x
 
 | 6.x
-| 6.0 -> 6.5 -> 6.6 -> 7.0
+| 6.0 -> 6.5 -> 6.6 -> 7.0 -> 7.1x
 
 |===
 


### PR DESCRIPTION
Added 7.x to the upgrade tables.