### PR TITLE
DOC-10286 - Changed incorrect param name

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -56,7 +56,7 @@ You must drop the failed index using the `DROP INDEX` command.
 ====
 
 You can create multiple identical secondary indexes on a keyspace and place them on separate nodes for better index availability.
-In Couchbase Server Enterprise Edition, the recommended way to do this is using the `num_replicas` option.
+In Couchbase Server Enterprise Edition, the recommended way to do this is using the `num_replica` option.
 In Couchbase Server Community Edition, you need to create multiple identical indexes and place them using the `nodes` option.
 Refer to <<index-with,WITH Clause>> below for more details.
 


### PR DESCRIPTION
"num_replica" parameter was incorrectly written as "num_replicas" in the createindex.html page. 

The single occurrence has been corrected.