### PR TITLE
Forum link is dead

### DIFF
--- a/modules/fts/pages/fts-supported-queries-geo-spatial.adoc
+++ b/modules/fts/pages/fts-supported-queries-geo-spatial.adoc
@@ -1,5 +1,5 @@
 = Geospatial Queries
-:page-aliases: fts-geospatial-queries
+:page-aliases: fts-geospatial-queries.adoc
 
 [abstract]
 _Geospatial_ queries return documents that contain location. Each document specifies a geographical location.

--- a/modules/fts/pages/fts-supported-queries-geo-spatial.adoc
+++ b/modules/fts/pages/fts-supported-queries-geo-spatial.adoc
@@ -1,4 +1,5 @@
 = Geospatial Queries
+:page-aliases: fts-geospatial-queries
 
 [abstract]
 _Geospatial_ queries return documents that contain location. Each document specifies a geographical location.


### PR DESCRIPTION
The formum post https://forums.couchbase.com/t/how-to-add-fts-index-for-geo-search/29742/6 is now a dead link
need to add a page alias