### PR TITLE
DOC-10221: N1QL tutorial query context syntax incorrect

### DIFF
--- a/modules/getting-started/pages/try-a-query.adoc
+++ b/modules/getting-started/pages/try-a-query.adoc
@@ -202,7 +202,7 @@ For example, the following cbq command sets the query context to `travel-sample.
 
 [source,n1ql]
 ----
-\SET -query_context 'travel-sample.inventory';
+\SET -query_context travel-sample.inventory;
 ----
 
 Having set the query context, you can now reference a collection using just the collection name.

--- a/modules/n1ql/examples/n1ql-language-reference/create-idx-collection.n1ql
+++ b/modules/n1ql/examples/n1ql-language-reference/create-idx-collection.n1ql
@@ -1,5 +1,5 @@
 /* tag::context[] */
-\SET -query_context 'travel-sample.inventory';
+\SET -query_context travel-sample.inventory;
 /* end::context[] */
 
 /* tag::query[] */

--- a/modules/n1ql/examples/n1ql-language-reference/create-pri-collection.n1ql
+++ b/modules/n1ql/examples/n1ql-language-reference/create-pri-collection.n1ql
@@ -1,5 +1,5 @@
 /* tag::context[] */
-\SET -query_context 'travel-sample.inventory';
+\SET -query_context travel-sample.inventory;
 /* end::context[] */
 
 /* tag::query[] */

--- a/modules/n1ql/examples/n1ql-language-reference/drop-idx-collection.n1ql
+++ b/modules/n1ql/examples/n1ql-language-reference/drop-idx-collection.n1ql
@@ -1,5 +1,5 @@
 /* tag::context[] */
-\SET -query_context 'travel-sample.inventory';
+\SET -query_context travel-sample.inventory;
 /* end::context[] */
 
 /* tag::query[] */

--- a/modules/n1ql/examples/n1ql-language-reference/tmp-idx-collection.n1ql
+++ b/modules/n1ql/examples/n1ql-language-reference/tmp-idx-collection.n1ql
@@ -1,5 +1,5 @@
 /* tag::context[] */
-\SET -query_context 'travel-sample.inventory';
+\SET -query_context travel-sample.inventory;
 /* end::context[] */
 
 /* tag::query[] */

--- a/modules/n1ql/pages/n1ql-language-reference/createcollection.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createcollection.adoc
@@ -103,7 +103,7 @@ CBQ Shell::
 --
 [source,n1ql]
 ----
-\SET -query_context 'travel-sample.inventory';
+\SET -query_context travel-sample.inventory;
 ----
 --
 ====

--- a/modules/n1ql/pages/n1ql-language-reference/dropcollection.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropcollection.adoc
@@ -95,7 +95,7 @@ CBQ Shell::
 --
 [source,n1ql]
 ----
-\SET -query_context 'travel-sample.inventory';
+\SET -query_context travel-sample.inventory;
 ----
 --
 ====


### PR DESCRIPTION
The following draft documentation is ready for review:

* [Try a Query](https://docs.couchbase.com/server/current/getting-started/try-a-query.html#run-cbq)
* [CREATE COLLECTION](https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/createcollection.html#query-context)  
* [DROP COLLECTION](https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/dropcollection.html#query-context)
* [CREATE INDEX](https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/createindex.html#query-context)
* [CREATE PRIMARY INDEX](https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/createprimaryindex.html#query-context)
* [DROP INDEX](https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/dropindex.html#query-context)

Removed quotes from query context throughout.

Docs issue: [DOC-10221](https://issues.couchbase.com/browse/DOC-10221)