### PR TITLE
Remove out-of-date SDK refs from FTS page

### DIFF
--- a/modules/fts/pages/fts-searching-with-sdk.adoc
+++ b/modules/fts/pages/fts-searching-with-sdk.adoc
@@ -17,34 +17,34 @@ Couchbase provides several SDKs to allow applications to access a Couchbase clus
 | The Java SDK forms the cornerstone of our JVM clients.
 It allows Java applications to access a Couchbase Server cluster.
 The Java SDK offers traditional synchronous APIs and scalable asynchronous APIs to maximize performance
-|xref:3.1@java-sdk:hello-world:overview.adoc[Java SDK 3.2]
+|xref:java-sdk:hello-world:overview.adoc[Java SDK]
 
 | Scala SDK
 | Our new Scala SDK allows Scala applications to access a Couchbase Server cluster.
 It offers synchronous, asynchronous, and reactive APIs for flexibility and maximum performance.
-|xref:1.1@scala-sdk:hello-world:overview.adoc[Scala SDK 1.2]
+|xref:scala-sdk:hello-world:overview.adoc[Scala SDK]
 
 | .NET SDK
 | The .NET SDK enables you to interact with a Couchbase Server cluster from the .NET Framework using any Common Language Runtime (CLR) language, including C#, F#, and VB.NET. 
 It offers both a traditional synchronous API and an asynchronous API based on the Task-based Asynchronous Pattern (TAP).
 []
-|xref:3.1@dotnet-sdk:hello-world:overview.adoc[.NET SDK 3.2]
+|xref:dotnet-sdk:hello-world:overview.adoc[.NET SDK]
 
 |C SDK
 |The Couchbase C SDK (`libcouchbase`) enables C and C++ programs to access a Couchbase Server cluster.
 The C SDK is also commonly used as a core dependency of SDKs written in other languages to provide a common implementation and high performance.
 Libcouchbase also contains the `cbc` suite of command line tools.
-|xref:3.0@c-sdk:hello-world:start-using-sdk.adoc[C SDK 3.2]
+|xref:c-sdk:hello-world:start-using-sdk.adoc[C SDK]
 
 |Node.js SDK
 |he Node.js SDK allows you to connect to a Couchbase Server cluster from Node.js.
 The Node.js SDK is a native Node.js module using the very fast `libcouchbase` library to handle the communication with the cluster over the Couchbase binary protocol.
-|xref:3.1@nodejs-sdk:hello-world:overview.adoc[Node.js SDK 3.2]
+|xref:nodejs-sdk:hello-world:overview.adoc[Node.js SDK]
 
 |PHP SDK
 |The PHP SDK allows you to connect to a Couchbase Server cluster from PHP.
 The PHP SDK is a native PHP extension and uses the Couchbase high-performance C library `libcouchbase` to handle the communication to the cluster over Couchbase binary protocols.
-|xref:3.1@php-sdk:hello-world:start-using-sdk.adoc[PHP SDK 3.2]
+|xref:php-sdk:hello-world:start-using-sdk.adoc[PHP SDK]
 
 |Python SDK
 |The Python SDK allows Python applications to access a Couchbase Server cluster.
@@ -52,15 +52,15 @@ The Python SDK offers a traditional synchronous API and integration with twisted
 It depends on the C SDK (`libcouchbase`) and utilizes it for performance and reliability.
 |
 
-xref:3.0@python-sdk:hello-world:start-using-sdk.adoc[Python SDK 3.0]
+xref:python-sdk:hello-world:start-using-sdk.adoc[Python SDK]
 
 |Ruby SDK
 
 |The Ruby SDK allows Ruby applications to access a Couchbase Server cluster. 
 The Ruby SDK includes high-performance native Ruby extensions to handle communicating to the cluster over Couchbase's binary protocols.
-|xref:3.0@ruby-sdk:hello-world:start-using-sdk.adoc[Ruby SDK 3.1]
+|xref:ruby-sdk:hello-world:start-using-sdk.adoc[Ruby SDK]
 
 |Go SDK
 |The Couchbase Go SDK allows you to connect to a Couchbase Server cluster from Go.
 The Go SDK is a native Go library and uses the high-performance gocbcore to handle communicating to the cluster over Couchbase's binary protocols.
-|xref:2.2@go-sdk:hello-world:overview.adoc[Go SDK 2.3]
+|xref:go-sdk:hello-world:overview.adoc[Go SDK]


### PR DESCRIPTION
The SDK links on this page are mostly out-of-date and
inconsistent (e.g. xref and link display text out-of-sync)
and I think unnecessary. This commit removes them and just
links to latest version.