### PR TITLE
DOC-8641: New query functions and changes to query functions

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
@@ -1370,6 +1370,7 @@ If this argument is not an integer, then `null` is returned.
 
 *part*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<manipulating-components,component>> to truncate to.
+This function accepts the components `millennium`, `century`, `decade`, `year`, `quarter`, `month`, `week`, and `iso_week`.
 +
 If an invalid part is specified, then `null` is returned.
 
@@ -1422,6 +1423,7 @@ If this argument is not a valid date format, then `null` is returned.
 
 *part*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<manipulating-components,component>> to truncate to.
+This function accepts the components `millennium`, `century`, `decade`, `year`, `quarter`, `month`, `week`, and `iso_week`.
 +
 If an invalid part is specified, then `null` is returned.
 

--- a/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
@@ -2123,7 +2123,7 @@ STR_TO_DURATION('1s') as second;
 ====
 
 [#fn-date-str-to-millis]
-== STR_TO_MILLIS(date1)
+== STR_TO_MILLIS(date1 [, format])
 
 === Description
 
@@ -2132,10 +2132,16 @@ Converts a date string to Epoch/UNIX milliseconds.
 === Arguments
 
 *date1*::
-A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a date in a <<date-string,supported date format>>.
-This is the date to convert to Epoch/UNIX milliseconds.
+A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the date to convert to Epoch/UNIX milliseconds.
 +
 If this argument is not a valid date format, then `null` is returned.
+
+format::
+A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the expected format of the input date string, using the https://golang.org/pkg/time/#pkg-constants[Go language reference date^].
++
+*Optional argument*.
+If not specified, the input date string must be in a <<date-string,supported date format>>.
+If an incorrect format is provided, then `null` is returned.
 
 === Return Value
 
@@ -2143,10 +2149,11 @@ An integer representing the date string converted to Epoch/UNIX milliseconds.
 
 === Examples
 
+.Example 1
 ====
 [source,n1ql]
 ----
-SELECT STR_TO_MILLIS("2016-05-15T03:59:00Z") as Milliseconds;
+SELECT STR_TO_MILLIS("2016-05-15T03:59:00Z") AS Milliseconds;
 ----
 
 .Results
@@ -2155,6 +2162,24 @@ SELECT STR_TO_MILLIS("2016-05-15T03:59:00Z") as Milliseconds;
 [
   {
     "Milliseconds": 1463284740000
+  }
+]
+----
+====
+
+.Example 2
+====
+[source,n1ql]
+----
+SELECT STR_TO_MILLIS("19/08/2011 6:33:23+0000", "02/01/2006 15:04:05Z0700") AS Milliseconds;
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "Milliseconds": 1313735603000
   }
 ]
 ----

--- a/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
@@ -1,6 +1,7 @@
 = Date Functions
 :description: N1QL date functions return the system clock value or manipulate the datetime values, which are represented as a string or an integer.
-:page-topic-type: concept
+:page-topic-type: reference
+:example-caption!:
 
 [abstract]
 {description}
@@ -12,14 +13,14 @@ These functions are very useful for manipulating dates in datasets with various 
 Datetime values are always tied to a specific timezone, either explicitly in the date value, or implicitly in the application.
 The date functions in N1QL therefore support multiple different timezones.
 
-*UTC*::
+UTC::
 UTC, The Coordinated Universal Time is the primary time standard by which the world regulates clocks and time.
 It is defined as the time at 0° longitude and is consistent, as it does not take into account daylight savings time.
 You can read further about UTC at https://www.timeanddate.com/time/aboututc.html[^].
 +
 All N1QL functions which accept a timezone as an argument also accept `UTC`.
 
-*IANA Timezones*::
+IANA Timezones::
 Many applications operate across multiple different time zones and may not necessarily use `UTC`.
 Therefore, it is important for the database to be able to handle and manipulate dates in these time zones in a consistent manner.
 Many date functions take the time zone as an additional argument.
@@ -60,7 +61,7 @@ Below are a few examples of commonly used timezones and their offsets:
 | +05:30
 |===
 
-*Local System Timezone*:: Many functions default to using the local timezone of the system, which will be one of the IANA timezones.
+Local System Timezone:: Many functions default to using the local timezone of the system, which will be one of the IANA timezones.
 
 [#date-formats]
 == Date Formats
@@ -69,13 +70,13 @@ N1QL date functions accept dates in either Epoch/UNIX timestamp format or string
 N1QL is then able to represent the passed date as a standardized date object internally.
 In general, functions whose name contains the word `STR` are designed to use string formats while `MILLIS` functions are designed to use Epoch/UNIX timestamps.
 
-[[unix-time]]*Epoch/UNIX Timestamps*::
+[[unix-time]]Epoch/UNIX Timestamps::
 Epoch/UNIX time is the number of seconds (or milliseconds) that have elapsed since `1970-01-01T00:00:00.000Z` (Thursday, 1 January 1970 at midnight), not including leap seconds.
 This can be useful for numeric and timezone agnostic representations of dates.
 While Epoch/UNIX time can be represented in either seconds or milliseconds, *all N1QL date functions specifically treat Epoch/UNIX timestamps as milliseconds*.
 For example, the date `2017-01-31T10:02:07Z` would equate to an Epoch/UNIX timestamp of 1485856927000.
 
-[[date-string]]*Date String Formats*::
+[[date-string]]Date String Formats::
 In many cases, dates are not stored as Epoch/UNIX timestamp but instead as more human-readable formats, such as `2006-01-02T15:04:05.567+08:00`.
 Therefore, N1QL also provides convenience methods to allow you to manipulate and convert dates in string format.
 All date formats follow the https://www.w3.org/TR/NOTE-datetime[ISO-8601 standard^].
@@ -372,10 +373,11 @@ The current time (at function evaluation time) of the machine that the query ser
 
 === Arguments
 
-*fmt*::
+fmt::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a <<date-string,supported date format>> to output the result as.
 +
-*Optional argument*, if no format or an incorrect format is specified, then this defaults to the combined full date and time.
+*Optional argument*.
+If no format or an incorrect format is specified, then this defaults to the combined full date and time.
 
 === Return Value
 
@@ -462,11 +464,12 @@ The current time (at function evaluation time) of the machine that the query ser
 
 === Arguments
 
-*fmt*::
+fmt::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a <<date-string,supported date format>> to output the result as.
 .
 +
-*Optional argument*, if no format or an incorrect format is specified, then this defaults to the combined full date and time.
+*Optional argument*.
+If no format or an incorrect format is specified, then this defaults to the combined full date and time.
 
 === Return Value
 
@@ -512,15 +515,16 @@ This time is the local system time converted to the specified timezone.
 
 === Arguments
 
-*tz*::
+tz::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<date-timezone,timezone>> to convert the local time to.
 +
 If this argument is not a valid timezone then `null` is returned as the result.
 
-*fmt*::
+fmt::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a <<date-string,supported date format>> to output the result as.
 +
-*Optional argument*, if no format or an incorrect format is specified, then this defaults to the combined full date and time.
+*Optional argument*.
+If no format or an incorrect format is specified, then this defaults to the combined full date and time.
 
 === Return Value
 
@@ -573,10 +577,11 @@ This function is provided for convenience and is the same as `CLOCK_TZ('UTC')`.
 
 === Arguments
 
-*fmt*::
+fmt::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a <<date-string,supported date format>> to output the result as.
 +
-*Optional argument*, if no format or an incorrect format is specified, then this defaults to the combined full date and time.
+*Optional argument*.
+If no format or an incorrect format is specified, then this defaults to the combined full date and time.
 
 === Return Value
 
@@ -623,18 +628,18 @@ For example, a value of 3 for `n` and a value of `day` for `part` would add 3 da
 
 === Arguments
 
-*date1*::
+date1::
 An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing an Epoch/UNIX timestamp in milliseconds.
 +
 If this argument is not an integer then `null` is returned.
 
-*n*::
+n::
 The value to increment the date component by.
 This value must be an integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, and may be negative to perform date subtraction.
 +
 If a non-integer is passed to the function then `null` is returned.
 
-*part*::
+part::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<manipulating-components,component>> of the date to increment.
 +
 If an invalid part is passed to the function then `null` is returned.
@@ -679,15 +684,15 @@ For example a value of 3 for `n` and a value of `day` for `part` would add 3 day
 
 === Arguments
 
-*date1*:: A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the date in a <<date-string,supported date format>>.
+date1:: A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the date in a <<date-string,supported date format>>.
 
-*n*::
+n::
 The value to increment the date component by.
 This value must be an integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, and may be negative to perform date subtraction.
 +
 If a non-integer is passed to the function then `null` is returned.
 
-*part*::
+part::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<manipulating-components,component>> of the date to increment.
 +
 If an invalid part is passed to the function then `null` is returned.
@@ -732,20 +737,20 @@ If `date1` is greater than `date2`, then the value returned will be positive, ot
 
 === Arguments
 
-*date1*::
+date1::
 An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing a Epoch/UNIX timestamp in milliseconds.
 This is the value that is subtracted from `date1`.
 +
 If this argument is not an integer, then `null` is returned.
 
-*date2*::
+date2::
 An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing a Epoch/UNIX timestamp in milliseconds.
 +
 This is the value that is subtracted from `date1`.
 +
 If this argument is not an integer, then `null` is returned.
 
-*part*::
+part::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<manipulating-components,component>> of the date to increment.
 +
 If an invalid part is passed to the function, then `null` is returned.
@@ -790,20 +795,20 @@ If `date1` is greater than `date2` then the value returned will be positive, oth
 
 === Arguments
 
-*date1*::
+date1::
 An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing a Epoch/UNIX timestamp in milliseconds.
 This is the value that is subtracted from `date1`.
 +
 If this argument is not an integer, then `null` is returned.
 
-*date2*::
+date2::
 An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing a Epoch/UNIX timestamp in milliseconds.
 +
 This is the value that is subtracted from `date1`.
 +
 If this argument is not an integer, then `null` is returned.
 
-*part*::
+part::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<manipulating-components,component>> of the date to increment.
 +
 If an invalid part is passed to the function, then `null` is returned.
@@ -916,12 +921,12 @@ Converts datetime strings from one supported date string format to a different s
 
 === Arguments
 
-*date1*::
+date1::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a date in a <<date-string,supported date format>>.
 +
 If this argument is not a valid date string then `null` is returned.
 
-*fmt*::
+fmt::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a <<date-string,supported date format>> to output the result as.
 +
 If an incorrect format is specified then this defaults to the combined full date and time.
@@ -962,21 +967,22 @@ Extracts the value of a given date component from an Epoch/UNIX timestamp value.
 
 === Arguments
 
-*date1*::
+date1::
 An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing a Epoch/UNIX timestamp in milliseconds.
 This is the value that is subtracted from `date1`.
 +
 If this argument is not an integer, then `null` is returned.
 
-*part*::
+part::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<manipulating-components,component>> of the date to increment.
 +
 If an invalid part is passed to the function, then `null` is returned.
 
-*tz*::
+tz::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<date-timezone,timezone>> to convert the local time to.
 +
-*Optional argument*, defaults to the system timezone if not specified.
+*Optional argument*.
+Defaults to the system timezone if not specified.
 If an incorrect time zone is provided, then `null` is returned.
 
 === Return Value
@@ -1021,13 +1027,13 @@ Extracts the value of a given date component from a date string.
 
 === Arguments
 
-*date1*::
+date1::
 An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing a Epoch/UNIX timestamp in milliseconds.
 This is the value that is subtracted from `date1`.
 +
 If this argument is not an integer, then `null` is returned.
 
-*part*::
+part::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<manipulating-components,component>> of the date to increment.
 +
 If an invalid part is passed to the function, then `null` is returned.
@@ -1073,28 +1079,29 @@ The difference between each subsequent generated date can be adjusted.
 
 === Arguments
 
-*date1*::
+date1::
 An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing a Epoch/UNIX timestamp in milliseconds.
 This is the value that is subtracted from `date1`.
 +
 If this argument is not an integer, then `null` is returned.
 
-*date2*::
+date2::
 An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing a Epoch/UNIX timestamp in milliseconds.
 +
 This is the value that is subtracted from `date1`.
 +
 If this argument is not an integer, then `null` is returned.
 
-*part*::
+part::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<manipulating-components,component>> of the date to increment.
 +
 If an invalid part is passed to the function, then `null` is returned.
 
-*n*::
+n::
 An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing the value by which to increment the part component for each generated date.
 +
-*Optional argument*, if not specified, this defaults to 1.
+*Optional argument*.
+If not specified, this defaults to 1.
 If a value which is not an integer is specified, then `null` is returned.
 
 === Return Value
@@ -1178,27 +1185,28 @@ The input dates can be in any of the <<date-string,supported date formats>>.
 
 === Arguments
 
-*start_date*::
+start_date::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a date in a <<date-string,supported date format>>.
 This is the date used as the start date of the array generation.
 +
 If this argument is not an integer, then `null` is returned.
 
-*end_date*::
+end_date::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a date in a <<date-string,supported date format>>.
 This is the date used as the end date of the array generation, and this value is exclusive, that is, the end date will not be included in the result.
 +
 If this argument is not an integer, then `null` is returned.
 
-*date_interval*::
+date_interval::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<manipulating-components,component>> of the date to increment.
 +
 If an invalid part is passed to the function, then `null` is returned.
 
-*quantity_int*::
+quantity_int::
 An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing the value by which to increment the interval component for each generated date.
 +
-*Optional argument*, if not specified, this defaults to 1.
+*Optional argument*.
+If not specified, this defaults to 1.
 If a value which is not an integer is specified, then `null` is returned.
 
 === Return Value
@@ -1225,7 +1233,8 @@ Ranges by quarters.
 
 [source,n1ql]
 ----
-SELECT DATE_RANGE_STR('2015-11-30T15:04:05.999', '2017-04-14T15:04:06.998', 'quarter') AS Quarters;
+SELECT DATE_RANGE_STR('2015-11-30T15:04:05.999', '2017-04-14T15:04:06.998', 'quarter')
+AS Quarters;
 ----
 
 .Results
@@ -1252,7 +1261,8 @@ Ranges by a single day.
 
 [source,n1ql]
 ----
-SELECT DATE_RANGE_STR('2016-01-01T15:04:05.999', '2016-01-05T15:04:05.998', 'day', 1) as Days;
+SELECT DATE_RANGE_STR('2016-01-01T15:04:05.999', '2016-01-05T15:04:05.998', 'day', 1)
+AS Days;
 ----
 
 .Results
@@ -1275,9 +1285,10 @@ SELECT DATE_RANGE_STR('2016-01-01T15:04:05.999', '2016-01-05T15:04:05.998', 'day
 ====
 Ranges by four months.
 
-[source,json]
+[source,n1ql]
 ----
-SELECT DATE_RANGE_STR('2018-01-01','2019-01-01', 'month', 4) as Months;
+SELECT DATE_RANGE_STR('2018-01-01','2019-01-01', 'month', 4)
+AS Months;
 ----
 
 .Results
@@ -1301,7 +1312,8 @@ Ranges by previous days.
 
 [source,n1ql]
 ----
-SELECT DATE_RANGE_STR('2016-01-05T15:04:05.999', '2016-01-01T15:04:06.998', 'day', -1) as Previous;
+SELECT DATE_RANGE_STR('2016-01-05T15:04:05.999', '2016-01-01T15:04:06.998', 'day', -1)
+AS Previous;
 ----
 
 .Results
@@ -1326,7 +1338,8 @@ Ranges by month.
 
 [source,n1ql]
 ----
-SELECT DATE_RANGE_STR('2015-01-01T01:01:01', '2015-12-11T00:00:00', 'month', 1) as Months;
+SELECT DATE_RANGE_STR('2015-01-01T01:01:01', '2015-12-11T00:00:00', 'month', 1)
+AS Months;
 ----
 
 .Results
@@ -1362,14 +1375,14 @@ Truncates an Epoch/UNIX timestamp up to the specified date component.
 
 === Arguments
 
-*date1*::
+date1::
 An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing a Epoch/UNIX timestamp in milliseconds.
 This is the date used as the date to truncate.
 +
 If this argument is not an integer, then `null` is returned.
 
-*part*::
-A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<manipulating-components,component>> to truncate to.
+part::
+A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<extracting-components,component>> to truncate to.
 This function accepts the components `millennium`, `century`, `decade`, `year`, `quarter`, `month`, `week`, and `iso_week`.
 +
 If an invalid part is specified, then `null` is returned.
@@ -1415,14 +1428,14 @@ Truncates a date string up to the specified date component.
 
 === Arguments
 
-*date1*::
+date1::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a date in a <<date-string,supported date format>>.
 This is the date that is truncated.
 +
 If this argument is not a valid date format, then `null` is returned.
 
-*part*::
-A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<manipulating-components,component>> to truncate to.
+part::
+A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<extracting-components,component>> to truncate to.
 This function accepts the components `millennium`, `century`, `decade`, `year`, `quarter`, `month`, `week`, and `iso_week`.
 +
 If an invalid part is specified, then `null` is returned.
@@ -1463,7 +1476,7 @@ Converts a number into a human-readable time duration with units.
 
 === Arguments
 
-*duration*::
+duration::
 A number, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a number, which represents the duration to convert to a string.
 This value is specified in nanoseconds (`1x10-9 seconds`).
 +
@@ -1505,12 +1518,11 @@ Converts a date string to Epoch/UNIX milliseconds.
 
 === Arguments
 
-*date1*::
+date1::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a date in a <<date-string,supported date format>>.
 This is the date to convert to Epoch/UNIX milliseconds.
 +
-If this argument is not a valid date format.
-then `null` is returned.
+If this argument is not a valid date format, then `null` is returned.
 
 === Return Value
 
@@ -1549,16 +1561,17 @@ Converts an Epoch/UNIX timestamp into the specified date string format.
 
 === Arguments
 
-*date1*::
+date1::
 An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing a Epoch/UNIX timestamp in milliseconds.
 This is the date to convert.
 +
 If this argument is not an integer, then `null` is returned.
 
-*fmt*::
+fmt::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a <<date-string,supported date format>> to output the result as.
 +
-*Optional argument*, if unspecified or an incorrect format is specified, then this defaults to the combined full date and time.
+*Optional argument*.
+If unspecified or an incorrect format is specified, then this defaults to the combined full date and time.
 
 === Return Value
 
@@ -1601,22 +1614,24 @@ Converts an Epoch/UNIX timestamp into the specified time zone in the specified d
 
 === Arguments
 
-*date1*::
+date1::
 An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing a Epoch/UNIX timestamp in milliseconds.
 This is the date to convert.
 +
 If this argument is not an integer, then `null` is returned.
 
-*tz*::
+tz::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<date-timezone,timezone>> to convert the local time to.
-*Optional argument*, defaults to the system timezone if not specified.
+*Optional argument*.
+Defaults to the system timezone if not specified.
 +
 If an incorrect time zone is provided, then `null` is returned.
 
-*fmt*::
+fmt::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a <<date-string,supported date format>> to output the result as.
 +
-*Optional argument*, if no format or an incorrect format is specified, then this defaults to the combined full date and time.
+*Optional argument*.
+If no format or an incorrect format is specified, then this defaults to the combined full date and time.
 
 === Return Value
 
@@ -1654,16 +1669,17 @@ Converts an Epoch/UNIX timestamp into local time in the specified date string fo
 
 === Arguments
 
-*date1*::
+date1::
 An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing a Epoch/UNIX timestamp in milliseconds.
 This is the date to convert to UTC.
 +
 If this argument is not an integer, then `null` is returned.
 
-*fmt*::
+fmt::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a <<date-string,supported date format>> to output the result as.
 +
-*Optional argument*, if unspecified or an incorrect format is specified, then this defaults to the combined full date and time.
+*Optional argument*.
+If unspecified or an incorrect format is specified, then this defaults to the combined full date and time.
 
 === Return Value
 
@@ -1707,10 +1723,11 @@ Will not vary during a query.
 
 === Arguments
 
-*fmt*::
+fmt::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a <<date-string,supported date format>> to output the result as.
 +
-*Optional argument*, if no format or an incorrect format is specified, then this defaults to the combined full date and time.
+*Optional argument*.
+If no format or an incorrect format is specified, then this defaults to the combined full date and time.
 
 === Return Value
 
@@ -1848,15 +1865,16 @@ Will not vary during a query.
 
 === Arguments
 
-*tz*::
+tz::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<date-timezone,timezone>> to convert the query timestamp to.
 +
 If an incorrect time zone is provided then `null` is returned.
 
-*fmt*::
+fmt::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a <<date-string,supported date format>> to output the result as.
 +
-*Optional argument*, if unspecified or an incorrect format is specified, then this defaults to the combined full date and time.
+*Optional argument*.
+If unspecified or an incorrect format is specified, then this defaults to the combined full date and time.
 
 === Return Value
 
@@ -1928,10 +1946,11 @@ Will not vary during a query.
 
 === Arguments
 
-*fmt*::
+fmt::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a <<date-string,supported date format>> to output the result as.
 +
-*Optional argument*, if unspecified or an incorrect format is specified, then this defaults to the combined full date and time.
+*Optional argument*.
+If unspecified or an incorrect format is specified, then this defaults to the combined full date and time.
 
 === Return Value
 
@@ -2004,10 +2023,11 @@ Will not vary during a query.
 
 === Arguments
 
-*fmt*::
+fmt::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a <<date-string,supported date format>> to output the result as.
 +
-*Optional argument*, if unspecified or an incorrect format is specified, then this defaults to the combined full date and time.
+*Optional argument*.
+If unspecified or an incorrect format is specified, then this defaults to the combined full date and time.
 
 === Return Value
 
@@ -2084,7 +2104,7 @@ This accepts the following units:
 
 === Arguments
 
-*duration*::
+duration::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the duration to convert.
 +
 If an invalid duration string is specified, then `null` is returned.
@@ -2131,7 +2151,7 @@ Converts a date string to Epoch/UNIX milliseconds.
 
 === Arguments
 
-*date1*::
+date1::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the date to convert to Epoch/UNIX milliseconds.
 +
 If this argument is not a valid date format, then `null` is returned.
@@ -2171,7 +2191,8 @@ SELECT STR_TO_MILLIS("2016-05-15T03:59:00Z") AS Milliseconds;
 ====
 [source,n1ql]
 ----
-SELECT STR_TO_MILLIS("19/08/2011 6:33:23+0000", "02/01/2006 15:04:05Z0700") AS Milliseconds;
+SELECT STR_TO_MILLIS("19/08/2011 6:33:23+0000", "02/01/2006 15:04:05Z0700")
+AS Milliseconds;
 ----
 
 .Results
@@ -2195,7 +2216,7 @@ The output date format follows the date format of the date passed as input.
 
 === Arguments
 
-*date1*::
+date1::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a date in a <<date-string,supported date format>>.
 This is the date to convert to UTC.
 +
@@ -2236,13 +2257,13 @@ The output date format follows the date format of the date passed as input.
 
 === Arguments
 
-*date1*::
+date1::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a date in a <<date-string,supported date format>>.
 This is the date to convert to UTC.
 +
 If this argument is not a valid date format then `null` is returned.
 
-*tz*::
+tz::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<date-timezone,timezone>> to convert the local time to.
 +
 If this argument is not a valid timezone, then `null` is returned.
@@ -2288,12 +2309,13 @@ The output date format follows the date format of the date passed as input.
 
 === Arguments
 
-*expr*:: An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing an Epoch/UNIX timestamp in milliseconds.
+expr:: An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing an Epoch/UNIX timestamp in milliseconds.
 
-*tz*::
+tz::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<date-timezone,timezone>> to for the expr argument.
 +
-*Optional argument*, defaults to the system timezone if not specified.
+*Optional argument*.
+Defaults to the system timezone if not specified.
 If an incorrect time zone is provided then `null` is returned.
 
 === Return Value
@@ -2328,7 +2350,7 @@ Note that his function returns the string value of the day of the week, where <<
 
 === Arguments
 
-*date*::
+date::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a date in a <<date-string,supported date format>>.
 This is the date to convert to UTC.
 +

--- a/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
@@ -128,7 +128,7 @@ In cases where the timezone is not specified, the local system time is assumed:
 +
 .Date String Examples
 [cols="1,2"]
-|===
+|====
 | Format | Example
 
 | YYYY-MM-DDThh:mm:ss.sTZD
@@ -169,7 +169,7 @@ In cases where the timezone is not specified, the local system time is assumed:
 
 | hh:mm:ss
 | 15:04:05
-|===
+|====
 +
 [NOTE]
 ====
@@ -221,7 +221,7 @@ For all examples, the date being used is `2006-01-02T15:04:05.999Z`
 
 .Timestamp Components
 [cols="2,6,1,1,1"]
-|===
+|====
 | Component | Description | Lower Bound | Upper Bound | Example
 
 | millennium
@@ -349,7 +349,7 @@ Should be used in conjunction with `iso_year` to get consistent results.
 | -59
 | 59
 | 0
-|===
+|====
 
 == Date Functions
 
@@ -366,34 +366,40 @@ Similarly, if any of the arguments are `NULL` then `NULL` is returned.
 [#fn-date-clock-local]
 == CLOCK_LOCAL([fmt])
 
-*Description*:: The current time (at function evaluation time) of the machine that the query service is running on, in the specified string format.
+=== Description
 
-*Arguments*::
-*fmt*;;
+The current time (at function evaluation time) of the machine that the query service is running on, in the specified string format.
+
+=== Arguments
+
+*fmt*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a <<date-string,supported date format>> to output the result as.
 +
 *Optional argument*, if no format or an incorrect format is specified, then this defaults to the combined full date and time.
 
-*Return Value*:: A date string in the format specified representing the local system time.
+=== Return Value
 
-*Limitations*::
+A date string in the format specified representing the local system time.
+
+=== Limitations
+
 `CLOCK_LOCAL()` cannot be used as part of an index definition, this includes the indexed fields and the `WHERE` clause of the index.
-+
+
 If this function is called multiple times within the same query then the values returned may differ, particularly if the query takes a long time to run.
 To avoid inconsistencies between multiple calls to `CLOCK_LOCAL()` within a single query, use <<fn-date-now-local,NOW_LOCAL()>> instead.
 
-*Examples*::
-+
+=== Examples
+
+====
 [source,n1ql]
 ----
 SELECT CLOCK_LOCAL() as full_date,
        CLOCK_LOCAL('invalid date') as invalid_date,
        CLOCK_LOCAL('1111-11-11') as short_date;
 ----
-+
-Results:
-+
-[source,n1ql]
+
+.Results
+[source,json]
 ----
 [
   {
@@ -403,33 +409,40 @@ Results:
   }
 ]
 ----
+====
 
 [#fn-date-clock-millis]
 == CLOCK_MILLIS()
 
-*Description*::
+=== Description
+
 The current time as an Epoch/UNIX timestamp.
 Its fractional part represents nanoseconds, but the additional precision beyond milliseconds may not be consistent or guaranteed on all platforms.
 
-*Arguments*:: This function accepts no arguments.
+=== Arguments
 
-*Return Value*:: A single float value (with 3 decimal places) representing the system time as Epoch/UNIX time.
+This function accepts no arguments.
 
-*Limitations*::
+=== Return Value
+
+A single float value (with 3 decimal places) representing the system time as Epoch/UNIX time.
+
+=== Limitations
+
 `CLOCK_MILLIS()` cannot be used as part of an index definition, this includes the indexed fields and the `WHERE` clause of the index.
-+
+
 If this function is called multiple times within the same query then the values returned may differ, particularly if the query takes a long time to run.
 To avoid inconsistencies between multiple calls to `CLOCK_MILLIS()` within a single query, use <<fn-date-now-millis,NOW_MILLIS()>> instead.
 
-*Examples*::
-+
+=== Examples
+
+====
 [source,n1ql]
 ----
 SELECT CLOCK_MILLIS() AS CurrentTime;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -438,38 +451,45 @@ Results:
   }
 ]
 ----
+====
 
 [#fn-date-clock-str]
 == CLOCK_STR([fmt])
 
-*Description*:: The current time (at function evaluation time) of the machine that the query service is running on, in the specified string format.
+=== Description
 
-*Arguments*::
-*fmt*;;
+The current time (at function evaluation time) of the machine that the query service is running on, in the specified string format.
+
+=== Arguments
+
+*fmt*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a <<date-string,supported date format>> to output the result as.
 .
 +
 *Optional argument*, if no format or an incorrect format is specified, then this defaults to the combined full date and time.
 
-*Return Value*:: A date string in the format specified representing the system time.
+=== Return Value
 
-*Limitations*::
+A date string in the format specified representing the system time.
+
+=== Limitations
+
 `CLOCK_STR()` cannot be used as part of an index definition, this includes the indexed fields and the `WHERE` clause of the index.
-+
+
 If this function is called multiple times within the same query then the values returned may differ, particularly if the query takes a long time to run.
 To avoid inconsistencies between multiple calls to `CLOCK_STR()` within a single query, use <<fn-date-now-str,NOW_STR()>> instead.
 
-*Examples*::
-+
+=== Examples
+
+====
 [source,n1ql]
 ----
 SELECT CLOCK_STR() as full_date,
        CLOCK_STR('invalid date') as invalid_date,
        CLOCK_STR('1111-11-11') as short_date;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -480,37 +500,44 @@ Results:
   }
 ]
 ----
+====
 
 [#fn-date-clock-tz]
 == CLOCK_TZ(tz [, fmt])
 
-*Description*::
+=== Description
+
 The current time (at function evaluation time) in the timezone given by the timezone argument passed to the function.
 This time is the local system time converted to the specified timezone.
 
-*Arguments*::
-*tz*;;
+=== Arguments
+
+*tz*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<date-timezone,timezone>> to convert the local time to.
 +
 If this argument is not a valid timezone then `null` is returned as the result.
 
-*fmt*;;
+*fmt*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a <<date-string,supported date format>> to output the result as.
 +
 *Optional argument*, if no format or an incorrect format is specified, then this defaults to the combined full date and time.
 
-*Return Value*:: An date string in the format specified representing the system time in the specified timezone.
+=== Return Value
 
-*Limitations*::
+An date string in the format specified representing the system time in the specified timezone.
+
+=== Limitations
+
 As this function converts the local time, it may not accurately represent the true time in that timezone.
-+
+
 `CLOCK_TZ()` cannot be used as part of an index definition, this includes the indexed fields and the `WHERE` clause of the index.
-+
+
 If this function is called multiple times within the same query then the values returned may differ, particularly if the query takes a long time to run.
 To avoid inconsistencies between multiple calls to `CLOCK_TZ()` within a single query, use <<fn-date-now-tz,NOW_TZ()>> instead.
 
-*Examples*::
-+
+=== Examples
+
+====
 [source,n1ql]
 ----
 SELECT CLOCK_TZ('UTC') as UTC_full_date,
@@ -519,9 +546,8 @@ SELECT CLOCK_TZ('UTC') as UTC_full_date,
        CLOCK_TZ('US/Eastern') as us_east,
        CLOCK_TZ('US/Pacific') as us_west;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -534,40 +560,46 @@ Results:
   }
 ]
 ----
+====
 
 [#fn-date-clock-utc]
 == CLOCK_UTC([fmt])
 
-*Description*::
+=== Description
+
 The current time in UTC.
 This time is the local system time converted to UTC.
 This function is provided for convenience and is the same as `CLOCK_TZ('UTC')`.
 
-*Arguments*::
-*fmt*;;
+=== Arguments
+
+*fmt*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a <<date-string,supported date format>> to output the result as.
 +
 *Optional argument*, if no format or an incorrect format is specified, then this defaults to the combined full date and time.
 
-*Return Value*:: An date string in the format specified representing the system time in UTC.
+=== Return Value
 
-*Limitations*::
+An date string in the format specified representing the system time in UTC.
+
+=== Limitations
+
 As this function converts the local time, it may not accurately represent the true time in UTC.
-+
+
 `CLOCK_UTC()` cannot be used as part of an index definition, this includes the indexed fields and the `WHERE` clause of the index.
-+
+
 If this function is called multiple times within the same query then the values returned may differ, particularly if the query takes a long time to run.
 To avoid inconsistencies between multiple calls to `CLOCK_UTC()` within a single query, use <<fn-date-now-utc,NOW_UTC()>> instead.
 
-*Examples*::
-+
+=== Examples
+
+====
 [source,n1ql]
 ----
 SELECT CLOCK_UTC() as full_date, CLOCK_UTC('1111-11-11') as short_date;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -577,37 +609,43 @@ Results:
   }
 ]
 ----
+====
 
 [#fn-date-add-millis]
 == DATE_ADD_MILLIS(date1, n, part)
 
-*Description*::
+=== Description
+
 Performs date arithmetic on a particular component of an Epoch/UNIX timestamp value.
 This calculation is specified by the arguments `n` and `part`.
 +
 For example, a value of 3 for `n` and a value of `day` for `part` would add 3 days to the date specified by `date1`.
 
-*Arguments*::
-*date1*;;
+=== Arguments
+
+*date1*::
 An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing an Epoch/UNIX timestamp in milliseconds.
 +
 If this argument is not an integer then `null` is returned.
 
-*n*;;
+*n*::
 The value to increment the date component by.
 This value must be an integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, and may be negative to perform date subtraction.
 +
 If a non-integer is passed to the function then `null` is returned.
 
-*part*;;
+*part*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<manipulating-components,component>> of the date to increment.
 +
 If an invalid part is passed to the function then `null` is returned.
 
-*Return Value*:: An integer, representing the result of the calculation as an Epoch/UNIX timestamp in milliseconds.
+=== Return Value
 
-*Examples*::
-+
+An integer, representing the result of the calculation as an Epoch/UNIX timestamp in milliseconds.
+
+=== Examples
+
+====
 [source,n1ql]
 ----
 SELECT DATE_ADD_MILLIS(1463284740000, 3, 'day') as add_3_days,
@@ -615,9 +653,8 @@ SELECT DATE_ADD_MILLIS(1463284740000, 3, 'day') as add_3_days,
        DATE_ADD_MILLIS(1463284740000, -3, 'day') as sub_3_days,
        DATE_ADD_MILLIS(1463284740000, -3, 'year') as sub_3_years;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -629,33 +666,39 @@ Results:
   }
 ]
 ----
+====
 
 [#fn-date-add-str]
 == DATE_ADD_STR(date1, n, part)
 
-*Description*::
+=== Description
+
 Performs date arithmetic on a date string.
 This calculation is specified by the arguments `n` and `part`.
 For example a value of 3 for `n` and a value of `day` for `part` would add 3 days to the date specified by `date1`.
 
-*Arguments*::
-*date1*;; A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the date in a <<date-string,supported date format>>.
+=== Arguments
 
-*n*;;
+*date1*:: A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the date in a <<date-string,supported date format>>.
+
+*n*::
 The value to increment the date component by.
 This value must be an integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, and may be negative to perform date subtraction.
 +
 If a non-integer is passed to the function then `null` is returned.
 
-*part*;;
+*part*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<manipulating-components,component>> of the date to increment.
 +
 If an invalid part is passed to the function then `null` is returned.
 
-*Return Value*:: An integer representing the result of the calculation as an Epoch/UNIX timestamp in milliseconds.
+=== Return Value
 
-*Examples*::
-+
+An integer representing the result of the calculation as an Epoch/UNIX timestamp in milliseconds.
+
+=== Examples
+
+====
 [source,n1ql]
 ----
 SELECT DATE_ADD_STR('2016-05-15 03:59:00Z', 3, 'day') as add_3_days,
@@ -663,9 +706,8 @@ SELECT DATE_ADD_STR('2016-05-15 03:59:00Z', 3, 'day') as add_3_days,
        DATE_ADD_STR('2016-05-15 03:59:00Z', -3, 'day') as sub_3_days,
        DATE_ADD_STR('2016-05-15 03:59:00Z', -3, 'year') as sub_3_years;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -677,38 +719,44 @@ Results:
   }
 ]
 ----
+====
 
 [#fn-date-diff-millis]
 == DATE_DIFF_MILLIS(date1, date2, part)
 
-*Description*::
+=== Description
+
 Finds the elapsed time between two Epoch/UNIX timestamps.
 This elapsed time is measured from the date specified by `date2` to the date specified by `date1`.
 If `date1` is greater than `date2`, then the value returned will be positive, otherwise the value returned will be negative.
 
-*Arguments*::
-*date1*;;
+=== Arguments
+
+*date1*::
 An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing a Epoch/UNIX timestamp in milliseconds.
 This is the value that is subtracted from `date1`.
 +
 If this argument is not an integer, then `null` is returned.
 
-*date2*;;
+*date2*::
 An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing a Epoch/UNIX timestamp in milliseconds.
 +
 This is the value that is subtracted from `date1`.
 +
 If this argument is not an integer, then `null` is returned.
 
-*part*;;
+*part*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<manipulating-components,component>> of the date to increment.
 +
 If an invalid part is passed to the function, then `null` is returned.
 
-*Return Value*:: An integer representing the elapsed time (based on the specified `part`) between both dates.
+=== Return Value
 
-*Examples*::
-+
+An integer representing the elapsed time (based on the specified `part`) between both dates.
+
+=== Examples
+
+====
 [source,n1ql]
 ----
 SELECT DATE_DIFF_MILLIS(1463543940000, 1463284740000, 'day') as add_3_days,
@@ -716,9 +764,8 @@ SELECT DATE_DIFF_MILLIS(1463543940000, 1463284740000, 'day') as add_3_days,
        DATE_DIFF_MILLIS(1463025540000, 1463284740000, 'day') as sub_3_days,
        DATE_DIFF_MILLIS(1368590340000, 1463284740000, 'year') as sub_3_years;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -730,39 +777,47 @@ Results:
   }
 ]
 ----
+====
 
 [#fn-date-diff-str]
 == DATE_DIFF_STR(date1, date2, part)
 
-*Description*::
+=== Description
+
 Finds the elapsed time between two dates specified as formatted strings.
 This elapsed time is measured from the date specified by `date2` to the date specified by `date1`.
 If `date1` is greater than `date2` then the value returned will be positive, otherwise the value returned will be negative.
 
-*Arguments*::
-*date1*;;
+=== Arguments
+
+*date1*::
 An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing a Epoch/UNIX timestamp in milliseconds.
 This is the value that is subtracted from `date1`.
 +
 If this argument is not an integer, then `null` is returned.
 
-*date2*;;
+*date2*::
 An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing a Epoch/UNIX timestamp in milliseconds.
 +
 This is the value that is subtracted from `date1`.
 +
 If this argument is not an integer, then `null` is returned.
 
-*part*;;
+*part*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<manipulating-components,component>> of the date to increment.
 +
 If an invalid part is passed to the function, then `null` is returned.
 
-*Return Value*:: An integer representing the elapsed time (based on the specified `part`) between both dates.
+=== Return Value
 
-*Examples*::
-*Example 1:* Find the day difference and year difference between two strings.
-+
+An integer representing the elapsed time (based on the specified `part`) between both dates.
+
+=== Examples
+
+.Example 1
+====
+Find the day difference and year difference between two strings.
+
 [source,n1ql]
 ----
 SELECT DATE_DIFF_STR('2016-05-18T03:59:00Z', '2016-05-15 03:59:00Z', 'day') as add_3_days,
@@ -770,9 +825,8 @@ SELECT DATE_DIFF_STR('2016-05-18T03:59:00Z', '2016-05-15 03:59:00Z', 'day') as a
        DATE_DIFF_STR('2016-05-12T03:59:00Z', '2016-05-15 03:59:00Z', 'day') as sub_3_days,
        DATE_DIFF_STR('2013-05-15T03:59:00Z', '2016-05-15 03:59:00Z', 'year') as sub_3_years;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -784,18 +838,21 @@ Results:
   }
 ]
 ----
-+
-*Example 2:* List all hotel documents that were reviewed between two dates.
-+
+====
+
+.Example 2
+====
+List all hotel documents that were reviewed between two dates.
+
 [source,n1ql]
 ----
 SELECT name, reviews[0].date
 FROM `travel-sample`.inventory.hotel
 WHERE reviews[0].date BETWEEN "2013-01-01 00:00:00 +0100" AND "2014-01-01 00:00:00 +0100";
 ----
-+
+
 The same as:
-+
+
 [source,n1ql]
 ----
 SELECT name, reviews[0].date
@@ -803,7 +860,6 @@ FROM `travel-sample`.inventory.hotel
 WHERE reviews[0].date BETWEEN "2013-01-01 %" AND "2014-01-01 %";
 ----
 
-+
 .Results
 [source,json]
 ----
@@ -844,41 +900,47 @@ WHERE reviews[0].date BETWEEN "2013-01-01 %" AND "2014-01-01 %";
     "date": "2013-05-08 17:54:41 +0300",
     "name": "Alberta House B&B"
   },
-...
+  // ...
 ]
 ----
-+
+====
+
 NOTE: When querying between two dates, you must specify the full date (with time and time zone) or use the wildcard character (%).
 
 [#fn-date-format-str]
 == DATE_FORMAT_STR(date1, fmt)
 
-*Description*:: Converts datetime strings from one supported date string format to a different supported date string format.
+=== Description
 
-*Arguments*::
-*date1*;;
+Converts datetime strings from one supported date string format to a different supported date string format.
+
+=== Arguments
+
+*date1*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a date in a <<date-string,supported date format>>.
 +
 If this argument is not a valid date string then `null` is returned.
 
-*fmt*;;
+*fmt*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a <<date-string,supported date format>> to output the result as.
 +
 If an incorrect format is specified then this defaults to the combined full date and time.
 
-*Return Value*:: A date string in the format specified.
+=== Return Value
 
-*Examples*::
-+
+A date string in the format specified.
+
+=== Examples
+
+====
 [source,n1ql]
 ----
 SELECT DATE_FORMAT_STR('2016-05-15T00:00:23+00:00', '1111-11-11') as full_to_short,
        DATE_FORMAT_STR('2016-05-15', '1111-11-11T00:00:00+00:00') as short_to_full,
        DATE_FORMAT_STR('01:10:05', '1111-11-11T01:01:01Z') as time_to_full;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -889,34 +951,41 @@ Results:
   }
 ]
 ----
+====
 
 [#fn-date-part-millis]
 == DATE_PART_MILLIS(date1, part [, tz])
 
-*Description*:: Extracts the value of a given date component from an Epoch/UNIX timestamp value.
+=== Description
 
-*Arguments*::
-*date1*;;
+Extracts the value of a given date component from an Epoch/UNIX timestamp value.
+
+=== Arguments
+
+*date1*::
 An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing a Epoch/UNIX timestamp in milliseconds.
 This is the value that is subtracted from `date1`.
 +
 If this argument is not an integer, then `null` is returned.
 
-*part*;;
+*part*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<manipulating-components,component>> of the date to increment.
 +
 If an invalid part is passed to the function, then `null` is returned.
 
-*tz*;;
+*tz*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<date-timezone,timezone>> to convert the local time to.
 +
 *Optional argument*, defaults to the system timezone if not specified.
 If an incorrect time zone is provided, then `null` is returned.
 
-*Return Value*:: An integer representing the value of the component extracted from the timestamp.
+=== Return Value
 
-*Examples*::
-+
+An integer representing the value of the component extracted from the timestamp.
+
+=== Examples
+
+====
 [source,n1ql]
 ----
 SELECT DATE_PART_MILLIS(1463284740000, 'day') as day_local,
@@ -926,9 +995,8 @@ SELECT DATE_PART_MILLIS(1463284740000, 'day') as day_local,
        DATE_PART_MILLIS(1463284740000, 'week') as week,
        DATE_PART_MILLIS(1463284740000, 'year') as year;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -942,28 +1010,35 @@ Results:
   }
 ]
 ----
+====
 
 [#fn-date-part-str]
 == DATE_PART_STR(date1, part)
 
-*Description*:: Extracts the value of a given date component from a date string.
+=== Description
 
-*Arguments*::
-*date1*;;
+Extracts the value of a given date component from a date string.
+
+=== Arguments
+
+*date1*::
 An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing a Epoch/UNIX timestamp in milliseconds.
 This is the value that is subtracted from `date1`.
 +
 If this argument is not an integer, then `null` is returned.
 
-*part*;;
+*part*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<manipulating-components,component>> of the date to increment.
 +
 If an invalid part is passed to the function, then `null` is returned.
 
-*Return Value*:: An integer representing the value of the component extracted from the timestamp.
+=== Return Value
 
-*Examples*::
-+
+An integer representing the value of the component extracted from the timestamp.
+
+=== Examples
+
+====
 [source,n1ql]
 ----
 SELECT DATE_PART_STR('2016-05-15T03:59:00Z', 'day') as day,
@@ -972,9 +1047,8 @@ SELECT DATE_PART_STR('2016-05-15T03:59:00Z', 'day') as day,
        DATE_PART_STR('2016-05-15T03:59:00Z', 'week') as week,
        DATE_PART_STR('2016-05-15T03:59:00Z', 'year') as year;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -987,59 +1061,67 @@ Results:
   }
 ]
 ----
+====
 
 [#fn-date-range-millis]
 == DATE_RANGE_MILLIS(date1, date2, part [,n])
 
-*Description*::
+=== Description
+
 Generates an array of dates from the start date specified by `date1` and the end date specified by `date2`, as Epoch/UNIX timestamps.
 The difference between each subsequent generated date can be adjusted.
 
-*Arguments*::
-*date1*;;
+=== Arguments
+
+*date1*::
 An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing a Epoch/UNIX timestamp in milliseconds.
 This is the value that is subtracted from `date1`.
 +
 If this argument is not an integer, then `null` is returned.
 
-*date2*;;
+*date2*::
 An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing a Epoch/UNIX timestamp in milliseconds.
 +
 This is the value that is subtracted from `date1`.
 +
 If this argument is not an integer, then `null` is returned.
 
-*part*;;
+*part*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<manipulating-components,component>> of the date to increment.
 +
 If an invalid part is passed to the function, then `null` is returned.
 
-*n*;;
+*n*::
 An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing the value by which to increment the part component for each generated date.
 +
 *Optional argument*, if not specified, this defaults to 1.
 If a value which is not an integer is specified, then `null` is returned.
 
-*Return Value*:: An array of integers representing the generated dates, as Epoch/UNIX timestamps, between `date1` and `date2`.
+=== Return Value
 
-*Limitations*::
+An array of integers representing the generated dates, as Epoch/UNIX timestamps, between `date1` and `date2`.
+
+=== Limitations
+
 It is possible to generate very large arrays using this function.
 In some cases the query engine may be unable to process all of these and cause excessive resource consumption.
 It is therefore recommended that you first validate the inputs to this function to ensure that the generated result is a reasonable size.
-+
+
 If the start date is greater than the end date passed to the function then an error will not be thrown, but the result array will be empty.
 An array of descending dates can be generated by setting the start date greater than the end date and specifying a negative value for `n`.
 
-*Examples*::
-*Example 1:* Range of milliseconds by month.
-+
+=== Examples
+
+.Example 1
+====
+Range of milliseconds by month.
+
 [source,n1ql]
 ----
 SELECT DATE_RANGE_MILLIS(1480752000000, 1475478000000, 'month', -1) as Milliseconds;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -1051,16 +1133,18 @@ Results:
   }
 ]
 ----
-+
-*Example 1b:* Range of milliseconds by previous month.
-+
+====
+
+.Example 2
+====
+Range of milliseconds by previous month.
+
 [source,n1ql]
 ----
 SELECT DATE_RANGE_MILLIS(1480752000000, 1449129600000, 'month', -1) as Months;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -1082,41 +1166,47 @@ Results:
   }
 ]
 ----
+====
 
 [#fn-date-range-str]
 == DATE_RANGE_STR(start_date, end_date, date_interval [, quantity_int ])
 
-*Description*::
+=== Description
+
 Generates an array of date strings between the start date and end date, calculated by the interval and quantity values.
 The input dates can be in any of the <<date-string,supported date formats>>.
 
-*Arguments*::
-*start_date*;;
+=== Arguments
+
+*start_date*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a date in a <<date-string,supported date format>>.
 This is the date used as the start date of the array generation.
 +
 If this argument is not an integer, then `null` is returned.
 
-*end_date*;;
+*end_date*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a date in a <<date-string,supported date format>>.
 This is the date used as the end date of the array generation, and this value is exclusive, that is, the end date will not be included in the result.
 +
 If this argument is not an integer, then `null` is returned.
 
-*date_interval*;;
+*date_interval*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<manipulating-components,component>> of the date to increment.
 +
 If an invalid part is passed to the function, then `null` is returned.
 
-*quantity_int*;;
+*quantity_int*::
 An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing the value by which to increment the interval component for each generated date.
 +
 *Optional argument*, if not specified, this defaults to 1.
 If a value which is not an integer is specified, then `null` is returned.
 
-*Return Value*:: An array of strings representing the generated dates, as date strings, between `start_date` and `end_date`.
+=== Return Value
 
-*Limitations*::
+An array of strings representing the generated dates, as date strings, between `start_date` and `end_date`.
+
+=== Limitations
+
 * It is possible to generate very large arrays using this function.
 In some cases the query engine may be unable to process all of these and cause excessive resource consumption.
 It is therefore recommended that you first validate the inputs of this function to ensure that the generated result is a reasonable size.
@@ -1127,16 +1217,18 @@ An array of descending dates can be generated by setting the `start_date` greate
 * From 4.6.2, both specified dates can be different acceptable date formats; but prior to 4.6.2, both specified dates must have the same string format, otherwise `null` will be returned.
 To ensure that both dates have the same format, you should use <<fn-date-format-str,DATE_FORMAT_STR()>>.
 
-*Examples*::
-*Example 1:* Ranges by quarters.
-+
-[source,json]
+=== Examples
+
+.Example 1
+====
+Ranges by quarters.
+
+[source,n1ql]
 ----
 SELECT DATE_RANGE_STR('2015-11-30T15:04:05.999', '2017-04-14T15:04:06.998', 'quarter') AS Quarters;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -1152,16 +1244,18 @@ Results:
   }
 ]
 ----
-+
-*Example 2:* Ranges by a single day.
-+
-[source,json]
+====
+
+.Example 2
+====
+Ranges by a single day.
+
+[source,n1ql]
 ----
 SELECT DATE_RANGE_STR('2016-01-01T15:04:05.999', '2016-01-05T15:04:05.998', 'day', 1) as Days;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -1175,16 +1269,18 @@ Results:
   }
 ]
 ----
-+
-*Example 3:* Ranges by four months.
-+
+====
+
+.Example 3
+====
+Ranges by four months.
+
 [source,json]
 ----
 SELECT DATE_RANGE_STR('2018-01-01','2019-01-01', 'month', 4) as Months;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -1197,16 +1293,18 @@ Results:
   }
 ]
 ----
-+
-*Example 4:* Ranges by previous days.
-+
+====
+
+.Example 4
+====
+Ranges by previous days.
+
 [source,n1ql]
 ----
 SELECT DATE_RANGE_STR('2016-01-05T15:04:05.999', '2016-01-01T15:04:06.998', 'day', -1) as Previous;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -1220,16 +1318,18 @@ Results:
   }
 ]
 ----
-+
-*Example 5:* Ranges by month.
-+
+====
+
+.Example 5
+====
+Ranges by month.
+
 [source,n1ql]
 ----
 SELECT DATE_RANGE_STR('2015-01-01T01:01:01', '2015-12-11T00:00:00', 'month', 1) as Months;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -1251,41 +1351,48 @@ Results:
   }
 ]
 ----
+====
 
 [#fn-date-trunc-millis]
 == DATE_TRUNC_MILLIS(date1, part)
 
-*Description*:: Truncates an Epoch/UNIX timestamp up to the specified date component.
+=== Description
 
-*Arguments*::
-*date1*;;
+Truncates an Epoch/UNIX timestamp up to the specified date component.
+
+=== Arguments
+
+*date1*::
 An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing a Epoch/UNIX timestamp in milliseconds.
 This is the date used as the date to truncate.
 +
 If this argument is not an integer, then `null` is returned.
 
-*part*;;
+*part*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<manipulating-components,component>> to truncate to.
 +
 If an invalid part is specified, then `null` is returned.
 
-*Return Value*:: An integer representing the truncated timestamp in Epoch/UNIX time.
+=== Return Value
 
-*Limitations*::
+An integer representing the truncated timestamp in Epoch/UNIX time.
+
+=== Limitations
+
 In some cases, where the timestamp is smaller than the duration of the provided part, this function returns the incorrect result.
 It is recommended that you do not use this function for very small Epoch/UNIX timestamps.
 
-*Examples*::
-+
+=== Examples
+
+====
 [source,n1ql]
 ----
 SELECT DATE_TRUNC_MILLIS(1463284740000, 'day') as day,
        DATE_TRUNC_MILLIS(1463284740000, 'month') as month,
        DATE_TRUNC_MILLIS(1463284740000, 'year') as year;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -1296,37 +1403,43 @@ Results:
   }
 ]
 ----
+====
 
 [#fn-date-trunc-str]
 == DATE_TRUNC_STR(date1, part)
 
-*Description*:: Truncates a date string up to the specified date component.
+=== Description
 
-*Arguments*::
-*date1*;;
+Truncates a date string up to the specified date component.
+
+=== Arguments
+
+*date1*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a date in a <<date-string,supported date format>>.
 This is the date that is truncated.
 +
 If this argument is not a valid date format, then `null` is returned.
 
-*part*;;
+*part*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<manipulating-components,component>> to truncate to.
 +
 If an invalid part is specified, then `null` is returned.
 
-*Return Value*:: A date string representing the truncated date.
+=== Return Value
 
-*Examples*::
-+
+A date string representing the truncated date.
+
+=== Examples
+
+====
 [source,n1ql]
 ----
 SELECT DATE_TRUNC_STR('2016-05-18T03:59:00Z', 'day') as day,
        DATE_TRUNC_STR('2016-05-18T03:59:00Z', 'month') as month,
        DATE_TRUNC_STR('2016-05-18T03:59:00Z', 'year') as year;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -1337,32 +1450,38 @@ Results:
   }
 ]
 ----
+====
 
 [#fn-date-duration-to-str]
 == DURATION_TO_STR(duration)
 
-*Description*:: Converts a number into a human-readable time duration with units.
+=== Description
 
-*Arguments*::
-*duration*;;
+Converts a number into a human-readable time duration with units.
+
+=== Arguments
+
+*duration*::
 A number, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a number, which represents the duration to convert to a string.
 This value is specified in nanoseconds (`1x10-9 seconds`).
 +
 If a value which is not a number is specified, then `null` is returned.
 
-*Return Value*:: A string representing the human-readable duration.
+=== Return Value
 
-*Examples*::
-+
+A string representing the human-readable duration.
+
+=== Examples
+
+====
 [source,n1ql]
 ----
 SELECT DURATION_TO_STR(2000) as microsecs,
        DURATION_TO_STR(2000000) as millisecs,
        DURATION_TO_STR(2000000000) as secs;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -1373,31 +1492,37 @@ Results:
   }
 ]
 ----
+====
 
 [#fn-date-millis]
 == MILLIS(date1)
 
-*Description*:: Converts a date string to Epoch/UNIX milliseconds.
+=== Description
 
-*Arguments*::
-*date1*;;
+Converts a date string to Epoch/UNIX milliseconds.
+
+=== Arguments
+
+*date1*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a date in a <<date-string,supported date format>>.
 This is the date to convert to Epoch/UNIX milliseconds.
 +
 If this argument is not a valid date format.
 then `null` is returned.
 
-*Return Value*:: An integer representing the date string converted to Epoch/UNIX milliseconds.
+=== Return Value
 
-*Examples*::
-+
+An integer representing the date string converted to Epoch/UNIX milliseconds.
+
+=== Examples
+
+====
 [source,n1ql]
 ----
 SELECT MILLIS("2016-05-15T03:59:00Z") as DateStringInMilliseconds;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -1406,6 +1531,7 @@ Results:
   }
 ]
 ----
+====
 
 [#fn-date-millis-to-local]
 == MILLIS_TO_LOCAL(date1 [, fmt])
@@ -1415,37 +1541,43 @@ Alias for <<fn-date-millis-to-str,MILLIS_TO_STR()>>.
 [#fn-date-millis-to-str]
 == MILLIS_TO_STR(date1 [, fmt ])
 
-*Description*:: Converts an Epoch/UNIX timestamp into the specified date string format.
+=== Description
 
-*Arguments*::
-*date1*;;
+Converts an Epoch/UNIX timestamp into the specified date string format.
+
+=== Arguments
+
+*date1*::
 An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing a Epoch/UNIX timestamp in milliseconds.
 This is the date to convert.
 +
 If this argument is not an integer, then `null` is returned.
 
-*fmt*;;
+*fmt*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a <<date-string,supported date format>> to output the result as.
 +
 *Optional argument*, if unspecified or an incorrect format is specified, then this defaults to the combined full date and time.
 
-*Return Value*:: A date string representing the local date in the specified format.
+=== Return Value
 
-*Limitations*::
+A date string representing the local date in the specified format.
+
+=== Limitations
+
 In some cases, where the timestamp is smaller than the duration of the provided part, this function returns the incorrect result.
 It is recommended that you do not use this function for very small Epoch/UNIX timestamps.
 
-*Examples*::
-+
+=== Examples
+
+====
 [source,n1ql]
 ----
 SELECT MILLIS_TO_STR(1463284740000) as full_date,
        MILLIS_TO_STR(1463284740000, 'invalid format') as invalid_format,
        MILLIS_TO_STR(1463284740000, '1111-11-11') as short_date;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -1456,43 +1588,49 @@ Results:
   }
 ]
 ----
+====
 
 [#fn-date-millis-to-tz]
 == MILLIS_TO_TZ(date1, tz [, fmt])
 
-*Description*:: Converts an Epoch/UNIX timestamp into the specified time zone in the specified date string format.
+=== Description
 
-*Arguments*::
-*date1*;;
+Converts an Epoch/UNIX timestamp into the specified time zone in the specified date string format.
+
+=== Arguments
+
+*date1*::
 An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing a Epoch/UNIX timestamp in milliseconds.
 This is the date to convert.
 +
 If this argument is not an integer, then `null` is returned.
 
-*tz*;;
+*tz*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<date-timezone,timezone>> to convert the local time to.
 *Optional argument*, defaults to the system timezone if not specified.
 +
 If an incorrect time zone is provided, then `null` is returned.
 
-*fmt*;;
+*fmt*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a <<date-string,supported date format>> to output the result as.
 +
 *Optional argument*, if no format or an incorrect format is specified, then this defaults to the combined full date and time.
 
-*Return Value*:: A date string representing the date in the specified timezone in the specified format..
+=== Return Value
 
-*Examples*::
-+
+A date string representing the date in the specified timezone in the specified format..
+
+=== Examples
+
+====
 [source,n1ql]
 ----
 SELECT MILLIS_TO_TZ(1463284740000, 'America/New_York') as est,
 	   MILLIS_TO_TZ(1463284740000, 'Asia/Kolkata') as ist,
 	   MILLIS_TO_TZ(1463284740000, 'UTC') as utc;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -1503,37 +1641,43 @@ Results:
   }
 ]
 ----
+====
 
 [#fn-date-millis-to-utc]
 == MILLIS_TO_UTC(date1 [, fmt])
 
-*Description*:: Converts an Epoch/UNIX timestamp into local time in the specified date string format.
+=== Description
 
-*Arguments*::
-*date1*;;
+Converts an Epoch/UNIX timestamp into local time in the specified date string format.
+
+=== Arguments
+
+*date1*::
 An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing a Epoch/UNIX timestamp in milliseconds.
 This is the date to convert to UTC.
 +
 If this argument is not an integer, then `null` is returned.
 
-*fmt*;;
+*fmt*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a <<date-string,supported date format>> to output the result as.
 +
 *Optional argument*, if unspecified or an incorrect format is specified, then this defaults to the combined full date and time.
 
-*Return Value*:: A date string representing the date in UTC in the specified format.
+=== Return Value
 
-*Examples*::
-+
+A date string representing the date in UTC in the specified format.
+
+=== Examples
+
+====
 [source,n1ql]
 ----
 SELECT MILLIS_TO_UTC(1463284740000) as full_date,
        MILLIS_TO_UTC(1463284740000, 'invalid format') as invalid_format,
        MILLIS_TO_UTC(1463284740000, '1111-11-11') as short_date;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -1544,6 +1688,7 @@ Results:
   }
 ]
 ----
+====
 
 [#fn-date-millis-to-zone-name]
 == MILLIS_TO_ZONE_NAME(date1, tz [, fmt])
@@ -1553,34 +1698,41 @@ Alias for <<fn-date-millis-to-tz,MILLIS_TO_TZ()>>
 [#fn-date-now-local]
 == NOW_LOCAL([fmt])
 
-*Description*::
+=== Description
+
 The timestamp of the query as date string in the system timezone.
 Will not vary during a query.
 
-*Arguments*::
-*fmt*;;
+=== Arguments
+
+*fmt*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a <<date-string,supported date format>> to output the result as.
 +
 *Optional argument*, if no format or an incorrect format is specified, then this defaults to the combined full date and time.
 
-*Return Value*:: A date time string in the format specified.
+=== Return Value
 
-*Limitations*::
+A date time string in the format specified.
+
+=== Limitations
+
 If this function is called multiple times within the same query it will always return the same time.
 If you wish to use the system time when the function is evaluated, use <<fn-date-clock-local,CLOCK_LOCAL()>> instead.
 
-*Examples*::
-*Example 1:* Various arguments of NOW_LOCAL().
-+
+=== Examples
+
+.Example 1
+====
+Various arguments of NOW_LOCAL().
+
 [source,n1ql]
 ----
 SELECT NOW_LOCAL() as full_date,
        NOW_LOCAL('invalid date') as invalid_date,
        NOW_LOCAL('1111-11-11') as short_date;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -1591,16 +1743,18 @@ Results:
   }
 ]
 ----
-+
-Example 2: Difference between NOW_LOCAL() and CLOCK_LOCAL().
-+
+====
+
+.Example 2
+====
+Difference between NOW_LOCAL() and CLOCK_LOCAL().
+
 [source,n1ql]
 ----
 SELECT NOW_LOCAL(), NOW_LOCAL(), NOW_LOCAL(), NOW_LOCAL(), NOW_LOCAL(), CLOCK_LOCAL();
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -1614,32 +1768,41 @@ Results:
   }
 ]
 ----
+====
 
 [#fn-date-now-millis]
 == NOW_MILLIS()
 
-*Description*::
+=== Description
+
 The timestamp of the query as an Epoch/UNIX timestamp.
 Will not vary during a query.
 
-*Arguments*:: This function accepts no arguments.
+=== Arguments
 
-*Return Value*:: A floating point number representing the Epoch/UNIX timestamp of the query.
+This function accepts no arguments.
 
-*Limitations*::
+=== Return Value
+
+A floating point number representing the Epoch/UNIX timestamp of the query.
+
+=== Limitations
+
 If this function is called multiple times within the same query it will always return the same time.
 If you wish to use the system time when the function is evaluated, use <<fn-date-clock-millis,CLOCK_MILLIS()>> instead.
 
-*Examples*::
-*Example 1:* The time now in milliseconds.
-+
+=== Examples
+
+.Example 1
+====
+The time now in milliseconds.
+
 [source,n1ql]
 ----
 SELECT NOW_MILLIS() as NowInMilliseconds;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -1648,16 +1811,18 @@ Results:
   }
 ]
 ----
-+
-*Example 2:* Difference between NOW_MILLIS() and CLOCK_MILLIS().
-+
+====
+
+.Example 2
+====
+Difference between NOW_MILLIS() and CLOCK_MILLIS().
+
 [source,n1ql]
 ----
 SELECT NOW_MILLIS(), NOW_MILLIS(), NOW_MILLIS(), NOW_MILLIS(), CLOCK_MILLIS();
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -1669,34 +1834,43 @@ Results:
   }
 ]
 ----
+====
 
 [#fn-date-now-tz]
 == NOW_TZ(tz [, fmt])
 
-*Description*::
+=== Description
+
 The timestamp of the query as date string in the specified timezone.
 Will not vary during a query.
 
-*Arguments*::
-*tz*;;
+=== Arguments
+
+*tz*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<date-timezone,timezone>> to convert the query timestamp to.
 +
 If an incorrect time zone is provided then `null` is returned.
 
-*fmt*;;
+*fmt*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a <<date-string,supported date format>> to output the result as.
 +
 *Optional argument*, if unspecified or an incorrect format is specified, then this defaults to the combined full date and time.
 
-*Return Value*:: A date string in the format specified representing the timestamp of the query in the specified timezone.
+=== Return Value
 
-*Limitations*::
+A date string in the format specified representing the timestamp of the query in the specified timezone.
+
+=== Limitations
+
 If this function is called multiple times within the same query it will always return the same time.
 If you wish to use the system time when the function is evaluated, use <<fn-date-clock-tz,CLOCK_TZ()>> instead.
 
-*Examples*::
-*Example 1:* Various arguments for NOW_TZ().
-+
+=== Examples
+
+.Example 1
+====
+Various arguments for NOW_TZ().
+
 [source,n1ql]
 ----
 SELECT NOW_TZ('invalid tz') as invalid_tz,
@@ -1704,9 +1878,8 @@ SELECT NOW_TZ('invalid tz') as invalid_tz,
        NOW_TZ('UTC') as utc,
        NOW_TZ('UTC', '1111-11-11') as utc_short_date;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -1718,16 +1891,18 @@ Results:
   }
 ]
 ----
-+
-*Example 2:* Difference between NOW_TZ() and CLOCK_TZ().
-+
+====
+
+.Example 2
+====
+Difference between NOW_TZ() and CLOCK_TZ().
+
 [source,n1ql]
 ----
 SELECT NOW_TZ('UTC'), NOW_TZ('UTC'), NOW_TZ('UTC'), CLOCK_TZ('UTC');
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -1739,38 +1914,46 @@ Results:
   }
 ]
 ----
+====
 
 [#fn-date-now-str]
 == NOW_STR([fmt])
 
-*Description*::
+=== Description
+
 The timestamp of the query as date string in the system timezone.
 Will not vary during a query.
 
-*Arguments*::
-*fmt*;;
+=== Arguments
+
+*fmt*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a <<date-string,supported date format>> to output the result as.
 +
 *Optional argument*, if unspecified or an incorrect format is specified, then this defaults to the combined full date and time.
 
-*Return Value*:: A date string in the format specified representing the timestamp of the query.
+=== Return Value
 
-*Limitations*::
+A date string in the format specified representing the timestamp of the query.
+
+=== Limitations
+
 If this function is called multiple times within the same query it will always return the same time.
 If you wish to use the system time when the function is evaluated, use <<fn-date-clock-str,CLOCK_STR()>> instead.
 
-*Examples*::
-*Example 1:* Various arguments for NOW_STR().
-+
+=== Examples
+
+.Example 1
+====
+Various arguments for NOW_STR().
+
 [source,n1ql]
 ----
 SELECT NOW_STR() as full_date,
        NOW_STR('invalid date') as invalid_date,
        NOW_STR('1111-11-11') as short_date;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -1781,16 +1964,18 @@ Results:
   }
 ]
 ----
-+
-*Example 2:* Difference between NOW_STR() and CLOCK_STR().
-+
+====
+
+.Example 2
+====
+Difference between NOW_STR() and CLOCK_STR().
+
 [source,n1ql]
 ----
 SELECT NOW_STR(), NOW_STR(), NOW_STR(), NOW_STR(), NOW_STR(), NOW_STR(), CLOCK_STR();
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -1805,36 +1990,44 @@ Results:
   }
 ]
 ----
+====
 
 [#fn-date-now-utc]
 == NOW_UTC([fmt])
 
-*Description*::
+=== Description
+
 The timestamp of the query as date string in UTC.
 Will not vary during a query.
 
-*Arguments*::
-*fmt*;;
+=== Arguments
+
+*fmt*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a <<date-string,supported date format>> to output the result as.
 +
 *Optional argument*, if unspecified or an incorrect format is specified, then this defaults to the combined full date and time.
 
-*Return Value*:: A date string in the format specified representing the timestamp of the query in UTC.
+=== Return Value
 
-*Limitations*::
+A date string in the format specified representing the timestamp of the query in UTC.
+
+=== Limitations
+
 If this function is called multiple times within the same query it will always return the same time.
 If you wish to use the system time when the function is evaluated, use <<fn-date-clock-utc,CLOCK_MILLIS()>> instead.
 
-*Examples*::
-*Example 1:* The current UTC time.
-+
+=== Examples
+
+.Example 1
+====
+The current UTC time.
+
 [source,n1ql]
 ----
 SELECT NOW_UTC() as CurrentUTC;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -1843,16 +2036,18 @@ Results:
   }
 ]
 ----
-+
-*Example 2:* Difference between NOW_UTC() and CLOCK_UTC().
-+
+====
+
+.Example 2
+====
+Difference between NOW_UTC() and CLOCK_UTC().
+
 [source,n1ql]
 ----
 SELECT NOW_UTC(), NOW_UTC(), NOW_UTC(), NOW_UTC(), NOW_UTC(), NOW_UTC(), NOW_UTC(), CLOCK_UTC();
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -1868,13 +2063,16 @@ Results:
   }
 ]
 ----
+====
 
 [#fn-date-str-to-duration]
 == STR_TO_DURATION(duration)
 
-*Description*::
+=== Description
+
 Converts a string representation of a time duration into nanoseconds.
 This accepts the following units:
+
 * nanoseconds (`ns`)
 * microseconds (`us` or `µs`)
 * milliseconds (`ms`)
@@ -1882,16 +2080,20 @@ This accepts the following units:
 * minutes (`m`)
 * hours (`h`)
 
-*Arguments*::
-*duration*;;
+=== Arguments
+
+*duration*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the duration to convert.
 +
 If an invalid duration string is specified, then `null` is returned.
 
-*Return Value*:: A single integer representing the duration in nanoseconds.
+=== Return Value
 
-*Examples*::
-+
+A single integer representing the duration in nanoseconds.
+
+=== Examples
+
+====
 [source,n1ql]
 ----
 SELECT STR_TO_DURATION('1h') as hour,
@@ -1901,9 +2103,8 @@ STR_TO_DURATION('1m') as minute,
 STR_TO_DURATION('1ns') as nanosecond,
 STR_TO_DURATION('1s') as second;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -1917,30 +2118,36 @@ Results:
   }
 ]
 ----
+====
 
 [#fn-date-str-to-millis]
 == STR_TO_MILLIS(date1)
 
-*Description*:: Converts a date string to Epoch/UNIX milliseconds.
+=== Description
 
-*Arguments*::
-*date1*;;
+Converts a date string to Epoch/UNIX milliseconds.
+
+=== Arguments
+
+*date1*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a date in a <<date-string,supported date format>>.
 This is the date to convert to Epoch/UNIX milliseconds.
 +
 If this argument is not a valid date format, then `null` is returned.
 
-*Return Value*:: An integer representing the date string converted to Epoch/UNIX milliseconds.
+=== Return Value
 
-*Examples*::
-+
+An integer representing the date string converted to Epoch/UNIX milliseconds.
+
+=== Examples
+
+====
 [source,n1ql]
 ----
 SELECT STR_TO_MILLIS("2016-05-15T03:59:00Z") as Milliseconds;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -1949,33 +2156,38 @@ Results:
   }
 ]
 ----
+====
 
 [#fn-date-str-to-utc]
 == STR_TO_UTC(date1)
 
-*Description*::
+=== Description
+
 Converts a date string into the equivalent date in UTC.
 The output date format follows the date format of the date passed as input.
 
-*Arguments*::
-*date1*;;
+=== Arguments
+
+*date1*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a date in a <<date-string,supported date format>>.
 This is the date to convert to UTC.
 +
 If this argument is not a valid date format, then `null` is returned.
 
-*Return Value*:: A single date string representing the date string converted to UTC.
+=== Return Value
 
-*Examples*::
-+
+A single date string representing the date string converted to UTC.
+
+=== Examples
+
+====
 [source,n1ql]
 ----
 SELECT STR_TO_UTC('1111-11-11T00:00:00+08:00') as full_date,
 STR_TO_UTC('1111-11-11') as short_date;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -1985,39 +2197,44 @@ Results:
   }
 ]
 ----
+====
 
 [#fn-date-str-to-tz]
 == STR_TO_TZ(date1, tz)
 
-*Description*::
+=== Description
+
 Converts a date string to its equivalent in the specified timezone.
 The output date format follows the date format of the date passed as input.
 
-*Arguments*::
-*date1*;;
+=== Arguments
+
+*date1*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a date in a <<date-string,supported date format>>.
 This is the date to convert to UTC.
 +
 If this argument is not a valid date format then `null` is returned.
 
-*tz*;;
+*tz*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<date-timezone,timezone>> to convert the local time to.
 +
 If this argument is not a valid timezone, then `null` is returned.
 
-*Return Value*:: A single date string representing the date string converted to the specified timezone.
+=== Return Value
 
-*Examples*::
-+
+A single date string representing the date string converted to the specified timezone.
+
+=== Examples
+
+====
 [source,n1ql]
 ----
 SELECT STR_TO_TZ('1111-11-11T00:00:00+08:00', 'America/New_York') as est,
     STR_TO_TZ('1111-11-11T00:00:00+08:00', 'UTC') as utc,
     STR_TO_TZ('1111-11-11', 'UTC') as utc_short;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -2028,6 +2245,7 @@ Results:
   }
 ]
 ----
+====
 
 [#fn-date-str-to-zone-name]
 == STR_TO_ZONE_NAME(date1, tz)
@@ -2036,30 +2254,34 @@ Alias for <<fn-date-str-to-tz,STR_TO_TZ()>>.
 
 == WEEKDAY_MILLIS(expr [, tz ])
 
-*Description*::
+=== Description
+
 Converts a date string to its equivalent in the specified timezone.
 The output date format follows the date format of the date passed as input.
 
-*Arguments*::
-*expr*;; An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing an Epoch/UNIX timestamp in milliseconds.
+=== Arguments
 
-*tz*;;
+*expr*:: An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, representing an Epoch/UNIX timestamp in milliseconds.
+
+*tz*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the <<date-timezone,timezone>> to for the expr argument.
 +
 *Optional argument*, defaults to the system timezone if not specified.
 If an incorrect time zone is provided then `null` is returned.
 
-*Return Value*:: A single date string representing the date string converted to the specified timezone.
+=== Return Value
 
-*Examples*::
-+
+A single date string representing the date string converted to the specified timezone.
+
+=== Examples
+
+====
 [source,n1ql]
 ----
 SELECT WEEKDAY_MILLIS(1486237655742, 'America/Tijuana') as Day;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -2068,32 +2290,36 @@ Results:
   }
 ]
 ----
-
+====
 == WEEKDAY_STR(date)
 
-*Description*::
+=== Description
+
 Returns the day of the week string value from the input date string.
 Returns the weekday name from the input date in Unix timestamp.
 Note that his function returns the string value of the day of the week, where <<fn-date-part-str,DATE_PART_STR()>> with part = "dow" returns an integer value of the weekday (0-6).
 
-*Arguments*::
-*date*;;
+=== Arguments
+
+*date*::
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing a date in a <<date-string,supported date format>>.
 This is the date to convert to UTC.
 +
 If this argument is not a valid date format then `null` is returned.
 
-*Return Value*:: The text string name of the day of the week, such as "Monday" or "Friday".
+=== Return Value
 
-*Examples*::
-+
+The text string name of the day of the week, such as "Monday" or "Friday".
+
+=== Examples
+
+====
 [source,n1ql]
 ----
 SELECT WEEKDAY_STR('2017-02-05') as Day;
 ----
-+
-Results:
-+
+
+.Results
 [source,json]
 ----
 [
@@ -2102,3 +2328,4 @@ Results:
   }
 ]
 ----
+====

--- a/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
@@ -218,7 +218,7 @@ Below is a list of accepted parts, these are expressed as strings and are not ca
 It is important for applications to be able to extract the specific component of the timestamps, such as day, year, month, hours, minutes, or seconds, so that these can be used in N1QL queries.
 The following are the supported date parts that can be passed to the date extraction functions.
 These date parts are expressed as strings and are not case-sensitive, so `year` is regarded the same as `YeAr`.
-For all examples, the date being used is `2006-01-02T15:04:05.999Z`
+For all examples, the date being used is `2006-01-02T15:04:05.999Z`.
 
 .Timestamp Components
 [cols="2,6,1,1,1"]
@@ -283,7 +283,7 @@ This is the ceiling value of the day of the year divided by 7.
 | The number of the week of the year, based on the ISO definition.
 ISO weeks start on Mondays and the first week of a year contains January 4 of that year.
 In other words, the first Thursday of a year will always be in week 1 of that year.
-This results in some different results between week and `iso_week`, based on the input date.
+This results in some different results between `week` and `iso_week`, based on the input date.
 
 For example the `iso_week` of `2006-01-08T15:04:05.999Z` is 1, while the `week` is 2.
 Should be used in conjunction with `iso_year` to get consistent results.

--- a/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
@@ -117,7 +117,7 @@ endif::[]
 === Description
 
 This function returns the value of the specified field within the given object.
-A field may be any attribute or element, nested at any level within the object.
+A field in this context may be any attribute or element, nested at any level within the object.
 
 === Arguments
 
@@ -190,8 +190,11 @@ In the path to the nested object attribute, the final attribute name is escaped,
 .Query
 [source,n1ql]
 ----
-SELECT OBJECT_FIELD(hotel, "reviews[1]") AS array_element,
-       OBJECT_FIELD(hotel, "reviews[1].ratings.`Business service (e.g., internet access)`") AS object_attribute
+SELECT
+  OBJECT_FIELD(hotel, "reviews[1]")
+    AS array_element,
+  OBJECT_FIELD(hotel, "reviews[1].ratings.`Business service (e.g., internet access)`")
+    AS object_attribute
 FROM `travel-sample`.inventory.hotel
 LIMIT 1;
 ----
@@ -681,7 +684,7 @@ object:: An expression representing an object.
 options:: [Optional] An object containing the following possible parameters:
 
 composites;; A boolean.
-If `true`, every level of every nested field is displayed; if `false` only the deepest possible nested fields are returned.
+If `true`, every level of every nested field is displayed; if `false`, only the deepest possible nested fields are returned.
 Default `false`.
 
 pattern;; A regular expression used to filter the returned paths.
@@ -887,7 +890,7 @@ object:: An expression representing an object.
 options:: [Optional] An object containing the following possible parameters:
 
 composites;; A boolean.
-If `true`, every level of every nested field is displayed; if `false` only the deepest possible nested fields are returned.
+If `true`, every level of every nested field is displayed; if `false`, only the deepest possible nested fields are returned.
 Default `true`.
 
 arraysubscript;; A boolean.
@@ -903,12 +906,12 @@ pattern;; A regular expression used to filter the returned paths.
 Used in conjunction with the following setting.
 
 patternspace;; A string literal with two possible values.
-Default `path`.
+Default `"path"`.
 +
 [horizontal]
-`field`::: The pattern is matched against individual field names.
+`"field"`::: The pattern is matched against individual field names.
 
-`path`::: The pattern is matched against composite path names.
+`"path"`::: The pattern is matched against composite path names.
 
 === Return Value
 
@@ -962,11 +965,15 @@ SELECT OBJECT_PATHS(input, {"composites": true}) AS composite,
 [source,n1ql]
 ----
 WITH input AS ({
-  "attribute": {"name": "elem1"}
+  "attribute": [ { "name": "elem1"}, {"name": "elem2"}]
 })
-SELECT OBJECT_PATHS(input, {"arraysubscript": true}) AS subscripts,
-       OBJECT_PATHS(input, {"arraysubscript": false, "unique": false}) AS no_subscripts_not_unique,
-       OBJECT_PATHS(input, {"arraysubscript": false, "unique": true}) AS no_subscripts_unique;
+SELECT
+  OBJECT_PATHS(input, {"arraysubscript": true})
+    AS subscripts,
+  OBJECT_PATHS(input, {"arraysubscript": false, "unique": false})
+    AS no_subscripts_not_unique,
+  OBJECT_PATHS(input, {"arraysubscript": false, "unique": true})
+    AS no_subscripts_unique;
 ----
 
 .Results
@@ -1004,9 +1011,13 @@ This example searches for strings beginning with "n" in the given object paths.
 WITH input AS ({
   "attribute": {"name": "elem1"}
 })
-SELECT OBJECT_PATHS(input) AS all_paths,
-       OBJECT_PATHS(input, {"pattern": "^n", "patternspace": "field"}) AS field_starts_with_n,
-       OBJECT_PATHS(input, {"pattern": "^n", "patternspace": "path"}) AS path_starts_with_n;
+SELECT
+  OBJECT_PATHS(input)
+    AS all_paths,
+  OBJECT_PATHS(input, {"pattern": "^n", "patternspace": "field"})
+    AS field_starts_with_n,
+  OBJECT_PATHS(input, {"pattern": "^n", "patternspace": "path"})
+    AS path_starts_with_n;
 ----
 
 .Results

--- a/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
@@ -125,7 +125,7 @@ expr:: An expression representing an object.
 
 field:: A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the path to a field within the object.
 +
-You can use xref:n1ql-language-reference/nestedops.adoc#len[nested operators] to specify the path to a nested attribute or element.
+You can use xref:n1ql-language-reference/nestedops.adoc[nested operators] to specify the path to a nested attribute or element.
 If any attribute names within the field path contain special characters, they must be escaped using backticks (`{backtick}{backtick}`).
 
 === Return Value

--- a/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
@@ -107,6 +107,121 @@ SELECT OBJECT_CONCAT({"abc": 1}, {"def": 2}, {"ghi": 3}, {"ghi": 4}, {"ghi": [5,
 ----
 ====
 
+[[fn-obj-field,OBJECT_FIELD()]]
+== OBJECT_FIELD(`object`, `field`)
+
+ifeval::['{page-component-version}' == '7.1']
+_(Introduced in Couchbase Server 7.1)_
+endif::[]
+
+=== Description
+
+This function returns the value of the specified field within the given object.
+A field may be any attribute or element, nested at any level within the object.
+
+=== Arguments
+
+expr:: An expression representing an object.
+
+field:: A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, representing the path to a field within the object.
++
+You can use xref:n1ql-language-reference/nestedops.adoc#len[nested operators] to specify the path to a nested attribute or element.
+If any attribute names within the field path contain special characters, they must be escaped using backticks (`{backtick}{backtick}`).
+
+=== Return Value
+
+The value of the specified field.
+If the object does not exist, or the field cannot be found within the object at the specified location, the function returns NULL.
+
+=== Examples
+
+[[obj-field-ex1,OBJECT_FIELD() Example 1]]
+.Top-Level Fields
+====
+This example returns the complete values of the specified attributes at the top level of the object.
+
+.Query
+[source,n1ql]
+----
+SELECT OBJECT_FIELD(hotel, "public_likes") AS `array`,
+       OBJECT_FIELD(hotel, "vacancy") AS `boolean`,
+       OBJECT_FIELD(hotel, "id") AS `number`,
+       OBJECT_FIELD(hotel, "geo") AS `object`,
+       OBJECT_FIELD(hotel, "name") AS `string`
+FROM `travel-sample`.inventory.hotel
+LIMIT 1;
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "array": [
+      "Julius Tromp I",
+      "Corrine Hilll",
+      "Jaeden McKenzie",
+      "Vallie Ryan",
+      "Brian Kilback",
+      "Lilian McLaughlin",
+      "Ms. Moses Feeney",
+      "Elnora Trantow"
+    ],
+    "boolean": true,
+    "number": 10025,
+    "object": {
+      "accuracy": "RANGE_INTERPOLATED",
+      "lat": 51.35785,
+      "lon": 0.55818
+    },
+    "string": "Medway Youth Hostel"
+  }
+]
+----
+====
+
+[[obj-field-ex2,OBJECT_FIELD() Example 2]]
+.Nested Fields
+====
+This example specifies a nested array element and a nested object attribute at different depths in the hierarchy.
+In the path to the nested object attribute, the final attribute name is escaped, as it contains special characters.
+
+
+.Query
+[source,n1ql]
+----
+SELECT OBJECT_FIELD(hotel, "reviews[1]") AS array_element,
+       OBJECT_FIELD(hotel, "reviews[1].ratings.`Business service (e.g., internet access)`") AS object_attribute
+FROM `travel-sample`.inventory.hotel
+LIMIT 1;
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "array_element": {
+      "author": "Barton Marks",
+      "content": "We found the hotel de la Monnaie through Interval ...",
+      "date": "2015-03-02 19:56:13 +0300",
+      "ratings": {
+        "Business service (e.g., internet access)": 4,
+        "Check in / front desk": 4,
+        "Cleanliness": 4,
+        "Location": 4,
+        "Overall": 4,
+        "Rooms": 3,
+        "Service": 3,
+        "Value": 5
+      }
+    },
+    "object_attribute": 4
+  }
+]
+----
+====
+
 [[fn-obj-inner-pairs,OBJECT_INNER_PAIRS()]]
 == OBJECT_INNER_PAIRS(`expression`)
 

--- a/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
@@ -540,7 +540,7 @@ SELECT OBJECT_NAMES(special_flights[*]) AS names;
 [[fn-obj-pairs,OBJECT_PAIRS()]]
 == OBJECT_PAIRS(`expression`)
 
-_Alias_: *OBJECT_OUTER_PAIRS(expression)*
+_Alias_: *OBJECT_OUTER_PAIRS(`expression`)*
 
 === Description
 
@@ -652,6 +652,227 @@ SELECT OBJECT_PAIRS(special_flights[*]) AS outer_pairs;
           "2:22:22"
         ]
       }
+    ]
+  }
+]
+----
+====
+
+[[fn-obj-paths,OBJECT_PATHS()]]
+== OBJECT_PATHS(`object` [, `options`] )
+
+ifeval::['{page-component-version}' == '7.1']
+_(Introduced in Couchbase Server 7.1)_
+endif::[]
+
+=== Description
+
+This function returns the paths to all the fields within an object.
+A field in this context may be any attribute or element, nested at any level within the object.
+
+=== Arguments
+
+object:: An expression representing an object.
+
+options:: [Optional] An object containing the following possible parameters:
+
+composites;; A boolean.
+If `true`, every level of every nested field is displayed; if `false` only the deepest possible nested fields are returned.
+Default `true`.
+
+arraysubscript;; A boolean.
+If `true`, array subscripts are returned; if `false`, array subscripts are replaced by `*`.
+Default `true`.
+
+unique;; A boolean.
+If `true`, duplicate field names are collapsed to single unique field name; if `false`, all duplicate field names are returned.
+Typically used when arrays are expanded and array subscripts are not returned.
+Default `true`.
+
+pattern;; A regular expression used to filter the returned paths.
+Used in conjunction with the following setting.
+
+patternspace;; A string literal with two possible values.
+Default `path`.
++
+[horizontal]
+`field`::: The pattern is matched against individual field names.
+
+`path`::: The pattern is matched against composite path names.
+
+=== Return Value
+
+An array containing the full path to every possible field within the source object, subject to the specified options.
+
+The result uses xref:n1ql-language-reference/nestedops.adoc[nested operators] to specify the path to all nested attributes or elements.
+If any attribute names within a field path contain special characters, they are escaped using backticks (`{backtick}{backtick}`).
+
+* If `object` is MISSING, the function returns a MISSING value.
+* If `object` is not an object, the function returns a NULL value.
+* If `options` is not an object, the function returns a NULL value.
+
+=== Examples
+
+[[obj-paths-ex1,OBJECT_PATHS() Example 1]]
+.Composite paths
+====
+.Query
+[source,n1ql]
+----
+WITH input AS ({
+  "attribute": {"first-part": 1, "second-part": 2}
+})
+SELECT OBJECT_PATHS(input, {"composites": true}) AS composite,
+       OBJECT_PATHS(input, {"composites": false}) AS non_composite;
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "composite": [
+      "attribute",
+      "attribute.first-part",
+      "attribute.second-part"
+    ],
+    "non_composite": [
+      "attribute.first-part",
+      "attribute.second-part"
+    ]
+  }
+]
+----
+====
+
+[[obj-paths-ex2,OBJECT_PATHS() Example 2]]
+.Array subscripts and unique field names
+====
+.Query
+[source,n1ql]
+----
+WITH input AS ({
+  "attribute": {"name": "elem1"}
+})
+SELECT OBJECT_PATHS(input, {"arraysubscript": true}) AS subscripts,
+       OBJECT_PATHS(input, {"arraysubscript": false, "unique": false}) AS no_subscripts_not_unique,
+       OBJECT_PATHS(input, {"arraysubscript": false, "unique": true}) AS no_subscripts_unique;
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "no_subscripts_not_unique": [
+      "attribute",
+      "attribute[*].name",
+      "attribute[*].name"
+    ],
+    "no_subscripts_unique": [
+      "attribute",
+      "attribute[*].name"
+    ],
+    "subscripts": [
+      "attribute",
+      "attribute[0].name",
+      "attribute[1].name"
+    ]
+  }
+]
+----
+====
+
+[[obj-paths-ex3,OBJECT_PATHS() Example 3]]
+.Pattern matching and pattern space
+====
+This example searches for strings beginning with "n" in the given object paths.
+
+.Query
+[source,n1ql]
+----
+WITH input AS ({
+  "attribute": {"name": "elem1"}
+})
+SELECT OBJECT_PATHS(input) AS all_paths,
+       OBJECT_PATHS(input, {"pattern": "^n", "patternspace": "field"}) AS field_starts_with_n,
+       OBJECT_PATHS(input, {"pattern": "^n", "patternspace": "path"}) AS path_starts_with_n;
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "all_paths": [
+      "attribute",
+      "attribute.name"
+    ],
+    "field_starts_with_n": [
+      "attribute.name"
+    ],
+    "path_starts_with_n": []
+  }
+]
+----
+====
+
+[[obj-paths-ex4,OBJECT_PATHS() Example 4]]
+.Complex example
+====
+.Query
+[source,n1ql]
+----
+SELECT OBJECT_PATHS(hotel, {"composites": false, "arraysubscript": false}) AS paths
+FROM `travel-sample`.inventory.hotel
+LIMIT 1;
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "paths": [
+      "address",
+      "alias",
+      "checkin",
+      "checkout",
+      "city",
+      "country",
+      "description",
+      "directions",
+      "email",
+      "fax",
+      "free_breakfast",
+      "free_internet",
+      "free_parking",
+      "geo.accuracy",
+      "geo.lat",
+      "geo.lon",
+      "id",
+      "name",
+      "pets_ok",
+      "phone",
+      "price",
+      "public_likes",
+      "reviews[*].author",
+      "reviews[*].content",
+      "reviews[*].date",
+      "reviews[*].ratings[*].Cleanliness",
+      "reviews[*].ratings[*].Location",
+      "reviews[*].ratings[*].Overall",
+      "reviews[*].ratings[*].Rooms",
+      "reviews[*].ratings[*].Service",
+      "reviews[*].ratings[*].Value",
+      "reviews[*].ratings[*].`Business service (e.g., internet access)`",
+      "reviews[*].ratings[*].`Check in / front desk`",
+      "state",
+      "title",
+      "tollfree",
+      "type",
+      "url",
+      "vacancy"
     ]
   }
 ]
@@ -958,9 +1179,9 @@ SELECT OBJECT_UNWRAP({"name": "value"}) AS single,
 ====
 
 [[fn-obj-values,OBJECT_VALUES()]]
-== OBJECT_VALUES(expression)
+== OBJECT_VALUES(`expression`)
 
-_Alias_: *OBJECT_OUTER_VALUES(expression)*
+_Alias_: *OBJECT_OUTER_VALUES(`expression`)*
 
 === Description
 

--- a/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
@@ -658,6 +658,216 @@ SELECT OBJECT_PAIRS(special_flights[*]) AS outer_pairs;
 ----
 ====
 
+[[fn-obj-pairs-nested,OBJECT_PAIRS_NESTED()]]
+== OBJECT_PAIRS_NESTED(`object` [, `options`])
+
+ifeval::['{page-component-version}' == '7.1']
+_(Introduced in Couchbase Server 7.1)_
+endif::[]
+
+=== Description
+
+Similar to <<fn-obj-pairs>>, this function returns an array of objects, containing the names and values of each field in the input object.
+A field in this context may be any attribute or element, nested at any level within the object.
+
+This function may be useful when iterating over multiple objects in an array, as it collates and unnests the values from similarly-named fields across all objects in the input array.
+In this case, the function returns a null entry from any object which does not contain the shared field name, rather like an OUTER JOIN.
+For an illustration, refer to the examples below.
+
+=== Arguments
+
+object:: An expression representing an object.
+
+options:: [Optional] An object containing the following possible parameters:
+
+composites;; A boolean.
+If `true`, every level of every nested field is displayed; if `false` only the deepest possible nested fields are returned.
+Default `false`.
+
+pattern;; A regular expression used to filter the returned paths.
+The pattern is matched against the composite path names, not the individual field names.
+
+=== Return Value
+
+An array of objects, each containing two attributes:
+
+name:: The full path to every possible field within the source object, subject to the specified options.
++
+The result uses xref:n1ql-language-reference/nestedops.adoc[nested operators] to specify the path to all nested attributes or elements.
+If any attribute names within a field path contain special characters, they are escaped using backticks (`{backtick}{backtick}`).
+
+val:: The value of an attribute in the source object; or an array, containing the collated values of similarly-named attributes in the source objects.
+
+The objects in the array are sorted by attribute name, in N1QL collation order.
+
+=== Examples
+
+[[obj-pairs-nested-ex1,OBJECT_PAIRS_NESTED() Example 1]]
+.Single object
+====
+.Query
+[source,n1ql]
+----
+WITH input AS ({
+ "attribute": {"first-part": 1, "second-part": 2}
+})
+SELECT OBJECT_PAIRS_NESTED(input) AS nested_pairs,
+       OBJECT_PAIRS_NESTED(input, {"composites": true}) AS nested_pairs_comp,
+       OBJECT_PAIRS_NESTED(input, {"pattern": "first"}) AS nested_pairs_pattern;
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "nested_pairs": [
+      {
+        "name": "attribute.first-part",
+        "val": 1
+      },
+      {
+        "name": "attribute.second-part",
+        "val": 2
+      }
+    ],
+    "nested_pairs_comp": [
+      {
+        "name": "attribute",
+        "val": {
+          "first-part": 1,
+          "second-part": 2
+        }
+      },
+      {
+        "name": "attribute.first-part",
+        "val": 1
+      },
+      {
+        "name": "attribute.second-part",
+        "val": 2
+      }
+    ],
+    "nested_pairs_pattern": [
+      {
+        "name": "attribute.first-part",
+        "val": 1
+      }
+    ]
+  }
+]
+----
+====
+
+[[obj-pairs-nested-ex2,OBJECT_PAIRS_NESTED() Example 2]]
+.Iterating over objects in an array
+====
+In this example, notice that where the source objects have similarly-named attributes, the values from each of those attributes are collated into a single array in the output.
+Each collated array is then unnested to show the name and value of its elements.
+
+.Example
+[source,n1ql]
+----
+WITH special_flights AS ([{"flight": "AI444", "utc": "4:44:44", "codename": "green"},
+                          {"flight": "AI333", "utc": "3:33:33", "alert": "red"},
+                          {"flight": "AI222", "utc": "2:22:22", "codename": "yellow"}])
+SELECT OBJECT_PAIRS_NESTED(special_flights[*], {"composites": true}) AS nested_pairs;
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "nested_pairs": [
+      {
+        "name": "alert",
+        "val": [
+          null,
+          "red",
+          null
+        ]
+      },
+      {
+        "name": "alert[0]",
+        "val": null
+      },
+      {
+        "name": "alert[1]",
+        "val": "red"
+      },
+      {
+        "name": "alert[2]",
+        "val": null
+      },
+      {
+        "name": "codename",
+        "val": [
+          "green",
+          null,
+          "yellow"
+        ]
+      },
+      {
+        "name": "codename[0]",
+        "val": "green"
+      },
+      {
+        "name": "codename[1]",
+        "val": null
+      },
+      {
+        "name": "codename[2]",
+        "val": "yellow"
+      },
+      {
+        "name": "flight",
+        "val": [
+          "AI444",
+          "AI333",
+          "AI222"
+        ]
+      },
+      {
+        "name": "flight[0]",
+        "val": "AI444"
+      },
+      {
+        "name": "flight[1]",
+        "val": "AI333"
+      },
+      {
+        "name": "flight[2]",
+        "val": "AI222"
+      },
+      {
+        "name": "utc",
+        "val": [
+          "4:44:44",
+          "3:33:33",
+          "2:22:22"
+        ]
+      },
+      {
+        "name": "utc[0]",
+        "val": "4:44:44"
+      },
+      {
+        "name": "utc[1]",
+        "val": "3:33:33"
+      },
+      {
+        "name": "utc[2]",
+        "val": "2:22:22"
+      }
+    ]
+  }
+]
+----
+
+Compare this example with <<obj-pairs-ex2>>.
+====
+
 [[fn-obj-paths,OBJECT_PATHS()]]
 == OBJECT_PATHS(`object` [, `options`] )
 

--- a/modules/n1ql/pages/n1ql-language-reference/stringfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/stringfun.adoc
@@ -677,6 +677,60 @@ SELECT REVERSE("N1QL is awesome") as n1ql,
 ----
 ====
 
+[#fn-str-rpad]
+== RPAD(in_str, size [, char])
+
+ifeval::['{page-component-version}' == '7.1']
+_(Introduced in Couchbase Server 7.1)_
+endif::[]
+
+=== Description
+Pads a string with trailing characters.
+The function adds characters to the end of the string to pad the string to a specified length.
+
+=== Arguments
+in_str:: A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, that is the string to add the trailing characters to.
+
+size:: An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, that specifies the desired length of the result string.
+
+char::
+[Optional; default is whitespace, i.e. 
+`" "`]
++
+A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, that represents the characters to add to the input string.
+
+=== Return Value
+A string representing the input string with trailing characters added.
+
+* If the specified size is smaller than the length of the input string, the input string is truncated and no padding is added.
+* If the specified size is larger than the length of the input string, but shorter than the length of the input string plus the padding characters, the padding characters are truncated.
+* If the specified size is greater than the length of the input string plus the padding characters, the padding characters are repeated in order until the specified size is reached.
+
+=== Examples
+====
+[source,n1ql]
+----
+SELECT RPAD("N1QL is awesome", 20) AS implicit_padding,
+       RPAD("N1QL is awesome", 20, "-*") AS repeated_padding,
+       RPAD("N1QL is awesome", 20, "123456789") AS truncate_padding,
+       RPAD("N1QL is awesome", 4, "123456789") AS truncate_string;
+----
+
+[source,json]
+----
+{
+    "results": [
+        {
+            "implicit_padding": "N1QL is awesome     ",
+            "repeated_padding": "N1QL is awesome-*-*-",
+            "truncate_padding": "N1QL is awesome12345",
+            "truncate_string": "N1QL"
+        }
+    ]
+}
+----
+====
+
 [#fn-str-rtrim]
 == RTRIM(in_str [, char])
 

--- a/modules/n1ql/pages/n1ql-language-reference/stringfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/stringfun.adoc
@@ -224,6 +224,60 @@ SELECT LOWER("N1QL is awesome") as n1ql;
 ----
 ====
 
+[#fn-str-lpad]
+== LPAD(in_str, size [, char])
+
+ifeval::['{page-component-version}' == '7.1']
+_(Introduced in Couchbase Server 7.1)_
+endif::[]
+
+=== Description
+Pads a string with leading characters.
+The function adds characters to the beginning of the string to pad the string to a specified length.
+
+=== Arguments
+in_str:: A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, that is the string to add the leading characters to.
+
+size:: An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, that specifies the desired length of the result string.
+
+char::
+[Optional; default is whitespace, i.e. 
+`" "`]
++
+A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, that represents the characters to add to the input string.
+
+=== Return Value
+A string representing the input string with leading characters added.
+
+* If the specified size is smaller than the length of the input string, the input string is truncated and no padding is added.
+* If the specified size is larger than the length of the input string, but shorter than the length of the input string plus the padding characters, the padding characters are truncated.
+* If the specified size is greater than the length of the input string plus the padding characters, the padding characters are repeated in order until the specified size is reached.
+
+=== Examples
+====
+[source,n1ql]
+----
+SELECT LPAD("N1QL is awesome", 20) AS implicit_padding,
+       LPAD("N1QL is awesome", 20, "-*") AS repeated_padding,
+       LPAD("N1QL is awesome", 20, "987654321") AS truncate_padding,
+       LPAD("N1QL is awesome", 4, "987654321") AS truncate_string;
+----
+
+[source,json]
+----
+{
+    "results": [
+        {
+            "implicit_padding": "     N1QL is awesome",
+            "repeated_padding": "-*-*-N1QL is awesome",
+            "truncate_padding": "98765N1QL is awesome",
+            "truncate_string": "N1QL"
+        }
+    ]
+}
+----
+====
+
 [#fn-str-ltrim]
 == LTRIM(in_str [, char])
 

--- a/modules/n1ql/pages/n1ql-language-reference/stringfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/stringfun.adoc
@@ -241,7 +241,7 @@ in_str:: A string, or any valid xref:n1ql-language-reference/index.adoc[expressi
 size:: An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, that specifies the desired length of the result string.
 
 char::
-[Optional; default is whitespace, i.e. 
+[Optional; default is Unicode U+0020, i.e. space
 `" "`]
 +
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, that represents the characters to add to the input string.
@@ -290,7 +290,7 @@ in_str:: A string, or any valid xref:n1ql-language-reference/index.adoc[expressi
 
 char::
 [Optional; default is whitespace, i.e.
-`" "`]
+space `" "`, tab `"\t"`, newline `"\n"`, formfeed `"\f"`, or carriage return `"\r"`]
 +
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, that represents the characters to trim from the input string.
 Each character in this string will be trimmed from the input string, it is therefore not necessary to delimit the characters to trim.
@@ -305,7 +305,7 @@ A string representing the input string with leading characters removed.
 ----
 SELECT LTRIM("...N1QL is awesome", ".") as dots,
        LTRIM("     N1QL is awesome", " ") as explicit_spaces,
-       LTRIM("     N1QL is awesome") as implicit_spaces,
+       LTRIM("	  N1QL is awesome") as implicit_spaces,
        LTRIM("N1QL is awesome") as no_dots;
 ----
 
@@ -694,7 +694,7 @@ in_str:: A string, or any valid xref:n1ql-language-reference/index.adoc[expressi
 size:: An integer, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to an integer, that specifies the desired length of the result string.
 
 char::
-[Optional; default is whitespace, i.e. 
+[Optional; default is Unicode U+0020, i.e. space
 `" "`]
 +
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, that represents the characters to add to the input string.
@@ -743,7 +743,7 @@ in_str:: A string, or any valid xref:n1ql-language-reference/index.adoc[expressi
 
 char::
 [Optional; default is whitespace, i.e.
-`" "`]
+space `" "`, tab `"\t"`, newline `"\n"`, formfeed `"\f"`, or carriage return `"\r"`]
 +
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, that represents the characters to trim from the input string.
 Each character in this string will be trimmed from the input string, it is therefore not necessary to delimit the characters to trim.
@@ -977,7 +977,7 @@ This function is equivalent to calling `LTRIM()` and `RTRIM()` successively.
 in_str:: A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, that is the string to convert to remove trailing and leading characters from.
 
 char::
-[Optional; default is whitespace, i.e.
+[Optional; default is Unicode U+0020, i.e.
 `" "`]
 +
 A string, or any valid xref:n1ql-language-reference/index.adoc[expression] which evaluates to a string, that represents the characters to trim from the input string.


### PR DESCRIPTION
The following draft documentation is ready for review:

* [OBJECT_FIELD][1], [OBJECT_PATHS][2], and [OBJECT_PAIRS_NESTED][3]
* [LPAD][4] and [RPAD][5]
* [DATE_TRUNC_MILLIS][6], [DATE_TRUNC_STR][7], and [STR_TO_MILLIS][8]

[1]: https://simon-dew.github.io/docs-site/DOC-8641/server/current/n1ql/n1ql-language-reference/objectfun.html#fn-obj-field
[2]: https://simon-dew.github.io/docs-site/DOC-8641/server/current/n1ql/n1ql-language-reference/objectfun.html#fn-obj-paths
[3]: https://simon-dew.github.io/docs-site/DOC-8641/server/current/n1ql/n1ql-language-reference/objectfun.html#fn-obj-pairs-nested
[4]: https://simon-dew.github.io/docs-site/DOC-8641/server/current/n1ql/n1ql-language-reference/stringfun.html#fn-str-lpad
[5]: https://simon-dew.github.io/docs-site/DOC-8641/server/current/n1ql/n1ql-language-reference/stringfun.html#fn-str-rpad
[6]: https://simon-dew.github.io/docs-site/DOC-8641/server/current/n1ql/n1ql-language-reference/datefun.html#fn-date-trunc-millis
[7]: https://simon-dew.github.io/docs-site/DOC-8641/server/current/n1ql/n1ql-language-reference/datefun.html#fn-date-trunc-str
[8]: https://simon-dew.github.io/docs-site/DOC-8641/server/current/n1ql/n1ql-language-reference/datefun.html#fn-date-str-to-millis

Docs issues: [DOC-8641](https://issues.couchbase.com/browse/DOC-8641) and [DOC-8806](https://issues.couchbase.com/browse/DOC-8806)