### PR TITLE
Update xdcr-security-and-networking.adoc

### DIFF
--- a/modules/xdcr-reference/pages/xdcr-security-and-networking.adoc
+++ b/modules/xdcr-reference/pages/xdcr-security-and-networking.adoc
@@ -20,7 +20,7 @@ Each is explained below.
 [#dnssrv]
 == Handling Couchbase Schemes, Using DNS SRV
 
-Targets for XDCR replication can be specified using the schemes _http://_ and _https://_, and with the standard port number `8091` or `18091`, as applicable.
+Targets for XDCR replication can be specified with the standard port number `8091` or `18091`, as applicable.
 Targets _cannot_ be specified with the _Couchbase_ schemes _couchbase://_ and _couchbases://_, which are, instead, used to support the memcached protocol on ports `11210` and `11207`, respectively.
 
 Targets _can_, however, be specified with a _Fully Qualified Domain Name_ (_FQDN_) that is either tagged with one of the standard port numbers, or is untagged.


### PR DESCRIPTION
The `hostname` field should *not* include "https://" or "http://"