### PR TITLE
Update eventing-Terminologies.adoc

### DIFF
--- a/modules/eventing/pages/eventing-Terminologies.adoc
+++ b/modules/eventing/pages/eventing-Terminologies.adoc
@@ -116,7 +116,7 @@ At times, the Eventing Function's JavaScript code can trigger data mutations on 
 If the Eventing Function code directly modifies documents in the source collection, the Eventing Service will suppress the mutation back to the Eventing Function making the mutation. 
 When implementing multiple Functions it is possible to create infinite recursions, however the Eventing Service by default will prevent deploying Functions that would result in recursion loops.  It should be noted that not all recursion loops can be detected nor are all recursion loops wrong -- the default recursion checks can be disabled. For more detail on cyclic generation of data changes, refer to xref:troubleshooting-best-practices.adoc#cyclicredun[Bucket Allocation Considerations].
 
-At times, the Eventing Function's JavaScript code can trigger can trigger data mutations on documents via the Query Service (SQL++/N1QL) via inline N1QL statements or N1QL() function calls. In this case the Eventing Function will see the mutation it just generated and additional business logic may be needed to terminate  or protect against possible recursion.
+At times, the Eventing Function's JavaScript code can trigger data mutations on documents via the Query Service (SQL++/N1QL) via inline N1QL statements or N1QL() function calls. In this case the Eventing Function will see the mutation it just generated and additional business logic may be needed to terminate  or protect against possible recursion.
 
 *Eventing Storage (the Eventing metadata)*
 

--- a/modules/eventing/pages/eventing-language-constructs.adoc
+++ b/modules/eventing/pages/eventing-language-constructs.adoc
@@ -21,12 +21,12 @@ The following JavaScript features have been removed and cannot be used in Eventi
 * <<global_state,Global State>>
 * <<asynchrony,Asynchrony>>
 * <<browser_extensions,Browser and other Extensions>>
-* <<added-lang-features,Added Language Features>>
+* <<library_imports,Library Imports>>
 
 [#global_state]
 === Global State
 
-Eventing Functions do not allow global variables. All state must be saved and retrieved from persistence providers. In Couchbase Server, the Data Service provider is used as a persistence provider. Therefore, all global states are contained in the Data Service bucket(s) made available to the Eventing Functions through bindings. This restriction is mandatory for the Eventing Function logic to remain agnostic of the rebalance operation.
+Eventing Functions do not allow global variables. All state must be saved and retrieved from persistence providers. In Couchbase Server, the Data Service is used as a persistence provider. Therefore, all global states are contained in the Data Service bucket(s) made available to the Eventing Functions through bindings. This restriction is mandatory for the Eventing Function logic to remain agnostic of the rebalance operation.
 
 [source,javascript]
 ----
@@ -36,7 +36,7 @@ function OnUpdate(doc, meta) {
 }
 ----
 
-Note the use of 'Constant alias' bindings in the Function's settings can be used to provide global constants accessible within a Function's JavaScript.  For example you might have a Constant alias of _debug_ with a value of _true_ (or _false_) to control verbose logging this would behaves just like adding a statement `const debug = true;` at the beginning of your JavaScript code.
+Note the use of 'Constant alias' bindings in the Function's settings can be used to provide global constants accessible within a Function's JavaScript.  For example you might have a Constant alias of _debug_ with a value of _true_ (or _false_) to control verbose logging this would behave just like adding a statement `const debug = true;` at the beginning of your JavaScript code.
 
 [#asynchrony]
 === Asynchrony
@@ -67,6 +67,11 @@ function OnUpdate(doc, meta) {
   var rpc = window.XMLHttpRequest();  // Not allowed - browser extension.
 }
 ----
+
+[#library_imports]
+=== Library Imports
+
+Eventing service restricts importing libraries into eventing functions.
 
 [#added-lang-features]
 == Added Language Features


### PR DESCRIPTION
Typo `can trigger` repeating twice in the `Eventing Keyspaces` section