### PR TITLE
DOC-9130: Document HA support for Analytics

### DIFF
--- a/modules/learn/pages/clusters-and-availability/hard-failover.adoc
+++ b/modules/learn/pages/clusters-and-availability/hard-failover.adoc
@@ -156,15 +156,21 @@ The processing of duplicate mutations can happen only within a limited time-wind
 
 The Analytics Service uses _shadow data_, which is a copy of a subset of the data maintained by the Data Service.
 By default, the shadow data is not replicated; however, it may be partitioned across all cluster nodes that run the Analytics Service.
-If there are no replicas of the shadow data, and any single Analytics node undergoes hard failover, the Analytics Service and all analytics processing stop, cluster-wide.
-If the lost Analytics node is permanently removed or replaced, all shadow data must be rebuilt, if and when the Analytics Service is restarted.
-
 Starting with Couchbase Server 7.1, the shadow data and its partitions may be replicated up to 3 times.
-Each replica partition resides on an Analytics node: a given Analytics node can host a replica partition, or the active partition on which replicas are based.
-If replicas of the shadow data exist, and any single Analytics node undergoes hard failover, any currently-running analytics processing stops, but the Analytics Service remains available after rebalance, using the replica shadow data.
-The Analytics Service only needs to rebuild any shadow data that isn't already replicated from the Data Service.
+Each replica resides on an Analytics node: a given Analytics node can host a replica partition, or the active partition on which replicas are based.
 
-In both cases, if the lost Analytics node is restored to the cluster, and the service is restarted, no rebuilding of shadow data is necessary, and analytics processing resumes across the Analytics nodes of the cluster.
+If there are no Analytics replicas, and an Analytics node fails over, the Analytics Service stops working cluster-wide: ingestion of shadow data stops and no Analytics operations can be run.
+
+* If the Analytics node is recovered, the Analytics Service is resumed and ingestion of shadow data resumes from the point before the node failed over.
+
+* If the Analytics node is removed, the Analytics Service becomes active again after rebalance, but ingestion of shadow data must begin again from scratch.
+
+If there are Analytics replicas, and an Analytics node fails over, the Analytics Service continues to work: one of the replicas is promoted to serve the shadow data that was stored on the failed over node.
+The Analytics Service only needs to rebuild any shadow data that isn't already ingested from the Data Service, depending on the state of the promoted replica.
+
+* If the Analytics node is recovered, the shadow data on the recovered node is updated from the promoted replica, and it becomes the active partition again.
+
+* If the Analytics node is removed, the shadow data is redistributed among the remaining Analytics nodes in the cluster.
 
 [#hard-failover-and-the-backup-service]
 === Backup Service

--- a/modules/learn/pages/clusters-and-availability/hard-failover.adoc
+++ b/modules/learn/pages/clusters-and-availability/hard-failover.adoc
@@ -154,7 +154,7 @@ The processing of duplicate mutations can happen only within a limited time-wind
 [#hard-failover-and-the-analytics-service]
 === Analytics Service
 
-The Analytics Service uses _shadow data_, which is a copy of a subset of the data maintained by the Data Service.
+The Analytics Service uses _shadow data_, which is a copy of all or some of the data maintained by the Data Service.
 By default, the shadow data is not replicated; however, it may be partitioned across all cluster nodes that run the Analytics Service.
 Starting with Couchbase Server 7.1, the shadow data and its partitions may be replicated up to 3 times.
 Each replica resides on an Analytics node: a given Analytics node can host a replica partition, or the active partition on which replicas are based.

--- a/modules/learn/pages/clusters-and-availability/hard-failover.adoc
+++ b/modules/learn/pages/clusters-and-availability/hard-failover.adoc
@@ -159,14 +159,14 @@ By default, the shadow data is not replicated; however, it may be partitioned ac
 Starting with Couchbase Server 7.1, the shadow data and its partitions may be replicated up to 3 times.
 Each replica resides on an Analytics node: a given Analytics node can host a replica partition, or the active partition on which replicas are based.
 
-_If there are no Analytics replicas_, and an Analytics node fails over, the Analytics Service stops working cluster-wide: ingestion of shadow data stops and no Analytics operations can be run.
+If there are _no_ Analytics replicas, and an Analytics node fails over, the Analytics Service stops working cluster-wide: ingestion of shadow data stops and no Analytics operations can be run.
 In this case:
 
 * If the Analytics node is recovered, the Analytics Service is resumed and ingestion of shadow data resumes from the point before the node failed over.
 
 * If the Analytics node is removed, the Analytics Service becomes active again after rebalance, but ingestion of shadow data must begin again from scratch.
 
-_If there are Analytics replicas_, and an Analytics node fails over, the Analytics Service continues to work: one of the replicas is promoted to serve the shadow data that was stored on the failed over node.
+If there _are_ Analytics replicas, and an Analytics node fails over, the Analytics Service continues to work: one of the replicas is promoted to serve the shadow data that was stored on the failed over node.
 The Analytics Service only needs to rebuild any shadow data that isn't already ingested from the Data Service, depending on the state of the promoted replica.
 In this case:
 

--- a/modules/learn/pages/clusters-and-availability/hard-failover.adoc
+++ b/modules/learn/pages/clusters-and-availability/hard-failover.adoc
@@ -25,12 +25,12 @@ For further information on initiating hard failover, see xref:manage:manage-node
 [#default-and-unsafe]
 == Hard Failover in Default and Unsafe Modes
 
-In the event of a cluster’s xref:learn:clusters-and-availability/cluster-manager.adoc#master-services[Master Services] not being able to contact a majority of the cluster’s nodes (sometimes referred to as a _quorum failure_), an attempted failover will _not_ be executed.
+In the event of a cluster's xref:learn:clusters-and-availability/cluster-manager.adoc#master-services[Master Services] not being able to contact a majority of the cluster's nodes (sometimes referred to as a _quorum failure_), an attempted failover will _not_ be executed.
 This protects the cluster from the situation where:
 
-. The cluster’s nodes get divided into two separate sets, due to an unanticipated https://en.wikipedia.org/wiki/Network_partition[network partition^].
+. The cluster's nodes get divided into two separate sets, due to an unanticipated https://en.wikipedia.org/wiki/Network_partition[network partition^].
 
-. Each of the separate sets is accessed by a different administrator &#8212; each administrator being unaware of the other’s access.
+. Each of the separate sets is accessed by a different administrator -- each administrator being unaware of the other's access.
 
 . Each administrator simultaneously performs a hard failover of the nodes they cannot contact (resulting in a corrupted cluster-configuration, once the network partition is healed).
 
@@ -143,7 +143,7 @@ If a cluster contains a single node that hosts the Eventing Service, and this no
 If the node is restored to the cluster, and the Eventing Service is restarted, Eventing-Service functions redeploy, and mutation-processing resumes: however, this may result in the processing of mutations that are duplicates of mutations made immediately prior to failover, and may result in inappropriate changes to data, if the business logic in function-code is not idempotent.
 
 If multiple cluster-nodes host the Eventing Service, responsibility for handling data-mutations is divided between these nodes; with each node handling the data-mutations for a defined subset of vBuckets.
-If a hard failover is performed on one of the Eventing-Service nodes, the failed-over node's former responsibilities are assigned to the surviving Eventing-Service nodes as part of the hard-failover process &#8212; thereby ensuring continuity of mutation-processing, and avoiding the immediate need for a rebalance.
+If a hard failover is performed on one of the Eventing-Service nodes, the failed-over node's former responsibilities are assigned to the surviving Eventing-Service nodes as part of the hard-failover process -- thereby ensuring continuity of mutation-processing, and avoiding the immediate need for a rebalance.
 If hard failover is, in these circumstances, selected by means of Couchbase Web Console, a notification such as the following is provided, when failover-confirmation is requested: _Failover of this node will trigger internal processing after failover for the following service: Eventing._
 _This processing may take some time to complete._
 
@@ -154,12 +154,17 @@ The processing of duplicate mutations can happen only within a limited time-wind
 [#hard-failover-and-the-analytics-service]
 === Analytics Service
 
-The Analytics Service uses _shadow data_, which is a single copy of a subset of the data maintained by the Data Service.
-The shadow data is not replicated; however, its single copy is partitioned across all cluster nodes that run the Analytics Service.
+The Analytics Service uses _shadow data_, which is a copy of a subset of the data maintained by the Data Service.
+By default, the shadow data is not replicated; however, it may be partitioned across all cluster nodes that run the Analytics Service.
+If there are no replicas of the shadow data, and any single Analytics node undergoes hard failover, the Analytics Service and all analytics processing stop, cluster-wide.
+If the lost Analytics node is permanently removed or replaced, all shadow data must be rebuilt, if and when the Analytics Service is restarted.
 
-If any single Analytics-Service node undergoes hard failover, the Analytics Service and all analytics processing stop, cluster-wide.
-If the lost Analytics-Service node is restored to the cluster, and the service is restarted, no rebuilding of shadow data is necessary, and analytics processing resumes across the Analytics-Service nodes of the cluster.
-However, if a lost Analytics-Service node is permanently removed or replaced, all shadow data must be rebuilt, if and when the Analytics Service is restarted.
+Starting with Couchbase Server 7.1, the shadow data and its partitions may be replicated up to 3 times.
+Each replica partition resides on an Analytics node: a given Analytics node can host a replica partition, or the active partition on which replicas are based.
+If replicas of the shadow data exist, and any single Analytics node undergoes hard failover, any currently-running analytics processing stops, but the Analytics Service remains available after rebalance, using the replica shadow data.
+The Analytics Service only needs to rebuild any shadow data that isn't already replicated from the Data Service.
+
+In both cases, if the lost Analytics node is restored to the cluster, and the service is restarted, no rebuilding of shadow data is necessary, and analytics processing resumes across the Analytics nodes of the cluster.
 
 [#hard-failover-and-the-backup-service]
 === Backup Service

--- a/modules/learn/pages/clusters-and-availability/hard-failover.adoc
+++ b/modules/learn/pages/clusters-and-availability/hard-failover.adoc
@@ -159,14 +159,16 @@ By default, the shadow data is not replicated; however, it may be partitioned ac
 Starting with Couchbase Server 7.1, the shadow data and its partitions may be replicated up to 3 times.
 Each replica resides on an Analytics node: a given Analytics node can host a replica partition, or the active partition on which replicas are based.
 
-If there are no Analytics replicas, and an Analytics node fails over, the Analytics Service stops working cluster-wide: ingestion of shadow data stops and no Analytics operations can be run.
+_If there are no Analytics replicas_, and an Analytics node fails over, the Analytics Service stops working cluster-wide: ingestion of shadow data stops and no Analytics operations can be run.
+In this case:
 
 * If the Analytics node is recovered, the Analytics Service is resumed and ingestion of shadow data resumes from the point before the node failed over.
 
 * If the Analytics node is removed, the Analytics Service becomes active again after rebalance, but ingestion of shadow data must begin again from scratch.
 
-If there are Analytics replicas, and an Analytics node fails over, the Analytics Service continues to work: one of the replicas is promoted to serve the shadow data that was stored on the failed over node.
+_If there are Analytics replicas_, and an Analytics node fails over, the Analytics Service continues to work: one of the replicas is promoted to serve the shadow data that was stored on the failed over node.
 The Analytics Service only needs to rebuild any shadow data that isn't already ingested from the Data Service, depending on the state of the promoted replica.
+In this case:
 
 * If the Analytics node is recovered, the shadow data on the recovered node is updated from the promoted replica, and it becomes the active partition again.
 

--- a/modules/learn/pages/clusters-and-availability/rebalance.adoc
+++ b/modules/learn/pages/clusters-and-availability/rebalance.adoc
@@ -203,13 +203,13 @@ When a node is removed and rebalanced, the query service will allow existing que
 === Eventing Service
 
 When an Eventing Service node has been added or removed, rebalance causes the mutation (_vBucket_ processing ownership) and timer event processing workload to be redistributed among available Eventing Service nodes.
-The eventing service continues to process mutations both during and after rebalance.
+The Eventing Service continues to process mutations both during and after rebalance.
 Checkpoint information ensures that no mutations are lost.
 
 [#rebalancing-the-analytics-service]
 === Analytics Service
 
-The Analytics Service uses _shadow data_, which is a copy of a subset of the data maintained by the Data Service.
+The Analytics Service uses _shadow data_, which is a copy of all or some of the data maintained by the Data Service.
 By default, the shadow data is not replicated; however, it may be partitioned across all cluster nodes that run the Analytics Service.
 Starting with Couchbase Server 7.1, the shadow data and its partitions may be replicated up to 3 times.
 Each replica resides on an Analytics node: a given Analytics node can host a replica partition, or the active partition on which replicas are based.

--- a/modules/learn/pages/clusters-and-availability/rebalance.adoc
+++ b/modules/learn/pages/clusters-and-availability/rebalance.adoc
@@ -202,20 +202,30 @@ When a node is removed and rebalanced, the query service will allow existing que
 [#rebalancing-the-eventing-service]
 === Eventing Service
 
-When an Eventing Service node has been added or removed, rebalance causes the mutation (_vBucket_ processing ownership) and timer event processing workload to be redistributed among available Eventing Service nodes. The eventing service continues to process mutations both during and after rebalance. Checkpoint information ensures that no mutations are lost.
+When an Eventing Service node has been added or removed, rebalance causes the mutation (_vBucket_ processing ownership) and timer event processing workload to be redistributed among available Eventing Service nodes.
+The eventing service continues to process mutations both during and after rebalance.
+Checkpoint information ensures that no mutations are lost.
 
 [#rebalancing-the-analytics-service]
 === Analytics Service
 
 The Analytics Service uses _shadow data_, which is a copy of a subset of the data maintained by the Data Service.
 By default, the shadow data is not replicated; however, it may be partitioned across all cluster nodes that run the Analytics Service.
-If there are no replicas of the shadow data, and an Analytics node is removed, the Analytics Service becomes unavailable.
-On rebalance, all shadow data must be rebuilt, if and when the Analytics Service is restarted.
-
 Starting with Couchbase Server 7.1, the shadow data and its partitions may be replicated up to 3 times.
-Each replica partition resides on an Analytics node: a given Analytics node can host a replica partition, or the active partition on which replicas are based.
-If replicas of the shadow data exist, and an Analytics node is removed, the Analytics Service remains available after rebalance, using the replica shadow data.
-The Analytics Service only needs to rebuild any shadow data that isn't already replicated from the Data Service.
+Each replica resides on an Analytics node: a given Analytics node can host a replica partition, or the active partition on which replicas are based.
+
+If there are no Analytics replicas, and an Analytics node fails over, the Analytics Service stops working cluster-wide: ingestion of shadow data stops and no Analytics operations can be run.
+
+* If the Analytics node is recovered, the Analytics Service is resumed and ingestion of shadow data resumes from the point before the node failed over.
+
+* If the Analytics node is removed, the Analytics Service becomes active again after rebalance, but ingestion of shadow data must begin again from scratch.
+
+If there are Analytics replicas, and an Analytics node fails over, the Analytics Service continues to work: one of the replicas is promoted to serve the shadow data that was stored on the failed over node.
+The Analytics Service only needs to rebuild any shadow data that isn't already ingested from the Data Service, depending on the state of the promoted replica.
+
+* If the Analytics node is recovered, the shadow data on the recovered node is updated from the promoted replica, and it becomes the active partition again.
+
+* If the Analytics node is removed, the shadow data is redistributed among the remaining Analytics nodes in the cluster.
 
 If no Analytics Service node has been removed or replaced, shadow data is not affected by rebalance.
 In consequence of rebalance, the Analytics Service receives an updated _cluster map_, and continues to work with the modified vBucket-topology.

--- a/modules/learn/pages/clusters-and-availability/rebalance.adoc
+++ b/modules/learn/pages/clusters-and-availability/rebalance.adoc
@@ -214,14 +214,16 @@ By default, the shadow data is not replicated; however, it may be partitioned ac
 Starting with Couchbase Server 7.1, the shadow data and its partitions may be replicated up to 3 times.
 Each replica resides on an Analytics node: a given Analytics node can host a replica partition, or the active partition on which replicas are based.
 
-If there are no Analytics replicas, and an Analytics node fails over, the Analytics Service stops working cluster-wide: ingestion of shadow data stops and no Analytics operations can be run.
+If there are no Analytics replicas_, and an Analytics node fails over, the Analytics Service stops working cluster-wide: ingestion of shadow data stops and no Analytics operations can be run.
+In this case:
 
 * If the Analytics node is recovered, the Analytics Service is resumed and ingestion of shadow data resumes from the point before the node failed over.
 
 * If the Analytics node is removed, the Analytics Service becomes active again after rebalance, but ingestion of shadow data must begin again from scratch.
 
-If there are Analytics replicas, and an Analytics node fails over, the Analytics Service continues to work: one of the replicas is promoted to serve the shadow data that was stored on the failed over node.
+_If there are Analytics replicas_, and an Analytics node fails over, the Analytics Service continues to work: one of the replicas is promoted to serve the shadow data that was stored on the failed over node.
 The Analytics Service only needs to rebuild any shadow data that isn't already ingested from the Data Service, depending on the state of the promoted replica.
+In this case:
 
 * If the Analytics node is recovered, the shadow data on the recovered node is updated from the promoted replica, and it becomes the active partition again.
 

--- a/modules/learn/pages/clusters-and-availability/rebalance.adoc
+++ b/modules/learn/pages/clusters-and-availability/rebalance.adoc
@@ -20,7 +20,7 @@ See xref:manage:manage-nodes/node-management-overview.adoc[Manage Nodes and Clus
 
 Each rebalance proceeds in sequential _stages_.
 Each stage corresponds to a Couchbase Service, deployed on the cluster.
-Therefore, if all services have been deployed, there are _seven_ stages in all &#8212; one each for the _Data_, _Query_, _Index_, _Search_, _Eventing_, _Backup_, and _Analytics_ services.
+Therefore, if all services have been deployed, there are _seven_ stages in all -- one each for the _Data_, _Query_, _Index_, _Search_, _Eventing_, _Backup_, and _Analytics_ services.
 When all stages have been completed, the rebalance process itself is complete.
 
 [#rebalancing-the-data-service]
@@ -43,7 +43,7 @@ See xref:learn:clusters-and-availability/intra-cluster-replication.adoc[Intra-Cl
 === Data-Service Rebalance Phases
 
 During the Data Service rebalance stage, vBuckets are moved in _phases_.
-The phases &#8212; which differ, depending on whether the vBucket is an _active_ or a _replica_ vBucket &#8212; are described below.
+The phases -- which differ, depending on whether the vBucket is an _active_ or a _replica_ vBucket -- are described below.
 
 [#rebalance-phases-for-replica-vbuckets]
 ==== Rebalance Phases for Replica vBuckets
@@ -115,7 +115,7 @@ On conclusion of a rebalance, its report can be accessed in any of the following
 
 * By accessing the directory `/opt/couchbase/var/lib/couchbase/logs/rebalance` on _any_ of the cluster nodes.
 A rebalance report is maintained here for (up to) the last _five_ rebalances performed.
-Each report is provided as a `*.json` file, whose name indicates the time at which the report was run &#8212; for example, `rebalance_report_2020-03-17T11:10:17Z.json`.
+Each report is provided as a `*.json` file, whose name indicates the time at which the report was run -- for example, `rebalance_report_2020-03-17T11:10:17Z.json`.
 
 A complete account of the report-content is provided in the xref:rebalance-reference:rebalance-reference.adoc[Rebalance Reference].
 
@@ -207,9 +207,15 @@ When an Eventing Service node has been added or removed, rebalance causes the mu
 [#rebalancing-the-analytics-service]
 === Analytics Service
 
-The Analytics Service uses _shadow data_, which is a single copy of a subset of the data maintained by the Data Service.
-The shadow data is not replicated; however, its single copy is partitioned across all cluster nodes that run the Analytics Service.
-If an Analytics node is permanently removed or replaced, all shadow data must be rebuilt, if and when the Analytics Service is restarted.
+The Analytics Service uses _shadow data_, which is a copy of a subset of the data maintained by the Data Service.
+By default, the shadow data is not replicated; however, it may be partitioned across all cluster nodes that run the Analytics Service.
+If there are no replicas of the shadow data, and an Analytics node is removed, the Analytics Service becomes unavailable.
+On rebalance, all shadow data must be rebuilt, if and when the Analytics Service is restarted.
+
+Starting with Couchbase Server 7.1, the shadow data and its partitions may be replicated up to 3 times.
+Each replica partition resides on an Analytics node: a given Analytics node can host a replica partition, or the active partition on which replicas are based.
+If replicas of the shadow data exist, and an Analytics node is removed, the Analytics Service remains available after rebalance, using the replica shadow data.
+The Analytics Service only needs to rebuild any shadow data that isn't already replicated from the Data Service.
 
 If no Analytics Service node has been removed or replaced, shadow data is not affected by rebalance.
 In consequence of rebalance, the Analytics Service receives an updated _cluster map_, and continues to work with the modified vBucket-topology.

--- a/modules/learn/pages/clusters-and-availability/rebalance.adoc
+++ b/modules/learn/pages/clusters-and-availability/rebalance.adoc
@@ -214,14 +214,14 @@ By default, the shadow data is not replicated; however, it may be partitioned ac
 Starting with Couchbase Server 7.1, the shadow data and its partitions may be replicated up to 3 times.
 Each replica resides on an Analytics node: a given Analytics node can host a replica partition, or the active partition on which replicas are based.
 
-If there are no Analytics replicas_, and an Analytics node fails over, the Analytics Service stops working cluster-wide: ingestion of shadow data stops and no Analytics operations can be run.
+If there are _no_ Analytics replicas, and an Analytics node fails over, the Analytics Service stops working cluster-wide: ingestion of shadow data stops and no Analytics operations can be run.
 In this case:
 
 * If the Analytics node is recovered, the Analytics Service is resumed and ingestion of shadow data resumes from the point before the node failed over.
 
 * If the Analytics node is removed, the Analytics Service becomes active again after rebalance, but ingestion of shadow data must begin again from scratch.
 
-_If there are Analytics replicas_, and an Analytics node fails over, the Analytics Service continues to work: one of the replicas is promoted to serve the shadow data that was stored on the failed over node.
+If there _are_ Analytics replicas, and an Analytics node fails over, the Analytics Service continues to work: one of the replicas is promoted to serve the shadow data that was stored on the failed over node.
 The Analytics Service only needs to rebuild any shadow data that isn't already ingested from the Data Service, depending on the state of the promoted replica.
 In this case:
 

--- a/modules/manage/pages/manage-settings/general-settings.adoc
+++ b/modules/manage/pages/manage-settings/general-settings.adoc
@@ -881,25 +881,34 @@ For more information, see the reference page xref:rest-api:rest-xdcr-adv-setting
 To establish the number of replicas for Analytics Service data, use the `/settings/analytics` endpoint.
 The `GET` method can be used to retrieve the current setting:
 
+[source,sh]
 ----
-curl -X GET http://127.0.0.1:8091/settings/analytics
+curl -X GET -u Administrator:password \
+http://localhost:8091/settings/analytics
 ----
 
 If successful, the call returns an object such as the following:
 
+[source,json]
 ----
 {"numReplicas":1}
 ----
 
-This indicates that the number of replicas currently configured for the Analytics Service is `1`
+This indicates that the number of replicas currently configured for the Analytics Service is `1`.
 To change this number to `2`, enter the following:
 
+[source,sh]
 ----
-curl -X POST http://127.0.0.1:8091/settings/analytics -u Administrator:password -d numReplicas=2
+curl -X POST -u Administrator:password \
+http://localhost:8091/settings/analytics \
+-d numReplicas=2
 ----
 
 If successful, the call returns an object confirming the newly established number of replicas:
 
+[source,json]
 ----
-{"numReplicas":1}
+{"numReplicas":2}
 ----
+
+// TODO: For more information, see the reference page.

--- a/modules/manage/pages/manage-settings/general-settings.adoc
+++ b/modules/manage/pages/manage-settings/general-settings.adoc
@@ -506,6 +506,46 @@ If successful, the command returns the following message:
 SUCCESS: Global XDCR settings updated
 ----
 
+[#analytics-setting-via-cli]
+=== Analytics Settings via CLI
+
+To obtain the current Analytics replica settings by means of the CLI, use the xref:cli:cbcli/couchbase-cli-setting-analytics.adoc[setting-analytics] command, with the `--get` option:
+
+[source,sh]
+----
+/opt/couchbase/bin/couchbase-cli setting-analytics \
+-c localhost \
+-u Administrator \
+-p password \
+--get
+----
+
+If successful, the command returns the current replica settings:
+
+[source,console]
+----
+numReplicas: 0
+----
+
+To establish the number of replicas for Analytics Service data, use the xref:cli:cbcli/couchbase-cli-setting-analytics.adoc[setting-analytics] command, with the `--set` and `--replicas` options:
+
+[source,sh]
+----
+/opt/couchbase/bin/couchbase-cli setting-analytics \
+-c localhost \
+-u Administrator \
+-p password \
+--set \
+--replicas 3
+----
+
+If successful, the command returns the following message:
+
+[source,console]
+----
+SUCCESS: Analytics settings updated
+----
+
 [#configure-general-settings-with-the-rest-api]
 == Configure General Settings with the REST API
 

--- a/modules/manage/pages/manage-settings/general-settings.adoc
+++ b/modules/manage/pages/manage-settings/general-settings.adoc
@@ -238,7 +238,7 @@ The default is 0.
 The default number of index replicas to be created by the Index Service whenever `CREATE INDEX` is invoked.
 For further details, refer to xref:learn:services-and-indexes/indexes/index-replication.adoc#index-replication[Index Replication].
 
-* *Indexer Rebalance Settings*
+* *Indexer Rebalance Settings*.
 When the *Optimize Index Placement On Rebalance* checkbox is checked, Couchbase Server redistributes indexes when rebalance occurs, in order to optimize performance.
 If the checkbox is unchecked (which is the default), such redistribution does not occur.
 For further details, refer to xref:learn:clusters-and-availability/rebalance.adoc#rebalancing-the-index-service[Rebalancing the Index Service].
@@ -252,8 +252,6 @@ The default is `Info`.
 Whether Bloom filters are enabled for memory management.
 When the *Enable Bloom Filter* checkbox is checked, Bloom filters are enabled; otherwise, they are disabled (which is the default).
 See xref:learn:services-and-indexes/indexes/storage-modes.adoc#per-page-bloom-filters[Per Page Bloom Filters].
-
-// TODO: Bloom Filter
 
 [#xdcr-maximum-processes]
 === XDCR Maximum Processes

--- a/modules/manage/pages/manage-settings/general-settings.adoc
+++ b/modules/manage/pages/manage-settings/general-settings.adoc
@@ -274,6 +274,12 @@ The absolute maximum number of replicas is 3.
 Each replica resides on an Analytics Node: a given Analytics Node can host either one replica, or the active data on which replicas are based.
 Thus, if a cluster contains three Analytics Nodes, the practical maximum number of replicas is 2; one node hosting the active data, and each of the other two nodes hosting a single replica.
 
+The panel appears as follows:
+
+image::manage-settings/analytics-replicas.png["The Analytics Replicas panel",548,align=center]
+
+Note that if you change this setting, you must run a rebalance for the changes to take effect.
+
 [#saving-settings]
 === Saving Settings
 To save settings, left-click on the *Save* button, at the lower left.

--- a/modules/manage/pages/manage-settings/general-settings.adoc
+++ b/modules/manage/pages/manage-settings/general-settings.adoc
@@ -510,7 +510,7 @@ If successful, the command returns the following message:
 SUCCESS: Global XDCR settings updated
 ----
 
-[#analytics-setting-via-cli]
+[#analytics-settings-via-cli]
 === Analytics Settings via CLI
 
 To obtain the current Analytics replica settings by means of the CLI, use the xref:cli:cbcli/couchbase-cli-setting-analytics.adoc[setting-analytics] command, with the `--get` option:
@@ -880,6 +880,7 @@ This output indicates that the value of `goMaxProcs` has been appropriately incr
 
 For more information, see the reference page xref:rest-api:rest-xdcr-adv-settings.adoc[Managing Advanced XDCR Settings].
 
+[#analytics-settings-via-rest]
 === Analytics Settings via REST
 
 To establish the number of replicas for Analytics Service data, use the `/settings/analytics` endpoint.

--- a/modules/manage/pages/manage-settings/general-settings.adoc
+++ b/modules/manage/pages/manage-settings/general-settings.adoc
@@ -515,7 +515,7 @@ SUCCESS: Global XDCR settings updated
 
 To obtain the current Analytics replica settings by means of the CLI, use the xref:cli:cbcli/couchbase-cli-setting-analytics.adoc[setting-analytics] command, with the `--get` option:
 
-[source,sh]
+[source,bash]
 ----
 /opt/couchbase/bin/couchbase-cli setting-analytics \
 -c localhost \
@@ -533,7 +533,7 @@ numReplicas: 0
 
 To establish the number of replicas for Analytics Service data, use the xref:cli:cbcli/couchbase-cli-setting-analytics.adoc[setting-analytics] command, with the `--set` and `--replicas` options:
 
-[source,sh]
+[source,bash]
 ----
 /opt/couchbase/bin/couchbase-cli setting-analytics \
 -c localhost \
@@ -885,7 +885,7 @@ For more information, see the reference page xref:rest-api:rest-xdcr-adv-setting
 To establish the number of replicas for Analytics Service data, use the `/settings/analytics` endpoint.
 The `GET` method can be used to retrieve the current setting:
 
-[source,sh]
+[source,bash]
 ----
 curl -X GET -u Administrator:password \
 http://localhost:8091/settings/analytics
@@ -901,7 +901,7 @@ If successful, the call returns an object such as the following:
 This indicates that the number of replicas currently configured for the Analytics Service is `1`.
 To change this number to `2`, enter the following:
 
-[source,sh]
+[source,bash]
 ----
 curl -X POST -u Administrator:password \
 http://localhost:8091/settings/analytics \
@@ -914,5 +914,3 @@ If successful, the call returns an object confirming the newly established numbe
 ----
 {"numReplicas":2}
 ----
-
-// TODO: For more information, see the reference page.


### PR DESCRIPTION
Docs issue: [DOC-9130](https://issues.couchbase.com/browse/DOC-9130)

The following draft documentation is ready for review:

* [Rebalance › Analytics Service](https://simon-dew.github.io/docs-site/DOC-9610/server/current/learn/clusters-and-availability/rebalance.html#rebalancing-the-analytics-service)
* [Hard Failover › Analytics Service](https://simon-dew.github.io/docs-site/DOC-9610/server/current/learn/clusters-and-availability/hard-failover.html#hard-failover-and-the-analytics-service)
* [General Settings › UI › Analytics Replicas](https://simon-dew.github.io/docs-site/DOC-9610/server/current/manage/manage-settings/general-settings.html#analytics-replicas)
* [General Settings › CLI › Analytics Settings](https://simon-dew.github.io/docs-site/DOC-9610/server/current/manage/manage-settings/general-settings.html#analytics-settings-via-cli)
* [General Settings › REST API › Analytics Settings](https://simon-dew.github.io/docs-site/DOC-9610/server/current/manage/manage-settings/general-settings.html#analytics-settings-via-rest)

Full documentation on using the Analytics Cluster Status REST API will be done as part of DOC-9786.
I'll also add a mention of HA to the Analytics pages as part of that issue.