### PR TITLE
DOC-9545: GSI Settings REST API — CE vs EE options

### DIFF
--- a/modules/rest-api/pages/post-settings-indexes.adoc
+++ b/modules/rest-api/pages/post-settings-indexes.adoc
@@ -25,7 +25,7 @@ The parameters are specified as key-value pairs (e.g `key=value`).
 
 *Optional*
 
-[cols="1,4,1"]
+[cols="2,3a,2"]
 |===
 | Name | Description | Type
 
@@ -54,7 +54,7 @@ Possible values are:
 | integer
 
 | `memorySnapshotInterval`
-| InMemory snapshotting interval in milliseconds.
+| In-memory snapshotting interval in milliseconds.
 | integer
 
 | `stableSnapshotInterval`
@@ -62,19 +62,29 @@ Possible values are:
 | integer
 
 | `storageMode`
-| The storage mode to be used for all global secondary indexes in the cluster.* A value of `plasma` sets the cluster-wide index storage mode to use the Plasma storeage engine, which can utilize both memory and persistent storage for index maintenance and index scans.
+| The storage mode to be used for all global secondary indexes in the cluster.
+
+'''
+[.edition]#{enterprise}#
+
+In the Enterprise Edition of Couchbase Server, the options are `plasma` and `memory_optimized`.
+A value of `plasma` sets the cluster-wide index storage mode to use the Plasma storage engine, which can utilize both memory and persistent storage for index maintenance and index scans.
 A value of `memory_optimized` sets the cluster-wide index storage mode to use memory optimized global secondary indexes which can perform index maintenance and index scan faster at in-memory speeds.
+
 This setting can only be changed while there are no index nodes in the cluster.
 To change from standard GSI to memory optimized GSI or vice versa, you need to remove all the index service nodes in the cluster.
+
+'''
+[.edition]#{community}#
+
+If you are using the Community Edition, the default (and only) value is `forestdb`.
 a|
 Possible values are:
 
 * `plasma`
 * `memory_optimized`
+* `forestdb`
 |===
-
-* `Plasma` and `memory_optimized` are options in the Enterprise Edition of Couchbase Server 5.5.
-If you are using the Community Edition, the default (and only) value is `forestdb`.
 
 == Response Codes
 


### PR DESCRIPTION
Backport from DOC-7638 to release/6.5