### PR TITLE
NO ISSUE: Add alt text to syntax diagrams

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/adaptive-indexing.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/adaptive-indexing.adoc
@@ -46,7 +46,7 @@ Refer to the {createindex}[CREATE INDEX] statement for details of the syntax.
 include::partial$grammar/ddl.ebnf[tag=simple-array-expr]
 ----
 
-image::n1ql-language-reference/simple-array-expr.png[align=left]
+image::n1ql-language-reference/simple-array-expr.png["Syntax diagram: refer to source code listing", align=left]
 
 To create an adaptive index, the index key must be a simple array expression containing a {pairs}[PAIRS()] function.
 
@@ -58,7 +58,7 @@ To create an adaptive index, the index key must be a simple array expression con
 include::partial$grammar/ddl.ebnf[tag=pairs-function]
 ----
 
-image::n1ql-language-reference/pairs-function.png[align=left]
+image::n1ql-language-reference/pairs-function.png["Syntax diagram: refer to source code listing", align=left]
 
 When the `SELF` keyword is used, the adaptive index is created with all fields in the documents of the keyspace.
 
@@ -72,7 +72,7 @@ If you want to create an adaptive index on selected fields only, you must specif
 include::partial$grammar/ddl.ebnf[tag=index-key-object]
 ----
 
-image::n1ql-language-reference/index-key-object.png[align=left]
+image::n1ql-language-reference/index-key-object.png["Syntax diagram: refer to source code listing", align=left]
 
 This is an object of name-value pairs of the document fields that should be indexed.
 

--- a/modules/n1ql/pages/n1ql-language-reference/advise.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/advise.adoc
@@ -75,7 +75,7 @@ For more details about user roles, see xref:learn:security/authorization-overvie
 include::partial$grammar/utility.ebnf[tag=advise]
 ----
 
-image::n1ql-language-reference/advise.png[align=left]
+image::n1ql-language-reference/advise.png["Syntax diagram: refer to source code listing", align=left]
 
 The statement consists of the `ADVISE` keyword, and optionally the `INDEX` keyword, followed by the query for which you want index advice -- a {select}[SELECT] query, an {update}[UPDATE] query, a {delete}[DELETE] query, or a {merge}[MERGE] query.
 

--- a/modules/n1ql/pages/n1ql-language-reference/alterindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/alterindex.adoc
@@ -63,7 +63,7 @@ In addition, altering the number of replicas or deleting an index replica is onl
 include::partial$grammar/ddl.ebnf[tag=alter-index]
 ----
 
-image::n1ql-language-reference/alter-index.png[align=left]
+image::n1ql-language-reference/alter-index.png["Syntax diagram: refer to source code listing", align=left]
 
 The ALTER INDEX statement provides two possible syntaxes for specifying the index and the keyspace where the index is located.
 
@@ -91,7 +91,7 @@ Refer to <<index-with>> below.
 include::partial$grammar/ddl.ebnf[tag=index-path]
 ----
 
-image::n1ql-language-reference/index-path.png[align=left]
+image::n1ql-language-reference/index-path.png["Syntax diagram: refer to source code listing", align=left]
 
 You can use a dotted notation to specify the index and the keyspace on which the index is built.
 This syntax provides compatibility with legacy versions of Couchbase Server.
@@ -108,7 +108,7 @@ Refer to the examples below.
 include::partial$grammar/ddl.ebnf[tag=keyspace-full]
 ----
 
-image::n1ql-language-reference/keyspace-full.png[align=left]
+image::n1ql-language-reference/keyspace-full.png["Syntax diagram: refer to source code listing", align=left]
 
 If the index is built on a named collection, the index path may be a full keyspace path, including namespace, bucket, scope, and collection, followed by the index name.
 In this case, the {query-context}[query context] is ignored.
@@ -138,7 +138,7 @@ For example, `default:{backtick}travel-sample{backtick}.inventory.airline.{backt
 include::partial$grammar/ddl.ebnf[tag=keyspace-prefix]
 ----
 
-image::n1ql-language-reference/keyspace-prefix.png[align=left]
+image::n1ql-language-reference/keyspace-prefix.png["Syntax diagram: refer to source code listing", align=left]
 
 If the index is built on the default collection in the default scope within a bucket, the index path may be just an optional namespace and the bucket name, followed by the index name.
 In this case, the {query-context}[query context] should not be set.
@@ -163,7 +163,7 @@ For example, `default:{backtick}travel-sample{backtick}.def_type` indicates the 
 include::partial$grammar/dql.ebnf[tag=keyspace-partial]
 ----
 
-image::n1ql-language-reference/keyspace-partial.png[align=left]
+image::n1ql-language-reference/keyspace-partial.png["Syntax diagram: refer to source code listing", align=left]
 
 Alternatively, if the keyspace is a named collection, the index path may be just the collection name, followed by the index name.
 In this case, you must set the {query-context}[query context] to indicate the required namespace, bucket, and scope.
@@ -183,7 +183,7 @@ For example, `airline.{backtick}idx-name{backtick}` indicates the `idx-name` ind
 include::partial$grammar/dql.ebnf[tag=keyspace-ref]
 ----
 
-image::n1ql-language-reference/keyspace-ref.png[align=left]
+image::n1ql-language-reference/keyspace-ref.png["Syntax diagram: refer to source code listing", align=left]
 
 In Couchbase Server 7.0 and later, you can use the index name with the `ON` keyword and a keyspace reference to specify the keyspace on which the index is built.
 The keyspace reference may be a <<keyspace-path>> or a <<keyspace-partial>>.
@@ -199,7 +199,7 @@ Refer to the examples below.
 include::partial$grammar/dql.ebnf[tag=keyspace-path]
 ----
 
-image::n1ql-language-reference/keyspace-path.png[align=left]
+image::n1ql-language-reference/keyspace-path.png["Syntax diagram: refer to source code listing", align=left]
 
 If the keyspace is a named collection, or the default collection in the default scope within a bucket, the keyspace reference may be a keyspace path.
 In this case, the {query-context}[query context] should not be set.
@@ -234,7 +234,7 @@ Similarly, `{backtick}idx-name{backtick} ON default:{backtick}travel-sample{back
 include::partial$grammar/dql.ebnf[tag=keyspace-partial]
 ----
 
-image::n1ql-language-reference/keyspace-partial.png[align=left]
+image::n1ql-language-reference/keyspace-partial.png["Syntax diagram: refer to source code listing", align=left]
 
 Alternatively, if the keyspace is a named collection, the keyspace reference may be just the collection name.
 In this case, you must set the {query-context}[query context] to indicate the required namespace, bucket, and scope.
@@ -254,7 +254,7 @@ For example, `{backtick}idx-name{backtick} ON airline` indicates the `idx-name` 
 include::partial$grammar/ddl.ebnf[tag=index-using]
 ----
 
-image::n1ql-language-reference/index-using.png[align=left]
+image::n1ql-language-reference/index-using.png["Syntax diagram: refer to source code listing", align=left]
 
 In Couchbase Server 6.5 and later, the index type for a secondary index must be Global Secondary Index (GSI).
 The `USING GSI` keywords are optional and may be omitted.
@@ -267,7 +267,7 @@ The `USING GSI` keywords are optional and may be omitted.
 include::partial$grammar/ddl.ebnf[tag=index-with]
 ----
 
-image::n1ql-language-reference/index-with.png[align=left]
+image::n1ql-language-reference/index-with.png["Syntax diagram: refer to source code listing", align=left]
 
 Use the `WITH` clause to specify additional options.
 

--- a/modules/n1ql/pages/n1ql-language-reference/begin-transaction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/begin-transaction.adoc
@@ -45,7 +45,7 @@ NOTE: You can also specify a single DML statement as an ACID transaction by sett
 include::partial$grammar/tcl.ebnf[tag=begin-transaction]
 ----
 
-image::n1ql-language-reference/begin-transaction.png[align=left]
+image::n1ql-language-reference/begin-transaction.png["Syntax diagram: refer to source code listing", align=left]
 
 The `BEGIN` and `START` keywords are synonyms.
 The statement must begin with one of these keywords.

--- a/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
@@ -64,7 +64,7 @@ For more details about user roles, see
 include::partial$grammar/ddl.ebnf[tag=build-index]
 ----
 
-image::n1ql-language-reference/build-index.png[align=left]
+image::n1ql-language-reference/build-index.png["Syntax diagram: refer to source code listing", align=left]
 
 // TODO: Automatic links in EBNF.
 
@@ -85,21 +85,21 @@ Refer to <<index-using>> below.
 include::partial$grammar/dql.ebnf[tag=keyspace-ref]
 ----
 
-image::n1ql-language-reference/keyspace-ref.png[align=left]
+image::n1ql-language-reference/keyspace-ref.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#keyspace-path,ebnf,reftext="keyspace path"]
 ----
 include::partial$grammar/dql.ebnf[tag=keyspace-path]
 ----
 
-image::n1ql-language-reference/keyspace-path.png[align=left]
+image::n1ql-language-reference/keyspace-path.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#keyspace-partial,ebnf,reftext="keyspace partial"]
 ----
 include::partial$grammar/dql.ebnf[tag=keyspace-partial]
 ----
 
-image::n1ql-language-reference/keyspace-partial.png[align=left]
+image::n1ql-language-reference/keyspace-partial.png["Syntax diagram: refer to source code listing", align=left]
 
 The simple name or fully-qualified name of the keyspace on which to build the index.
 Refer to the {keyspace-ref}[CREATE INDEX] statement for details of the syntax.
@@ -112,7 +112,7 @@ Refer to the {keyspace-ref}[CREATE INDEX] statement for details of the syntax.
 include::partial$grammar/ddl.ebnf[tag=index-term]
 ----
 
-image::n1ql-language-reference/index-term.png[align=left]
+image::n1ql-language-reference/index-term.png["Syntax diagram: refer to source code listing", align=left]
 
 You can specify one index term, or multiple index terms separated by commas.
 An index term must be specified for each index to be built.
@@ -128,7 +128,7 @@ The BUILD INDEX clause may contain a mixture of the different types of index ter
 include::partial$grammar/dql.ebnf[tag=index-name]
 ----
 
-image::n1ql-language-reference/index-name.png[align=left]
+image::n1ql-language-reference/index-name.png["Syntax diagram: refer to source code listing", align=left]
 
 An {identifiers}[identifier] that refers to the name of an index.
 
@@ -147,7 +147,7 @@ BUILD INDEX ON `travel-sample`.inventory.airline(ix1, ix2, ix3);
 include::partial$grammar/ddl.ebnf[tag=index-expr]
 ----
 
-image::n1ql-language-reference/index-expr.png[align=left]
+image::n1ql-language-reference/index-expr.png["Syntax diagram: refer to source code listing", align=left]
 
 An {expression}[expression] that may be a string, or an array of strings, each referring to the name of an index.
 
@@ -179,7 +179,7 @@ BUILD INDEX ON `travel-sample`.inventory.airline([ix1], [ix2, ix3]);
 include::partial$grammar/dql.ebnf[tag=subquery-expr]
 ----
 
-image::n1ql-language-reference/subquery-expr.png[align=left]
+image::n1ql-language-reference/subquery-expr.png["Syntax diagram: refer to source code listing", align=left]
 
 Use parentheses to specify a subquery.
 
@@ -196,7 +196,7 @@ For more details and examples, see {selectclause}[SELECT Clause] and {subqueries
 include::partial$grammar/ddl.ebnf[tag=index-using]
 ----
 
-image::n1ql-language-reference/index-using.png[align=left]
+image::n1ql-language-reference/index-using.png["Syntax diagram: refer to source code listing", align=left]
 
 The index type for a deferred index build must be Global Secondary Index (GSI).
 The `USING GSI` keywords are optional and may be omitted.

--- a/modules/n1ql/pages/n1ql-language-reference/commit-transaction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/commit-transaction.adoc
@@ -39,7 +39,7 @@ NOTE: If you are using the cbq shell, and a transaction fails for any reason, yo
 include::partial$grammar/tcl.ebnf[tag=commit-transaction]
 ----
 
-image::n1ql-language-reference/commit-transaction.png[align=left]
+image::n1ql-language-reference/commit-transaction.png["Syntax diagram: refer to source code listing", align=left]
 
 The `WORK`, `TRAN`, and `TRANSACTION` keywords are synonyms.
 These keywords are optional; you may include one of these keywords, or omit them entirely.

--- a/modules/n1ql/pages/n1ql-language-reference/createcollection.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createcollection.adoc
@@ -23,7 +23,7 @@
 include::partial$grammar/ddl.ebnf[tag=create-collection]
 ----
 
-image::n1ql-language-reference/create-collection.png[align=left]
+image::n1ql-language-reference/create-collection.png["Syntax diagram: refer to source code listing", align=left]
 
 namespace::
 (Optional) An {identifier}[identifier] that refers to the {logical-hierarchy}[namespace] of the bucket in which you want to create the collection.

--- a/modules/n1ql/pages/n1ql-language-reference/createfunction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createfunction.adoc
@@ -86,7 +86,7 @@ Refer to <<create-function-inline>> or <<create-function-external>> below.
 include::partial$grammar/ddl.ebnf[tag=create-function]
 ----
 
-image::n1ql-language-reference/create-function.png[align=left]
+image::n1ql-language-reference/create-function.png["Syntax diagram: refer to source code listing", align=left]
 
 [[create-function-inline]]
 :section: inline
@@ -100,7 +100,7 @@ The two syntaxes are synonymous.
 include::partial$grammar/ddl.ebnf[tag=create-function-inline]
 ----
 
-image::n1ql-language-reference/create-function-inline.png[align=left]
+image::n1ql-language-reference/create-function-inline.png["Syntax diagram: refer to source code listing", align=left]
 
 // TODO: Automatic links in EBNF.
 
@@ -119,7 +119,7 @@ body:: (Required) Refer to <<inline-expression>> below.
 include::partial$grammar/ddl.ebnf[tag=function]
 ----
 
-image::n1ql-language-reference/function.png[align=left]
+image::n1ql-language-reference/function.png["Syntax diagram: refer to source code listing", align=left]
 
 The function name specifies the name of the function to create.
 It is recommended to use an unqualified identifier for the function name, such as `func1` or `{backtick}func-1{backtick}`.
@@ -139,7 +139,7 @@ A function name with a specified namespace or scope may have the same name as a 
 include::partial$grammar/ddl.ebnf[tag=params]
 ----
 
-image::n1ql-language-reference/params.png[align=left]
+image::n1ql-language-reference/params.png["Syntax diagram: refer to source code listing", align=left]
 
 [Optional] The function parameter list specifies parameters for the function.
 If you specify named parameters for the function, then you must call the function with exactly the same number of arguments at execution time.
@@ -195,7 +195,7 @@ If the statement contains both the `OR REPLACE` clause and the `IF NOT EXISTS` c
 include::partial$grammar/ddl.ebnf[tag=create-function-external]
 ----
 
-image::n1ql-language-reference/create-function-external.png[align=left]
+image::n1ql-language-reference/create-function-external.png["Syntax diagram: refer to source code listing", align=left]
 
 // TODO: Automatic links in EBNF.
 

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -77,7 +77,7 @@ For more details about user roles, see
 include::partial$grammar/ddl.ebnf[tag=create-index]
 ----
 
-image::n1ql-language-reference/create-index.png[align=left]
+image::n1ql-language-reference/create-index.png["Syntax diagram: refer to source code listing", align=left]
 
 [[index-name,index-name]]
 index-name:: [Required] A unique name that identifies the index.
@@ -127,7 +127,7 @@ If an index with the same name already exists within the specified keyspace, the
 include::partial$grammar/dql.ebnf[tag=keyspace-ref]
 ----
 
-image::n1ql-language-reference/keyspace-ref.png[align=left]
+image::n1ql-language-reference/keyspace-ref.png["Syntax diagram: refer to source code listing", align=left]
 
 Specifies the keyspace for which the index needs to be created.
 The keyspace reference may be a <<keyspace-path>> or a <<keyspace-partial>>.
@@ -143,7 +143,7 @@ Refer to the examples below.
 include::partial$grammar/dql.ebnf[tag=keyspace-path]
 ----
 
-image::n1ql-language-reference/keyspace-path.png[align=left]
+image::n1ql-language-reference/keyspace-path.png["Syntax diagram: refer to source code listing", align=left]
 
 If the keyspace is a named collection, or the default collection in the default scope within a bucket, the keyspace reference may be a keyspace path.
 In this case, the {query-context}[query context] should not be set.
@@ -178,7 +178,7 @@ Similarly, `default:{backtick}travel-sample{backtick}.inventory.airline` indicat
 include::partial$grammar/dql.ebnf[tag=keyspace-partial]
 ----
 
-image::n1ql-language-reference/keyspace-partial.png[align=left]
+image::n1ql-language-reference/keyspace-partial.png["Syntax diagram: refer to source code listing", align=left]
 
 Alternatively, if the keyspace is a named collection, the keyspace reference may be just the collection name with no path.
 In this case, you must set the {query-context}[query context] to indicate the required namespace, bucket, and scope.
@@ -198,7 +198,7 @@ For example, `airline` indicates the `airline` collection, assuming the query co
 include::partial$grammar/ddl.ebnf[tag=index-key]
 ----
 
-image::n1ql-language-reference/index-key.png[align=left]
+image::n1ql-language-reference/index-key.png["Syntax diagram: refer to source code listing", align=left]
 
 Refers to an attribute name or a scalar function or an ARRAY expression on the attribute.
 This constitutes an index-key for the index.
@@ -220,7 +220,7 @@ For details about array expressions, refer to <<array-indexing>> below.
 include::partial$grammar/ddl.ebnf[tag=index-order]
 ----
 
-image::n1ql-language-reference/index-order.png[align=left]
+image::n1ql-language-reference/index-order.png["Syntax diagram: refer to source code listing", align=left]
 
 Specifies the sort order of the index key.
 
@@ -246,7 +246,7 @@ For details, refer to <<index-partitioning>> below.
 include::partial$grammar/dql.ebnf[tag=where-clause]
 ----
 
-image::n1ql-language-reference/where-clause.png[align=left]
+image::n1ql-language-reference/where-clause.png["Syntax diagram: refer to source code listing", align=left]
 
 [[where-clause-args]]
 cond::
@@ -260,7 +260,7 @@ Specifies WHERE clause predicates to qualify the subset of documents to include 
 include::partial$grammar/ddl.ebnf[tag=index-using]
 ----
 
-image::n1ql-language-reference/index-using.png[align=left]
+image::n1ql-language-reference/index-using.png["Syntax diagram: refer to source code listing", align=left]
 
 In Couchbase Server 6.5 and later, the index type for a secondary index must be Global Secondary Index (GSI).
 The `USING GSI` keywords are optional and may be omitted.
@@ -273,7 +273,7 @@ The `USING GSI` keywords are optional and may be omitted.
 include::partial$grammar/ddl.ebnf[tag=index-with]
 ----
 
-image::n1ql-language-reference/index-with.png[align=left]
+image::n1ql-language-reference/index-with.png["Syntax diagram: refer to source code listing", align=left]
 
 Use the WITH clause to specify additional options.
 

--- a/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
@@ -69,7 +69,7 @@ For more details about user roles, see
 include::partial$grammar/ddl.ebnf[tag=create-primary-index]
 ----
 
-image::n1ql-language-reference/create-primary-index.png[align=left]
+image::n1ql-language-reference/create-primary-index.png["Syntax diagram: refer to source code listing", align=left]
 
 index-name::
 [Optional] A unique name that identifies the index.
@@ -110,7 +110,7 @@ If a primary index with the same name already exists within the specified keyspa
 include::partial$grammar/dql.ebnf[tag=keyspace-ref]
 ----
 
-image::n1ql-language-reference/keyspace-ref.png[align=left]
+image::n1ql-language-reference/keyspace-ref.png["Syntax diagram: refer to source code listing", align=left]
 
 Specifies the keyspace for which the index needs to be created.
 The keyspace reference may be a <<keyspace-path>> or a <<keyspace-partial>>.
@@ -126,7 +126,7 @@ Refer to the examples below.
 include::partial$grammar/dql.ebnf[tag=keyspace-path]
 ----
 
-image::n1ql-language-reference/keyspace-path.png[align=left]
+image::n1ql-language-reference/keyspace-path.png["Syntax diagram: refer to source code listing", align=left]
 
 If the keyspace is a named collection, or the default collection in the default scope within a bucket, the keyspace reference may be a keyspace path.
 In this case, the {query-context}[query context] should not be set.
@@ -161,7 +161,7 @@ Similarly, `default:{backtick}travel-sample{backtick}.inventory.airline` indicat
 include::partial$grammar/dql.ebnf[tag=keyspace-partial]
 ----
 
-image::n1ql-language-reference/keyspace-partial.png[align=left]
+image::n1ql-language-reference/keyspace-partial.png["Syntax diagram: refer to source code listing", align=left]
 
 Alternatively, if the keyspace is a named collection, the keyspace reference may be just the collection name with no path.
 In this case, you must set the {query-context}[query context] to indicate the required namespace, bucket, and scope.
@@ -181,7 +181,7 @@ For example, `airline` indicates the `airline` collection, assuming the query co
 include::partial$grammar/ddl.ebnf[tag=index-using]
 ----
 
-image::n1ql-language-reference/index-using.png[align=left]
+image::n1ql-language-reference/index-using.png["Syntax diagram: refer to source code listing", align=left]
 
 In Couchbase Server 6.5 and later, the index type for a primary index must be Global Secondary Index (GSI).
 The `USING GSI` keywords are optional and may be omitted.
@@ -194,7 +194,7 @@ The `USING GSI` keywords are optional and may be omitted.
 include::partial$grammar/ddl.ebnf[tag=index-with]
 ----
 
-image::n1ql-language-reference/index-with.png[align=left]
+image::n1ql-language-reference/index-with.png["Syntax diagram: refer to source code listing", align=left]
 
 Use the WITH clause to specify additional options.
 

--- a/modules/n1ql/pages/n1ql-language-reference/createscope.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createscope.adoc
@@ -22,7 +22,7 @@
 include::partial$grammar/ddl.ebnf[tag=create-scope]
 ----
 
-image::n1ql-language-reference/create-scope.png[align=left]
+image::n1ql-language-reference/create-scope.png["Syntax diagram: refer to source code listing", align=left]
 
 namespace::
 (Optional) An {identifier}[identifier] that refers to the {logical-hierarchy}[namespace] of the bucket in which you want to create the scope.

--- a/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
@@ -373,7 +373,7 @@ Format specifiers begin with a percent character `%` and take the following form
 format-specifier ::= '%' ( '%' | ( '-' | '_' | '0' | '^' )? width? element)
 ----
 
-image::n1ql-language-reference/format-specifier.png[align=left]
+image::n1ql-language-reference/format-specifier.png["Syntax diagram: refer to source code listing", align=left]
 
 The optional hyphen (`-`), underscore (`&lowbar;`), or zero (`0`) characters specify the padding for number fields.
 

--- a/modules/n1ql/pages/n1ql-language-reference/delete.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/delete.adoc
@@ -56,7 +56,7 @@ In summary, see the below table.
 include::partial$grammar/dml.ebnf[tag=delete]
 ----
 
-image::n1ql-language-reference/delete.png[align=left]
+image::n1ql-language-reference/delete.png["Syntax diagram: refer to source code listing", align=left]
 
 // TODO: Automatic links from EBNF
 
@@ -75,7 +75,7 @@ returning-clause:: <<returning-clause>> icon:caret-down[]
 include::partial$grammar/dml.ebnf[tag=target-keyspace]
 ----
 
-image::n1ql-language-reference/target-keyspace.png[align=left]
+image::n1ql-language-reference/target-keyspace.png["Syntax diagram: refer to source code listing", align=left]
 
 Specifies the data source from which to delete the document.
 
@@ -91,21 +91,21 @@ alias:: <<delete-alias>> icon:caret-down[]
 include::partial$grammar/dql.ebnf[tag=keyspace-ref]
 ----
 
-image::n1ql-language-reference/keyspace-ref.png[align=left]
+image::n1ql-language-reference/keyspace-ref.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#keyspace-path,ebnf,reftext="keyspace path"]
 ----
 include::partial$grammar/dql.ebnf[tag=keyspace-path]
 ----
 
-image::n1ql-language-reference/keyspace-path.png[align=left]
+image::n1ql-language-reference/keyspace-path.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#keyspace-partial,ebnf,reftext="keyspace partial"]
 ----
 include::partial$grammar/dql.ebnf[tag=keyspace-partial]
 ----
 
-image::n1ql-language-reference/keyspace-partial.png[align=left]
+image::n1ql-language-reference/keyspace-partial.png["Syntax diagram: refer to source code listing", align=left]
 
 Keyspace reference for the delete target.
 For more details, refer to {from-keyspace-ref}[Keyspace Reference].
@@ -133,7 +133,7 @@ For details, refer to {use-keys-clause}[USE KEYS Clause].
 include::partial$grammar/dql.ebnf[tag=where-clause]
 ----
 
-image::n1ql-language-reference/where-clause.png[align=left]
+image::n1ql-language-reference/where-clause.png["Syntax diagram: refer to source code listing", align=left]
 
 Specifies the condition that needs to be met for data to be deleted.
 Optional.
@@ -146,7 +146,7 @@ Optional.
 include::partial$grammar/dql.ebnf[tag=limit-clause]
 ----
 
-image::n1ql-language-reference/limit-clause.png[align=left]
+image::n1ql-language-reference/limit-clause.png["Syntax diagram: refer to source code listing", align=left]
 
 Specifies the greatest number of objects that can be deleted.
 This clause must have a non-negative integer as its upper bound.
@@ -160,7 +160,7 @@ Optional.
 include::partial$grammar/dml.ebnf[tag=returning-clause]
 ----
 
-image::n1ql-language-reference/returning-clause.png[align=left]
+image::n1ql-language-reference/returning-clause.png["Syntax diagram: refer to source code listing", align=left]
 
 Specifies the information to be returned by the operation as a query result.
 For more details, refer to {returning-clause}[RETURNING Clause].

--- a/modules/n1ql/pages/n1ql-language-reference/dropcollection.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropcollection.adoc
@@ -22,7 +22,7 @@
 include::partial$grammar/ddl.ebnf[tag=drop-collection]
 ----
 
-image::n1ql-language-reference/drop-collection.png[align=left]
+image::n1ql-language-reference/drop-collection.png["Syntax diagram: refer to source code listing", align=left]
 
 namespace::
 (Optional) An {identifier}[identifier] that refers to the {logical-hierarchy}[namespace] of the bucket which contains the collection you want to delete.

--- a/modules/n1ql/pages/n1ql-language-reference/dropfunction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropfunction.adoc
@@ -26,7 +26,7 @@ xref:learn:security/authorization-overview.adoc[Authorization].
 include::partial$grammar/ddl.ebnf[tag=drop-function]
 ----
 
-image::n1ql-language-reference/drop-function.png[align=left]
+image::n1ql-language-reference/drop-function.png["Syntax diagram: refer to source code listing", align=left]
 
 // TODO: Automatic links in EBNF.
 
@@ -40,7 +40,7 @@ function:: (Required) Refer to <<name>> below.
 include::partial$grammar/ddl.ebnf[tag=function]
 ----
 
-image::n1ql-language-reference/function.png[align=left]
+image::n1ql-language-reference/function.png["Syntax diagram: refer to source code listing", align=left]
 
 The name of the function.
 This is usually an unqualified identifier, such as `func1` or `{backtick}func-1{backtick}`.

--- a/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
@@ -29,7 +29,7 @@ For more details about user roles, see
 include::partial$grammar/ddl.ebnf[tag=drop-index]
 ----
 
-image::n1ql-language-reference/drop-index.png[align=left]
+image::n1ql-language-reference/drop-index.png["Syntax diagram: refer to source code listing", align=left]
 
 The DROP INDEX statement provides two possible syntaxes for specifying the index and the keyspace where the index is located.
 
@@ -64,7 +64,7 @@ If the index does not exist within the specified keyspace, then:
 include::partial$grammar/ddl.ebnf[tag=index-path]
 ----
 
-image::n1ql-language-reference/index-path.png[align=left]
+image::n1ql-language-reference/index-path.png["Syntax diagram: refer to source code listing", align=left]
 
 You can use a dotted notation to specify the index and the keyspace on which the index is built.
 This syntax provides compatibility with legacy versions of Couchbase Server.
@@ -81,7 +81,7 @@ Refer to the examples below.
 include::partial$grammar/ddl.ebnf[tag=keyspace-full]
 ----
 
-image::n1ql-language-reference/keyspace-full.png[align=left]
+image::n1ql-language-reference/keyspace-full.png["Syntax diagram: refer to source code listing", align=left]
 
 If the index is built on a named collection, the index path may be a full keyspace path, including namespace, bucket, scope, and collection, followed by the index name.
 In this case, the {query-context}[query context] is ignored.
@@ -111,7 +111,7 @@ For example, `default:{backtick}travel-sample{backtick}.inventory.airline.{backt
 include::partial$grammar/ddl.ebnf[tag=keyspace-prefix]
 ----
 
-image::n1ql-language-reference/keyspace-prefix.png[align=left]
+image::n1ql-language-reference/keyspace-prefix.png["Syntax diagram: refer to source code listing", align=left]
 
 If the index is built on the default collection in the default scope within a bucket, the index path may be just an optional namespace and the bucket name, followed by the index name.
 In this case, the {query-context}[query context] should not be set.
@@ -136,7 +136,7 @@ For example, `default:{backtick}travel-sample{backtick}.def_type` indicates the 
 include::partial$grammar/dql.ebnf[tag=keyspace-partial]
 ----
 
-image::n1ql-language-reference/keyspace-partial.png[align=left]
+image::n1ql-language-reference/keyspace-partial.png["Syntax diagram: refer to source code listing", align=left]
 
 Alternatively, if the keyspace is a named collection, the index path may be just the collection name, followed by the index name.
 In this case, you must set the {query-context}[query context] to indicate the required namespace, bucket, and scope.
@@ -156,7 +156,7 @@ For example, `airline.{backtick}idx-name{backtick}` indicates the `idx-name` ind
 include::partial$grammar/dql.ebnf[tag=keyspace-ref]
 ----
 
-image::n1ql-language-reference/keyspace-ref.png[align=left]
+image::n1ql-language-reference/keyspace-ref.png["Syntax diagram: refer to source code listing", align=left]
 
 In Couchbase Server 7.0 and later, you can use the index name with the `ON` keyword and a keyspace reference to specify the keyspace on which the index is built.
 The keyspace reference may be a <<keyspace-path>> or a <<keyspace-partial>>.
@@ -172,7 +172,7 @@ Refer to the examples below.
 include::partial$grammar/dql.ebnf[tag=keyspace-path]
 ----
 
-image::n1ql-language-reference/keyspace-path.png[align=left]
+image::n1ql-language-reference/keyspace-path.png["Syntax diagram: refer to source code listing", align=left]
 
 If the keyspace is a named collection, or the default collection in the default scope within a bucket, the keyspace reference may be a keyspace path.
 In this case, the {query-context}[query context] should not be set.
@@ -207,7 +207,7 @@ Similarly, `{backtick}idx-name{backtick} ON default:{backtick}travel-sample{back
 include::partial$grammar/dql.ebnf[tag=keyspace-partial]
 ----
 
-image::n1ql-language-reference/keyspace-partial.png[align=left]
+image::n1ql-language-reference/keyspace-partial.png["Syntax diagram: refer to source code listing", align=left]
 
 Alternatively, if the keyspace is a named collection, the keyspace reference may be just the collection name.
 In this case, you must set the {query-context}[query context] to indicate the required namespace, bucket, and scope.
@@ -227,7 +227,7 @@ For example, `{backtick}idx-name{backtick} ON airline` indicates the `idx-name` 
 include::partial$grammar/ddl.ebnf[tag=index-using]
 ----
 
-image::n1ql-language-reference/index-using.png[align=left]
+image::n1ql-language-reference/index-using.png["Syntax diagram: refer to source code listing", align=left]
 
 In Couchbase Server 6.5 and later, the index type for a secondary index must be Global Secondary Index (GSI).
 The `USING GSI` keywords are optional and may be omitted.

--- a/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
@@ -27,7 +27,7 @@ For more details about user roles, see {roles}[Roles].
 include::partial$grammar/ddl.ebnf[tag=drop-primary-index]
 ----
 
-image::n1ql-language-reference/drop-primary-index.png[align=left]
+image::n1ql-language-reference/drop-primary-index.png["Syntax diagram: refer to source code listing", align=left]
 
 // TODO: Automatic links in EBNF.
 
@@ -55,7 +55,7 @@ If the primary index does not exist within the specified keyspace, then:
 include::partial$grammar/dql.ebnf[tag=keyspace-ref]
 ----
 
-image::n1ql-language-reference/keyspace-ref.png[align=left]
+image::n1ql-language-reference/keyspace-ref.png["Syntax diagram: refer to source code listing", align=left]
 
 Specifies the keyspace for the primary index to drop.
 The keyspace reference may be a <<keyspace-path>> or a <<keyspace-partial>>.
@@ -71,7 +71,7 @@ Refer to the examples below.
 include::partial$grammar/dql.ebnf[tag=keyspace-path]
 ----
 
-image::n1ql-language-reference/keyspace-path.png[align=left]
+image::n1ql-language-reference/keyspace-path.png["Syntax diagram: refer to source code listing", align=left]
 
 If the keyspace is a named collection, or the default collection in the default scope within a bucket, the keyspace reference may be a keyspace path.
 In this case, the {query-context}[query context] should not be set.
@@ -106,7 +106,7 @@ Similarly, `default:{backtick}travel-sample{backtick}.inventory.airline` indicat
 include::partial$grammar/dql.ebnf[tag=keyspace-partial]
 ----
 
-image::n1ql-language-reference/keyspace-partial.png[align=left]
+image::n1ql-language-reference/keyspace-partial.png["Syntax diagram: refer to source code listing", align=left]
 
 Alternatively, if the keyspace is a named collection, the keyspace reference may be just the collection name with no path.
 In this case, you must set the {query-context}[query context] to indicate the required namespace, bucket, and scope.
@@ -126,7 +126,7 @@ For example, `airline` indicates the `airline` collection, assuming the query co
 include::partial$grammar/ddl.ebnf[tag=index-using]
 ----
 
-image::n1ql-language-reference/index-using.png[align=left]
+image::n1ql-language-reference/index-using.png["Syntax diagram: refer to source code listing", align=left]
 
 In Couchbase Server 6.5 and later, the index type for a primary index must be Global Secondary Index (GSI).
 The `USING GSI` keywords are optional and may be omitted.

--- a/modules/n1ql/pages/n1ql-language-reference/dropscope.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropscope.adoc
@@ -21,7 +21,7 @@
 include::partial$grammar/ddl.ebnf[tag=drop-scope]
 ----
 
-image::n1ql-language-reference/drop-scope.png[align=left]
+image::n1ql-language-reference/drop-scope.png["Syntax diagram: refer to source code listing", align=left]
 
 namespace::
 (Optional) An {identifier}[identifier] that refers to the {logical-hierarchy}[namespace] of the bucket which contains the scope you want to delete.

--- a/modules/n1ql/pages/n1ql-language-reference/execute.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/execute.adoc
@@ -14,7 +14,7 @@
 include::partial$grammar/utility.ebnf[tag=execute]
 ----
 
-image::n1ql-language-reference/execute.png[align=left]
+image::n1ql-language-reference/execute.png["Syntax diagram: refer to source code listing", align=left]
 
 name::
 The name of the prepared statement.

--- a/modules/n1ql/pages/n1ql-language-reference/explain.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/explain.adoc
@@ -37,7 +37,7 @@ EXPLAIN UPSERT INTO testbucket VALUES ("key1", { "a" : "b" }) RETURNING meta().c
 include::partial$grammar/utility.ebnf[tag=explain]
 ----
 
-image::n1ql-language-reference/explain.png[align=left]
+image::n1ql-language-reference/explain.png["Syntax diagram: refer to source code listing", align=left]
 
 The statement consists of the `EXPLAIN` keyword, followed by the query whose execution plan you want to see.
 

--- a/modules/n1ql/pages/n1ql-language-reference/grant.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/grant.adoc
@@ -34,7 +34,7 @@ For more details about user roles, see {authorization-overview}[Authorization].
 include::partial$grammar/dcl.ebnf[tag=grant]
 ----
 
-image::n1ql-language-reference/grant.png[align=left]
+image::n1ql-language-reference/grant.png["Syntax diagram: refer to source code listing", align=left]
 
 role::
 One of the {authorization-overview}[RBAC role names predefined] by Couchbase Server.
@@ -57,21 +57,21 @@ A user name created by the Couchbase Server RBAC system.
 include::partial$grammar/dql.ebnf[tag=keyspace-ref]
 ----
 
-image::n1ql-language-reference/keyspace-ref.png[align=left]
+image::n1ql-language-reference/keyspace-ref.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#keyspace-path,ebnf,reftext="keyspace path"]
 ----
 include::partial$grammar/dql.ebnf[tag=keyspace-path]
 ----
 
-image::n1ql-language-reference/keyspace-path.png[align=left]
+image::n1ql-language-reference/keyspace-path.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#keyspace-partial,ebnf,reftext="keyspace partial"]
 ----
 include::partial$grammar/dql.ebnf[tag=keyspace-partial]
 ----
 
-image::n1ql-language-reference/keyspace-partial.png[align=left]
+image::n1ql-language-reference/keyspace-partial.png["Syntax diagram: refer to source code listing", align=left]
 
 The simple name or fully-qualified name of a keyspace.
 Refer to the {keyspace-ref}[CREATE INDEX] statement for details of the syntax.

--- a/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
@@ -52,7 +52,7 @@ Refer to the {createindex}[CREATE INDEX] statement for details of the syntax.
 include::partial$grammar/ddl.ebnf[tag=index-partition]
 ----
 
-image::n1ql-language-reference/index-partition.png[align=left]
+image::n1ql-language-reference/index-partition.png["Syntax diagram: refer to source code listing", align=left]
 
 _partition-key-expr_::
 A field or an expression over a field representing a partition key.
@@ -66,7 +66,7 @@ For details and examples, refer to <<partition-keys>>.
 include::partial$grammar/ddl.ebnf[tag=index-with]
 ----
 
-image::n1ql-language-reference/index-with.png[align=left]
+image::n1ql-language-reference/index-with.png["Syntax diagram: refer to source code listing", align=left]
 
 When creating a partitioned index, you can use the WITH clause to specify additional options for the partitions.
 

--- a/modules/n1ql/pages/n1ql-language-reference/indexing-arrays.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/indexing-arrays.adoc
@@ -30,7 +30,7 @@ Refer to the {createindex}[CREATE INDEX] statement for details of the syntax.
 include::partial$grammar/ddl.ebnf[tag=index-key]
 ----
 
-image::n1ql-language-reference/index-key.png[align=left]
+image::n1ql-language-reference/index-key.png["Syntax diagram: refer to source code listing", align=left]
 
 To create an array index, one index key must be an array expression.
 The index key containing the array expression is referred to as the _array index key_.
@@ -66,7 +66,7 @@ See <<query-predicate-format>> for details.
 include::partial$grammar/ddl.ebnf[tag=array-expr]
 ----
 
-image::n1ql-language-reference/array-expr.png[align=left]
+image::n1ql-language-reference/array-expr.png["Syntax diagram: refer to source code listing", align=left]
 
 The array expression can be either a <<full-array-expr>>, which uses the `ARRAY` operator to index specified fields and elements within the array; or a <<simple-array-expr>>, which indexes all fields and elements in the array.
 
@@ -78,7 +78,7 @@ The array expression can be either a <<full-array-expr>>, which uses the `ARRAY`
 include::partial$grammar/ddl.ebnf[tag=full-array-expr]
 ----
 
-image::n1ql-language-reference/full-array-expr.png[align=left]
+image::n1ql-language-reference/full-array-expr.png["Syntax diagram: refer to source code listing", align=left]
 
 The `ARRAY` operator lets you map and filter the elements or attributes of a collection, object, or objects.
 It evaluates to an array of the operand expression that satisfies the WHEN clause, if specified.
@@ -120,7 +120,7 @@ Refer to <<example-6>> below.
 include::partial$grammar/ddl.ebnf[tag=simple-array-expr]
 ----
 
-image::n1ql-language-reference/simple-array-expr.png[align=left]
+image::n1ql-language-reference/simple-array-expr.png["Syntax diagram: refer to source code listing", align=left]
 
 Couchbase Server 5.0 and later provides a simpler syntax for array indexing when all array elements are indexed as is, without needing to use the `ARRAY` operator in the index definition.
 

--- a/modules/n1ql/pages/n1ql-language-reference/infer.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/infer.adoc
@@ -33,7 +33,7 @@ For example, to execute <<ex-1>> below, you must have the _Query Select_ privile
 include::partial$grammar/utility.ebnf[tag=infer]
 ----
 
-image::n1ql-language-reference/infer.png[align=left]
+image::n1ql-language-reference/infer.png["Syntax diagram: refer to source code listing", align=left]
 
 The `COLLECTION` or `KEYSPACE` keywords are optional.
 These keywords are purely a visual mnemonic;
@@ -53,21 +53,21 @@ options:: <<infer-parameters>> icon:caret-down[]
 include::partial$grammar/dql.ebnf[tag=keyspace-ref]
 ----
 
-image::n1ql-language-reference/keyspace-ref.png[align=left]
+image::n1ql-language-reference/keyspace-ref.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#keyspace-path,ebnf,reftext="keyspace path"]
 ----
 include::partial$grammar/dql.ebnf[tag=keyspace-path]
 ----
 
-image::n1ql-language-reference/keyspace-path.png[align=left]
+image::n1ql-language-reference/keyspace-path.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#keyspace-partial,ebnf,reftext="keyspace partial"]
 ----
 include::partial$grammar/dql.ebnf[tag=keyspace-partial]
 ----
 
-image::n1ql-language-reference/keyspace-partial.png[align=left]
+image::n1ql-language-reference/keyspace-partial.png["Syntax diagram: refer to source code listing", align=left]
 
 The simple name or fully-qualified name of a keyspace.
 Refer to the {keyspace-ref}[CREATE INDEX] statement for details of the syntax.

--- a/modules/n1ql/pages/n1ql-language-reference/insert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/insert.adoc
@@ -120,7 +120,7 @@ FROM `travel-sample`.inventory.hotel AS doc;
 include::partial$grammar/dml.ebnf[tag=insert]
 ----
 
-image::n1ql-language-reference/insert.png[align=left]
+image::n1ql-language-reference/insert.png["Syntax diagram: refer to source code listing", align=left]
 
 // TODO: Automatic links from EBNF
 
@@ -138,7 +138,7 @@ returning-clause:: <<returning-clause>> icon:caret-down[]
 include::partial$grammar/dml.ebnf[tag=target-keyspace]
 ----
 
-image::n1ql-language-reference/target-keyspace.png[align=left]
+image::n1ql-language-reference/target-keyspace.png["Syntax diagram: refer to source code listing", align=left]
 
 The insert target is the keyspace into which the documents are inserted.
 Ensure that the keyspace exists before trying to insert a document.
@@ -155,21 +155,21 @@ alias:: <<insert-target-alias>> icon:caret-down[]
 include::partial$grammar/dql.ebnf[tag=keyspace-ref]
 ----
 
-image::n1ql-language-reference/keyspace-ref.png[align=left]
+image::n1ql-language-reference/keyspace-ref.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#keyspace-path,ebnf,reftext="keyspace path"]
 ----
 include::partial$grammar/dql.ebnf[tag=keyspace-path]
 ----
 
-image::n1ql-language-reference/keyspace-path.png[align=left]
+image::n1ql-language-reference/keyspace-path.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#keyspace-partial,ebnf,reftext="keyspace partial"]
 ----
 include::partial$grammar/dql.ebnf[tag=keyspace-partial]
 ----
 
-image::n1ql-language-reference/keyspace-partial.png[align=left]
+image::n1ql-language-reference/keyspace-partial.png["Syntax diagram: refer to source code listing", align=left]
 
 Keyspace reference for the insert target.
 For more details, refer to {from-keyspace-ref}[Keyspace Reference].
@@ -190,7 +190,7 @@ If you assign an alias to the keyspace reference, the `AS` keyword may be omitte
 ----
 include::partial$grammar/dml.ebnf[tag=insert-values]
 ----
-image::n1ql-language-reference/insert-values.png[align=left]
+image::n1ql-language-reference/insert-values.png["Syntax diagram: refer to source code listing", align=left]
 
 Specifies one or more documents to be inserted using the VALUES clause.
 Each document requires a unique key and the values must be specified as well-formed JSON.
@@ -213,7 +213,7 @@ There is no syntactic requirement to include the OPTIONS keyword when setting me
 include::partial$grammar/dml.ebnf[tag=values-clause]
 ----
 
-image::n1ql-language-reference/values-clause.png[align=left]
+image::n1ql-language-reference/values-clause.png["Syntax diagram: refer to source code listing", align=left]
 
 [horizontal]
 key::
@@ -404,7 +404,7 @@ For more examples illustrating the variations of the values-clause, see <<insert
 include::partial$grammar/dml.ebnf[tag=insert-select]
 ----
 
-image::n1ql-language-reference/insert-select.png[align=left]
+image::n1ql-language-reference/insert-select.png["Syntax diagram: refer to source code listing", align=left]
 
 Use the projection of a SELECT statement which generates well-formed JSON to insert.
 
@@ -493,7 +493,7 @@ See <<Example_15_copy_bucket>> to use the INSERT statement to copy one keyspace'
 include::partial$grammar/dml.ebnf[tag=returning-clause]
 ----
 
-image::n1ql-language-reference/returning-clause.png[align=left]
+image::n1ql-language-reference/returning-clause.png["Syntax diagram: refer to source code listing", align=left]
 
 Specifies the fields that must be returned as part of the results object.
 
@@ -508,7 +508,7 @@ result-expr:: <<result-expr>> icon:caret-down[]
 include::partial$grammar/dql.ebnf[tag=result-expr]
 ----
 
-image::n1ql-language-reference/result-expr.png[align=left]
+image::n1ql-language-reference/result-expr.png["Syntax diagram: refer to source code listing", align=left]
 
 Specifies an expression on the inserted documents, that will be returned as output.
 Use `*` to return all the fields in all the documents that were inserted.

--- a/modules/n1ql/pages/n1ql-language-reference/keyspace-hints.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/keyspace-hints.adoc
@@ -34,7 +34,7 @@ If not specified, the optimizer selects the optimal available index.
 include::partial$grammar/hints.ebnf[tag=gsi-hint-simple]
 ----
 
-image::n1ql-language-reference/gsi-hint-simple.png[align=left]
+image::n1ql-language-reference/gsi-hint-simple.png["Syntax diagram: refer to source code listing", align=left]
 
 With the simple syntax, this hint specifies a single keyspace expression, and zero, one, or more indexes.
 You can use this hint multiple times within the hint comment to specify hints for more than one keyspace.
@@ -57,7 +57,7 @@ This argument is optional; if omitted, the optimizer considers _all_ secondary i
 include::partial$grammar/hints.ebnf[tag=gsi-hint-json]
 ----
 
-image::n1ql-language-reference/gsi-hint-json.png[align=left]
+image::n1ql-language-reference/gsi-hint-json.png["Syntax diagram: refer to source code listing", align=left]
 
 With the JSON syntax, this hint takes the form of an `index` property.
 You may only use this property once within the hint comment.
@@ -71,7 +71,7 @@ The value of this property may be an <<index-array>> or an <<index-object>>.
 include::partial$grammar/hints.ebnf[tag=index-array]
 ----
 
-image::n1ql-language-reference/index-array.png[align=left]
+image::n1ql-language-reference/index-array.png["Syntax diagram: refer to source code listing", align=left]
 
 Use this array to specify indexes for multiple keyspaces.
 Each element must be an <<index-object>>.
@@ -84,7 +84,7 @@ Each element must be an <<index-object>>.
 include::partial$grammar/hints.ebnf[tag=index-object]
 ----
 
-image::n1ql-language-reference/index-object.png[align=left]
+image::n1ql-language-reference/index-object.png["Syntax diagram: refer to source code listing", align=left]
 
 Use this object to specify indexes for a single keyspace.
 It must contain a <<keyspace-property>> and an <<indexes-property>>.
@@ -98,7 +98,7 @@ The order of the properties within the object is not significant.
 include::partial$grammar/hints.ebnf[tag=keyspace-property]
 ----
 
-image::n1ql-language-reference/keyspace-property.png[align=left]
+image::n1ql-language-reference/keyspace-property.png["Syntax diagram: refer to source code listing", align=left]
 
 Synonym for `"keyspace"`: `"alias"`
 
@@ -114,7 +114,7 @@ The value of this property is the keyspace or alias to which this hint applies.
 include::partial$grammar/hints.ebnf[tag=indexes-property]
 ----
 
-image::n1ql-language-reference/indexes-property.png[align=left]
+image::n1ql-language-reference/indexes-property.png["Syntax diagram: refer to source code listing", align=left]
 
 The value of this property may be:
 
@@ -199,7 +199,7 @@ If not specified, the optimizer selects the optimal available index.
 include::partial$grammar/hints.ebnf[tag=fts-hint-simple]
 ----
 
-image::n1ql-language-reference/fts-hint-simple.png[align=left]
+image::n1ql-language-reference/fts-hint-simple.png["Syntax diagram: refer to source code listing", align=left]
 
 With the simple syntax, this hint specifies a single keyspace expression; and zero, one, or more indexes.
 You can use this hint multiple times within the hint comment to specify hints for more than one keyspace.
@@ -220,7 +220,7 @@ This argument is optional; if omitted, the optimizer considers _all_ full-text i
 include::partial$grammar/hints.ebnf[tag=fts-hint-json]
 ----
 
-image::n1ql-language-reference/fts-hint-json.png[align=left]
+image::n1ql-language-reference/fts-hint-json.png["Syntax diagram: refer to source code listing", align=left]
 
 With the JSON syntax, this hint takes the form of an `index_fts` property.
 You may only use this property once within the hint comment.
@@ -234,7 +234,7 @@ The value of this property may be an <<index-array-fts>> or an <<index-object-ft
 include::partial$grammar/hints.ebnf[tag=index-array]
 ----
 
-image::n1ql-language-reference/index-array.png[align=left]
+image::n1ql-language-reference/index-array.png["Syntax diagram: refer to source code listing", align=left]
 
 Use this array to specify indexes for multiple keyspaces.
 Each element must be an <<index-object-fts>>.
@@ -247,7 +247,7 @@ Each element must be an <<index-object-fts>>.
 include::partial$grammar/hints.ebnf[tag=index-object]
 ----
 
-image::n1ql-language-reference/index-object.png[align=left]
+image::n1ql-language-reference/index-object.png["Syntax diagram: refer to source code listing", align=left]
 
 Use this object to specify indexes for a single keyspace.
 It must contain a <<keyspace-property-fts>> and an <<indexes-property-fts>>.
@@ -261,7 +261,7 @@ The order of the properties within the object is not significant.
 include::partial$grammar/hints.ebnf[tag=keyspace-property]
 ----
 
-image::n1ql-language-reference/keyspace-property.png[align=left]
+image::n1ql-language-reference/keyspace-property.png["Syntax diagram: refer to source code listing", align=left]
 
 Synonym for `"keyspace"`: `"alias"`
 
@@ -275,7 +275,7 @@ include::keyspace-hints.adoc[tag=keyspace-property]
 include::partial$grammar/hints.ebnf[tag=indexes-property]
 ----
 
-image::n1ql-language-reference/indexes-property.png[align=left]
+image::n1ql-language-reference/indexes-property.png["Syntax diagram: refer to source code listing", align=left]
 
 The value of this property may be:
 
@@ -334,7 +334,7 @@ If not specified, the optimizer selects the optimal join method.
 include::partial$grammar/hints.ebnf[tag=nl-hint-simple]
 ----
 
-image::n1ql-language-reference/nl-hint-simple.png[align=left]
+image::n1ql-language-reference/nl-hint-simple.png["Syntax diagram: refer to source code listing", align=left]
 
 With the simple syntax, this hint specifies one or more keyspaces.
 You may also use this hint multiple times within the hint comment.
@@ -351,7 +351,7 @@ include::keyspace-hints.adoc[tag=keyspace]
 include::partial$grammar/hints.ebnf[tag=nl-hint-json]
 ----
 
-image::n1ql-language-reference/nl-hint-json.png[align=left]
+image::n1ql-language-reference/nl-hint-json.png["Syntax diagram: refer to source code listing", align=left]
 
 With the JSON syntax, this hint takes the form of a `use_nl` property.
 You may only use this property once within the hint comment.
@@ -365,7 +365,7 @@ The value of this property may be a <<keyspace-array>> or a <<keyspace-object>>.
 include::partial$grammar/hints.ebnf[tag=keyspace-array]
 ----
 
-image::n1ql-language-reference/keyspace-array.png[align=left]
+image::n1ql-language-reference/keyspace-array.png["Syntax diagram: refer to source code listing", align=left]
 
 Use this array to apply the hint to multiple keyspaces.
 Each element must be a <<keyspace-object>>.
@@ -378,7 +378,7 @@ Each element must be a <<keyspace-object>>.
 include::partial$grammar/hints.ebnf[tag=keyspace-object]
 ----
 
-image::n1ql-language-reference/keyspace-object.png[align=left]
+image::n1ql-language-reference/keyspace-object.png["Syntax diagram: refer to source code listing", align=left]
 
 Use this object to apply the hint to a single keyspace.
 It must contain a <<keyspace-property-nl>>.
@@ -391,7 +391,7 @@ It must contain a <<keyspace-property-nl>>.
 include::partial$grammar/hints.ebnf[tag=keyspace-property]
 ----
 
-image::n1ql-language-reference/keyspace-property.png[align=left]
+image::n1ql-language-reference/keyspace-property.png["Syntax diagram: refer to source code listing", align=left]
 
 Synonym for `"keyspace"`: `"alias"`
 
@@ -477,7 +477,7 @@ NOTE: For Couchbase Server Community Edition (CE), only nested-loop join is cons
 include::partial$grammar/hints.ebnf[tag=hash-hint-simple]
 ----
 
-image::n1ql-language-reference/hash-hint-simple.png[align=left]
+image::n1ql-language-reference/hash-hint-simple.png["Syntax diagram: refer to source code listing", align=left]
 
 With the simple syntax, this hint specifies one or more keyspaces.
 For each keyspace, you may also add a slash, followed by an option.
@@ -509,7 +509,7 @@ If you omit the option (including the slash), the optimizer determines whether t
 include::partial$grammar/hints.ebnf[tag=hash-hint-json]
 ----
 
-image::n1ql-language-reference/hash-hint-json.png[align=left]
+image::n1ql-language-reference/hash-hint-json.png["Syntax diagram: refer to source code listing", align=left]
 
 With the JSON syntax, this hint takes the form of a `use_hash` property.
 You may only use this property once within the hint comment.
@@ -523,7 +523,7 @@ The value of this property may be a <<hash-array>> or a <<hash-object>>.
 include::partial$grammar/hints.ebnf[tag=hash-array]
 ----
 
-image::n1ql-language-reference/hash-array.png[align=left]
+image::n1ql-language-reference/hash-array.png["Syntax diagram: refer to source code listing", align=left]
 
 Use this array to apply the hint to multiple keyspaces.
 Each element must be a <<hash-object>>.
@@ -536,7 +536,7 @@ Each element must be a <<hash-object>>.
 include::partial$grammar/hints.ebnf[tag=hash-object]
 ----
 
-image::n1ql-language-reference/hash-object.png[align=left]
+image::n1ql-language-reference/hash-object.png["Syntax diagram: refer to source code listing", align=left]
 
 Use this object to apply the hint to a single keyspace.
 It must contain a <<keyspace-property-hash>> and an optional <<option-property>>.
@@ -550,7 +550,7 @@ The order of the properties within the object is not significant.
 include::partial$grammar/hints.ebnf[tag=keyspace-property]
 ----
 
-image::n1ql-language-reference/keyspace-property.png[align=left]
+image::n1ql-language-reference/keyspace-property.png["Syntax diagram: refer to source code listing", align=left]
 
 Synonym for `"keyspace"`: `"alias"`
 
@@ -564,7 +564,7 @@ include::keyspace-hints.adoc[tag=keyspace-property]
 include::partial$grammar/hints.ebnf[tag=option-property]
 ----
 
-image::n1ql-language-reference/option-property.png[align=left]
+image::n1ql-language-reference/option-property.png["Syntax diagram: refer to source code listing", align=left]
 
 The value of this property may be:
 

--- a/modules/n1ql/pages/n1ql-language-reference/merge.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/merge.adoc
@@ -69,7 +69,7 @@ When the document expires, the data service deletes the document, even though th
 include::partial$grammar/dml.ebnf[tag=merge]
 ----
 
-image::n1ql-language-reference/merge.png[align=left]
+image::n1ql-language-reference/merge.png["Syntax diagram: refer to source code listing", align=left]
 
 // TODO: Automatic links from EBNF
 
@@ -87,7 +87,7 @@ returning-clause:: <<returning-clause>> icon:caret-down[]
 include::partial$grammar/dml.ebnf[tag=ansi-merge]
 ----
 
-image::n1ql-language-reference/ansi-merge.png[align=left]
+image::n1ql-language-reference/ansi-merge.png["Syntax diagram: refer to source code listing", align=left]
 
 [horizontal.compact]
 target-keyspace:: <<ansi-merge-target>> icon:caret-down[]
@@ -104,7 +104,7 @@ ansi-merge-actions:: <<ansi-merge-actions>> icon:caret-down[]
 include::partial$grammar/dml.ebnf[tag=target-keyspace]
 ----
 
-image::n1ql-language-reference/target-keyspace.png[align=left]
+image::n1ql-language-reference/target-keyspace.png["Syntax diagram: refer to source code listing", align=left]
 
 The merge target is the keyspace which you want to update, insert into, or delete from.
 
@@ -120,21 +120,21 @@ alias:: <<ansi-target-alias>> icon:caret-down[]
 include::partial$grammar/dql.ebnf[tag=keyspace-ref]
 ----
 
-image::n1ql-language-reference/keyspace-ref.png[align=left]
+image::n1ql-language-reference/keyspace-ref.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#keyspace-path,ebnf,reftext="keyspace path"]
 ----
 include::partial$grammar/dql.ebnf[tag=keyspace-path]
 ----
 
-image::n1ql-language-reference/keyspace-path.png[align=left]
+image::n1ql-language-reference/keyspace-path.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#keyspace-partial,ebnf,reftext="keyspace partial"]
 ----
 include::partial$grammar/dql.ebnf[tag=keyspace-partial]
 ----
 
-image::n1ql-language-reference/keyspace-partial.png[align=left]
+image::n1ql-language-reference/keyspace-partial.png["Syntax diagram: refer to source code listing", align=left]
 
 Keyspace reference for the merge target.
 For more details, refer to {from-keyspace-ref}[Keyspace Reference].
@@ -165,7 +165,7 @@ You cannot specify a `USE KEYS` hint or a join hint (`USE NL` or `USE HASH`) on 
 include::partial$grammar/dml.ebnf[tag=ansi-merge-source]
 ----
 
-image::n1ql-language-reference/ansi-merge-source.png[align=left]
+image::n1ql-language-reference/ansi-merge-source.png["Syntax diagram: refer to source code listing", align=left]
 
 The merge source is the recordset that you want to merge with the merge target.
 It can be a keyspace reference, a subquery, or a generic expression.
@@ -184,7 +184,7 @@ ansi-join-hints:: <<ansi-merge-source-hints>> icon:caret-down[]
 include::partial$grammar/dml.ebnf[tag=merge-source-keyspace]
 ----
 
-image::n1ql-language-reference/merge-source-keyspace.png[align=left]
+image::n1ql-language-reference/merge-source-keyspace.png["Syntax diagram: refer to source code listing", align=left]
 
 [horizontal.compact]
 keyspace-ref:: <<ansi-keyspace-ref>> icon:caret-down[]
@@ -198,21 +198,21 @@ alias:: <<ansi-keyspace-alias>> icon:caret-down[]
 include::partial$grammar/dql.ebnf[tag=keyspace-ref]
 ----
 
-image::n1ql-language-reference/keyspace-ref.png[align=left]
+image::n1ql-language-reference/keyspace-ref.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#source-keyspace-path,ebnf,reftext="keyspace path"]
 ----
 include::partial$grammar/dql.ebnf[tag=keyspace-path]
 ----
 
-image::n1ql-language-reference/keyspace-path.png[align=left]
+image::n1ql-language-reference/keyspace-path.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#source-keyspace-partial,ebnf,reftext="keyspace partial"]
 ----
 include::partial$grammar/dql.ebnf[tag=keyspace-partial]
 ----
 
-image::n1ql-language-reference/keyspace-partial.png[align=left]
+image::n1ql-language-reference/keyspace-partial.png["Syntax diagram: refer to source code listing", align=left]
 
 Keyspace reference for the merge source.
 For details, refer to {from-keyspace-ref}[Keyspace Reference].
@@ -234,7 +234,7 @@ If you assign an alias to the keyspace reference, the `AS` keyword may be omitte
 include::partial$grammar/dml.ebnf[tag=merge-source-subquery]
 ----
 
-image::n1ql-language-reference/merge-source-subquery.png[align=left]
+image::n1ql-language-reference/merge-source-subquery.png["Syntax diagram: refer to source code listing", align=left]
 
 [horizontal.compact]
 subquery-expr:: <<ansi-subquery-expr>> icon:caret-down[]
@@ -248,7 +248,7 @@ alias:: <<ansi-subquery-alias>> icon:caret-down[]
 include::partial$grammar/dql.ebnf[tag=subquery-expr]
 ----
 
-image::n1ql-language-reference/subquery-expr.png[align=left]
+image::n1ql-language-reference/subquery-expr.png["Syntax diagram: refer to source code listing", align=left]
 
 // {selectclause}[select]
 
@@ -272,7 +272,7 @@ However, when you assign an alias to the subquery, the `AS` keyword may be omitt
 include::partial$grammar/dml.ebnf[tag=merge-source-expr]
 ----
 
-image::n1ql-language-reference/merge-source-expr.png[align=left]
+image::n1ql-language-reference/merge-source-expr.png["Syntax diagram: refer to source code listing", align=left]
 
 [horizontal.compact]
 expr:: A N1QL {expression}[expression] generating JSON documents or objects for the merge source.
@@ -317,7 +317,7 @@ If such an index cannot be found an error will be returned.
 include::partial$grammar/dml.ebnf[tag=ansi-merge-predicate]
 ----
 
-image::n1ql-language-reference/ansi-merge-predicate.png[align=left]
+image::n1ql-language-reference/ansi-merge-predicate.png["Syntax diagram: refer to source code listing", align=left]
 
 The merge predicate enables you to specify an ANSI join between the <<ansi-merge-source,merge source>> and the <<ansi-merge-target,merge target>>.
 
@@ -333,7 +333,7 @@ This expression may contain fields, constant expressions, or any complex N1QL ex
 include::partial$grammar/dml.ebnf[tag=ansi-merge-actions]
 ----
 
-image::n1ql-language-reference/ansi-merge-actions.png[align=left]
+image::n1ql-language-reference/ansi-merge-actions.png["Syntax diagram: refer to source code listing", align=left]
 
 The merge actions enable you to specify insert, update, and delete actions on the target keyspace, based on a match or no match in the join.
 
@@ -350,7 +350,7 @@ ansi-merge-insert:: <<ansi-merge-insert>> icon:caret-down[]
 include::partial$grammar/dml.ebnf[tag=merge-update]
 ----
 
-image::n1ql-language-reference/merge-update.png[align=left]
+image::n1ql-language-reference/merge-update.png["Syntax diagram: refer to source code listing", align=left]
 
 Updates a document that already exists with updated values.
 
@@ -367,7 +367,7 @@ where-clause:: <<ansi-update-where>> icon:caret-down[]
 include::partial$grammar/dml.ebnf[tag=set-clause]
 ----
 
-image::n1ql-language-reference/set-clause.png[align=left]
+image::n1ql-language-reference/set-clause.png["Syntax diagram: refer to source code listing", align=left]
 
 Specifies the value for an attribute to be changed.
 Also enables you to set the expiration of the document.
@@ -384,7 +384,7 @@ update-for:: <<ansi-update-for>> icon:caret-down[]
 include::partial$grammar/dml.ebnf[tag=unset-clause]
 ----
 
-image::n1ql-language-reference/unset-clause.png[align=left]
+image::n1ql-language-reference/unset-clause.png["Syntax diagram: refer to source code listing", align=left]
 
 Removes a specified attribute from the document.
 For more details, refer to {unset-clause}[UNSET Clause].
@@ -400,14 +400,14 @@ update-for:: <<ansi-update-for>> icon:caret-down[]
 include::partial$grammar/dml.ebnf[tag=update-for]
 ----
 
-image::n1ql-language-reference/update-for.png[align=left]
+image::n1ql-language-reference/update-for.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#ansi-path,ebnf]
 ----
 include::partial$grammar/dql.ebnf[tag=path]
 ----
 
-image::n1ql-language-reference/path.png[align=left]
+image::n1ql-language-reference/path.png["Syntax diagram: refer to source code listing", align=left]
 
 Iterates over a nested array to SET or UNSET the given attribute for every matching element in the array.
 For more details, refer to {update-for}[FOR Clause].
@@ -420,7 +420,7 @@ For more details, refer to {update-for}[FOR Clause].
 include::partial$grammar/dql.ebnf[tag=where-clause]
 ----
 
-image::n1ql-language-reference/where-clause.png[align=left]
+image::n1ql-language-reference/where-clause.png["Syntax diagram: refer to source code listing", align=left]
 
 Optionally specifies a condition that must be met for data to be updated.
 For more details, refer to {where-clause}[WHERE Clause].
@@ -433,7 +433,7 @@ For more details, refer to {where-clause}[WHERE Clause].
 include::partial$grammar/dml.ebnf[tag=merge-delete]
 ----
 
-image::n1ql-language-reference/merge-delete.png[align=left]
+image::n1ql-language-reference/merge-delete.png["Syntax diagram: refer to source code listing", align=left]
 
 Removes the specified document from the keyspace.
 
@@ -448,7 +448,7 @@ where-clause:: <<ansi-delete-where>> icon:caret-down[]
 include::partial$grammar/dql.ebnf[tag=where-clause]
 ----
 
-image::n1ql-language-reference/where-clause.png[align=left]
+image::n1ql-language-reference/where-clause.png["Syntax diagram: refer to source code listing", align=left]
 
 Optionally specifies a condition that must be met for data to be deleted.
 For more details, refer to {where-clause}[WHERE Clause].
@@ -461,7 +461,7 @@ For more details, refer to {where-clause}[WHERE Clause].
 include::partial$grammar/dml.ebnf[tag=ansi-merge-insert]
 ----
 
-image::n1ql-language-reference/ansi-merge-insert.png[align=left]
+image::n1ql-language-reference/ansi-merge-insert.png["Syntax diagram: refer to source code listing", align=left]
 
 Inserts a new document into the keyspace.
 Use parentheses to specify the key and value for the inserted document, separated by a comma.
@@ -505,7 +505,7 @@ where-clause:: <<ansi-insert-where>> icon:caret-down[]
 include::partial$grammar/dql.ebnf[tag=where-clause]
 ----
 
-image::n1ql-language-reference/where-clause.png[align=left]
+image::n1ql-language-reference/where-clause.png["Syntax diagram: refer to source code listing", align=left]
 
 Optionally specifies a condition that must be met for data to be inserted.
 For more details, refer to {where-clause}[WHERE clause].
@@ -518,7 +518,7 @@ For more details, refer to {where-clause}[WHERE clause].
 include::partial$grammar/dml.ebnf[tag=lookup-merge]
 ----
 
-image::n1ql-language-reference/lookup-merge.png[align=left]
+image::n1ql-language-reference/lookup-merge.png["Syntax diagram: refer to source code listing", align=left]
 
 [horizontal.compact]
 target-keyspace:: <<lookup-merge-target>> icon:caret-down[]
@@ -541,7 +541,7 @@ Refer to <<ansi-merge-target,ANSI Merge Target>>.
 include::partial$grammar/dml.ebnf[tag=lookup-merge-source]
 ----
 
-image::n1ql-language-reference/lookup-merge-source.png[align=left]
+image::n1ql-language-reference/lookup-merge-source.png["Syntax diagram: refer to source code listing", align=left]
 
 The merge source is the recordset that you want to merge with the merge target.
 It can be a keyspace reference, a subquery, or a generic expression.
@@ -587,7 +587,7 @@ Refer to <<ansi-merge-source-expr>>.
 include::partial$grammar/dml.ebnf[tag=lookup-merge-predicate]
 ----
 
-image::n1ql-language-reference/lookup-merge-predicate.png[align=left]
+image::n1ql-language-reference/lookup-merge-predicate.png["Syntax diagram: refer to source code listing", align=left]
 
 The merge predicate produces a document key for the target of the lookup merge.
 
@@ -602,7 +602,7 @@ expr:: [Required] String or expression representing the primary key of the docum
 include::partial$grammar/dml.ebnf[tag=lookup-merge-actions]
 ----
 
-image::n1ql-language-reference/lookup-merge-actions.png[align=left]
+image::n1ql-language-reference/lookup-merge-actions.png["Syntax diagram: refer to source code listing", align=left]
 
 The merge actions enable you to specify insert, update, and delete actions on the target keyspace, based on a match or no match in the join.
 
@@ -633,7 +633,7 @@ Refer to <<ansi-merge-delete>> for details.
 include::partial$grammar/dml.ebnf[tag=lookup-merge-insert]
 ----
 
-image::n1ql-language-reference/lookup-merge-insert.png[align=left]
+image::n1ql-language-reference/lookup-merge-insert.png["Syntax diagram: refer to source code listing", align=left]
 
 Inserts a new document into the keyspace.
 The key specified in the <<lookup-merge-predicate>> is used as the key for the newly inserted document.
@@ -654,7 +654,7 @@ If you need to specify the document expiration, rewrite the query using the ANSI
 include::partial$grammar/dql.ebnf[tag=where-clause]
 ----
 
-image::n1ql-language-reference/where-clause.png[align=left]
+image::n1ql-language-reference/where-clause.png["Syntax diagram: refer to source code listing", align=left]
 
 Optionally specifies a condition that must be met for data to be inserted.
 For more details, refer to {where-clause}[WHERE clause].
@@ -671,7 +671,7 @@ The following clauses are common to both ANSI Merge and Lookup Merge.
 include::partial$grammar/dql.ebnf[tag=limit-clause]
 ----
 
-image::n1ql-language-reference/limit-clause.png[align=left]
+image::n1ql-language-reference/limit-clause.png["Syntax diagram: refer to source code listing", align=left]
 
 Specifies the _minimum_ number of records to be processed.
 For more details, refer to {limit-clause}[LIMIT Clause].
@@ -684,7 +684,7 @@ For more details, refer to {limit-clause}[LIMIT Clause].
 include::partial$grammar/dml.ebnf[tag=returning-clause]
 ----
 
-image::n1ql-language-reference/returning-clause.png[align=left]
+image::n1ql-language-reference/returning-clause.png["Syntax diagram: refer to source code listing", align=left]
 
 Specifies the information to be returned by the operation as a query result.
 For more details, refer to {returning-clause}[RETURNING Clause].

--- a/modules/n1ql/pages/n1ql-language-reference/optimizer-hints.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/optimizer-hints.adoc
@@ -20,21 +20,21 @@ TIP: Generally speaking, you should rely on the optimizer to generate the query 
 include::partial$grammar/hints.ebnf[tag=hint-comment]
 ----
 
-image::n1ql-language-reference/hint-comment.png[align=left]
+image::n1ql-language-reference/hint-comment.png["Syntax diagram: refer to source code listing", align=left]
 
 [source,ebnf]
 ----
 include::partial$grammar/hints.ebnf[tag=block-hint-comment]
 ----
 
-image::n1ql-language-reference/block-hint-comment.png[align=left]
+image::n1ql-language-reference/block-hint-comment.png["Syntax diagram: refer to source code listing", align=left]
 
 [source,ebnf]
 ----
 include::partial$grammar/hints.ebnf[tag=line-hint-comment]
 ----
 
-image::n1ql-language-reference/line-hint-comment.png[align=left]
+image::n1ql-language-reference/line-hint-comment.png["Syntax diagram: refer to source code listing", align=left]
 
 You can supply hints to the operator within a specially-formatted _hint comment_.
 The hint comment may be a block comment or a line comment.
@@ -103,21 +103,21 @@ This query generates a syntax error, as it contains multiple hint comments.
 include::partial$grammar/hints.ebnf[tag=hints]
 ----
 
-image::n1ql-language-reference/hints.png[align=left]
+image::n1ql-language-reference/hints.png["Syntax diagram: refer to source code listing", align=left]
 
 [source,ebnf]
 ----
 include::partial$grammar/hints.ebnf[tag=simple-hint-sequence]
 ----
 
-image::n1ql-language-reference/simple-hint-sequence.png[align=left]
+image::n1ql-language-reference/simple-hint-sequence.png["Syntax diagram: refer to source code listing", align=left]
 
 [source,ebnf]
 ----
 include::partial$grammar/hints.ebnf[tag=json-hint-object]
 ----
 
-image::n1ql-language-reference/json-hint-object.png[align=left]
+image::n1ql-language-reference/json-hint-object.png["Syntax diagram: refer to source code listing", align=left]
 
 Internally, the hint comment may take one of two equivalent formats:
 

--- a/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
@@ -22,7 +22,7 @@ If you know that a statement text will be executed repeatedly, you can request t
 include::partial$grammar/utility.ebnf[tag=prepare]
 ----
 
-image::n1ql-language-reference/prepare.png[align=left]
+image::n1ql-language-reference/prepare.png["Syntax diagram: refer to source code listing", align=left]
 
 statement::
 The full text of the N1QL statement to prepare.

--- a/modules/n1ql/pages/n1ql-language-reference/query-hints.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/query-hints.adoc
@@ -27,7 +27,7 @@ If not specified, the optimizer determines the optimal join order.
 include::partial$grammar/hints.ebnf[tag=ordered-hint-simple]
 ----
 
-image::n1ql-language-reference/ordered-hint-simple.png[align=left]
+image::n1ql-language-reference/ordered-hint-simple.png["Syntax diagram: refer to source code listing", align=left]
 
 With the simple syntax, this hint takes no arguments.
 You may only use this hint once within the hint comment.
@@ -39,7 +39,7 @@ You may only use this hint once within the hint comment.
 include::partial$grammar/hints.ebnf[tag=ordered-hint-json]
 ----
 
-image::n1ql-language-reference/ordered-hint-json.png[align=left]
+image::n1ql-language-reference/ordered-hint-json.png["Syntax diagram: refer to source code listing", align=left]
 
 With the JSON syntax, this hint takes the form of an `ordered` property.
 You may only use this property once within the hint comment.

--- a/modules/n1ql/pages/n1ql-language-reference/revoke.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/revoke.adoc
@@ -35,7 +35,7 @@ For more details about user roles, see
 include::partial$grammar/dcl.ebnf[tag=revoke]
 ----
 
-image::n1ql-language-reference/revoke.png[align=left]
+image::n1ql-language-reference/revoke.png["Syntax diagram: refer to source code listing", align=left]
 
 role::
 One of the {authorization-overview}[RBAC role names predefined] by Couchbase Server.
@@ -58,21 +58,21 @@ A user name created by the Couchbase Server RBAC system.
 include::partial$grammar/dql.ebnf[tag=keyspace-ref]
 ----
 
-image::n1ql-language-reference/keyspace-ref.png[align=left]
+image::n1ql-language-reference/keyspace-ref.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#keyspace-path,ebnf,reftext="keyspace path"]
 ----
 include::partial$grammar/dql.ebnf[tag=keyspace-path]
 ----
 
-image::n1ql-language-reference/keyspace-path.png[align=left]
+image::n1ql-language-reference/keyspace-path.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#keyspace-partial,ebnf,reftext="keyspace partial"]
 ----
 include::partial$grammar/dql.ebnf[tag=keyspace-partial]
 ----
 
-image::n1ql-language-reference/keyspace-partial.png[align=left]
+image::n1ql-language-reference/keyspace-partial.png["Syntax diagram: refer to source code listing", align=left]
 
 The simple name or fully-qualified name of a keyspace.
 Refer to the {keyspace-ref}[CREATE INDEX] statement for details of the syntax.

--- a/modules/n1ql/pages/n1ql-language-reference/rollback-transaction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/rollback-transaction.adoc
@@ -39,7 +39,7 @@ NOTE: If you are using the cbq shell, and a transaction fails for any reason, yo
 include::partial$grammar/tcl.ebnf[tag=rollback-transaction]
 ----
 
-image::n1ql-language-reference/rollback-transaction.png[align=left]
+image::n1ql-language-reference/rollback-transaction.png["Syntax diagram: refer to source code listing", align=left]
 
 The `WORK`, `TRAN`, and `TRANSACTION` keywords are synonyms.
 These keywords are optional; you may include one of these keywords, or omit them entirely.

--- a/modules/n1ql/pages/n1ql-language-reference/savepoint.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/savepoint.adoc
@@ -34,7 +34,7 @@ include::partial$n1ql-language-reference/transaction-id.adoc[]
 include::partial$grammar/tcl.ebnf[tag=savepoint]
 ----
 
-image::n1ql-language-reference/savepoint.png[align=left]
+image::n1ql-language-reference/savepoint.png["Syntax diagram: refer to source code listing", align=left]
 
 savepointname::
 An identifier specifying a name for the savepoint.

--- a/modules/n1ql/pages/n1ql-language-reference/set-transaction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/set-transaction.adoc
@@ -49,7 +49,7 @@ The `SET TRANSACTION` statement is therefore optional and may be omitted.
 include::partial$grammar/tcl.ebnf[tag=set-transaction]
 ----
 
-image::n1ql-language-reference/set-transaction.png[align=left]
+image::n1ql-language-reference/set-transaction.png["Syntax diagram: refer to source code listing", align=left]
 
 == Example
 

--- a/modules/n1ql/pages/n1ql-language-reference/statistics-delete.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/statistics-delete.adoc
@@ -40,7 +40,7 @@ Deleting all statistics for a keyspace turns off the cost-based optimizer for al
 include::partial$grammar/utility.ebnf[tag=update-statistics-delete]
 ----
 
-image::n1ql-language-reference/update-statistics-delete.png[align=left]
+image::n1ql-language-reference/update-statistics-delete.png["Syntax diagram: refer to source code listing", align=left]
 
 For this syntax, `UPDATE STATISTICS` and `ANALYZE` are synonyms.
 The statement must begin with one of these alternatives.
@@ -63,21 +63,21 @@ delete-clause:: <<delete-clause>> icon:caret-down[]
 include::partial$grammar/dql.ebnf[tag=keyspace-ref]
 ----
 
-image::n1ql-language-reference/keyspace-ref.png[align=left]
+image::n1ql-language-reference/keyspace-ref.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#keyspace-path,ebnf,reftext="keyspace-path"]
 ----
 include::partial$grammar/dql.ebnf[tag=keyspace-path]
 ----
 
-image::n1ql-language-reference/keyspace-path.png[align=left]
+image::n1ql-language-reference/keyspace-path.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#keyspace-partial,ebnf,reftext="keyspace-partial"]
 ----
 include::partial$grammar/dql.ebnf[tag=keyspace-partial]
 ----
 
-image::n1ql-language-reference/keyspace-partial.png[align=left]
+image::n1ql-language-reference/keyspace-partial.png["Syntax diagram: refer to source code listing", align=left]
 
 The simple name or fully-qualified name of the keyspace for which you want to delete statistics.
 Refer to the {keyspace-ref}[CREATE INDEX] statement for details of the syntax.
@@ -90,7 +90,7 @@ Refer to the {keyspace-ref}[CREATE INDEX] statement for details of the syntax.
 include::partial$grammar/utility.ebnf[tag=delete-clause]
 ----
 
-image::n1ql-language-reference/delete-clause.png[align=left]
+image::n1ql-language-reference/delete-clause.png["Syntax diagram: refer to source code listing", align=left]
 
 The `DELETE` clause enables you to provide a comma-separated list of index expressions for which you want to delete statistics, or to specify that you want to delete all statistics for the keyspace.
 
@@ -106,7 +106,7 @@ delete-all:: <<delete-all>> icon:caret-down[]
 include::partial$grammar/utility.ebnf[tag=delete-expr]
 ----
 
-image::n1ql-language-reference/delete-expr.png[align=left]
+image::n1ql-language-reference/delete-expr.png["Syntax diagram: refer to source code listing", align=left]
 
 Constraint: if you used the `UPDATE STATISTICS` keywords at the beginning of the statement, you may not use the `STATISTICS` keyword in this clause.
 
@@ -131,7 +131,7 @@ This may be any expression that is supported as an index key, including, but not
 include::partial$grammar/utility.ebnf[tag=delete-all]
 ----
 
-image::n1ql-language-reference/delete-all.png[align=left]
+image::n1ql-language-reference/delete-all.png["Syntax diagram: refer to source code listing", align=left]
 
 Constraint: If you used the `UPDATE STATISTICS` keywords at the beginning of the statement, you must use the `ALL` keyword in this clause.
 

--- a/modules/n1ql/pages/n1ql-language-reference/statistics-expressions.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/statistics-expressions.adoc
@@ -49,7 +49,7 @@ For a query which filters on an array or array of objects, you must collect the 
 include::partial$grammar/utility.ebnf[tag=update-statistics-expr]
 ----
 
-image::n1ql-language-reference/update-statistics-expr.png[align=left]
+image::n1ql-language-reference/update-statistics-expr.png["Syntax diagram: refer to source code listing", align=left]
 
 For this syntax, `UPDATE STATISTICS` and `ANALYZE` are synonyms.
 The statement must begin with one of these alternatives.
@@ -73,21 +73,21 @@ index-with:: <<index-with>> icon:caret-down[]
 include::partial$grammar/dql.ebnf[tag=keyspace-ref]
 ----
 
-image::n1ql-language-reference/keyspace-ref.png[align=left]
+image::n1ql-language-reference/keyspace-ref.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#keyspace-path,ebnf,reftext="keyspace-path"]
 ----
 include::partial$grammar/dql.ebnf[tag=keyspace-path]
 ----
 
-image::n1ql-language-reference/keyspace-path.png[align=left]
+image::n1ql-language-reference/keyspace-path.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#keyspace-partial,ebnf,reftext="keyspace-partial"]
 ----
 include::partial$grammar/dql.ebnf[tag=keyspace-partial]
 ----
 
-image::n1ql-language-reference/keyspace-partial.png[align=left]
+image::n1ql-language-reference/keyspace-partial.png["Syntax diagram: refer to source code listing", align=left]
 
 The simple name or fully-qualified name of the keyspace for which you want to gather statistics.
 Refer to the {keyspace-ref}[CREATE INDEX] statement for details of the syntax.

--- a/modules/n1ql/pages/n1ql-language-reference/statistics-index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/statistics-index.adoc
@@ -40,7 +40,7 @@ This provides a shorthand so that you do not need to list all the index key expr
 include::partial$grammar/utility.ebnf[tag=update-statistics-index]
 ----
 
-image::n1ql-language-reference/update-statistics-index.png[align=left]
+image::n1ql-language-reference/update-statistics-index.png["Syntax diagram: refer to source code listing", align=left]
 
 For this syntax, `UPDATE STATISTICS FOR` and `ANALYZE` are synonyms.
 The statement must begin with one of these alternatives.
@@ -58,7 +58,7 @@ index-with:: <<index-with>> icon:caret-down[]
 include::partial$grammar/utility.ebnf[tag=index-clause]
 ----
 
-image::n1ql-language-reference/index-clause.png[align=left]
+image::n1ql-language-reference/index-clause.png["Syntax diagram: refer to source code listing", align=left]
 
 For this syntax, the `INDEX` clause enables you to specify the index name and a keyspace.
 
@@ -75,28 +75,28 @@ keyspace-ref:: <<keyspace-ref>> icon:caret-down[]
 include::partial$grammar/ddl.ebnf[tag=index-path]
 ----
 
-image::n1ql-language-reference/index-path.png[align=left]
+image::n1ql-language-reference/index-path.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#keyspace-full-index,ebnf,reftext="keyspace-full"]
 ----
 include::partial$grammar/ddl.ebnf[tag=keyspace-full]
 ----
 
-image::n1ql-language-reference/keyspace-full.png[align=left]
+image::n1ql-language-reference/keyspace-full.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#keyspace-prefix-index,ebnf,reftext="keyspace-prefix"]
 ----
 include::partial$grammar/ddl.ebnf[tag=keyspace-prefix]
 ----
 
-image::n1ql-language-reference/keyspace-prefix.png[align=left]
+image::n1ql-language-reference/keyspace-prefix.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#keyspace-partial-index,ebnf,reftext="keyspace-partial"]
 ----
 include::partial$grammar/dql.ebnf[tag=keyspace-partial]
 ----
 
-image::n1ql-language-reference/keyspace-partial.png[align=left]
+image::n1ql-language-reference/keyspace-partial.png["Syntax diagram: refer to source code listing", align=left]
 
 You can use a dotted notation to specify the index and the keyspace on which the index is built.
 Refer to the {index-path-alter}[ALTER INDEX] or {index-path-drop}[DROP INDEX] statements for details of the syntax.
@@ -109,21 +109,21 @@ Refer to the {index-path-alter}[ALTER INDEX] or {index-path-drop}[DROP INDEX] st
 include::partial$grammar/dql.ebnf[tag=keyspace-ref]
 ----
 
-image::n1ql-language-reference/keyspace-ref.png[align=left]
+image::n1ql-language-reference/keyspace-ref.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#keyspace-path,ebnf,reftext="keyspace-path"]
 ----
 include::partial$grammar/dql.ebnf[tag=keyspace-path]
 ----
 
-image::n1ql-language-reference/keyspace-path.png[align=left]
+image::n1ql-language-reference/keyspace-path.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#keyspace-partial,ebnf,reftext="keyspace-partial"]
 ----
 include::partial$grammar/dql.ebnf[tag=keyspace-partial]
 ----
 
-image::n1ql-language-reference/keyspace-partial.png[align=left]
+image::n1ql-language-reference/keyspace-partial.png["Syntax diagram: refer to source code listing", align=left]
 
 Alternatively, you can use the index name with the `ON` keyword and a keyspace reference to specify the keyspace on which the index is built.
 Refer to the {keyspace-ref-alter}[ALTER INDEX] or {keyspace-ref-drop}[DROP INDEX] statements for details of the syntax.
@@ -136,7 +136,7 @@ Refer to the {keyspace-ref-alter}[ALTER INDEX] or {keyspace-ref-drop}[DROP INDEX
 include::partial$grammar/ddl.ebnf[tag=index-using]
 ----
 
-image::n1ql-language-reference/index-using.png[align=left]
+image::n1ql-language-reference/index-using.png["Syntax diagram: refer to source code listing", align=left]
 
 In Couchbase Server 6.5 and later, the index type for a secondary index must be Global Secondary Index (GSI).
 The `USING GSI` keywords are optional and may be omitted.

--- a/modules/n1ql/pages/n1ql-language-reference/statistics-indexes.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/statistics-indexes.adoc
@@ -40,7 +40,7 @@ If the same index expression is included in multiple indexes, duplicate index ex
 include::partial$grammar/utility.ebnf[tag=update-statistics-indexes]
 ----
 
-image::n1ql-language-reference/update-statistics-indexes.png[align=left]
+image::n1ql-language-reference/update-statistics-indexes.png["Syntax diagram: refer to source code listing", align=left]
 
 For this syntax, `UPDATE STATISTICS` and `ANALYZE` are synonyms.
 The statement must begin with one of these alternatives.
@@ -65,21 +65,21 @@ index-with:: <<index-with>> icon:caret-down[]
 include::partial$grammar/dql.ebnf[tag=keyspace-ref]
 ----
 
-image::n1ql-language-reference/keyspace-ref.png[align=left]
+image::n1ql-language-reference/keyspace-ref.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#keyspace-path,ebnf,reftext="keyspace-path"]
 ----
 include::partial$grammar/dql.ebnf[tag=keyspace-path]
 ----
 
-image::n1ql-language-reference/keyspace-path.png[align=left]
+image::n1ql-language-reference/keyspace-path.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#keyspace-partial,ebnf,reftext="keyspace-partial"]
 ----
 include::partial$grammar/dql.ebnf[tag=keyspace-partial]
 ----
 
-image::n1ql-language-reference/keyspace-partial.png[align=left]
+image::n1ql-language-reference/keyspace-partial.png["Syntax diagram: refer to source code listing", align=left]
 
 The simple name or fully-qualified name of the keyspace on which the indexes are built.
 Refer to the {keyspace-ref}[CREATE INDEX] statement for details of the syntax.
@@ -92,7 +92,7 @@ Refer to the {keyspace-ref}[CREATE INDEX] statement for details of the syntax.
 include::partial$grammar/utility.ebnf[tag=indexes-clause]
 ----
 
-image::n1ql-language-reference/indexes-clause.png[align=left]
+image::n1ql-language-reference/indexes-clause.png["Syntax diagram: refer to source code listing", align=left]
 
 For this syntax, the `INDEX` clause enables you to specify a comma-separated list of index names, a subquery which returns an array of index names, or all the indexes in the specified keyspace.
 
@@ -108,7 +108,7 @@ subquery-expr:: <<subquery-expr>> icon:caret-down[]
 include::partial$grammar/dql.ebnf[tag=subquery-expr]
 ----
 
-image::n1ql-language-reference/subquery-expr.png[align=left]
+image::n1ql-language-reference/subquery-expr.png["Syntax diagram: refer to source code listing", align=left]
 
 Use parentheses to specify a subquery.
 
@@ -129,7 +129,7 @@ Refer to <<ex-5>> and <<ex-6>> for details.
 include::partial$grammar/ddl.ebnf[tag=index-using]
 ----
 
-image::n1ql-language-reference/index-using.png[align=left]
+image::n1ql-language-reference/index-using.png["Syntax diagram: refer to source code listing", align=left]
 
 In Couchbase Server 6.5 and later, the index type for a secondary index must be Global Secondary Index (GSI).
 The `USING GSI` keywords are optional and may be omitted.

--- a/modules/n1ql/pages/n1ql-language-reference/update.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/update.adoc
@@ -69,7 +69,7 @@ When the document expires, the data service deletes the document, even though th
 include::partial$grammar/dml.ebnf[tag=update]
 ----
 
-image::n1ql-language-reference/update.png[align=left]
+image::n1ql-language-reference/update.png["Syntax diagram: refer to source code listing", align=left]
 
 // TODO: Automatic links from EBNF
 
@@ -90,7 +90,7 @@ returning-clause:: <<returning-clause>> icon:caret-down[]
 include::partial$grammar/dml.ebnf[tag=target-keyspace]
 ----
 
-image::n1ql-language-reference/target-keyspace.png[align=left]
+image::n1ql-language-reference/target-keyspace.png["Syntax diagram: refer to source code listing", align=left]
 
 The update target is the keyspace which you want to update.
 
@@ -106,21 +106,21 @@ alias:: <<update-alias>> icon:caret-down[]
 include::partial$grammar/dql.ebnf[tag=keyspace-ref]
 ----
 
-image::n1ql-language-reference/keyspace-ref.png[align=left]
+image::n1ql-language-reference/keyspace-ref.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#keyspace-path,ebnf,reftext="keyspace path"]
 ----
 include::partial$grammar/dql.ebnf[tag=keyspace-path]
 ----
 
-image::n1ql-language-reference/keyspace-path.png[align=left]
+image::n1ql-language-reference/keyspace-path.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#keyspace-partial,ebnf,reftext="keyspace partial"]
 ----
 include::partial$grammar/dql.ebnf[tag=keyspace-partial]
 ----
 
-image::n1ql-language-reference/keyspace-partial.png[align=left]
+image::n1ql-language-reference/keyspace-partial.png["Syntax diagram: refer to source code listing", align=left]
 
 Keyspace reference for the update target.
 For more details, refer to {from-keyspace-ref}[Keyspace Reference].
@@ -148,7 +148,7 @@ For details, refer to {use-keys-clause}[USE KEYS Clause].
 include::partial$grammar/dml.ebnf[tag=set-clause]
 ----
 
-image::n1ql-language-reference/set-clause.png[align=left]
+image::n1ql-language-reference/set-clause.png["Syntax diagram: refer to source code listing", align=left]
 
 Specifies the value for an attribute to be changed.
 
@@ -182,7 +182,7 @@ If this is `true`, the existing document expiration is preserved; if `false`, th
 include::partial$grammar/dml.ebnf[tag=unset-clause]
 ----
 
-image::n1ql-language-reference/unset-clause.png[align=left]
+image::n1ql-language-reference/unset-clause.png["Syntax diagram: refer to source code listing", align=left]
 
 Removes the specified attribute from the document.
 
@@ -205,14 +205,14 @@ Alternatively, if the request-level {preserve_expiration}[preserve_expiration] p
 include::partial$grammar/dml.ebnf[tag=update-for]
 ----
 
-image::n1ql-language-reference/update-for.png[align=left]
+image::n1ql-language-reference/update-for.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#path,ebnf]
 ----
 include::partial$grammar/dql.ebnf[tag=path]
 ----
 
-image::n1ql-language-reference/path.png[align=left]
+image::n1ql-language-reference/path.png["Syntax diagram: refer to source code listing", align=left]
 
 Uses the FOR statement to iterate over a nested array to SET or UNSET the given attribute for every matching element in the array.
 The FOR clause can evaluate functions and expressions, and the UPDATE statement supports multiple nested FOR expressions to access and update fields in nested arrays.
@@ -226,7 +226,7 @@ Additional array levels are supported by chaining the FOR clauses.
 include::partial$grammar/dql.ebnf[tag=where-clause]
 ----
 
-image::n1ql-language-reference/where-clause.png[align=left]
+image::n1ql-language-reference/where-clause.png["Syntax diagram: refer to source code listing", align=left]
 
 Specifies the condition that needs to be met for data to be updated.
 Optional.
@@ -239,7 +239,7 @@ Optional.
 include::partial$grammar/dql.ebnf[tag=limit-clause]
 ----
 
-image::n1ql-language-reference/limit-clause.png[align=left]
+image::n1ql-language-reference/limit-clause.png["Syntax diagram: refer to source code listing", align=left]
 
 Specifies the greatest number of objects that can be updated.
 This clause must have a non-negative integer as its upper bound.
@@ -253,7 +253,7 @@ Optional.
 include::partial$grammar/dml.ebnf[tag=returning-clause]
 ----
 
-image::n1ql-language-reference/returning-clause.png[align=left]
+image::n1ql-language-reference/returning-clause.png["Syntax diagram: refer to source code listing", align=left]
 
 Specifies the information to be returned by the operation as a query result.
 For more details, refer to {returning-clause}[RETURNING Clause].

--- a/modules/n1ql/pages/n1ql-language-reference/updatestatistics.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/updatestatistics.adoc
@@ -41,7 +41,7 @@ The cost-based optimizer uses these distribution statistics, together with keysp
 include::partial$grammar/utility.ebnf[tag=update-statistics]
 ----
 
-image::n1ql-language-reference/update-statistics.png[align=left]
+image::n1ql-language-reference/update-statistics.png["Syntax diagram: refer to source code listing", align=left]
 
 The `UPDATE STATISTICS` statement provides several different syntaxes to enable you to manage statistics.
 For further details, refer to the following links.

--- a/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
@@ -82,7 +82,7 @@ When the document expires, the data service deletes the document, even though th
 include::partial$grammar/dml.ebnf[tag=upsert]
 ----
 
-image::n1ql-language-reference/upsert.png[align=left]
+image::n1ql-language-reference/upsert.png["Syntax diagram: refer to source code listing", align=left]
 
 // TODO: Automatic links from EBNF
 
@@ -100,7 +100,7 @@ returning-clause:: <<returning-clause>> icon:caret-down[]
 include::partial$grammar/dml.ebnf[tag=target-keyspace]
 ----
 
-image::n1ql-language-reference/target-keyspace.png[align=left]
+image::n1ql-language-reference/target-keyspace.png["Syntax diagram: refer to source code listing", align=left]
 
 Specifies the keyspace into which to upsert documents.
 
@@ -116,21 +116,21 @@ alias:: <<insert-target-alias>> icon:caret-down[]
 include::partial$grammar/dql.ebnf[tag=keyspace-ref]
 ----
 
-image::n1ql-language-reference/keyspace-ref.png[align=left]
+image::n1ql-language-reference/keyspace-ref.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#keyspace-path,ebnf,reftext="keyspace path"]
 ----
 include::partial$grammar/dql.ebnf[tag=keyspace-path]
 ----
 
-image::n1ql-language-reference/keyspace-path.png[align=left]
+image::n1ql-language-reference/keyspace-path.png["Syntax diagram: refer to source code listing", align=left]
 
 [source#keyspace-partial,ebnf,reftext="keyspace partial"]
 ----
 include::partial$grammar/dql.ebnf[tag=keyspace-partial]
 ----
 
-image::n1ql-language-reference/keyspace-partial.png[align=left]
+image::n1ql-language-reference/keyspace-partial.png["Syntax diagram: refer to source code listing", align=left]
 
 Keyspace reference for the insert target.
 For more details, refer to {from-keyspace-ref}[Keyspace Reference].
@@ -151,7 +151,7 @@ If you assign an alias to the keyspace reference, the `AS` keyword may be omitte
 ----
 include::partial$grammar/dml.ebnf[tag=insert-values]
 ----
-image::n1ql-language-reference/insert-values.png[align=left]
+image::n1ql-language-reference/insert-values.png["Syntax diagram: refer to source code listing", align=left]
 
 Specifies one or more documents to be upserted using the VALUES clause.
 For details, refer to {insert-values}[Insert Values].
@@ -167,7 +167,7 @@ values-clause:: <<values-clause>> icon:caret-down[]
 include::partial$grammar/dml.ebnf[tag=values-clause]
 ----
 
-image::n1ql-language-reference/values-clause.png[align=left]
+image::n1ql-language-reference/values-clause.png["Syntax diagram: refer to source code listing", align=left]
 
 Specify the values as well-formed JSON.
 Also enables you to set the {document-expiration}[expiration] of the upserted documents.
@@ -185,7 +185,7 @@ If this is `true`, the existing document expiration is preserved; if `false`, th
 include::partial$grammar/dml.ebnf[tag=insert-select]
 ----
 
-image::n1ql-language-reference/insert-select.png[align=left]
+image::n1ql-language-reference/insert-select.png["Syntax diagram: refer to source code listing", align=left]
 
 Specifies the documents to be upserted as a SELECT statement.
 Also enables you to set the {document-expiration}[expiration] of the upserted documents.
@@ -211,7 +211,7 @@ For details, refer to {select-syntax}[SELECT Syntax].
 include::partial$grammar/dml.ebnf[tag=returning-clause]
 ----
 
-image::n1ql-language-reference/returning-clause.png[align=left]
+image::n1ql-language-reference/returning-clause.png["Syntax diagram: refer to source code listing", align=left]
 
 Specifies the fields that must be returned as part of the results object.
 
@@ -226,7 +226,7 @@ result-expr:: <<result-expr>> icon:caret-down[]
 include::partial$grammar/dql.ebnf[tag=result-expr]
 ----
 
-image::n1ql-language-reference/result-expr.png[align=left]
+image::n1ql-language-reference/result-expr.png["Syntax diagram: refer to source code listing", align=left]
 
 Specifies an expression on the data you upserted, to be returned as output.
 For details, refer to {result-expression}[Result Expression].

--- a/modules/n1ql/partials/n1ql-language-reference/statistics-options.adoc
+++ b/modules/n1ql/partials/n1ql-language-reference/statistics-options.adoc
@@ -7,7 +7,7 @@
 include::partial$grammar/ddl.ebnf[tag=index-with]
 ----
 
-image::n1ql-language-reference/index-with.png[align=left]
+image::n1ql-language-reference/index-with.png["Syntax diagram: refer to source code listing", align=left]
 
 Use the `WITH` clause to specify additional options.
 


### PR DESCRIPTION
Following on from [discussion](https://github.com/couchbase/docs-server/pull/2788#discussion_r911742406) in #2788 