### PR TITLE
DOC-10439 release/7.1: Fixes missing graphic

### DIFF
--- a/modules/learn/pages/data/transactions.adoc
+++ b/modules/learn/pages/data/transactions.adoc
@@ -12,28 +12,28 @@
 
 Couchbase transactions support ACID properties for protected actions on the database.
 
-*Atomicity* ensures that a transaction provides all-or-nothing semantics -- i.e.,  either all the documents modified in a transaction are committed, or none of the changes are committed. If there is a failure during transaction execution (such as the client crashing) all its changes are rolled back. 
+*Atomicity* ensures that a transaction provides all-or-nothing semantics -- i.e.,  either all the documents modified in a transaction are committed, or none of the changes are committed. If there is a failure during transaction execution (such as the client crashing) all its changes are rolled back.
 
 *Consistency* -- Couchbase transactions ensure that the database moves from one consistent state to another and all derived artifacts such as indexes are updated automatically (though asynchronously from the transaction). Note that the traditional definition of consistency is not relevant as there are no foreign key constraints in Couchbase.
 
-*Isolation* -- Couchbase transactions guarantee that the changes made in a transaction are not visible until the transaction is committed. This is the ‘Read Committed’ level of isolation. 
+*Isolation* -- Couchbase transactions guarantee that the changes made in a transaction are not visible until the transaction is committed. This is the ‘Read Committed’ level of isolation.
 
 * The isolation provided to transactional reads is stricter than Read Committed -- it is Monotonic Atomic View (MAV). Monotonic Atomic View ensures that all effects of a previously committed transaction are observed  i.e. after commit a transaction is never partially observed.
-* Lost Updates are always prevented by checking against the CAS value which behaves like an optimistic lock. 
+* Lost Updates are always prevented by checking against the CAS value which behaves like an optimistic lock.
 
-*Durability* is a property that ensures changes made by committed transactions are not lost if failures occur. Couchbase transactions provide tunable durability to tolerate different failure scenarios with 3 different levels: 
+*Durability* is a property that ensures changes made by committed transactions are not lost if failures occur. Couchbase transactions provide tunable durability to tolerate different failure scenarios with 3 different levels:
 
-* `majority` -- replicate to a majority of the replicas before acknowledging the write. This is the default level. 
+* `majority` -- replicate to a majority of the replicas before acknowledging the write. This is the default level.
 * `majorityAndPersistActive` -- replicate to a majority of the replicas and persist to disk on the primary before acknowledging the write
-* `persistToMajority` -- persist to disk on a majority of the replicas before acknowledging the write. 
+* `persistToMajority` -- persist to disk on a majority of the replicas before acknowledging the write.
 
 `persistToMajority` provides the strongest protection from failures but is the least performant amongst the Durability levels. For more information, see xref:durability.adoc#durability-requirements[Durability Levels].
 
-NOTE: Statement Level Atomicity is provided for N1QL statements that are executed inside a transaction. This means that if a query statement fails during execution for a reason like a unique key violation that statement is completely rolled back and the rest of the transaction continues. It is as though the statement is not part of the transaction. No other work in the transaction is affected by the failure of this statement. If the query statement succeeds, it would be committed or rolled back based on the outcome of the overall transaction. 
+NOTE: Statement Level Atomicity is provided for N1QL statements that are executed inside a transaction. This means that if a query statement fails during execution for a reason like a unique key violation that statement is completely rolled back and the rest of the transaction continues. It is as though the statement is not part of the transaction. No other work in the transaction is affected by the failure of this statement. If the query statement succeeds, it would be committed or rolled back based on the outcome of the overall transaction.
 
 === Distributed Transactions: Multi-node and Multi-Bucket
 
-Couchbase transactions are distributed and work across multiple documents which can reside on multiple nodes. Only nodes that contain data to be updated are affected by a transaction. 
+Couchbase transactions are distributed and work across multiple documents which can reside on multiple nodes. Only nodes that contain data to be updated are affected by a transaction.
 
 Further, these documents can belong to multiple collections, scopes, and buckets.
 
@@ -56,7 +56,7 @@ Consider a basic debit and credit transaction to transfer $1000.00 from Beth’s
 [source,java]
 ----
 transactions.run((txnctx) -> {
-    // get the account documents for Andy and Beth    
+    // get the account documents for Andy and Beth
     var andy = txnctx.get(collection, "Andy");
     var andyContent = andy.contentAsObject();
 
@@ -64,31 +64,31 @@ transactions.run((txnctx) -> {
     var beth = txnctx.get(collection, "Beth");
 
 	var bethContent = beth.contentAsObject();
-    int bethBalance = bethContent.getInt("account_balance"); 
+    int bethBalance = bethContent.getInt("account_balance");
 
     // if Beth has sufficient funds, make the transfer
     if (bethBalance > transferAmount) {
 	 	andyContent.put("account_balance", andyBalance + transferAmount);
         txnctx.replace(andy, andyContent);
-    
+
         bethContent.put("account_balance", bethBalance - transferAmount);
         txnctx.replace(beth, bethContent)
         }
-        else throw new InsufficientFunds();  
+        else throw new InsufficientFunds();
    	// commit transaction - optional, can be omitted
    	txnctx.commit();
 });
----- 
+----
 
-The Java example above is a classic example to transfer money between two accounts. 
-Note the use of a lambda function to express the transaction. 
+The Java example above is a classic example to transfer money between two accounts.
+Note the use of a lambda function to express the transaction.
 
-The application supplies the logic for the transaction inside a lambda, including any conditional logic required, and the transactions API takes care of getting the transaction committed. If the transactions API encounters a transient error, such as a temporary conflict with another transaction, then it can rollback what has been done so far and run the lambda again. 
+The application supplies the logic for the transaction inside a lambda, including any conditional logic required, and the transactions API takes care of getting the transaction committed. If the transactions API encounters a transient error, such as a temporary conflict with another transaction, then it can rollback what has been done so far and run the lambda again.
 The application does not have to do these retries and error handling itself.
 
 NOTE: Use transactions only on documents less than 10 MB in size.
 
-For application-level transactions, create and use transactions through Couchbase SDK APIs. 
+For application-level transactions, create and use transactions through Couchbase SDK APIs.
 
 Here is another example that combines the usage of key-value and query operations:
 
@@ -102,7 +102,7 @@ transactions.run((ctx) -> {
 });
 ----
 
-For more information on distributed transactions through the SDK APIs, see: 
+For more information on distributed transactions through the SDK APIs, see:
 
 * xref:java-sdk:howtos:distributed-acid-transactions-from-the-sdk.adoc[Java SDK]
 * xref:dotnet-sdk:howtos:distributed-acid-transactions-from-the-sdk.adoc[.NET SDK]
@@ -111,7 +111,7 @@ For more information on distributed transactions through the SDK APIs, see:
 * xref:nodejs-sdk:howtos:distributed-acid-transactions-from-the-sdk.adoc[Node.js SDK]
 
 
-For use-cases which need to run ad-hoc data changes, you can directly use transactional constructs in N1QL. This can be accomplished using cbq, Query Workbench, CLI, or REST API in Couchbase Server, or through SDKs. 
+For use-cases which need to run ad-hoc data changes, you can directly use transactional constructs in N1QL. This can be accomplished using cbq, Query Workbench, CLI, or REST API in Couchbase Server, or through SDKs.
 
 [source,n1ql]
 ----
@@ -127,9 +127,9 @@ NOTE: Take a look at the https://transactions.couchbase.com[Query Transaction Si
 
 == Structure of a Transaction
 
-Every transaction has a beginning and a commit or a rollback at the end. 
+Every transaction has a beginning and a commit or a rollback at the end.
 
-Every transaction consists of one or more KV operations, and optionally one or more query statements. 
+Every transaction consists of one or more KV operations, and optionally one or more query statements.
 
 === Create Transaction
 
@@ -145,13 +145,13 @@ A transaction can end when one of the following conditions are true:
 
 * A commit operation is executed -- `ctx.commit()` in the example above.
 * A rollback is executed -- `ctx.rollback()`, or by executing the xref:n1ql:n1ql-language-reference/rollback-transaction.adoc[`ROLLBACK TRANSACTION`] statement.
-* Transaction callback completes successfully, in which case the transaction is committed implicitly. 
+* Transaction callback completes successfully, in which case the transaction is committed implicitly.
 * The application encounters an issue that can’t be resolved, in which case the transaction is automatically rolled back.
 * A transaction expiry also results in a rollback.
 
 === Savepoint
 
-A savepoint is a user-defined intermediate state that is available for the duration of the transaction. In a long running transaction, savepoints can be used to rollback to that state instead of rolling back the entire transaction in case of an error. 
+A savepoint is a user-defined intermediate state that is available for the duration of the transaction. In a long running transaction, savepoints can be used to rollback to that state instead of rolling back the entire transaction in case of an error.
 
 Note that savepoints are only available within the context of a transaction (for example, `ctx.query("SAVEPOINT")` inside the lambda) and are removed once a transaction is committed or rolled back.
 
@@ -159,10 +159,10 @@ Note that savepoints are only available within the context of a transaction (for
 
 All Couchbase services only see committed data. Uncommitted transaction modifications (i.e. dirty data) are never visible to any Couchbase service.
 
-The indexes provided by the Index, Search, and Analytics services are not synchronously updated with the commits performed by transactions, and instead they are updated with _Eventual Consistency_. Hence, a query performed immediately after committing a transaction may not see the effects of the transaction. 
+The indexes provided by the Index, Search, and Analytics services are not synchronously updated with the commits performed by transactions, and instead they are updated with _Eventual Consistency_. Hence, a query performed immediately after committing a transaction may not see the effects of the transaction.
 
 The Query Service provides the transactional scan consistency parameter, `request_plus`, which allows queries to wait for indexes to be appropriately updated, following a transaction. This `request_plus` parameter ensures that your queries operate on the latest visible data.
-When a query is used inside a transaction, the transactional scan consistency is set to `request_plus` by default, and hence ensures that the query will see all the committed changes. 
+When a query is used inside a transaction, the transactional scan consistency is set to `request_plus` by default, and hence ensures that the query will see all the committed changes.
 
 Note that you can choose to update the scan consistency level to `not_bounded` in some cases such as the following:
 
@@ -174,23 +174,23 @@ Note that you can choose to update the scan consistency level to `not_bounded` i
 
 xref:learn:clusters-and-availability/xdcr-overview.adoc[Cross Data Center Replication] (XDCR) supports eventual consistency of transactional changes. No uncommitted changes will be ever sent to the target clusters.  Once committed, the transactional changes will arrive one by one at the target. If the connection is lost midway while receiving a transaction it is possible for the target to receive a partial transaction.
 
-* Transactionally modified documents should only be replicated across clusters if no transactions involving the same documents can occur on those clusters simultaneously in a bidirectional XDCR. 
+* Transactionally modified documents should only be replicated across clusters if no transactions involving the same documents can occur on those clusters simultaneously in a bidirectional XDCR.
 
 * Always follow the steps to xref:learn:clusters-and-availability/xdcr-conflict-resolution.adoc#ensuring_safe_failover[Ensure Safe Failover] for information on failing a transactional application from one data center to another.
 
 == Transaction Mechanics
 
-Consider the transaction example to transfer funds from Beth’s account to Andy’s account. 
+Consider the transaction example to transfer funds from Beth’s account to Andy’s account.
 
 Assuming that the 2 documents involved in this transaction live in two different nodes, here are the high-level steps that the transaction follows:
 
-image::modules:learn:data/transaction-mechanics-steps.png["Transaction mechanics explaining the high-level steps that a transaction follows"]
+image::server:learn:data/transaction-mechanics-steps.png["Transaction mechanics explaining the high-level steps that a transaction follows"]
 
 Each execution of the transaction logic in an application is called an 'attempt' inside the overall transaction.
 
 === Active Transaction Record Entries
 
-The first mechanic is that each of these attempts adds an entry to a metadata document in the Couchbase cluster. These metadata documents are called _Active Transaction Records_, or ATRs. 
+The first mechanic is that each of these attempts adds an entry to a metadata document in the Couchbase cluster. These metadata documents are called _Active Transaction Records_, or ATRs.
 ATRs are created and maintained automatically and are easily distinguishable by their prefix `pass:c[_txn:atr-]`. They are viewable and _should not be modified externally_.
 
 Each ATR contains entries for multiple attempts. Each ATR entry stores some metadata and, crucially, whether the attempt has been committed or not. In this way, the entry acts as the single point of truth for the transaction, which is essential for providing an 'atomic commit' during reads.
@@ -204,7 +204,7 @@ The second mechanic is that mutating a document inside a transaction, does not d
 
 These staged document changes effectively act as a lock against other transactions trying to modify the document, preventing write-write conflicts.
 
-In Steps 2 and 3 in the illustration above, the transaction id and the content for the first and second mutations are staged in the XATTRs of their respective documents. 
+In Steps 2 and 3 in the illustration above, the transaction id and the content for the first and second mutations are staged in the XATTRs of their respective documents.
 
 === Cleanup
 
@@ -214,7 +214,7 @@ Note that if an application is not running, then this cleanup is also not runnin
 
 The cleanup process is detailed in xref:java-sdk:howtos:distributed-acid-transactions-from-the-sdk.adoc#asynchronous-cleanup[Asynchronous Cleanup].
 
-In Steps 4 and 5 in the illustration above, the documents “userA” and “userB” are unstaged, i.e., removed from xAttrs and replaced with the document body. 
+In Steps 4 and 5 in the illustration above, the documents “userA” and “userB” are unstaged, i.e., removed from xAttrs and replaced with the document body.
 
 === Committing
 
@@ -224,7 +224,7 @@ After this atomic commit point is reached, the individual documents are committe
 
 In Step 4 in the illustration above, the transaction attempt is marked as “Committed” in the ATR and the list of document ids involved in the transaction is updated.
 
-In Step 7 in the illustration above, the transaction attempt is marked as “Completed” and is removed from the ATR. 
+In Step 7 in the illustration above, the transaction attempt is marked as “Completed” and is removed from the ATR.
 
 == Permissions
 
@@ -233,9 +233,9 @@ include::partial$transaction-privileges.adoc[]
 [[custom-metadata-collections]]
 == Custom Metadata Collections
 
-By default, metadata documents are created in the default collection of the bucket of the first mutated document in the transaction. 
+By default, metadata documents are created in the default collection of the bucket of the first mutated document in the transaction.
 
-The metadata documents contain, for documents involved in each transaction, the document’s key and the name of the bucket, scope, and collection it exists on. 
+The metadata documents contain, for documents involved in each transaction, the document’s key and the name of the bucket, scope, and collection it exists on.
 
 In cases where deployments need a more granular way of organizing and sharing data across buckets, scopes, and collections, a custom metadata collection with appropriate RBAC permissions can be used to control visibility.  You can also use a custom metadata collection if you wish to remove the default collection.
 
@@ -260,13 +260,13 @@ For more information, see xref:java-sdk:howtos:distributed-acid-transactions-fro
 
 * The number of writes required by a transactional update is greater than the number required for a non-transactional update. Thus transactional updates may be less performant than non-transactional updates.
 +
-Note that data within a single document is always updated atomically (without the need for transactions): therefore,whenever practical, design your data model such that a single document holds values that need to be updated atomically.  
+Note that data within a single document is always updated atomically (without the need for transactions): therefore,whenever practical, design your data model such that a single document holds values that need to be updated atomically.
 
 * Non-transactional updates should not be made to any document involved in a transaction while the transaction is itself in progress: this prevents the non-transactional update from being overwritten.
 
 * When using Query statements in a transaction, we recommend that you limit the number of mutations within a transaction as the delta table grows with every mutation resulting in increased memory usage. Use the “memory-quota” setting in the query service to manage the amount of memory consumed by delta tables.
 +
-For ETL-like loads or massive updates that need ACID guarantees, consider using xref:java-sdk:howtos:distributed-acid-transactions-from-the-sdk.adoc#single-query-transactions[single query transactions]  directly from the Query Workbench, CLI, or cbq. Single query transactions, also referred to as _implicit transactions_, do not require a delta table to be maintained. 
+For ETL-like loads or massive updates that need ACID guarantees, consider using xref:java-sdk:howtos:distributed-acid-transactions-from-the-sdk.adoc#single-query-transactions[single query transactions]  directly from the Query Workbench, CLI, or cbq. Single query transactions, also referred to as _implicit transactions_, do not require a delta table to be maintained.
 
 == Deployment Considerations
 
@@ -276,7 +276,7 @@ Use of transactions requires Network Time Protocol (NTP) to be used to synchroni
 
 == Settings and Parameters
 
-Transactions can be configured using a number of settings and request-level parameters. 
+Transactions can be configured using a number of settings and request-level parameters.
 
 [cols="2", options="header"]
 |===
@@ -306,7 +306,7 @@ See xref:settings:query-settings.adoc#tximplicit[tximplicit] for details.
 |Specifies the maximum time to wait for a KV operation before timing out. The default value is 2.5s. See xref:settings:query-settings.adoc#kvtimeout[kvtimeout] for details.
 
 |atrcollection
-|Specifies the collection where the active transaction records (ATRs) and client records are stored. The collection must be present. If not specified, the ATR is stored in the default collection in the default scope in the bucket containing the first mutated document within the transaction. See 
+|Specifies the collection where the active transaction records (ATRs) and client records are stored. The collection must be present. If not specified, the ATR is stored in the default collection in the default scope in the bucket containing the first mutated document within the transaction. See
 xref:settings:query-settings.adoc#atrcollection_req[atrcollection] for details.
 |===
 


### PR DESCRIPTION
DOC-10439 release/7.1: Fixes missing graphic.

Reverted to:

image::data/transaction-mechanics-steps.png["Transaction mechanics explaining the high-level steps that a transaction follows"]

The new resource ID coordinates have spurred new additions in the document. On review, they did not seem to change in form.

Backport of #2909 


Note: Enrico Pagayucan is not searchable as a reviewer