### PR TITLE
DOC-9642: Privileges in a transaction that includes KV and N1QL operations

### DIFF
--- a/modules/learn/pages/data/transactions.adoc
+++ b/modules/learn/pages/data/transactions.adoc
@@ -227,6 +227,11 @@ In Step 4 in the illustration above, the transaction attempt is marked as “Com
 
 In Step 7 in the illustration above, the transaction attempt is marked as “Completed” and is removed from the ATR. 
 
+== Permissions
+
+include::partial$transaction-privileges.adoc[]
+
+[[custom-metadata-collections]]
 == Custom Metadata Collections
 
 By default, metadata documents are created in the default collection of the bucket of the first mutated document in the transaction. 

--- a/modules/learn/pages/data/transactions.adoc
+++ b/modules/learn/pages/data/transactions.adoc
@@ -1,7 +1,6 @@
 = Transactions
-:description: pass:q[A _transaction_ is an atomic unit of work that contains one or more operations. It is a group of operations that are either committed to the database together or they are all undone from the database.]
+:description: A transaction is an atomic unit of work that contains one or more operations. It is a group of operations that is either committed to the database together, or undone from the database.
 :page-aliases: acid-transactions,transactions,learn:data/distributed-acid-transactions,introduction:distributed-acid-transactions
-:txn-atr: _txn:atr-
 :tabs:
 
 [abstract]
@@ -13,20 +12,20 @@ Couchbase transactions support ACID properties for protected actions on the data
 
 *Atomicity* ensures that a transaction provides all-or-nothing semantics -- i.e.,  either all the documents modified in a transaction are committed, or none of the changes are committed. If there is a failure during transaction execution (such as the client crashing) all its changes are rolled back. 
 
-*Consistency* - Couchbase transactions ensure that the database moves from one consistent state to another and all derived artifacts such as indexes are updated automatically (though asynchronously from the transaction). Note that the traditional definition of consistency is not relevant as there are no foreign key constraints in Couchbase.
+*Consistency* -- Couchbase transactions ensure that the database moves from one consistent state to another and all derived artifacts such as indexes are updated automatically (though asynchronously from the transaction). Note that the traditional definition of consistency is not relevant as there are no foreign key constraints in Couchbase.
 
-*Isolation* - Couchbase transactions guarantee that the changes made in a transaction are not visible until the transaction is committed. This is the ‘Read Committed’ level of isolation. 
+*Isolation* -- Couchbase transactions guarantee that the changes made in a transaction are not visible until the transaction is committed. This is the ‘Read Committed’ level of isolation. 
 
-* The isolation provided to transactional reads is stricter than Read Committed - it is Monotonic Atomic View (MAV). Monotonic Atomic View ensures that all effects of a previously committed transaction are observed  i.e. after commit a transaction is never partially observed.
+* The isolation provided to transactional reads is stricter than Read Committed -- it is Monotonic Atomic View (MAV). Monotonic Atomic View ensures that all effects of a previously committed transaction are observed  i.e. after commit a transaction is never partially observed.
 * Lost Updates are always prevented by checking against the CAS value which behaves like an optimistic lock. 
 
 *Durability* is a property that ensures changes made by committed transactions are not lost if failures occur. Couchbase transactions provide tunable durability to tolerate different failure scenarios with 3 different levels: 
 
-* `majority` - replicate to a majority of the replicas before acknowledging the write. This is the default level. 
-* `majorityAndPersistActive` - replicate to a majority of the replicas and persist to disk on the primary before acknowledging the write
-* `persistToMajority` - persist to disk on a majority of the replicas before acknowledging the write. 
+* `majority` -- replicate to a majority of the replicas before acknowledging the write. This is the default level. 
+* `majorityAndPersistActive` -- replicate to a majority of the replicas and persist to disk on the primary before acknowledging the write
+* `persistToMajority` -- persist to disk on a majority of the replicas before acknowledging the write. 
 
-`persistToMajority` provides the strongest protection from failures but is the least performant amongst the Durability levels. For more information, see xref:durability.adoc#durability-requirements[Durability Levels]. 
+`persistToMajority` provides the strongest protection from failures but is the least performant amongst the Durability levels. For more information, see xref:durability.adoc#durability-requirements[Durability Levels].
 
 NOTE: Statement Level Atomicity is provided for N1QL statements that are executed inside a transaction. This means that if a query statement fails during execution for a reason like a unique key violation that statement is completely rolled back and the rest of the transaction continues. It is as though the statement is not part of the transaction. No other work in the transaction is affected by the failure of this statement. If the query statement succeeds, it would be committed or rolled back based on the outcome of the overall transaction. 
 
@@ -42,11 +41,11 @@ Transaction APIs support:
 
 * Key-Value _insert_, _update_, and _delete_ operations, across any number of documents
 
-* Seamless integration between Key-Value(KV) and Query DML statements (SELECT, INSERT, UPDATE, DELETE, UPSERT, MERGE) within transactions
+* Seamless integration between Key-Value (KV) and Query DML statements (SELECT, INSERT, UPDATE, DELETE, UPSERT, MERGE) within transactions
 
 Multiple Key-Value and Query DML statements can be used together inside a transaction.
 
-When query DML statements are used within a transaction, xref:n1ql:n1ql-rest-api/index.adoc#table_xmr_grl_lt[request_plus] semantics are automatically used to ensure all updates done (and committed if done in a transaction) before the start of the transaction are visible to the query statements within it.
+When query DML statements are used within a transaction, xref:settings:query-settings.adoc#transactional-scan-consistency[request_plus] semantics are automatically used to ensure all updates done (and committed if done in a transaction) before the start of the transaction are visible to the query statements within it.
 
 == Using Transactions
 
@@ -85,8 +84,6 @@ Note the use of a lambda function to express the transaction.
 The application supplies the logic for the transaction inside a lambda, including any conditional logic required, and the transactions API takes care of getting the transaction committed. If the transactions API encounters a transient error, such as a temporary conflict with another transaction, then it can rollback what has been done so far and run the lambda again. 
 The application does not have to do these retries and error handling itself.
 
-For more information and examples of using the transactions API, see Java, C++, and C SDK documentation.
-
 NOTE: Use transactions only on documents less than 10 MB in size.
 
 For application-level transactions, create and use transactions through Couchbase SDK APIs. 
@@ -107,7 +104,7 @@ For more information on distributed transactions through the SDK APIs, see:
 
 * xref:java-sdk:howtos:distributed-acid-transactions-from-the-sdk.adoc[Java SDK]
 * xref:dotnet-sdk:howtos:distributed-acid-transactions-from-the-sdk.adoc[.NET SDK]
-* xref:cxx-txns:distributed-acid-transactions-from-the-sdk.adoc[C++ API]
+* xref:cxx-txns::distributed-acid-transactions-from-the-sdk.adoc[C++ API]
 * xref:go-sdk:howtos:distributed-acid-transactions-from-the-sdk.adoc[Go SDK]
 * xref:nodejs-sdk:howtos:distributed-acid-transactions-from-the-sdk.adoc[Node.js SDK]
 
@@ -136,16 +133,16 @@ Every transaction consists of one or more KV operations, and optionally one or m
 
 A transaction begins when one of the following conditions are true:
 
-* A transactions is started from the SDK (`transactions.run((ctx)` in the example above) 
-* The xref:n1ql:n1ql-language-reference/begin-transaction.adoc[`BEGIN TRANSACTION`] statement is executed (for example, say from the Query Workbench). 
-* A single query transaction which implicitly starts a transaction is executed, using `transactions.query(statement)` from the SDK, enabling "Run as TX" from the Query Workbench, or using the `tximplicit` query parameter.
+* A transactions is started from the SDK -- `transactions.run((ctx)` in the example above.
+* The xref:n1ql:n1ql-language-reference/begin-transaction.adoc[`BEGIN TRANSACTION`] statement is executed -- for example, from the Query Workbench.
+* A single query transaction which implicitly starts a transaction is executed, using `transactions.query(statement)` from the SDK, using btn:[Run as TX] from the Query Workbench, or using the `tximplicit` query parameter.
 
 === End Transaction
 
 A transaction can end when one of the following conditions are true:
 
-* A commit operation is executed (`ctx.commit()` in the example above)
-* A rollback is executed (`ctx.rollback()`) or by executing the xref:n1ql:n1ql-language-reference/rollback-transaction.adoc[`ROLLBACK TRANSACTION`] statement.
+* A commit operation is executed -- `ctx.commit()` in the example above.
+* A rollback is executed -- `ctx.rollback()`, or by executing the xref:n1ql:n1ql-language-reference/rollback-transaction.adoc[`ROLLBACK TRANSACTION`] statement.
 * Transaction callback completes successfully, in which case the transaction is committed implicitly. 
 * The application encounters an issue that can’t be resolved, in which case the transaction is automatically rolled back.
 * A transaction expiry also results in a rollback.
@@ -154,7 +151,7 @@ A transaction can end when one of the following conditions are true:
 
 A savepoint is a user-defined intermediate state that is available for the duration of the transaction. In a long running transaction, savepoints can be used to rollback to that state instead of rolling back the entire transaction in case of an error. 
 
-Note that savepoints are only available within the context of a transaction (for example, 'ctx.query("SAVEPOINT")' inside the lambda) and are removed once a transaction is committed or rolled back.
+Note that savepoints are only available within the context of a transaction (for example, `ctx.query("SAVEPOINT")` inside the lambda) and are removed once a transaction is committed or rolled back.
 
 == Transactions and Couchbase Services
 
@@ -192,16 +189,16 @@ Each execution of the transaction logic in an application is called an 'attempt'
 === Active Transaction Record Entries
 
 The first mechanic is that each of these attempts adds an entry to a metadata document in the Couchbase cluster. These metadata documents are called _Active Transaction Records_, or ATRs. 
-ATRs are created and maintained automatically and are easily distinguishable by their prefix `_{txn-atr}`. They are viewable and _should not be modified externally_.
+ATRs are created and maintained automatically and are easily distinguishable by their prefix `pass:c[_txn:atr-]`. They are viewable and _should not be modified externally_.
 
 Each ATR contains entries for multiple attempts. Each ATR entry stores some metadata and, crucially, whether the attempt has been committed or not. In this way, the entry acts as the single point of truth for the transaction, which is essential for providing an 'atomic commit' during reads.
 In Step 1 above, a new entry is added to the ATR.
 
-By default, the metadata documents are created in the default collection of the bucket of the first mutated document in the transaction. However, you can choose to use a named collection to store metadata documents. See <<Custom metadata collections>> for details.
+By default, the metadata documents are created in the default collection of the bucket of the first mutated document in the transaction. However, you can choose to use a named collection to store metadata documents. See <<custom-metadata-collections>> for details.
 
 === Staged Mutations
 
-The second mechanic is that mutating a document inside a transaction, does not directly change the body of the document. Instead, the post-transaction version of the document is staged alongside the document (technically in its xref:java-sdk:concept-docs/xattr.adoc[extended attributes] (XATTRs)). In this way, all changes are invisible to all parts of the Couchbase cluster until the commit point is reached.
+The second mechanic is that mutating a document inside a transaction, does not directly change the body of the document. Instead, the post-transaction version of the document is staged alongside the document -- technically in its xref:learn:data/extended-attributes-fundamentals.adoc[extended attributes] (XATTRs). In this way, all changes are invisible to all parts of the Couchbase cluster until the commit point is reached.
 
 These staged document changes effectively act as a lock against other transactions trying to modify the document, preventing write-write conflicts.
 

--- a/modules/learn/partials/transaction-privileges.adoc
+++ b/modules/learn/partials/transaction-privileges.adoc
@@ -1,0 +1,11 @@
+To execute a key-value operation within a transaction, users must have the relevant _Administrative_ or _Data_ RBAC roles, and permissions on the relevant buckets, scopes and collections.
+
+Similarly, to run a query statement within a transaction, users must have the relevant _Administrative_ or _Query & Index_ RBAC roles, and permissions on the relevant buckets, scopes and collections.
+
+Refer to xref:learn:security/roles.adoc[Roles] for details.
+
+[NOTE]
+.Query Mode
+When a transaction executes a query statement, the transaction enters query mode, which means that the query is executed with the user's query permissions.
+Any key-value operations which are executed by the transaction _after_ the query statement are _also_ executed with the user's query permissions.
+These may be different to the user's data permissions, which may lead to unexpected results.

--- a/modules/learn/partials/transaction-privileges.adoc
+++ b/modules/learn/partials/transaction-privileges.adoc
@@ -8,4 +8,4 @@ Refer to xref:learn:security/roles.adoc[Roles] for details.
 .Query Mode
 When a transaction executes a query statement, the transaction enters query mode, which means that the query is executed with the user's query permissions.
 Any key-value operations which are executed by the transaction _after_ the query statement are _also_ executed with the user's query permissions.
-These may be different to the user's data permissions, which may lead to unexpected results.
+These may or may not be different to the user's data permissions; if they are different, you may get unexpected results.

--- a/modules/n1ql/pages/n1ql-language-reference/transactions.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/transactions.adoc
@@ -1,12 +1,11 @@
 = N1QL Support for Couchbase Transactions
 :page-topic-type: tutorial
-:page-status: Couchbase Server 7.0
 :imagesdir: ../../assets/images
 :description: N1QL offers full support for Couchbase ACID transactions.
 :tabs:
 :page-partial:
 
-// Cross-references
+// N1QL cross-references
 :insert: xref:n1ql:n1ql-language-reference/insert.adoc
 :upsert: xref:n1ql:n1ql-language-reference/upsert.adoc
 :delete: xref:n1ql:n1ql-language-reference/delete.adoc
@@ -16,12 +15,21 @@
 :execfunction: xref:n1ql:n1ql-language-reference/execfunction.adoc
 :prepare: xref:n1ql:n1ql-language-reference/prepare.adoc
 :execute: xref:n1ql:n1ql-language-reference/execute.adoc
+
+// Learn cross-references
 :transactions: xref:learn:data/transactions.adoc
+:roles: xref:learn:security/roles.adoc
+
+// Manage cross-references
 :install-sample-buckets: xref:manage:manage-settings/install-sample-buckets.adoc
 :sys-transactions: xref:manage:monitor/monitoring-n1ql-query.adoc#sys-transactions
+
+// Tools cross-references
 :query-workbench: xref:tools:query-workbench.adoc
 :cbq-shell: xref:tools:cbq-shell.adoc
 :n1ql-rest-api: xref:n1ql:n1ql-rest-api/index.adoc
+
+// Settings cross-references
 :txid: xref:settings:query-settings.adoc#txid
 :tximplicit: xref:settings:query-settings.adoc#tximplicit
 :txstmtnum: xref:settings:query-settings.adoc#txstmtnum
@@ -126,7 +134,10 @@ Refer to {transactional-scan-consistency}[Transactional Scan Consistency] for de
 
 To create a Couchbase transaction using N1QL, you can use any of the tools that you use to run a N1QL query: the {query-workbench}[Query Workbench], the {cbq-shell}[cbq shell], or the {n1ql-rest-api}[Query REST API].
 There are slight differences in the way these tools operate when creating Couchbase transactions.
-These are explained below.
+These are explained in the sections below.
+
+Note that some Couchbase SDKs provide APIs to support Couchbase transactions.
+For further details, refer to {transactions}[Transactions].
 
 === Couchbase Transactions with the Query Workbench
 
@@ -167,9 +178,15 @@ In this case, you do not need to specify the `txid` parameter.
 You can monitor active Couchbase transactions using the `system:transactions` catalog.
 For more information, refer to {sys-transactions}[system:transactions].
 
+== Privileges
+
+When developing a transaction with an SDK, the transaction may contain a mixture of key-value operations and query statements.
+
+include::learn:partial$transaction-privileges.adoc[]
+
 == Worked Example
 
-This worked example guides you through a complete Couchbase transaction session.
+This worked example guides you through a complete Couchbase transaction session using N1QL.
 
 [[preparation]]
 === Preparation

--- a/modules/n1ql/pages/n1ql-language-reference/transactions.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/transactions.adoc
@@ -178,7 +178,7 @@ In this case, you do not need to specify the `txid` parameter.
 You can monitor active Couchbase transactions using the `system:transactions` catalog.
 For more information, refer to {sys-transactions}[system:transactions].
 
-== Privileges
+== Permissions
 
 When developing a transaction with an SDK, the transaction may contain a mixture of key-value operations and query statements.
 


### PR DESCRIPTION
The following draft documentation is ready for review:

* [Learn › Data › Transactions](https://simon-dew.github.io/docs-site/DOC-9831/server/current/learn/data/transactions.html#permissions) — added Permissions section with Query Mode note
* [N1QL Support for Couchbase Transactions](https://simon-dew.github.io/docs-site/DOC-9831/server/current/n1ql/n1ql-language-reference/transactions.html#permissions) — added Permissions section with Query Mode note

Changes to SDK documentation (with code samples) to follow in separate PR.

Docs issue: [DOC-9642](https://issues.couchbase.com/browse/DOC-9642)