### PR TITLE
DOC-9786: Document Analytics High Availability APIs

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -750,6 +750,7 @@ include::cli:partial$cbcli/nav.adoc[]
     *** xref:analytics:rest-service.adoc[Analytics Service REST API]
     *** xref:analytics:rest-admin.adoc[Analytics Admin REST API]
     *** xref:analytics:rest-config.adoc[Analytics Config REST API]
+    *** xref:analytics:rest-settings.adoc[Analytics Settings REST API]
     *** xref:analytics:rest-links.adoc[Analytics Links REST API]
     *** xref:analytics:rest-library.adoc[Analytics Library REST API]
 

--- a/modules/rest-api/partials/rest-analytics-service-table.adoc
+++ b/modules/rest-api/partials/rest-analytics-service-table.adoc
@@ -87,11 +87,11 @@
 
 | `GET`
 | `/settings/analytics`
-| xref:analytics:rest-settings.adoc#get-cluster-settings[Get Analytics Settings]
+| xref:analytics:rest-settings.adoc#view-analytics-settings[View Analytics Settings]
 
 | `PUT`
 | `/settings/analytics`
-| xref:analytics:rest-settings.adoc#set-cluster-settings[Set Analytics Settings]
+| xref:analytics:rest-settings.adoc#modify-analytics-settings[Modify Analytics Settings]
 
 |===
 

--- a/modules/rest-api/partials/rest-analytics-service-table.adoc
+++ b/modules/rest-api/partials/rest-analytics-service-table.adoc
@@ -32,6 +32,10 @@
 | `/analytics/admin/active_requests`
 | xref:analytics:rest-admin.adoc#request-cancellation[Request Cancellation]
 
+| `GET`
+| `/analytics/cluster`
+| xref:analytics:rest-admin.adoc#cluster-status[Cluster Status]
+
 | `POST`
 | `/analytics/cluster/restart`
 | xref:analytics:rest-admin.adoc#cluster-restart[Cluster Restart]
@@ -72,6 +76,22 @@
 | `PUT`
 | `/analytics/config/node`
 | xref:analytics:rest-config.adoc#modify-node-specific-parameters[Modify Node-Specific Parameters]
+
+|===
+
+=== Analytics Settings API
+
+[cols="76,215,249"]
+|===
+| HTTP Method | URI | Documented at
+
+| `GET`
+| `/settings/analytics`
+| xref:analytics:rest-settings.adoc#get-cluster-settings[Get Analytics Settings]
+
+| `PUT`
+| `/settings/analytics`
+| xref:analytics:rest-settings.adoc#set-cluster-settings[Set Analytics Settings]
 
 |===
 


### PR DESCRIPTION
The following draft documentation is ready for review:

* [REST API Reference › Analytics Service API](https://simon-dew.github.io/docs-site/DOC-9786/server/current/rest-api/rest-intro.html#analytics-service-api) — updated nav and REST API landing page

Docs issue: [DOC-9786](https://issues.couchbase.com/browse/DOC-9786)
→ Upstream OpenAPI change: [couchbaselabs/cb-swagger#78](https://github.com/couchbaselabs/cb-swagger/pull/78)  
→ Upstream Analytics change: [+173655](https://review.couchbase.org/c/cbas-core/+/173655)