### PR TITLE
DOC-10040: Fix join enumeration docs and what's new

### DIFF
--- a/modules/guides/pages/select-index.adoc
+++ b/modules/guides/pages/select-index.adoc
@@ -52,27 +52,20 @@ The index must be applicable to the query.
 
 To specify an index by name:
 
-. Use the USE clause within the FROM clause.
+. Use an index hint within a hint comment, immediately after the SELECT keyword.
 
-. Specify the index name in parentheses.
+. In the index hint, specify the keyspace to which the hint applies, and the index to use.
 
 ====
-The following query creates an index of airlines and destination airports.
+This example uses an index hint to select the index `def_inventory_route_route_src_dst_day`, which is installed with the `travel-sample` bucket.
 
-[source,n1ql]
+[source.no-callouts,n1ql]
 ----
-include::n1ql:example$n1ql-language-reference/create-idx-hints.n1ql[]
-----
-
-The following query uses an index hint to select the `idx_destinations` index.
-
-[source,n1ql]
-----
-include::n1ql:example$n1ql-language-reference/select-idx-hints.n1ql[]
+include::n1ql:example$select/index-hint.n1ql[tag=query]
 ----
 ====
 
-For further details and examples, refer to xref:n1ql:n1ql-language-reference/hints.adoc[USE Clause].
+For further details and examples, refer to xref:n1ql:n1ql-language-reference/keyspace-hints.adoc#index[INDEX].
 
 == Related Links
 
@@ -80,7 +73,7 @@ Reference and explanation:
 
 * xref:learn:services-and-indexes/indexes/global-secondary-indexes.adoc[Using Indexes]
 * xref:n1ql:n1ql-language-reference/selectintro.adoc[SELECT]
-* xref:n1ql:n1ql-language-reference/select-syntax.adoc[SELECT Syntax]
+* xref:n1ql:n1ql-language-reference/optimizer-hints.adoc[Hints]
 
 Administrator guides:
 

--- a/modules/n1ql/examples/n1ql-language-reference/create-idx-hints.n1ql
+++ b/modules/n1ql/examples/n1ql-language-reference/create-idx-hints.n1ql
@@ -1,2 +1,0 @@
-CREATE INDEX idx_destinations
-ON `travel-sample`.inventory.route (airlineid, airline, destinationairport);

--- a/modules/n1ql/examples/n1ql-language-reference/select-idx-hints.n1ql
+++ b/modules/n1ql/examples/n1ql-language-reference/select-idx-hints.n1ql
@@ -1,3 +1,0 @@
-SELECT airlineid, airline, sourceairport, destinationairport
-FROM `travel-sample`.inventory.route USE INDEX (idx_destinations USING GSI)
-WHERE sourceairport = "SFO";

--- a/modules/n1ql/examples/select/index-hint.jsonc
+++ b/modules/n1ql/examples/select/index-hint.jsonc
@@ -1,0 +1,119 @@
+{
+  "cardinality": 1,
+  "cost": 25.48328348473815,
+  "optimizer_hints": {
+    "hints_followed": [
+      "INDEX(route def_inventory_route_route_src_dst_day)"
+    ]
+  },
+  "plan": {
+    "#operator": "Sequence",
+    "~children": [
+      {
+        "#operator": "Sequence",
+        "~children": [
+          {
+            "#operator": "DistinctScan",
+            "limit": "1",
+            "optimizer_estimates": {
+              "cardinality": 1681.2723543436066,
+              "cost": 395.71744847285015,
+              "fr_cost": 12.220147704229976,
+              "size": 11
+            },
+// tag::index[]
+            "scan": {
+              "#operator": "IndexScan3",
+              "bucket": "travel-sample",
+              "index": "def_inventory_route_route_src_dst_day",
+// end::index[]
+              "index_id": "e0105bdd794dda39",
+              "index_projection": {
+                "primary_key": true
+              },
+              "keyspace": "route",
+              "namespace": "default",
+              "optimizer_estimates": {
+                "cardinality": 1743,
+                "cost": 354.17696421953406,
+                "fr_cost": 12.196314953654351,
+                "size": 11
+              },
+              "scope": "inventory",
+              "spans": [
+                {
+                  "exact": true,
+                  "range": [
+                    {
+                      "high": "\"SFO\"",
+                      "inclusion": 3,
+                      "index_key": "`sourceairport`",
+                      "low": "\"SFO\""
+                    }
+                  ]
+                }
+              ],
+              "using": "gsi"
+            }
+          },
+          {
+            "#operator": "Fetch",
+            "bucket": "travel-sample",
+            "keyspace": "route",
+            "namespace": "default",
+            "optimizer_estimates": {
+              "cardinality": 1681.2723543436066,
+              "cost": 2411.1846820111814,
+              "fr_cost": 25.411785233011273,
+              "size": 568
+            },
+            "scope": "inventory"
+          },
+          {
+            "#operator": "Parallel",
+            "~child": {
+              "#operator": "Sequence",
+              "~children": [
+                {
+                  "#operator": "Filter",
+                  "condition": "((`route`.`sourceairport`) = \"SFO\")",
+                  "optimizer_estimates": {
+                    "cardinality": 1681.2723543436066,
+                    "cost": 2451.254026681948,
+                    "fr_cost": 25.435617983586898,
+                    "size": 568
+                  }
+                },
+                {
+                  "#operator": "InitialProject",
+                  "optimizer_estimates": {
+                    "cardinality": 1681.2723543436066,
+                    "cost": 2491.3233713527143,
+                    "fr_cost": 25.459450734162523,
+                    "size": 568
+                  },
+                  "result_terms": [
+                    {
+                      "expr": "(`route`.`id`)"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "#operator": "Limit",
+        "expr": "1",
+        "optimizer_estimates": {
+          "cardinality": 1,
+          "cost": 25.48328348473815,
+          "fr_cost": 25.48328348473815,
+          "size": 568
+        }
+      }
+    ]
+  },
+  "text": "\nSELECT /*+ INDEX (route def_inventory_route_route_src_dst_day) */ id -- <.>\nFROM `travel-sample`.inventory.route -- <.>\nWHERE sourceairport = \"SFO\"\nLIMIT 1;"
+}

--- a/modules/n1ql/examples/select/index-hint.n1ql
+++ b/modules/n1ql/examples/select/index-hint.n1ql
@@ -1,0 +1,10 @@
+UPDATE STATISTICS FOR `travel-sample`.inventory.route
+INDEX (def_inventory_route_route_src_dst_day, def_inventory_route_sourceairport);
+
+EXPLAIN
+/* tag::query[] */
+SELECT /*+ INDEX (route def_inventory_route_route_src_dst_day) */ id -- <.>
+FROM `travel-sample`.inventory.route -- <.>
+WHERE sourceairport = "SFO"
+LIMIT 1;
+/* end::query[] */

--- a/modules/n1ql/examples/select/index-legacy.n1ql
+++ b/modules/n1ql/examples/select/index-legacy.n1ql
@@ -1,0 +1,9 @@
+UPDATE STATISTICS FOR `travel-sample`.inventory.route
+INDEX (def_inventory_route_route_src_dst_day, def_inventory_route_sourceairport);
+
+/* tag::query[] */
+SELECT id FROM `travel-sample`.inventory.route
+USE INDEX (def_inventory_route_route_src_dst_day USING GSI)
+WHERE sourceairport = "SFO"
+LIMIT 1;
+/* end::query[] */

--- a/modules/n1ql/examples/select/index-opt.jsonc
+++ b/modules/n1ql/examples/select/index-opt.jsonc
@@ -1,0 +1,105 @@
+{
+  "cardinality": 1,
+  "cost": 25.484123541275103,
+  "plan": {
+    "#operator": "Sequence",
+    "~children": [
+      {
+        "#operator": "Sequence",
+        "~children": [
+// tag::index[]
+          {
+            "#operator": "IndexScan3",
+            "bucket": "travel-sample",
+            "index": "def_inventory_route_sourceairport",
+// end::index[]
+            "index_id": "10962bf412f58e32",
+            "index_projection": {
+              "primary_key": true
+            },
+            "keyspace": "route",
+            "limit": "1",
+            "namespace": "default",
+            "optimizer_estimates": {
+              "cardinality": 249,
+              "cost": 67.02595243096545,
+              "fr_cost": 12.22098776076693,
+              "size": 11
+            },
+            "scope": "inventory",
+            "spans": [
+              {
+                "exact": true,
+                "range": [
+                  {
+                    "high": "\"SFO\"",
+                    "inclusion": 3,
+                    "index_key": "`sourceairport`",
+                    "low": "\"SFO\""
+                  }
+                ]
+              }
+            ],
+            "using": "gsi"
+          },
+          {
+            "#operator": "Fetch",
+            "bucket": "travel-sample",
+            "keyspace": "route",
+            "namespace": "default",
+            "optimizer_estimates": {
+              "cardinality": 249,
+              "cost": 375.7436970975088,
+              "fr_cost": 25.412625289548227,
+              "size": 568
+            },
+            "scope": "inventory"
+          },
+          {
+            "#operator": "Parallel",
+            "~child": {
+              "#operator": "Sequence",
+              "~children": [
+                {
+                  "#operator": "Filter",
+                  "condition": "((`route`.`sourceairport`) = \"SFO\")",
+                  "optimizer_estimates": {
+                    "cardinality": 249,
+                    "cost": 381.67805199083966,
+                    "fr_cost": 25.436458040123853,
+                    "size": 568
+                  }
+                },
+                {
+                  "#operator": "InitialProject",
+                  "optimizer_estimates": {
+                    "cardinality": 249,
+                    "cost": 387.6124068841705,
+                    "fr_cost": 25.460290790699478,
+                    "size": 568
+                  },
+                  "result_terms": [
+                    {
+                      "expr": "(`route`.`id`)"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "#operator": "Limit",
+        "expr": "1",
+        "optimizer_estimates": {
+          "cardinality": 1,
+          "cost": 25.484123541275103,
+          "fr_cost": 25.484123541275103,
+          "size": 568
+        }
+      }
+    ]
+  },
+  "text": "\nSELECT id -- <.>\nFROM `travel-sample`.inventory.route -- <.>\nWHERE sourceairport = \"SFO\"\nLIMIT 1;"
+}

--- a/modules/n1ql/examples/select/index-opt.n1ql
+++ b/modules/n1ql/examples/select/index-opt.n1ql
@@ -1,0 +1,10 @@
+UPDATE STATISTICS FOR `travel-sample`.inventory.route
+INDEX (def_inventory_route_route_src_dst_day, def_inventory_route_sourceairport);
+
+EXPLAIN
+/* tag::query[] */
+SELECT id
+FROM `travel-sample`.inventory.route
+WHERE sourceairport = "SFO"
+LIMIT 1;
+/* end::query[] */

--- a/modules/n1ql/examples/select/ordered-hint.n1ql
+++ b/modules/n1ql/examples/select/ordered-hint.n1ql
@@ -2,7 +2,7 @@ UPDATE STATISTICS FOR `travel-sample`.inventory.airport INDEX ALL;
 UPDATE STATISTICS FOR `travel-sample`.inventory.airline INDEX ALL;
 UPDATE STATISTICS FOR `travel-sample`.inventory.route INDEX (def_inventory_route_sourceairport);
 
--- tag::simple[]
+/* tag::simple[] */
 SELECT /*+ ORDERED */
        a.airportname AS source, r.id AS route, l.name AS airline
 FROM `travel-sample`.inventory.airport AS a
@@ -11,9 +11,9 @@ JOIN `travel-sample`.inventory.route AS r -- <1>
 JOIN `travel-sample`.inventory.airline AS l -- <2>
   ON r.airlineid = META(l).id
 WHERE l.name = "40-Mile Air";
--- end::simple[]
+/* end::simple[] */
 
--- tag::json[]
+/* tag::json[] */
 SELECT /*+ {"ordered": true} */
        a.airportname AS source, r.id AS route, l.name AS airline
 FROM `travel-sample`.inventory.airport AS a
@@ -22,9 +22,9 @@ JOIN `travel-sample`.inventory.route AS r -- <1>
 JOIN `travel-sample`.inventory.airline AS l -- <2>
   ON r.airlineid = META(l).id
 WHERE l.name = "40-Mile Air";
--- end::json[]
+/* end::json[] */
 
--- tag::none[]
+/* tag::none[] */
 SELECT a.airportname AS source, r.id AS route, l.name AS airline
 FROM `travel-sample`.inventory.airport AS a
 JOIN `travel-sample`.inventory.route AS r -- <1>
@@ -32,4 +32,4 @@ JOIN `travel-sample`.inventory.route AS r -- <1>
 JOIN `travel-sample`.inventory.airline AS l -- <2>
   ON r.airlineid = META(l).id
 WHERE l.name = "40-Mile Air";
--- end::none[]
+/* end::none[] */

--- a/modules/n1ql/examples/select/use-hash-build-hint.jsonc
+++ b/modules/n1ql/examples/select/use-hash-build-hint.jsonc
@@ -1,0 +1,183 @@
+{
+  "cardinality": 1,
+  "cost": 38152.742951506196,
+  "optimizer_hints": {
+    "hints_followed": [
+      {
+        "hint": "{\"use_hash\":{\"keyspace\":\"rte\",\"option\":\"BUILD\"}}"
+      }
+    ]
+  },
+  "plan": {
+    "#operator": "Sequence",
+    "~children": [
+      {
+        "#operator": "IndexScan3",
+        "as": "aline",
+        "bucket": "travel-sample",
+        "covers": [
+          "cover ((meta(`aline`).`id`))"
+        ],
+        "index": "def_inventory_airline_primary",
+        "index_id": "11aa5c3f9d710599",
+        "keyspace": "airline",
+        "namespace": "default",
+        "optimizer_estimates": {
+          "cardinality": 187,
+          "cost": 45.30545926533892,
+          "fr_cost": 12.178104060242454,
+          "size": 13
+        },
+        "scope": "inventory",
+        "spans": [
+          {
+            "exact": true,
+            "range": [
+              {
+                "inclusion": 0,
+                "low": "null"
+              }
+            ]
+          }
+        ],
+        "using": "gsi"
+      },
+// tag::method[]
+      {
+        "#operator": "HashJoin",
+        "build_aliases": [
+          "rte"
+        ],
+        "build_exprs": [
+          "(`rte`.`airlineid`)"
+        ],
+        "on_clause": "(((`rte`.`airlineid`) = cover ((meta(`aline`).`id`))))",
+// end::method[]
+// tag::ellipsis[]
+      // ...
+// end::ellipsis[]
+        "optimizer_estimates": {
+          "cardinality": 44924.88,
+          "cost": 37703.450047564605,
+          "fr_cost": 33338.278136855406,
+          "size": 581
+        },
+// tag::method[]
+        "probe_exprs": [
+          "cover ((meta(`aline`).`id`))"
+        ],
+// end::method[]
+        "~child": {
+          "#operator": "Sequence",
+          "~children": [
+            {
+              "#operator": "PrimaryScan3",
+              "as": "rte",
+              "bucket": "travel-sample",
+              "index": "def_inventory_route_primary",
+              "index_projection": {
+                "primary_key": true
+              },
+              "keyspace": "route",
+              "namespace": "default",
+              "optimizer_estimates": {
+                "cardinality": 24024,
+                "cost": 4108.612246388904,
+                "fr_cost": 12.170521655277593,
+                "size": 11
+              },
+              "scope": "inventory",
+              "using": "gsi"
+            },
+            {
+              "#operator": "Fetch",
+              "as": "rte",
+              "bucket": "travel-sample",
+              "keyspace": "route",
+              "namespace": "default",
+              "nested_loop": true,
+              "optimizer_estimates": {
+                "cardinality": 24024,
+                "cost": 32748.51223783082,
+                "fr_cost": 25.36215918405889,
+                "size": 568
+              },
+              "scope": "inventory"
+            }
+          ]
+        }
+      },
+      {
+        "#operator": "Parallel",
+        "~child": {
+          "#operator": "Sequence",
+          "~children": [
+            {
+              "#operator": "InitialGroup",
+              "aggregates": [
+                "count(1)"
+              ],
+              "group_keys": [],
+              "optimizer_estimates": {
+                "cardinality": 1,
+                "cost": 38152.69884756461,
+                "fr_cost": 38152.69884756461,
+                "size": 581
+              }
+            }
+          ]
+        }
+      },
+      {
+        "#operator": "IntermediateGroup",
+        "aggregates": [
+          "count(1)"
+        ],
+        "group_keys": [],
+        "optimizer_estimates": {
+          "cardinality": 1,
+          "cost": 38152.70884756461,
+          "fr_cost": 38152.70884756461,
+          "size": 581
+        }
+      },
+      {
+        "#operator": "FinalGroup",
+        "aggregates": [
+          "count(1)"
+        ],
+        "group_keys": [],
+        "optimizer_estimates": {
+          "cardinality": 1,
+          "cost": 38152.71884756461,
+          "fr_cost": 38152.71884756461,
+          "size": 581
+        }
+      },
+      {
+        "#operator": "Parallel",
+        "~child": {
+          "#operator": "Sequence",
+          "~children": [
+            {
+              "#operator": "InitialProject",
+              "optimizer_estimates": {
+                "cardinality": 1,
+                "cost": 38152.742951506196,
+                "fr_cost": 38152.742951506196,
+                "size": 581
+              },
+              "result_terms": [
+                {
+                  "as": "Total_Count",
+                  "expr": "count(1)"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "text": "\nSELECT /*+ { \"use_hash\": { \"keyspace\": \"rte\", \"option\": \"build\" } } */ -- <.>\n       COUNT(1) AS Total_Count\nFROM `travel-sample`.inventory.airline aline\nINNER JOIN `travel-sample`.inventory.route rte\nON (rte.airlineid = META(aline).id);"
+}

--- a/modules/n1ql/examples/select/use-hash-build-hint.n1ql
+++ b/modules/n1ql/examples/select/use-hash-build-hint.n1ql
@@ -1,0 +1,11 @@
+UPDATE STATISTICS FOR `travel-sample`.inventory.airline INDEX (def_inventory_airline_primary);
+UPDATE STATISTICS FOR `travel-sample`.inventory.route INDEX (def_inventory_route_primary);
+
+EXPLAIN
+/* tag::query[] */
+SELECT /*+ { "use_hash": { "keyspace": "rte", "option": "build" } } */
+       COUNT(1) AS Total_Count
+FROM `travel-sample`.inventory.airline aline
+INNER JOIN `travel-sample`.inventory.route rte
+ON (rte.airlineid = META(aline).id);
+/* end::query[] */

--- a/modules/n1ql/examples/select/use-hash-build-legacy.n1ql
+++ b/modules/n1ql/examples/select/use-hash-build-legacy.n1ql
@@ -1,0 +1,11 @@
+UPDATE STATISTICS FOR `travel-sample`.inventory.airline INDEX (def_inventory_airline_primary);
+UPDATE STATISTICS FOR `travel-sample`.inventory.route INDEX (def_inventory_route_primary);
+
+EXPLAIN
+/* tag::query[] */
+SELECT COUNT(1) AS Total_Count
+FROM `travel-sample`.inventory.airline aline
+INNER JOIN `travel-sample`.inventory.route rte
+USE HASH (BUILD)
+ON (rte.airlineid = META(aline).id);
+/* end::query[] */

--- a/modules/n1ql/examples/select/use-hash-null-hint.jsonc
+++ b/modules/n1ql/examples/select/use-hash-null-hint.jsonc
@@ -69,7 +69,7 @@
             "(`rte`.`airlineid`)"
           ],
 // end::method[]
-"~child": {
+          "~child": {
             "#operator": "Sequence",
             "~children": [
               {

--- a/modules/n1ql/examples/select/use-hash-null-hint.jsonc
+++ b/modules/n1ql/examples/select/use-hash-null-hint.jsonc
@@ -1,0 +1,183 @@
+[
+  {
+    "cardinality": 1,
+    "cost": 38147.80957213704,
+    "optimizer_hints": {
+      "hints_followed": [
+        "USE_HASH(aline)"
+      ]
+    },
+    "plan": {
+      "#operator": "Sequence",
+      "~children": [
+        {
+          "#operator": "PrimaryScan3",
+          "as": "rte",
+          "bucket": "travel-sample",
+          "index": "def_inventory_route_primary",
+          "index_projection": {
+            "primary_key": true
+          },
+          "keyspace": "route",
+          "namespace": "default",
+          "optimizer_estimates": {
+            "cardinality": 24024,
+            "cost": 4108.612246388904,
+            "fr_cost": 12.170521655277593,
+            "size": 11
+          },
+          "scope": "inventory",
+          "using": "gsi"
+        },
+        {
+          "#operator": "Fetch",
+          "as": "rte",
+          "bucket": "travel-sample",
+          "keyspace": "route",
+          "namespace": "default",
+          "nested_loop": true,
+          "optimizer_estimates": {
+            "cardinality": 24024,
+            "cost": 32748.51223783082,
+            "fr_cost": 25.36215918405889,
+            "size": 568
+          },
+          "scope": "inventory"
+        },
+// tag::method[]
+        {
+          "#operator": "HashJoin",
+          "build_aliases": [
+            "aline"
+          ],
+          "build_exprs": [
+            "cover ((meta(`aline`).`id`))"
+          ],
+          "on_clause": "(((`rte`.`airlineid`) = cover ((meta(`aline`).`id`))))",
+// end::method[]
+// tag::ellipsis[]
+        // ...
+// end::ellipsis[]
+          "optimizer_estimates": {
+            "cardinality": 44924.88,
+            "cost": 37698.51666819545,
+            "fr_cost": 71.43827230425512,
+            "size": 581
+          },
+// tag::method[]
+          "probe_exprs": [
+            "(`rte`.`airlineid`)"
+          ],
+// end::method[]
+"~child": {
+            "#operator": "Sequence",
+            "~children": [
+              {
+                "#operator": "IndexScan3",
+                "as": "aline",
+                "bucket": "travel-sample",
+                "covers": [
+                  "cover ((meta(`aline`).`id`))"
+                ],
+                "index": "def_inventory_airline_primary",
+                "index_id": "11aa5c3f9d710599",
+                "keyspace": "airline",
+                "namespace": "default",
+                "optimizer_estimates": {
+                  "cardinality": 187,
+                  "cost": 45.30545926533892,
+                  "fr_cost": 12.178104060242454,
+                  "size": 13
+                },
+                "scope": "inventory",
+                "spans": [
+                  {
+                    "exact": true,
+                    "range": [
+                      {
+                        "inclusion": 0,
+                        "low": "null"
+                      }
+                    ]
+                  }
+                ],
+                "using": "gsi"
+              }
+            ]
+          }
+        },
+        {
+          "#operator": "Parallel",
+          "~child": {
+            "#operator": "Sequence",
+            "~children": [
+              {
+                "#operator": "InitialGroup",
+                "aggregates": [
+                  "count(1)"
+                ],
+                "group_keys": [],
+                "optimizer_estimates": {
+                  "cardinality": 1,
+                  "cost": 38147.76546819545,
+                  "fr_cost": 38147.76546819545,
+                  "size": 581
+                }
+              }
+            ]
+          }
+        },
+        {
+          "#operator": "IntermediateGroup",
+          "aggregates": [
+            "count(1)"
+          ],
+          "group_keys": [],
+          "optimizer_estimates": {
+            "cardinality": 1,
+            "cost": 38147.775468195454,
+            "fr_cost": 38147.775468195454,
+            "size": 581
+          }
+        },
+        {
+          "#operator": "FinalGroup",
+          "aggregates": [
+            "count(1)"
+          ],
+          "group_keys": [],
+          "optimizer_estimates": {
+            "cardinality": 1,
+            "cost": 38147.785468195456,
+            "fr_cost": 38147.785468195456,
+            "size": 581
+          }
+        },
+        {
+          "#operator": "Parallel",
+          "~child": {
+            "#operator": "Sequence",
+            "~children": [
+              {
+                "#operator": "InitialProject",
+                "optimizer_estimates": {
+                  "cardinality": 1,
+                  "cost": 38147.80957213704,
+                  "fr_cost": 38147.80957213704,
+                  "size": 581
+                },
+                "result_terms": [
+                  {
+                    "as": "Total_Count",
+                    "expr": "count(1)"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "text": "\n/* tag::query[] */\nSELECT /*+ USE_HASH (aline) */\n       COUNT(1) AS Total_Count\nFROM `travel-sample`.inventory.route rte\nINNER JOIN `travel-sample`.inventory.airline aline\nON rte.airlineid = META(aline).id;\n/* end::query[] */"
+  }
+]

--- a/modules/n1ql/examples/select/use-hash-null-hint.n1ql
+++ b/modules/n1ql/examples/select/use-hash-null-hint.n1ql
@@ -1,0 +1,11 @@
+UPDATE STATISTICS FOR `travel-sample`.inventory.airline INDEX (def_inventory_airline_primary);
+UPDATE STATISTICS FOR `travel-sample`.inventory.route INDEX (def_inventory_route_primary);
+
+EXPLAIN
+/* tag::query[] */
+SELECT /*+ USE_HASH (aline) */
+       COUNT(1) AS Total_Count
+FROM `travel-sample`.inventory.route rte
+INNER JOIN `travel-sample`.inventory.airline aline
+ON rte.airlineid = META(aline).id;
+/* end::query[] */

--- a/modules/n1ql/examples/select/use-hash-opt.jsonc
+++ b/modules/n1ql/examples/select/use-hash-opt.jsonc
@@ -1,0 +1,178 @@
+[
+  {
+    "cardinality": 1,
+    "cost": 38147.80957213704,
+    "plan": {
+      "#operator": "Sequence",
+      "~children": [
+        {
+          "#operator": "PrimaryScan3",
+          "as": "rte",
+          "bucket": "travel-sample",
+          "index": "def_inventory_route_primary",
+          "index_projection": {
+            "primary_key": true
+          },
+          "keyspace": "route",
+          "namespace": "default",
+          "optimizer_estimates": {
+            "cardinality": 24024,
+            "cost": 4108.612246388904,
+            "fr_cost": 12.170521655277593,
+            "size": 11
+          },
+          "scope": "inventory",
+          "using": "gsi"
+        },
+        {
+          "#operator": "Fetch",
+          "as": "rte",
+          "bucket": "travel-sample",
+          "keyspace": "route",
+          "namespace": "default",
+          "nested_loop": true,
+          "optimizer_estimates": {
+            "cardinality": 24024,
+            "cost": 32748.51223783082,
+            "fr_cost": 25.36215918405889,
+            "size": 568
+          },
+          "scope": "inventory"
+        },
+// tag::method[]
+        {
+          "#operator": "HashJoin",
+          "build_aliases": [
+            "aline"
+          ],
+          "build_exprs": [
+            "cover ((meta(`aline`).`id`))"
+          ],
+          "on_clause": "(((`rte`.`airlineid`) = cover ((meta(`aline`).`id`))))",
+// end::method[]
+// tag::ellipsis[]
+        // ...
+// end::ellipsis[]
+          "optimizer_estimates": {
+            "cardinality": 44924.88,
+            "cost": 37698.51666819545,
+            "fr_cost": 71.43827230425512,
+            "size": 581
+          },
+// tag::method[]
+          "probe_exprs": [
+            "(`rte`.`airlineid`)"
+          ],
+// end::method[]
+          "~child": {
+            "#operator": "Sequence",
+            "~children": [
+              {
+                "#operator": "IndexScan3",
+                "as": "aline",
+                "bucket": "travel-sample",
+                "covers": [
+                  "cover ((meta(`aline`).`id`))"
+                ],
+                "index": "def_inventory_airline_primary",
+                "index_id": "11aa5c3f9d710599",
+                "keyspace": "airline",
+                "namespace": "default",
+                "optimizer_estimates": {
+                  "cardinality": 187,
+                  "cost": 45.30545926533892,
+                  "fr_cost": 12.178104060242454,
+                  "size": 13
+                },
+                "scope": "inventory",
+                "spans": [
+                  {
+                    "exact": true,
+                    "range": [
+                      {
+                        "inclusion": 0,
+                        "low": "null"
+                      }
+                    ]
+                  }
+                ],
+                "using": "gsi"
+              }
+            ]
+          }
+        },
+        {
+          "#operator": "Parallel",
+          "~child": {
+            "#operator": "Sequence",
+            "~children": [
+              {
+                "#operator": "InitialGroup",
+                "aggregates": [
+                  "count(1)"
+                ],
+                "group_keys": [],
+                "optimizer_estimates": {
+                  "cardinality": 1,
+                  "cost": 38147.76546819545,
+                  "fr_cost": 38147.76546819545,
+                  "size": 581
+                }
+              }
+            ]
+          }
+        },
+        {
+          "#operator": "IntermediateGroup",
+          "aggregates": [
+            "count(1)"
+          ],
+          "group_keys": [],
+          "optimizer_estimates": {
+            "cardinality": 1,
+            "cost": 38147.775468195454,
+            "fr_cost": 38147.775468195454,
+            "size": 581
+          }
+        },
+        {
+          "#operator": "FinalGroup",
+          "aggregates": [
+            "count(1)"
+          ],
+          "group_keys": [],
+          "optimizer_estimates": {
+            "cardinality": 1,
+            "cost": 38147.785468195456,
+            "fr_cost": 38147.785468195456,
+            "size": 581
+          }
+        },
+        {
+          "#operator": "Parallel",
+          "~child": {
+            "#operator": "Sequence",
+            "~children": [
+              {
+                "#operator": "InitialProject",
+                "optimizer_estimates": {
+                  "cardinality": 1,
+                  "cost": 38147.80957213704,
+                  "fr_cost": 38147.80957213704,
+                  "size": 581
+                },
+                "result_terms": [
+                  {
+                    "as": "Total_Count",
+                    "expr": "count(1)"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "text": "\n/* tag::query[] */\nSELECT COUNT(1) AS Total_Count\nFROM `travel-sample`.inventory.route rte\nINNER JOIN `travel-sample`.inventory.airline aline\nON rte.airlineid = META(aline).id;\n/* end::query[] */"
+  }
+]

--- a/modules/n1ql/examples/select/use-hash-opt.n1ql
+++ b/modules/n1ql/examples/select/use-hash-opt.n1ql
@@ -1,0 +1,10 @@
+UPDATE STATISTICS FOR `travel-sample`.inventory.airline INDEX (def_inventory_airline_primary);
+UPDATE STATISTICS FOR `travel-sample`.inventory.route INDEX (def_inventory_route_primary);
+
+EXPLAIN
+/* tag::query[] */
+SELECT COUNT(1) AS Total_Count
+FROM `travel-sample`.inventory.route rte
+INNER JOIN `travel-sample`.inventory.airline aline
+ON rte.airlineid = META(aline).id;
+/* end::query[] */

--- a/modules/n1ql/examples/select/use-hash-probe-hint.jsonc
+++ b/modules/n1ql/examples/select/use-hash-probe-hint.jsonc
@@ -1,0 +1,181 @@
+{
+  "cardinality": 1,
+  "cost": 38152.742951506196,
+  "optimizer_hints": {
+    "hints_followed": [
+      "USE_HASH(aline/PROBE)"
+    ]
+  },
+  "plan": {
+    "#operator": "Sequence",
+    "~children": [
+      {
+        "#operator": "IndexScan3",
+        "as": "aline",
+        "bucket": "travel-sample",
+        "covers": [
+          "cover ((meta(`aline`).`id`))"
+        ],
+        "index": "def_inventory_airline_primary",
+        "index_id": "11aa5c3f9d710599",
+        "keyspace": "airline",
+        "namespace": "default",
+        "optimizer_estimates": {
+          "cardinality": 187,
+          "cost": 45.30545926533892,
+          "fr_cost": 12.178104060242454,
+          "size": 13
+        },
+        "scope": "inventory",
+        "spans": [
+          {
+            "exact": true,
+            "range": [
+              {
+                "inclusion": 0,
+                "low": "null"
+              }
+            ]
+          }
+        ],
+        "using": "gsi"
+      },
+// tag::method[]
+      {
+        "#operator": "HashJoin",
+        "build_aliases": [
+          "rte"
+        ],
+        "build_exprs": [
+          "(`rte`.`airlineid`)"
+        ],
+        "on_clause": "(((`rte`.`airlineid`) = cover ((meta(`aline`).`id`))))",
+// end::method[]
+// tag::ellipsis[]
+      // ...
+// end::ellipsis[]
+        "optimizer_estimates": {
+          "cardinality": 44924.88,
+          "cost": 37703.450047564605,
+          "fr_cost": 33338.278136855406,
+          "size": 581
+        },
+// tag::method[]
+        "probe_exprs": [
+          "cover ((meta(`aline`).`id`))"
+        ],
+// end::method[]
+        "~child": {
+          "#operator": "Sequence",
+          "~children": [
+            {
+              "#operator": "PrimaryScan3",
+              "as": "rte",
+              "bucket": "travel-sample",
+              "index": "def_inventory_route_primary",
+              "index_projection": {
+                "primary_key": true
+              },
+              "keyspace": "route",
+              "namespace": "default",
+              "optimizer_estimates": {
+                "cardinality": 24024,
+                "cost": 4108.612246388904,
+                "fr_cost": 12.170521655277593,
+                "size": 11
+              },
+              "scope": "inventory",
+              "using": "gsi"
+            },
+            {
+              "#operator": "Fetch",
+              "as": "rte",
+              "bucket": "travel-sample",
+              "keyspace": "route",
+              "namespace": "default",
+              "nested_loop": true,
+              "optimizer_estimates": {
+                "cardinality": 24024,
+                "cost": 32748.51223783082,
+                "fr_cost": 25.36215918405889,
+                "size": 568
+              },
+              "scope": "inventory"
+            }
+          ]
+        }
+      },
+      {
+        "#operator": "Parallel",
+        "~child": {
+          "#operator": "Sequence",
+          "~children": [
+            {
+              "#operator": "InitialGroup",
+              "aggregates": [
+                "count(1)"
+              ],
+              "group_keys": [],
+              "optimizer_estimates": {
+                "cardinality": 1,
+                "cost": 38152.69884756461,
+                "fr_cost": 38152.69884756461,
+                "size": 581
+              }
+            }
+          ]
+        }
+      },
+      {
+        "#operator": "IntermediateGroup",
+        "aggregates": [
+          "count(1)"
+        ],
+        "group_keys": [],
+        "optimizer_estimates": {
+          "cardinality": 1,
+          "cost": 38152.70884756461,
+          "fr_cost": 38152.70884756461,
+          "size": 581
+        }
+      },
+      {
+        "#operator": "FinalGroup",
+        "aggregates": [
+          "count(1)"
+        ],
+        "group_keys": [],
+        "optimizer_estimates": {
+          "cardinality": 1,
+          "cost": 38152.71884756461,
+          "fr_cost": 38152.71884756461,
+          "size": 581
+        }
+      },
+      {
+        "#operator": "Parallel",
+        "~child": {
+          "#operator": "Sequence",
+          "~children": [
+            {
+              "#operator": "InitialProject",
+              "optimizer_estimates": {
+                "cardinality": 1,
+                "cost": 38152.742951506196,
+                "fr_cost": 38152.742951506196,
+                "size": 581
+              },
+              "result_terms": [
+                {
+                  "as": "Total_Count",
+                  "expr": "count(1)"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "text": "\nSELECT /*+ USE_HASH (aline/PROBE) */ -- <.>\n       COUNT(1) AS Total_Count\nFROM `travel-sample`.inventory.route rte\nINNER JOIN `travel-sample`.inventory.airline aline\nON rte.airlineid = META(aline).id;"
+}

--- a/modules/n1ql/examples/select/use-hash-probe-hint.n1ql
+++ b/modules/n1ql/examples/select/use-hash-probe-hint.n1ql
@@ -1,0 +1,11 @@
+UPDATE STATISTICS FOR `travel-sample`.inventory.airline INDEX (def_inventory_airline_primary);
+UPDATE STATISTICS FOR `travel-sample`.inventory.route INDEX (def_inventory_route_primary);
+
+EXPLAIN
+/* tag::query[] */
+SELECT /*+ USE_HASH (aline/PROBE) */
+       COUNT(1) AS Total_Count
+FROM `travel-sample`.inventory.route rte
+INNER JOIN `travel-sample`.inventory.airline aline
+ON rte.airlineid = META(aline).id;
+/* end::query[] */

--- a/modules/n1ql/examples/select/use-hash-probe-legacy.n1ql
+++ b/modules/n1ql/examples/select/use-hash-probe-legacy.n1ql
@@ -1,0 +1,11 @@
+UPDATE STATISTICS FOR `travel-sample`.inventory.airline INDEX (def_inventory_airline_primary);
+UPDATE STATISTICS FOR `travel-sample`.inventory.route INDEX (def_inventory_route_primary);
+
+EXPLAIN
+/* tag::query[] */
+SELECT COUNT(1) AS Total_Count
+FROM `travel-sample`.inventory.route rte
+INNER JOIN `travel-sample`.inventory.airline aline
+USE HASH (PROBE)
+ON rte.airlineid = META(aline).id;
+/* end::query[] */

--- a/modules/n1ql/examples/select/use-nl-hint.jsonc
+++ b/modules/n1ql/examples/select/use-nl-hint.jsonc
@@ -1,0 +1,190 @@
+{
+  "#operator": "Sequence",
+  "~children": [
+    {
+      "#operator": "Sequence",
+      "~children": [
+        {
+          "#operator": "IndexScan3",
+          "as": "r",
+          "bucket": "travel-sample",
+          "index": "def_inventory_route_sourceairport",
+          "index_id": "10962bf412f58e32",
+          "index_projection": {
+            "primary_key": true
+          },
+          "keyspace": "route",
+          "namespace": "default",
+          "optimizer_estimates": {
+            "cardinality": 249,
+            "cost": 409.3918315518446,
+            "fr_cost": 13.595951130730299,
+            "size": 11
+          },
+          "scope": "inventory",
+          "spans": [
+            {
+              "exact": true,
+              "range": [
+                {
+                  "high": "\"SFO\"",
+                  "inclusion": 3,
+                  "index_key": "`sourceairport`",
+                  "low": "\"SFO\""
+                }
+              ]
+            }
+          ],
+          "using": "gsi"
+        },
+        {
+          "#operator": "Fetch",
+          "as": "r",
+          "bucket": "travel-sample",
+          "keyspace": "route",
+          "namespace": "default",
+          "optimizer_estimates": {
+            "cardinality": 249,
+            "cost": 718.1095762183879,
+            "fr_cost": 26.7875886595116,
+            "size": 568
+          },
+          "scope": "inventory"
+        },
+        {
+          "#operator": "Parallel",
+          "~child": {
+            "#operator": "Sequence",
+            "~children": [
+              {
+                "#operator": "Filter",
+                "condition": "((`r`.`sourceairport`) = \"SFO\")",
+                "optimizer_estimates": {
+                  "cardinality": 249,
+                  "cost": 724.0439311117188,
+                  "fr_cost": 26.811421410087224,
+                  "size": 568
+                }
+              },
+// tag::method[]
+              {
+                "#operator": "NestedLoopJoin",
+// end::method[]
+                "alias": "a",
+                "filter": "((`a`.`faa`) = (`r`.`sourceairport`))",
+                "on_clause": "(((`a`.`faa`) = (`r`.`sourceairport`)))",
+                "optimizer_estimates": {
+                  "cardinality": 241.59705066624267,
+                  "cost": 6894.97492813281,
+                  "fr_cost": 1199.3543889498105,
+                  "size": 858
+                },
+                "~child": {
+                  "#operator": "Sequence",
+                  "~children": [
+                    {
+                      "#operator": "IndexScan3",
+                      "as": "a",
+                      "bucket": "travel-sample",
+                      "index": "def_inventory_airport_faa",
+                      "index_id": "da117c64837f7ad",
+                      "index_projection": {
+                        "primary_key": true
+                      },
+                      "keyspace": "airport",
+                      "namespace": "default",
+                      "nested_loop": true,
+                      "optimizer_estimates": {
+                        "cardinality": 0.970269279784107,
+                        "cost": 12.173544240859432,
+                        "fr_cost": 12.173544240859432,
+                        "size": 12
+                      },
+                      "scope": "inventory",
+                      "spans": [
+                        {
+                          "exact": true,
+                          "range": [
+                            {
+                              "high": "(`r`.`sourceairport`)",
+                              "inclusion": 3,
+                              "index_key": "`faa`",
+                              "low": "(`r`.`sourceairport`)"
+                            }
+                          ]
+                        }
+                      ],
+                      "using": "gsi"
+                    },
+                    {
+                      "#operator": "Fetch",
+                      "as": "a",
+                      "bucket": "travel-sample",
+                      "keyspace": "airport",
+                      "namespace": "default",
+                      "nested_loop": true,
+                      "optimizer_estimates": {
+                        "cardinality": 0.970269279784107,
+                        "cost": 24.64293012049035,
+                        "fr_cost": 24.64293012049035,
+                        "size": 290
+                      },
+                      "scope": "inventory"
+                    },
+                    {
+                      "#operator": "Parallel",
+                      "~child": {
+                        "#operator": "Sequence",
+                        "~children": [
+                          {
+                            "#operator": "Filter",
+                            "condition": "((`a`.`faa`) is not null)",
+                            "optimizer_estimates": {
+                              "cardinality": 0.8425763207068288,
+                              "cost": 24.659453210934785,
+                              "fr_cost": 24.659453210934785,
+                              "size": 290
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "#operator": "InitialProject",
+                "optimizer_estimates": {
+                  "cardinality": 241.59705066624267,
+                  "cost": 6909.128474364926,
+                  "fr_cost": 1199.412972223874,
+                  "size": 858
+                },
+                "result_terms": [
+                  {
+                    "as": "airport",
+                    "expr": "(`a`.`airportname`)"
+                  },
+                  {
+                    "as": "route",
+                    "expr": "(`r`.`id`)"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "#operator": "Limit",
+      "expr": "4",
+      "optimizer_estimates": {
+        "cardinality": 4,
+        "cost": 1270.6365967049305,
+        "fr_cost": 1199.4422638609058,
+        "size": 858
+      }
+    }
+  ]
+}

--- a/modules/n1ql/examples/select/use-nl-hint.n1ql
+++ b/modules/n1ql/examples/select/use-nl-hint.n1ql
@@ -1,0 +1,13 @@
+UPDATE STATISTICS FOR `travel-sample`.inventory.route INDEX (def_inventory_route_sourceairport);
+UPDATE STATISTICS FOR `travel-sample`.inventory.airport INDEX (def_inventory_airport_faa);
+
+EXPLAIN
+/* tag::query[] */
+SELECT /*+ USE_NL (a) */ -- <.>
+       a.airportname AS airport, r.id AS route
+FROM `travel-sample`.inventory.route AS r,
+     `travel-sample`.inventory.airport AS a -- <.>
+WHERE a.faa = r.sourceairport
+  AND r.sourceairport = "SFO"
+LIMIT 4;
+/* end::query[] */

--- a/modules/n1ql/examples/select/use-nl-legacy.n1ql
+++ b/modules/n1ql/examples/select/use-nl-legacy.n1ql
@@ -1,0 +1,13 @@
+UPDATE STATISTICS FOR `travel-sample`.inventory.route INDEX (def_inventory_route_sourceairport);
+UPDATE STATISTICS FOR `travel-sample`.inventory.airport INDEX (def_inventory_airport_faa);
+
+EXPLAIN
+/* tag::query[] */
+SELECT a.airportname AS airport, r.id AS route
+FROM `travel-sample`.inventory.route AS r
+JOIN `travel-sample`.inventory.airport AS a
+USE NL
+ON a.faa = r.sourceairport
+WHERE r.sourceairport = "SFO"
+LIMIT 4;
+/* end::query[] */

--- a/modules/n1ql/examples/select/use-nl-opt.jsonc
+++ b/modules/n1ql/examples/select/use-nl-opt.jsonc
@@ -1,0 +1,203 @@
+{
+  "#operator": "Sequence",
+  "~children": [
+    {
+      "#operator": "Sequence",
+      "~children": [
+        {
+          "#operator": "IndexScan3",
+          "as": "a",
+          "bucket": "travel-sample",
+          "index": "def_inventory_airport_faa",
+          "index_id": "da117c64837f7ad",
+          "index_projection": {
+            "primary_key": true
+          },
+          "keyspace": "airport",
+          "namespace": "default",
+          "optimizer_estimates": {
+            "cardinality": 1708.9999999999986,
+            "cost": 317.67504692590336,
+            "fr_cost": 12.17886193500638,
+            "size": 12
+          },
+          "scope": "inventory",
+          "spans": [
+            {
+              "exact": true,
+              "range": [
+                {
+                  "inclusion": 0,
+                  "index_key": "`faa`",
+                  "low": "null"
+                }
+              ]
+            }
+          ],
+          "using": "gsi"
+        },
+        {
+          "#operator": "Fetch",
+          "as": "a",
+          "bucket": "travel-sample",
+          "keyspace": "airport",
+          "namespace": "default",
+          "optimizer_estimates": {
+            "cardinality": 1708.9999999999986,
+            "cost": 1784.8361118943133,
+            "fr_cost": 25.0303312533027,
+            "size": 290
+          },
+          "scope": "inventory"
+        },
+        {
+          "#operator": "Parallel",
+          "~child": {
+            "#operator": "Sequence",
+            "~children": [
+              {
+                "#operator": "Filter",
+                "condition": "((`a`.`faa`) is not null)",
+                "optimizer_estimates": {
+                  "cardinality": 1708.9999999999986,
+                  "cost": 1813.9393331936815,
+                  "fr_cost": 25.047360639668625,
+                  "size": 290
+                }
+              }
+            ]
+          }
+        },
+// tag::method[]
+        {
+          "#operator": "HashJoin",
+// end::method[]
+          "build_aliases": [
+            "r"
+          ],
+          "build_exprs": [
+            "(`r`.`sourceairport`)"
+          ],
+          "filter": "((`a`.`faa`) = (`r`.`sourceairport`))",
+          "on_clause": "(((`a`.`faa`) = (`r`.`sourceairport`)))",
+          "optimizer_estimates": {
+            "cardinality": 241.59705066624267,
+            "cost": 2603.7479879964294,
+            "fr_cost": 762.7780175474376,
+            "size": 858
+          },
+          "probe_exprs": [
+            "(`a`.`faa`)"
+          ],
+          "~child": {
+            "#operator": "Sequence",
+            "~children": [
+              {
+                "#operator": "IndexScan3",
+                "as": "r",
+                "bucket": "travel-sample",
+                "index": "def_inventory_route_sourceairport",
+                "index_id": "10962bf412f58e32",
+                "index_projection": {
+                  "primary_key": true
+                },
+                "keyspace": "route",
+                "namespace": "default",
+                "optimizer_estimates": {
+                  "cardinality": 249,
+                  "cost": 409.3918315518446,
+                  "fr_cost": 13.595951130730299,
+                  "size": 11
+                },
+                "scope": "inventory",
+                "spans": [
+                  {
+                    "exact": true,
+                    "range": [
+                      {
+                        "high": "\"SFO\"",
+                        "inclusion": 3,
+                        "index_key": "`sourceairport`",
+                        "low": "\"SFO\""
+                      }
+                    ]
+                  }
+                ],
+                "using": "gsi"
+              },
+              {
+                "#operator": "Fetch",
+                "as": "r",
+                "bucket": "travel-sample",
+                "keyspace": "route",
+                "namespace": "default",
+                "optimizer_estimates": {
+                  "cardinality": 249,
+                  "cost": 718.1095762183879,
+                  "fr_cost": 26.7875886595116,
+                  "size": 568
+                },
+                "scope": "inventory"
+              },
+              {
+                "#operator": "Parallel",
+                "~child": {
+                  "#operator": "Sequence",
+                  "~children": [
+                    {
+                      "#operator": "Filter",
+                      "condition": "((`r`.`sourceairport`) = \"SFO\")",
+                      "optimizer_estimates": {
+                        "cardinality": 249,
+                        "cost": 724.0439311117188,
+                        "fr_cost": 26.811421410087224,
+                        "size": 568
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "#operator": "Parallel",
+          "~child": {
+            "#operator": "Sequence",
+            "~children": [
+              {
+                "#operator": "InitialProject",
+                "optimizer_estimates": {
+                  "cardinality": 241.59705066624267,
+                  "cost": 2617.9015342285447,
+                  "fr_cost": 762.8366008215011,
+                  "size": 858
+                },
+                "result_terms": [
+                  {
+                    "as": "airport",
+                    "expr": "(`a`.`airportname`)"
+                  },
+                  {
+                    "as": "route",
+                    "expr": "(`r`.`id`)"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "#operator": "Limit",
+      "expr": "4",
+      "optimizer_estimates": {
+        "cardinality": 4,
+        "cost": 785.9966614551204,
+        "fr_cost": 762.8658924585328,
+        "size": 858
+      }
+    }
+  ]
+}

--- a/modules/n1ql/examples/select/use-nl-opt.n1ql
+++ b/modules/n1ql/examples/select/use-nl-opt.n1ql
@@ -1,0 +1,12 @@
+UPDATE STATISTICS FOR `travel-sample`.inventory.route INDEX (def_inventory_route_sourceairport);
+UPDATE STATISTICS FOR `travel-sample`.inventory.airport INDEX (def_inventory_airport_faa);
+
+EXPLAIN
+/* tag::query[] */
+SELECT a.airportname AS airport, r.id AS route
+FROM `travel-sample`.inventory.route AS r,
+     `travel-sample`.inventory.airport AS a
+WHERE a.faa = r.sourceairport
+  AND r.sourceairport = "SFO"
+LIMIT 4;
+/* end::query[] */

--- a/modules/n1ql/pages/n1ql-language-reference/cost-based-optimizer.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/cost-based-optimizer.adoc
@@ -19,7 +19,11 @@
 :updatestatistics: {n1ql}/updatestatistics.adoc
 :optimizer-hints: {n1ql}/optimizer-hints.adoc
 :query-hints: {n1ql}/query-hints.adoc
+:ordered-hint: {query-hints}#ordered
 :keyspace-hints: {n1ql}/keyspace-hints.adoc
+:index-hint: {keyspace-hints}#index
+:use-nl-hint: {keyspace-hints}#use_nl
+:use-hash-hint: {keyspace-hints}#use_hash
 :collation: {n1ql}/datatypes.adoc#collation
 :query-service: xref:learn:services-and-indexes/services/query-service.adoc
 :query-service-architecture: {query-service}#query-service-architecture
@@ -70,12 +74,16 @@ The cost-based optimizer calculates a cost for a query plan that takes into cons
 The cost-based optimizer takes into consideration the characteristics of each qualified index, and thus can better differentiate between similar indexes.
 The cost-based optimizer also reduces the need for intersect scans, since it can determine whether one index is better than another based on cost information.
 
+Refer to {index-hint}[INDEX] for an example.
+
 [[join-method]]
 === Join Method
 
 In Couchbase Server Enterprise Edition, two join methods are supported: nested-loop join and hash join.
 With the legacy {query-service-architecture}[rules-based optimizer], nested-loop join is used by default, and hash join is only considered when a USE HASH hint is specified.
 With the cost-based optimizer, both join methods are considered, and the optimizer chooses a join method based on cost information.
+
+Refer to {use-nl-hint}[USE_NL] and {use-hash-hint}[USE_HASH] for examples.
 
 [[join-enumeration]]
 === Join Enumeration
@@ -86,6 +94,8 @@ endif::[]
 
 With the legacy {query-service-architecture}[rules-based optimizer], joins are performed in the order in which they are specified in the query, and no reordering of joins is considered.
 With the cost-based optimizer, different join orders can be considered, and the optimizer chooses the optimal join order based on cost information.
+
+Refer to {ordered-hint}[ORDERED] for an example.
 
 [[optimizer-stats]]
 == Optimizer Statistics

--- a/modules/n1ql/pages/n1ql-language-reference/hints.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/hints.adoc
@@ -219,16 +219,14 @@ This clause is optional; if omitted, the default is `USING GSI`.
 
 .Use a specified Global Secondary Index
 ====
-Create an index of airlines and destination airports, and then use it in a query for flights originating in San Francisco.
+This example uses the index `def_inventory_route_route_src_dst_day`, which is installed with the `travel-sample` bucket.
 
+The following query hints that the optimizer should select the specified index for the keyspace `pass:c[`travel-sample`.inventory.route]`.
+
+.INDEX hint
 [source,n1ql]
 ----
-include::example$n1ql-language-reference/create-idx-hints.n1ql[]
-----
-
-[source,n1ql]
-----
-include::example$n1ql-language-reference/select-idx-hints.n1ql[]
+include::example$select/index-legacy.n1ql[tag=query]
 ----
 ====
 

--- a/modules/n1ql/pages/n1ql-language-reference/join.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/join.adoc
@@ -486,11 +486,7 @@ The keyspace `aline` is to be joined (with `rte`) using hash join, and `aline` i
 
 [source,N1QL]
 ----
-SELECT COUNT(1) AS Total_Count
-FROM `travel-sample`.inventory.route rte
-INNER JOIN `travel-sample`.inventory.airline aline
-USE HASH (PROBE)
-ON (rte.airlineid = META(aline).id);
+include::example$select/use-hash-probe-legacy.n1ql[tag=query]
 ----
 
 .Results
@@ -511,11 +507,7 @@ This is effectively the same query as the previous example, except the two keysp
 
 [source,N1QL]
 ----
-SELECT COUNT(1) AS Total_Count
-FROM `travel-sample`.inventory.airline aline
-INNER JOIN `travel-sample`.inventory.route rte
-USE HASH (BUILD)
-ON (rte.airlineid = META(aline).id);
+include::example$select/use-hash-build-legacy.n1ql[tag=query]
 ----
 
 .Results
@@ -555,11 +547,7 @@ For more details, refer to xref:n1ql-language-reference/keyspace-hints.adoc#use-
 ====
 [source,N1QL]
 ----
-SELECT COUNT(1) AS Total_Count
-FROM `travel-sample`.inventory.route rte
-INNER JOIN `travel-sample`.inventory.airline aline
-USE NL
-ON (rte.airlineid = META(aline).id);
+include::example$select/use-nl-legacy.n1ql[tag=query]
 ----
 ====
 

--- a/modules/n1ql/pages/n1ql-language-reference/keyspace-hints.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/keyspace-hints.adoc
@@ -3,11 +3,14 @@
 :page-status: Couchbase Server 7.1
 :imagesdir: ../../assets/images
 :description: Keyspace hints apply to a specific keyspace.
+:cbo-preamble: For the examples in this section, it is assumed that the cost-based optimizer is active, and all optimizer statistics are up-to-date.
 :page-partial:
+:!example-caption:
 
 [abstract]
 {description}
 
+A keyspace hint is a type of xref:n1ql-language-reference/optimizer-hints.adoc[optimizer hint].
 Keyspace hints include _index_ hints, which enable you to specify indexes, and _join_ hints, which enable you to specify join methods.
 
 For each keyspace hint, you must specify the keyspace or keyspaces that the hint applies to.
@@ -22,6 +25,7 @@ Note that you cannot mix simple syntax and JSON syntax in the same hint comment.
 == INDEX
 
 This hint directs the optimizer to consider one or more specified secondary indexes.
+If not specified, the optimizer selects the optimal available index.
 
 === Simple Syntax
 
@@ -126,27 +130,52 @@ An array of secondary indexes that the optimizer should consider for the given k
 
 === Examples
 
-====
-This example hints that the optimizer should select the index `idx_destinations` for the keyspace `pass:c[`travel-sample`.inventory.route]`.
+{cbo-preamble}
 
-.Index
-[source,n1ql]
-----
-include::example$n1ql-language-reference/create-idx-hints.n1ql[]
-----
+[#ex-index-hint]
+.INDEX hint
+====
+This example uses the index `def_inventory_route_route_src_dst_day`, which is installed with the `travel-sample` bucket.
+
+The following query hints that the optimizer should select the specified index for the keyspace `pass:c[`travel-sample`.inventory.route]`.
 
 .Query
 [source,n1ql]
 ----
-SELECT /*+ INDEX (route idx_destinations) */ -- <.>
-  airlineid, airline, sourceairport, destinationairport
-FROM `travel-sample`.inventory.route -- <.>
-WHERE sourceairport = "SFO";
+include::example$select/index-hint.n1ql[tag=query]
 ----
 
 <.> The keyspace is not given an explicit alias in the query.
 You must therefore refer to the keyspace using the keyspace name or implicit alias.
 <.> The implicit alias is the last element in the keyspace path -- in this case, `route`.
+
+If you examine the plan for this query, you can see that the query uses the suggested index.
+
+.Explain plan
+[source,json,indent=0]
+----
+include::example$select/index-hint.jsonc[tag=index]
+----
+====
+
+[#ex-index-opt]
+.Optimized index selection
+====
+For comparison, the following query is equivalent to the one in the <<ex-index-hint>> example, but without the index hint.
+
+.Query
+[source,n1ql]
+----
+include::example$select/index-opt.n1ql[tag=query]
+----
+
+If you examine the plan for this query, you can see that the optimizer has selected a different index: `def_inventory_route_sourceairport`.
+
+.Explain plan
+[source,json,indent=0]
+----
+include::example$select/index-opt.jsonc[tag=index]
+----
 ====
 
 === Legacy Equivalent
@@ -160,6 +189,7 @@ If you do this, the hint comment and the `USE` clause are marked as erroneous an
 == INDEX_FTS
 
 This hint directs the optimizer to consider one or more specified full-text indexes.
+If not specified, the optimizer selects the optimal available index.
 
 === Simple Syntax
 
@@ -260,6 +290,8 @@ An array of full-text indexes that the optimizer should consider for the given k
 
 === Examples
 
+[#ex-index-fts-hint]
+.INDEX_FTS hint
 ====
 This example specifies that the optimizer should prefer any suitable FTS index, without specifying an index by name.
 To qualify for this query, there must be an FTS index on `state` and `type`, using the keyword analyzer.
@@ -291,6 +323,7 @@ If you do this, the hint comment and the `USE` clause are marked as erroneous an
 
 This hint directs the optimizer to consider a nested-loop join for the specified keyspace.
 This hint must be specified on the keyspace on the right-hand side of the join.
+If not specified, the optimizer selects the optimal join method.
 
 === Simple Syntax
 
@@ -348,7 +381,6 @@ image::n1ql-language-reference/keyspace-object.png[align=left]
 Use this object to apply the hint to a single keyspace.
 It must contain a <<keyspace-property-nl>>.
 
-
 [#keyspace-property-nl]
 ==== Keyspace Property
 
@@ -365,20 +397,48 @@ include::keyspace-hints.adoc[tag=keyspace-property]
 
 === Examples
 
-====
+{cbo-preamble}
+
+[#ex-use-nl-hint]
 .USE_NL Hint
+====
+.Query
 [source,n1ql]
 ----
-SELECT /*+ USE_NL (aline) */ -- <.>
-       COUNT(1) AS Total_Count
-FROM `travel-sample`.inventory.route rte
-INNER JOIN `travel-sample`.inventory.airline aline -- <.>
-ON (rte.airlineid = META(aline).id);
+include::example$select/use-nl-hint.n1ql[tag=query]
 ----
 
 <.> The keyspace is given an explicit alias in the query.
 You must therefore refer to the keyspace using the explicit alias.
-<.> In this case, the explicit alias is `aline`.
+<.> In this case, the explicit alias is `a`.
+
+If you examine the plan text for this query, you can see that the query uses the suggested join method.
+
+.Explain plan
+[source,json,indent=0]
+----
+include::example$select/use-nl-hint.jsonc[tag=method]
+----
+====
+
+[#ex-use-nl-opt]
+.Optimized join method selection
+====
+For comparison, the following query is equivalent to the one in the <<ex-use-nl-hint>> example, but without the join hint.
+
+.Query
+[source,n1ql]
+----
+include::example$select/use-nl-opt.n1ql[tag=query]
+----
+
+If you examine the plan for this query, you can see that the optimizer has selected a different join method.
+
+.Explain plan
+[source,json,indent=0]
+----
+include::example$select/use-nl-opt.jsonc[tag=method]
+----
 ====
 
 === Legacy Equivalent
@@ -395,6 +455,7 @@ If you do this, the optimizer hints and `USE` clause are both marked as erroneou
 
 This hint directs the optimizer to consider a hash join for the specified keyspace.
 This hint must be specified on the keyspace on the right-hand side of the join.
+If not specified, the optimizer selects the optimal join method.
 
 A hash join has two sides: a *build* side and a *probe* side.
 The build side of the join is used to create an in-memory hash table.
@@ -518,58 +579,87 @@ Similarly, if you omit this property entirely, the optimizer determines whether 
 
 === Examples
 
+{cbo-preamble}
+
+[#ex-use-hash-probe-hint]
+.USE_HASH with PROBE
 ====
 The keyspace `aline` is to be joined (with `rte`) using hash join, and `aline` is used as the probe side of the hash join.
 
-.USE_HASH with PROBE
+.Query -- simple syntax
 [source,n1ql]
 ----
-SELECT /*+ USE_HASH (aline/PROBE) */ -- <.>
-       COUNT(1) AS Total_Count
-FROM `travel-sample`.inventory.route rte
-INNER JOIN `travel-sample`.inventory.airline aline
-ON (rte.airlineid = META(aline).id);
+include::example$select/use-hash-probe-hint.n1ql[tag=query]
 ----
 
-<.> Simple syntax
+If you examine the explain plan for this query, you can see that the query uses the hash join method as suggested, with the `aline` keyspace on the probe side.
 
-.Results
-[source,JSON]
+.Explain plan
+[source,json,indent=0]
 ----
-[
-  {
-    "Total_Count": 17629
-  }
-]
+include::example$select/use-hash-probe-hint.jsonc[tags=method;ellipsis]
 ----
 ====
 
-====
-This is effectively the same query as the previous example, except the two keyspaces are switched, and here the `BUILD` option is used, indicating the hash join should use `rte` as the build side.
-
+[#ex-use-hash-build-hint]
 .USE_HASH with BUILD
+====
+This is effectively the same query as the <<ex-use-hash-probe-hint>> example, except the two keyspaces are switched, and here the `BUILD` option is used, indicating the hash join should use `rte` as the build side.
+
+.Query
 [source,n1ql]
 ----
-SELECT /*+ { "use_hash": { "keyspace": "rte", "option": "build" } } */ -- <.>
-       COUNT(1) AS Total_Count
-FROM `travel-sample`.inventory.airline aline
-INNER JOIN `travel-sample`.inventory.route rte
-ON (rte.airlineid = META(aline).id);
+include::example$select/use-hash-build-hint.n1ql[tag=query]
 ----
 
-<.> JSON syntax
+If you examine the explain plan for this query, you can see that the query uses the hash join method as suggested, with the `rte` keyspace on the build side.
 
-.Results
-[source,JSON]
+.Explain plan
+[source,json,indent=0]
 ----
-[
-  {
-    "Total_Count": 17629
-  }
-]
+include::example$select/use-hash-probe-hint.jsonc[tags=method;ellipsis]
 ----
 ====
 
+[#ex-use-hash-null-hint]
+.USE_HASH with optimizer
+====
+This is the same query as the <<ex-use-hash-probe-hint>> example, but the hint does not specify whether the `aline` keyspace should be on the probe side or the build side of the join.
+
+.Query -- JSON syntax
+[source,n1ql]
+----
+include::example$select/use-hash-null-hint.n1ql[tag=query]
+----
+
+If you examine the explain plan for this query, you can see that the query uses the hash join method as suggested, but the optimizer has selected to put the `aline` keyspace on the build side of the join.
+
+.Explain plan
+[source,json,indent=0]
+----
+include::example$select/use-hash-null-hint.jsonc[tags=method;ellipsis]
+----
+====
+
+[#ex-use-hash-opt]
+.Optimized join method selection
+====
+For comparison, the following query is equivalent to the one in the <<ex-use-hash-probe-hint>> example, but without the join hint.
+
+.Query
+[source,n1ql]
+----
+include::example$select/use-hash-opt.n1ql[tag=query]
+----
+
+If you examine the plan for this query, you can see that the optimizer has selected to use the hash join method as before, and to put the `aline` keyspace on the build side of the join.
+
+.Explain plan
+[source,json,indent=0]
+----
+include::example$select/use-hash-opt.jsonc[tags=method;ellipsis]
+----
+====
 
 === Legacy Equivalent
 

--- a/modules/n1ql/pages/n1ql-language-reference/keyspace-hints.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/keyspace-hints.adoc
@@ -128,6 +128,7 @@ A secondary index that the optimizer should consider for the given keyspace.
 An array of _index_ strings::
 An array of secondary indexes that the optimizer should consider for the given keyspace.
 
+[#index-examples,reftext="INDEX Examples"]
 === Examples
 
 {cbo-preamble}
@@ -288,6 +289,7 @@ A full-text index that the optimizer should consider for the given keyspace.
 _index_ array::
 An array of full-text indexes that the optimizer should consider for the given keyspace.
 
+[#index-fts-examples,reftext="INDEX_FTS Examples"]
 === Examples
 
 [#ex-index-fts-hint]
@@ -395,6 +397,7 @@ Synonym for `"keyspace"`: `"alias"`
 
 include::keyspace-hints.adoc[tag=keyspace-property]
 
+[#use-nl-examples,reftext="USE_NL Examples"]
 === Examples
 
 {cbo-preamble}
@@ -577,6 +580,7 @@ The optimizer determines whether the specified keyspace is to be used as the bui
 
 Similarly, if you omit this property entirely, the optimizer determines whether the specified keyspace is to be used as the build side or the probe side of the join.
 
+[#use-hash-examples,reftext="USE_HASH Examples"]
 === Examples
 
 {cbo-preamble}

--- a/modules/n1ql/pages/n1ql-language-reference/query-hints.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/query-hints.adoc
@@ -3,10 +3,13 @@
 :page-status: Couchbase Server 7.1
 :imagesdir: ../../assets/images
 :description: Query block hints are hints that apply to an entire query block.
+:cbo-preamble: For the examples in this section, it is assumed that the cost-based optimizer is active, and all optimizer statistics are up-to-date.
+:!example-caption:
 
 [abstract]
 {description}
 
+A query hint is a type of xref:n1ql-language-reference/optimizer-hints.adoc[optimizer hint].
 Currently N1QL supports only one query block hint: ORDERED.
 
 There are two possible formats for each optimizer hint: simple syntax and JSON syntax.
@@ -44,10 +47,11 @@ The value of this property must be set to `true`.
 
 === Examples
 
-For the examples in this section, it is assumed that the cost-based optimizer is active, and all optimizer statistics are up-to-date.
+{cbo-preamble}
 
-====
 .ORDERED hint -- simple syntax
+====
+.Query
 [source,n1ql]
 ----
 include::example$select/ordered-hint.n1ql[tag=simple]
@@ -57,8 +61,9 @@ include::example$select/ordered-hint.n1ql[tag=simple]
 <2> Join the resulting dataset to the `airline` keyspace.
 ====
 
-====
 .ORDERED hint -- JSON syntax
+====
+.Query
 [source,n1ql]
 ----
 include::example$select/ordered-hint.n1ql[tag=json]
@@ -69,17 +74,18 @@ include::example$select/ordered-hint.n1ql[tag=json]
 
 If you examine the plan for this query, or the query in the previous example, you can see that the joins are ordered just as they were written.
 
-image::join-order-hint.png["Query plan with join order hint"]
+image::join-order-hint.png["Query plan with ORDERED hint"]
 
 [discrete]
 <1> Join the `airport` keyspace to the `route` keyspace.
 <2> Join the resulting dataset to the `airline` keyspace.
 ====
 
+.Optimized join ordering
 ====
 For further insight into join enumeration, consider the following query, which is equivalent to the previous two examples, but without the ORDERED hint.
 
-.Optimized join ordering
+.Query
 [source,n1ql]
 ----
 include::example$select/ordered-hint.n1ql[tag=none]
@@ -88,7 +94,7 @@ include::example$select/ordered-hint.n1ql[tag=none]
 <1> Join the `airport` keyspace to the `route` keyspace.
 <2> Join the resulting dataset to the `airline` keyspace.
 
-If you examine the plan for this query, you can see that because there is no query hint, the optimizer has re-ordered the joins.
+If you examine the plan for this query, you can see that because there is no hint, the optimizer has re-ordered the joins.
 
 image::join-order-optimize.png["Query plan with optimized join order"]
 

--- a/modules/n1ql/pages/n1ql-language-reference/query-hints.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/query-hints.adoc
@@ -45,10 +45,12 @@ With the JSON syntax, this hint takes the form of an `ordered` property.
 You may only use this property once within the hint comment.
 The value of this property must be set to `true`.
 
+[#ordered-examples,reftext="ORDERED Examples"]
 === Examples
 
 {cbo-preamble}
 
+[#ex-ordered-simple]
 .ORDERED hint -- simple syntax
 ====
 .Query
@@ -61,6 +63,7 @@ include::example$select/ordered-hint.n1ql[tag=simple]
 <2> Join the resulting dataset to the `airline` keyspace.
 ====
 
+[#ex-ordered-json]
 .ORDERED hint -- JSON syntax
 ====
 .Query
@@ -81,6 +84,7 @@ image::join-order-hint.png["Query plan with ORDERED hint"]
 <2> Join the resulting dataset to the `airline` keyspace.
 ====
 
+[#ex-ordered-opt]
 .Optimized join ordering
 ====
 For further insight into join enumeration, consider the following query, which is equivalent to the previous two examples, but without the ORDERED hint.


### PR DESCRIPTION
The following draft documentation is ready for review:

* [INDEX hint examples](https://simon-dew.github.io/docs-site/DOC-10040/server/current/n1ql/n1ql-language-reference/keyspace-hints.html#index-examples) — added explain plan; added example with no hint to show optimizer in action
* [USE_NL hint examples](https://simon-dew.github.io/docs-site/DOC-10040/server/current/n1ql/n1ql-language-reference/keyspace-hints.html#use-nl-examples) — ditto
* [USE_HASH hint examples](https://simon-dew.github.io/docs-site/DOC-10040/server/current/n1ql/n1ql-language-reference/keyspace-hints.html#use-hash-examples) — ditto
* [Specifying an Index Hint](https://simon-dew.github.io/docs-site/DOC-10040/server/current/guides/select-index.html#specifying-an-index-hint) — updated developer guide to use optimizer hints, not USE clause
* [Advantages of the Cost-Based Optimizer](https://simon-dew.github.io/docs-site/DOC-10040/server/current/n1ql/n1ql-language-reference/cost-based-optimizer.html#advantages) — added links to the new optimizer examples

Docs issue: [DOC-10040](https://issues.couchbase.com/browse/DOC-10040)