### PR TITLE
DOC-9686: type mapping examples formatting changes

### DIFF
--- a/modules/fts/pages/fts-type-mappings.adoc
+++ b/modules/fts/pages/fts-type-mappings.adoc
@@ -397,52 +397,55 @@ For example, while working with the `travel-sample` bucket,  set up docid_regexp
 * airport
 
 Below is a full index definition using it.
+[source, JSON]
+----
 {
-    "name": "airline-airport-index",
-    "type": "fulltext-index",
-    "params": {
-              "doc_config": {
-              "docid_prefix_delim": "",
-              "docid_regexp": "air[a-z]{4}",
-              "mode": "docid_regexp",
-              "type_field": "type"
-              },
-    "mapping": {
-              "default_analyzer": "standard",
-              "default_datetime_parser": "dateTimeOptional",
-              "default_field": "_all",
-              "default_mapping": {
-              "dynamic": true,
-              "enabled": false
-              },
-      "default_type": "_default",
-      "docvalues_dynamic": false,
-      "index_dynamic": true,
-      "store_dynamic": false,
-      "type_field": "_type",
-  "types": {
-              "airline": {
-              "dynamic": true,
-              "enabled": true
-              },
-            "airport": {
-            "dynamic": true,
-            "enabled": true
-              }
+   "name":"airline-airport-index",
+   "type":"fulltext-index",
+   "params":{
+      "doc_config":{
+         "docid_prefix_delim":"",
+         "docid_regexp":"air[a-z]{4}",
+         "mode":"docid_regexp",
+         "type_field":"type"
+      },
+      "mapping":{
+         "default_analyzer":"standard",
+         "default_datetime_parser":"dateTimeOptional",
+         "default_field":"_all",
+         "default_mapping":{
+            "dynamic":true,
+            "enabled":false
+         },
+         "default_type":"_default",
+         "docvalues_dynamic":false,
+         "index_dynamic":true,
+         "store_dynamic":false,
+         "type_field":"_type",
+         "types":{
+            "airline":{
+               "dynamic":true,
+               "enabled":true
+            },
+            "airport":{
+               "dynamic":true,
+               "enabled":true
             }
-          },
-      "store": {
-      "indexType": "scorch",
-      "segmentVersion": 15
+         }
+      },
+      "store":{
+         "indexType":"scorch",
+         "segmentVersion":15
       }
-     },
-    "sourceType": "gocbcore",
-    "sourceName": "travel-sample",
-    "sourceParams": {},
-    "planParams": {
-      "indexPartitions": 1
-      }
+   },
+   "sourceType":"gocbcore",
+   "sourceName":"travel-sample",
+   "sourceParams":{},
+   "planParams":{
+      "indexPartitions":1
+   }
 }
+----
 
 So setting this as the index definition would index all attributes of documents with “airline” or "airport" in its document IDs.
 


### PR DESCRIPTION
It looks like one of the hanging pages(fts-type-mappings-Docid-with-regexp) was updated instead of the page that's part of the fts ToC(fts-type-mappings). This is something to clean up as per ticket DOC-9722. So, this PR contains the corrections regarding the same.