### PR TITLE
Doc 9969 whats new no reference to n1ql in jsudf

### DIFF
--- a/modules/introduction/pages/whats-new.adoc
+++ b/modules/introduction/pages/whats-new.adoc
@@ -100,10 +100,14 @@ See xref:learn:clusters-and-availability/automatic-failover.adoc[] and xref:lear
 //TODO: Add links to the documents when they're merged.
 
 Scope Hierarchy Support::
-The JavaScript UDF libraries can now be stored within collection scopes, allowing access to be restricted to users with the necessary security permissions.
+The JavaScript libraries can now be stored within collection scopes, allowing access to be restricted to users with the necessary security permissions. For more information, see the section on xref:javascript-udfs:javascript-functions-with-couchbase.adoc#libraries-and-scopes[libraries and scopes] in xref:javascript-udfs:javascript-functions-with-couchbase.adoc[]
+
+N1QL Support::
+JavaScript functions can run N1QL statements using either a function call (`N1QL(…)`) or by embedding the N1QL statement directly in the JavaScript code. See xref:javascript-udfs:calling-n1ql-from-javascript.adoc[] for more information.
 
 UI Support::
-Javascript libraries and functions can now be added through the Query tool in the administration console.
+Javascript libraries and functions can now be added through the Query tool in the administration console. 
+For more details, see the xref:tools:udfs-ui.adoc[] page.
 
 === Improvements to Full-Text Search
 


### PR DESCRIPTION
Added entry for N1QL support and links for reading more details.

https://issues.couchbase.com/browse/DOC-9969

