### PR TITLE
Bad permission syntax GET /api/pindex

### DIFF
--- a/modules/rest-api/pages/rest-fts-advanced.adoc
+++ b/modules/rest-api/pages/rest-fts-advanced.adoc
@@ -5,7 +5,7 @@
 [[g-api-index]]GET /api/pindex::
 Get information about an index partition.
 +
-*Permission Required*: cluster.bucket[[.var]`bucket_name`].fts!read
+*Permission Required*: cluster.bucket[].fts!read
 +
 *Role Required*: FTS-Searcher, FTS-Admin
 +


### PR DESCRIPTION
Simple change on only the GET /api/pindex call (the first item) as per DOC-9337
update for 7.0 and 7.1  (this PR)