### PR TITLE
DOC-9871 Provide a link to the Bucket storage engine selection page.

### DIFF
--- a/modules/learn/pages/buckets-memory-and-storage/storage-engines.adoc
+++ b/modules/learn/pages/buckets-memory-and-storage/storage-engines.adoc
@@ -47,7 +47,7 @@ NOTE: You cannot use FTS, Eventing, or Analytics in Magma buckets. We intend to 
 
 == When should you use Couchstore?
 
-The choice of Couchstore or Magma is available at the Bucket level. A single Couchbase cluster can have a mix of Couchstore and Magma buckets.
+The choice of Couchstore or Magma is set at the bucket level xref:manage:manage-buckets/create-bucket.adoc[when the bucket is created]. A single Couchbase cluster can have a mix of Couchstore and Magma buckets.
 
 You should use the Couchstore backend if:
 
@@ -62,6 +62,7 @@ You should use the Magma backend if:
 * Your working set is much larger than the available memory and you need disk access speed only.
 * You need to store and access large amounts of data (several terabytes) using lowest amount of memory.
 * Your application(s) makes heavy use of transactions with persistence based durability.
+
 
 == Migrating a Couchstore bucket to Magma
 

--- a/modules/manage/pages/manage-buckets/create-bucket.adoc
+++ b/modules/manage/pages/manage-buckets/create-bucket.adoc
@@ -38,6 +38,14 @@ image::manage-buckets/addDataBucketDialogInitial.png[,320,align=left]
 Enter a bucket name into the interactive [.ui]*Name* text-field.
 A bucket name can only contain characters in the ranges of A-Z, a-z, and 0-9; with the addition of the underscore, period, dash and percent characters; and can be no more than 100 characters in length.
 
+Specify the [.ui]*Storage Backend* for the bucket, which can be `Couchstore` or `Magma`.
+
+--
+include::partial$backend-description-section.adoc[]
+--
+
+See xref:learn:buckets-memory-and-storage/storage-engines.adoc[Storage Engines], for more information.
+
 Next, specify an appropriate memory quota for your bucket, in the [.ui]*Memory Quota* field: either enter a figure by typing at the keyboard; or, with the mouse, access the arrow-icons at the right-hand side of the interactive text-field, to increment or decrement the default value.
 The quota you specify is allocated for your bucket on a per node basis.
 The value you enter must fit with the overall cluster RAM quota.
@@ -117,15 +125,6 @@ See xref:learn:services-and-indexes/services/data-service.adoc[Data Service], fo
 Levels are accessed by means of a pull-down menu.
 The options are *none*, *majority*, *majorityAndPersistActive*, and *persistToMajority*.
 For information, see xref:learn:data/durability.adoc[Durability].
-
-[#storage-backend]
-* [.ui]*Storage Backend*: The Couchbase bucket supports two different storage engines:
-+
---
-include::partial$backend-description-section.adoc[]
---
-+
-See xref:learn:buckets-memory-and-storage/storage-engines.adoc[Storage Engines], for more information.
 
 * [.ui]*Auto-Compaction*: Allows triggering of the process whereby data and indexes are compacted automatically on a system-defined schedule, to save space.
 To override the default settings, check the checkbox marked [.ui]*Override the default auto-compation settings?* If you do so, the dialog goes through a further vertical expansion; and additional fields are displayed, whereby you can specify your own compaction-settings.


### PR DESCRIPTION
Done.
Tackled early because there was a problem with the descriptions where the page linked to.