### PR TITLE
DOC-9714 and DOC-9715 RHEL7 and CentOS 7 Deprecated in Neo (7.1.0)

### DIFF
--- a/modules/install/pages/install-platforms.adoc
+++ b/modules/install/pages/install-platforms.adoc
@@ -41,7 +41,7 @@ Nodes in a Couchbase cluster should all be running on the same OS, and every eff
 | Red Hat Enterprise Linux (RHEL)
 | 8.x
 
-7.x
+7.x (Deprecated)
 
 | SUSE Linux Enterprise Server (SLES)
 | 15.x

--- a/modules/install/pages/install-platforms.adoc
+++ b/modules/install/pages/install-platforms.adoc
@@ -31,7 +31,7 @@ Nodes in a Couchbase cluster should all be running on the same OS, and every eff
 
 10.x
 
-9.x
+9.x (Deprecated)
 
 | Oracle Linux{empty}footnote:[Only the Red Hat Compatible Kernel (RHCK) is supported. The Unbreakable Enterprise Kernel (UEK) is not supported.]
 | 8.x

--- a/modules/install/pages/install-platforms.adoc
+++ b/modules/install/pages/install-platforms.adoc
@@ -22,21 +22,19 @@ Nodes in a Couchbase cluster should all be running on the same OS, and every eff
 | LTS
 
 | CentOS
-| 8.x (Deprecated)
-
-7.x (Deprecated)
+| 7.x (Deprecated)
 
 | Debian
 | 11.x
 
 10.x
 
-9.x (Deprecated)
+
 
 | Oracle Linux{empty}footnote:[Only the Red Hat Compatible Kernel (RHCK) is supported. The Unbreakable Enterprise Kernel (UEK) is not supported.]
 | 8.x
 
-7.x
+7.x (Deprecated)
 
 | Red Hat Enterprise Linux (RHEL)
 | 8.x
@@ -56,9 +54,6 @@ Nodes in a Couchbase cluster should all be running on the same OS, and every eff
 | Windows Server
 | 2019
 
-2016 Standard Edition (Deprecated)
-
-2016 DataCenter Edition (Deprecated)
 |===
 
 .Supported Operating Systems for Development and Testing Only
@@ -69,9 +64,8 @@ Nodes in a Couchbase cluster should all be running on the same OS, and every eff
 | macOS
 | 11 "Big Sur"
 
-10.15 "Catalina"
+10.15 "Catalina" (Deprecated)
 
-10.14 "Mojave" (Deprecated)
 
 | Windows Desktop
 | 10 (requires Anniversary Update)

--- a/modules/install/pages/install-platforms.adoc
+++ b/modules/install/pages/install-platforms.adoc
@@ -24,7 +24,7 @@ Nodes in a Couchbase cluster should all be running on the same OS, and every eff
 | CentOS
 | 8.x (Deprecated)
 
-7.x
+7.x (Deprecated)
 
 | Debian
 | 11.x

--- a/modules/install/pages/install-platforms.adoc
+++ b/modules/install/pages/install-platforms.adoc
@@ -51,7 +51,7 @@ Nodes in a Couchbase cluster should all be running on the same OS, and every eff
 | Ubuntu
 | 20.04
 
-18.04
+18.04 (Deprecated)
 
 | Windows Server
 | 2019

--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -34,12 +34,15 @@ See xref:install:install-platforms.adoc[Supported Platforms] for the complete li
 
 The following platforms are deprecated and will be removed in a future release:
 
-* CentOS 7.x
-* CentOS 8.x
-* Debian 9.x
-* MacOS Catalina (deprecated)
-* Red Hat Enterprise Linux (RHEL) 7.x
-* Ubuntu 18.04
+* Apple OS X v10.14 (Mojave) – removed
+* Apple OS X v10.15 (Catalina) – deprecated
+* CentOS 7.x – deprecated
+* CentOS 8.x – removed
+* Debian 9.x – removed
+* Microsoft Windows Server 2016 – removed
+* Microsoft Windows Server 2016 (64-bit, DataCenter Edition) – removed
+* Red Hat Enterprise Linux (RHEL) 7.x – deprecated
+* Ubuntu 18.x – deprecated
 
 
 [#fixed-issues-710]

--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -37,6 +37,7 @@ The following platforms are deprecated and will be removed in a future release:
 * CentOS 7.x
 * CentOS 8.x
 * Debian 9.x
+* MacOS Catalina (deprecated)
 * Red Hat Enterprise Linux (RHEL) 7.x
 * Ubuntu 18.04
 

--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -30,7 +30,6 @@ See xref:install:install-platforms.adoc[Supported Platforms] for the complete li
 [#deprecated-features-and-platforms-710]
 == Deprecated Features and Platforms
 
-[#deprecated-and-removed-platforms-710]
 === Deprecated and Removed Platforms
 
 The following platforms are deprecated and will be removed in a future release:

--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -36,6 +36,7 @@ The following platforms are deprecated and will be removed in a future release:
 
 * CentOS 7.x
 * CentOS 8.x
+* Debian 9.x
 * Red Hat Enterprise Linux (RHEL) 7.x
 * Ubuntu 18.04
 

--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -21,7 +21,7 @@ This section highlights the notable new features and improvements in this releas
 
 This release adds support for the following platforms:
 
-* MacOS Big Sur for development only
+* Apple macOS v11.6 (Big Sur) for development only
 
 * Amazon Linux (ARM)
 
@@ -34,13 +34,14 @@ See xref:install:install-platforms.adoc[Supported Platforms] for the complete li
 
 The following platforms are deprecated and will be removed in a future release:
 
-* Apple OS X v10.14 (Mojave) – removed
-* Apple OS X v10.15 (Catalina) – deprecated
+* Apple macOS v10.14 (Mojave) – removed
+* Apple macOS v10.15 (Catalina) – deprecated
 * CentOS 7.x – deprecated
 * CentOS 8.x – removed
 * Debian 9.x – removed
 * Microsoft Windows Server 2016 – removed
 * Microsoft Windows Server 2016 (64-bit, DataCenter Edition) – removed
+* Oracle Linux 7.x – deprecated
 * Red Hat Enterprise Linux (RHEL) 7.x – deprecated
 * Ubuntu 18.x – deprecated
 

--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -35,8 +35,10 @@ See xref:install:install-platforms.adoc[Supported Platforms] for the complete li
 
 The following platforms are deprecated and will be removed in a future release:
 
-* Red Hat Enterprise Linux (RHEL) 7.x
 * CentOS 7.x
+* CentOS 8.x
+* Red Hat Enterprise Linux (RHEL) 7.x
+* Ubuntu 18.04
 
 
 [#fixed-issues-710]

--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -36,8 +36,7 @@ See xref:install:install-platforms.adoc[Supported Platforms] for the complete li
 The following platforms are deprecated and will be removed in a future release:
 
 * Red Hat Enterprise Linux (RHEL) 7.x
-
-
+* CentOS 7.x
 
 
 [#fixed-issues-710]

--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -27,6 +27,18 @@ This release adds support for the following platforms:
 
 See xref:install:install-platforms.adoc[Supported Platforms] for the complete list of supported platforms.
 
+[#deprecated-features-and-platforms-710]
+== Deprecated Features and Platforms
+
+[#deprecated-and-removed-platforms-710]
+=== Deprecated and Removed Platforms
+
+The following platforms are deprecated and will be removed in a future release:
+
+* Red Hat Enterprise Linux (RHEL) 7.x
+
+
+
 
 [#fixed-issues-710]
 === Fixed Issues


### PR DESCRIPTION
Fixed in install-platforms.adoc and relnotes.adoc