### PR TITLE
DOC-10439 release/7.0: Fixes missing graphic

### DIFF
--- a/modules/learn/pages/data/transactions.adoc
+++ b/modules/learn/pages/data/transactions.adoc
@@ -185,7 +185,7 @@ Consider the transaction example to transfer funds from Beth’s account to Andy
 
 Assuming that the 2 documents involved in this transaction live in two different nodes, here are the high-level steps that the transaction follows:
 
-image::modules/learn/assets/images/data/transaction-mechanics-steps.png["Transaction mechanics explaining the high-level steps that a transaction follows"]
+image::data/transaction-mechanics-steps.png["Transaction mechanics explaining the high-level steps that a transaction follows"]
 
 Each execution of the transaction logic in an application is called an 'attempt' inside the overall transaction.
 

--- a/modules/manage/pages/manage-security/configure-saslauthd.adoc
+++ b/modules/manage/pages/manage-security/configure-saslauthd.adoc
@@ -47,7 +47,7 @@ Instead, it can be enabled and configured later, after migration has been comple
 . Disable `saslauthd` authentication, as follows:
 +
 ----
-couchbase-cli setting-saslauthd -c 10.143.192.101:9001 -u Administrator -p password --enabled 0
+couchbase-cli setting-saslauthd -c 10.143.192.101:8091 -u Administrator -p password --enabled 0
 ----
 
 . Perform appropriate tests, to ensure that authentication with Native LDAP is working correctly.


### PR DESCRIPTION
DOC-10439 release/7.0: Fixes missing graphic. 

Reverted back to:

image::data/transaction-mechanics-steps.png["Transaction mechanics explaining the high-level steps that a transaction follows"]

note: Enrico Pagayucan is not searchable as a reviewer 