### PR TITLE
Small typo, change http to https for a TLS cURL call

### DIFF
--- a/modules/rest-api/pages/upload-retrieve-root-cert.adoc
+++ b/modules/rest-api/pages/upload-retrieve-root-cert.adoc
@@ -47,7 +47,7 @@ curl -X GET
   -u <username>:<password>
 
 curl -X GET
-  http://<ip-address-or-domain-name>:18091/pools/default
+  https://<ip-address-or-domain-name>:18091/pools/default
   --cacert <copy-of-current-root-certificate>
   -u <username>:<password>
 ----


### PR DESCRIPTION
when making a cURL call to port 18091, https not http, must be used.