### PR TITLE
DOC-10381: URL for this page has a typo

### DIFF
--- a/modules/learn/pages/security/roles.adoc
+++ b/modules/learn/pages/security/roles.adoc
@@ -5,7 +5,7 @@
 [abstract]
 {description}
 
-[#roles-and-privilages]
+[#roles-and-privileges]
 == Roles and Privileges
 
 Couchbase _roles_ each have a fixed association with a set of one or more privileges.


### PR DESCRIPTION
Can't see any xrefs that link to this heading, so I think we're safe to update the anchor