### PR TITLE
Update rest-fts-advanced to proper syntax DOC-9337

### DIFF
--- a/modules/rest-api/pages/rest-fts-advanced.adoc
+++ b/modules/rest-api/pages/rest-fts-advanced.adoc
@@ -5,7 +5,7 @@
 [[g-api-index]]GET /api/pindex::
 Get information about an index partition.
 +
-*Permission Required*: cluster.bucket[[.var]`bucket_name`].fts!read
+*Permission Required*: cluster.bucket[].fts!read
 +
 *Role Required*: FTS-Searcher, FTS-Admin
 +
@@ -32,26 +32,26 @@ Get information about an index partition.
 ----
 
 [[g-api-index-name]]GET /api/pindex/\{pindexName}::
-*Permission Required*: cluster.bucket[[.var]`bucket_name`].fts!read
+*Permission Required*: cluster.bucket[].fts!read
 +
 *Role Required*: FTS-Searcher, FTS-Admin
 
 == Index Partition Querying
 
 [[g-api-index-name-count]]GET /api/pindex/\{pindexName}/count::
-*Permission Required*: cluster.bucket[[.var]`bucket_name`].fts!read
+*Permission Required*: cluster.bucket[].fts!read
 +
 *Role Required*: FTS-Searcher, FTS-Admin
 
 [[p-api-index-name-query]]POST /api/pindex/\{pindexName}/query::
-*Permission Required*: cluster.bucket[[.var]`bucket_name`].fts!write
+*Permission Required*: cluster.bucket[].fts!write
 +
 *Role Required*: FTS-Admin
 
 == FTS Memory Quota
 
 [[p-api-fts-memory-quota]]POST /pools/default::
-*Permission Required*: cluster.bucket[[.var]`bucket_name`].fts!manage
+*Permission Required*: cluster.bucket[].fts!manage
 +
 *Role Required*: FTS-Admin
 +


### PR DESCRIPTION
Current documentation has below permissions mentioned for "GET /api/pindex":
Permission Required: cluster.bucket[bucket_name].fts!read
This has to be updated to "Permission Required: cluster.bucket[].fts!read"