### PR TITLE
DOC-9769 Debian 11 mistakenly added to 7.0 supported platforms.

### DIFF
--- a/modules/install/pages/install-platforms.adoc
+++ b/modules/install/pages/install-platforms.adoc
@@ -27,9 +27,7 @@ Nodes in a Couchbase cluster should all be running on the same OS, and every eff
 7.x
 
 | Debian
-| 11.x
-
-10.x
+| 10.x
 
 9.x
 


### PR DESCRIPTION
Fixed