### PR TITLE
NO ISSUE: Additional release notes for 6.6.x

### DIFF
--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -50,6 +50,9 @@ This section highlights the notable issues fixed in this release.
 | https://issues.couchbase.com/browse/MB-34280[MB-34280^]
 | *Summary*: Memcached should disallow DCP connections with names greater than 200 characters
 
+| https://issues.couchbase.com/browse/MB-48713[MB-48713^]
+| *Summary*: [Ephemeral] Rev id going backwards for SyncWrite add
+
 | https://issues.couchbase.com/browse/MB-49321[MB-49321^]
 | *Summary*: Reconfigure of interface does not work going from * to specific IP and vice versa
 
@@ -148,6 +151,17 @@ You can find more information in the blog post: https://blog.couchbase.com/what-
 
 | https://issues.couchbase.com/browse/MB-43238[MB-43238^]
 | *Summary*: Fixed issue: attempting to expire a committed item while a prepare is in flight generates new `seqno` for expiration/delete.
+|===
+
+==== Data Service
+
+[#table_fixedissues_v664-data,cols="25,66"]
+|===
+| Issue | Description
+
+| https://issues.couchbase.com/browse/MB-48179[MB-48179^]
+| *Summary*: Fixed issue: SyncDeletes do not update maxDelRevSeqno, which can cause rev ids to go backwards.
+
 |===
 
 


### PR DESCRIPTION
* MB-48179: SyncDeletes do not update maxDelRevSeqno
* MB-48713: Rev id going backwards for SyncWrite add