### PR TITLE
DOC-10051 - Remove semicolons from query/service requests

### DIFF
--- a/modules/guides/examples/javascript-udfs/execute-javascript-function.sh
+++ b/modules/guides/examples/javascript-udfs/execute-javascript-function.sh
@@ -1,3 +1,3 @@
 curl -v http://localhost:8093/query/service \
   -u Administrator:password \
-  -d 'statement=EXECUTE FUNCTION GetBusinessDays("02/14/2022", "04/16/2022");'
+  -d 'statement=EXECUTE FUNCTION GetBusinessDays("02/14/2022", "04/16/2022")'

--- a/modules/guides/examples/javascript-udfs/execute-scoped-function.sh
+++ b/modules/guides/examples/javascript-udfs/execute-scoped-function.sh
@@ -1,3 +1,3 @@
 curl -v http://localhost:8093/query/service \
   -u Administrator:password \
-  -d 'statement=EXECUTE FUNCTION default:`travel-sample`.inventory.GetBusinessDays("03/10/2022", "05/10.2022");'
+  -d 'statement=EXECUTE FUNCTION default:`travel-sample`.inventory.GetBusinessDays("03/10/2022", "05/10.2022")'

--- a/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
+++ b/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
@@ -177,7 +177,7 @@ To set query settings using the REST API, specify the parameters in the request 
 [source,console]
 ----
 $ curl http://localhost:8093/query/service -u user:pword \
-  -d 'profile=timings&statement=SELECT * FROM "world" AS hello;'
+  -d 'profile=timings&statement=SELECT * FROM "world" AS hello'
 ----
 
 [#monitor-profile-details]

--- a/modules/n1ql/pages/n1ql-language-reference/curl.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/curl.adoc
@@ -519,7 +519,7 @@ FROM CURL("http://localhost:8093/query/service",
     "user": "Administrator:password"}).results[*].t route
 JOIN `travel-sample`.inventory.airline
 ON KEYS route.airlineid
-LIMIT 4
+LIMIT 4;
 ----
 
 .Results

--- a/modules/n1ql/pages/n1ql-language-reference/curl.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/curl.adoc
@@ -519,7 +519,7 @@ FROM CURL("http://localhost:8093/query/service",
     "user": "Administrator:password"}).results[*].t route
 JOIN `travel-sample`.inventory.airline
 ON KEYS route.airlineid
-LIMIT 4;
+LIMIT 4
 ----
 
 .Results

--- a/modules/n1ql/pages/n1ql-language-reference/n1ql-error-codes.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/n1ql-error-codes.adoc
@@ -220,6 +220,8 @@ These errors are related to the service.
 | `Error processing [feature]`
 | Error processing that feature.
 
+For example, if you specify request parameters as form data and include an unescaped semicolon (;) in a statement, the Query Service REST API returns a `1040` error.
+
 | `1050`
 | `No [feature] value`
 | Missing value for that feature.

--- a/modules/n1ql/pages/n1ql-language-reference/n1ql-error-codes.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/n1ql-error-codes.adoc
@@ -220,7 +220,7 @@ These errors are related to the service.
 | `Error processing [feature]`
 | Error processing that feature.
 
-For example, if you specify request parameters as form data and include an unescaped semicolon (;) in a statement, the Query Service REST API returns a `1040` error.
+For example, the Query Service REST API returns this error if you specify request parameters as form data and include an unescaped semicolon (;) in a statement.
 
 | `1050`
 | `No [feature] value`

--- a/modules/n1ql/pages/n1ql-rest-api/exauthhttp.adoc
+++ b/modules/n1ql/pages/n1ql-rest-api/exauthhttp.adoc
@@ -9,7 +9,7 @@
 [source,sh]
 ----
 curl -v http://localhost:8093/query/service \
-     -d 'statement=SELECT name FROM `travel-sample`.inventory.hotel LIMIT 1;' \
+     -d 'statement=SELECT name FROM `travel-sample`.inventory.hotel LIMIT 1' \
      -u simon:fizzbuzz
 ----
 

--- a/modules/n1ql/pages/n1ql-rest-api/exauthrequest.adoc
+++ b/modules/n1ql/pages/n1ql-rest-api/exauthrequest.adoc
@@ -12,7 +12,7 @@ curl -v http://localhost:8093/query/service \
      -d 'statement=SELECT hotel.name, airport.airportname
                    FROM `travel-sample`.inventory.hotel
                    JOIN `travel-sample`.inventory.airport
-                   ON hotel.city = airport.city LIMIT 1;
+                   ON hotel.city = airport.city LIMIT 1
         & creds=[{"user": "local:simon", "pass": "fizzbuzz"},
                  {"user": "admin:Administrator", "pass": "password"}]'
 ----

--- a/modules/n1ql/pages/n1ql-rest-api/exn1qlerror.adoc
+++ b/modules/n1ql/pages/n1ql-rest-api/exn1qlerror.adoc
@@ -9,7 +9,7 @@
 [source,sh]
 ----
 curl -v http://localhost:8093/query/service \
-     -d 'statement=SLECT name FROM `travel-sample`.inventory.hotel LIMIT 1;' \
+     -d 'statement=SLECT name FROM `travel-sample`.inventory.hotel LIMIT 1' \
      -u Administrator:password
 ----
 
@@ -42,7 +42,7 @@ curl -v http://localhost:8093/query/service \
 [source,sh]
 ----
 curl -v http://localhost:8093/query/service \
-     -d 'statement=SELECT name FROM `travel-sample`.inventory.motel LIMIT 1;' \
+     -d 'statement=SELECT name FROM `travel-sample`.inventory.motel LIMIT 1' \
      -u Administrator:password
 ----
 

--- a/modules/n1ql/pages/n1ql-rest-api/exnamed.adoc
+++ b/modules/n1ql/pages/n1ql-rest-api/exnamed.adoc
@@ -26,7 +26,7 @@ This request contains the parameters described in the following table.
 ----
 curl -v http://localhost:8093/query/service \
      -d 'statement=SELECT airline FROM `travel-sample`.inventory.route
-                   WHERE sourceairport = $aval AND distance > $dval;
+                   WHERE sourceairport = $aval AND distance > $dval
        & $aval="LAX" & $dval=13000' \
      -u Administrator:password
 ----
@@ -73,7 +73,7 @@ curl -v http://localhost:8093/query/service \
      -u Administrator:password \
      -d 'statement=SELECT meta().id
                    FROM `travel-sample`.inventory.hotel
-                   WHERE meta().id LIKE $pattern;
+                   WHERE meta().id LIKE $pattern
        & $pattern="hotel_1002%25"'
 ----
 
@@ -116,7 +116,7 @@ curl -v http://localhost:8093/query/service \
      -u Administrator:password \
      -d 'statement=UPSERT INTO `travel-sample`.tenant_agent_00.users
                    VALUES ($id, {"name": $n})
-                   RETURNING *;
+                   RETURNING *
        & batch_named_args=[{"id": 9998, "n": "Esther"},
                            {"id": 9999, "n": "Patrick"}]'
 ----

--- a/modules/n1ql/pages/n1ql-rest-api/expositional.adoc
+++ b/modules/n1ql/pages/n1ql-rest-api/expositional.adoc
@@ -25,7 +25,7 @@ This request contains the parameters described in the following table.
 ----
 curl -v http://localhost:8093/query/service \
      -d 'statement=SELECT airline FROM `travel-sample`.inventory.route
-                   WHERE sourceairport = $1 AND distance > $2;
+                   WHERE sourceairport = $1 AND distance > $2
        & args=["LAX", 13000]' \
      -u Administrator:password
 ----
@@ -70,7 +70,7 @@ Positional parameters can also be specified in a statement using the question ma
 ----
 curl -v http://localhost:8093/query/service \
      -d 'statement=SELECT airline FROM `travel-sample`.inventory.route
-                   WHERE sourceairport = ? AND distance > ?;
+                   WHERE sourceairport = ? AND distance > ?
        & args=["LAX", 13000]' \
      -u Administrator:password
 ----
@@ -117,7 +117,7 @@ curl -v http://localhost:8093/query/service \
      -u Administrator:password \
      -d 'statement=UPSERT INTO `travel-sample`.tenant_agent_00.users
                    VALUES ($1, {"name": $2})
-                   RETURNING *;
+                   RETURNING *
        & batch_args=[[9998, "Esther"],
                      [9999, "Patrick"]]'
 ----

--- a/modules/n1ql/pages/n1ql-rest-api/extimeout.adoc
+++ b/modules/n1ql/pages/n1ql-rest-api/extimeout.adoc
@@ -9,7 +9,7 @@
 [source,sh]
 ----
 curl -v http://localhost:8093/query/service \
-     -d 'statement=SELECT name FROM `travel-sample`.inventory.hotel LIMIT 1;
+     -d 'statement=SELECT name FROM `travel-sample`.inventory.hotel LIMIT 1
        & timeout=1ms' \
      -u Administrator:password
 ----

--- a/modules/n1ql/pages/n1ql-rest-api/exunsupportedhttp.adoc
+++ b/modules/n1ql/pages/n1ql-rest-api/exunsupportedhttp.adoc
@@ -9,7 +9,7 @@
 [source,sh]
 ----
 curl -v http://localhost:8093/query/service -X PUT \
-     -d 'statement=SELECT name FROM `travel-sample`.inventory.hotel LIMIT 1;' \
+     -d 'statement=SELECT name FROM `travel-sample`.inventory.hotel LIMIT 1' \
      -u Administrator:password
 ----
 


### PR DESCRIPTION
Requests against `query/service` can't contain semi-colons without causing errors. 

I went through all of the files listed in the txt file on [DOC-10051](https://issues.couchbase.com/browse/DOC-10051) and removed semi-colons from the appropriate requests. 

Fix version in the ticket was listed as 7.1.1, so raising this against the 7.1 branch. 

Requesting a review from Sitaram as the reporter of the original ticket :) 