### PR TITLE
NO ISSUE: Additional release notes for 7.0.x

### DIFF
--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -294,6 +294,9 @@ This section highlights the notable issues fixed in this release.
 | https://issues.couchbase.com/browse/MB-38978[MB-38978^]
 | *Summary*: STAT "dcp" and "dcpagg" adversely affect front-end operation latency
 
+| https://issues.couchbase.com/browse/MB-48179[MB-48179^]
+| *Summary*: SyncDeletes do not update maxDelRevSeqno, which can cause rev ids to go backwards
+
 | https://issues.couchbase.com/browse/MB-48713[MB-48713^]
 | *Summary*: rev ids going backwards - non-sync-write delete
 

--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -16,7 +16,7 @@ This maintenance release contains fixes to issues.
 
 This section lists the notable fixes provided in this release.
 
-=== Cluster Manager
+==== Cluster Manager
 
 [#table_fixedissues_v704-clustermanager,cols="25,66"]
 |===
@@ -30,7 +30,7 @@ This section lists the notable fixes provided in this release.
 
 |===
 
-=== Data Service
+==== Data Service
 
 [#table_fixedissues_v704-dataservice,cols="25,66"]
 |===
@@ -41,7 +41,7 @@ This section lists the notable fixes provided in this release.
 
 |===
 
-=== XDCR
+==== XDCR
 
 [#table_fixedissues_v704-xdcr,cols="25,66"]
 |===
@@ -55,7 +55,7 @@ This section lists the notable fixes provided in this release.
 
 |===
 
-=== Query Service
+==== Query Service
 
 [#table_fixedissues_v704-queryservice,cols="25,66"]
 |===
@@ -90,7 +90,7 @@ This section lists the notable fixes provided in this release.
 
 |===
 
-=== Index Service
+==== Index Service
 
 [#table_fixedissues_v704-indexservice,cols="25,66"]
 |===
@@ -107,7 +107,7 @@ This section lists the notable fixes provided in this release.
 
 |===
 
-=== Search Service
+==== Search Service
 
 [#table_fixedissues_v704-searchservice,cols="25,66"]
 |===
@@ -118,7 +118,7 @@ This section lists the notable fixes provided in this release.
 
 |===
 
-=== Analytics Service
+==== Analytics Service
 
 [#table_fixedissues_v704-analyticsservice,cols="25,66"]
 |===
@@ -135,7 +135,7 @@ This section lists the notable fixes provided in this release.
 
 |===
 
-=== Eventing Service
+==== Eventing Service
 
 [#table_fixedissues_v704-eventingservice,cols="25,66"]
 |===
@@ -171,11 +171,11 @@ This section lists the notable fixes provided in this release.
 |===
 
 [#known-issues-704]
-== Known Issues
+=== Known Issues
 
 This section highlights the notable known issues in this release.
 
-=== Install and Upgrade
+==== Install and Upgrade
 
 [#table_knownissues_v704-installandupgrade,cols="25,66"]
 |===
@@ -186,7 +186,7 @@ This section highlights the notable known issues in this release.
 
 |===
 
-=== Query Service
+==== Query Service
 
 [#table_knownissues_v704-queryservice,cols="25,66"]
 |===


### PR DESCRIPTION
* MB-48179: SyncDeletes do not update maxDelRevSeqno