### PR TITLE
DOC-10436 release/6.5: Fixed typo

### DIFF
--- a/modules/introduction/pages/why-couchbase.adoc
+++ b/modules/introduction/pages/why-couchbase.adoc
@@ -136,7 +136,7 @@ Couchbase Server replicates data across multiple nodes to support failover.
 Ensuring that additional copies of the data are available is automated to deal with the inevitable failures that large distributed systems are designed to recover from.
 This functionality is provided automatically without need for manual intervention or downtime.
 
-Entire Couchbase Server clusters can be replicated to one or more alternate geographical location using Cross Data Center Replication (XDCR), a technology that delivers increased high availability, disaster recovery and geographic load balancing.
+Entire Couchbase Server clusters can be replicated to one or more alternate geographical locations using Cross Data Center Replication (XDCR), a technology that delivers increased high availability, disaster recovery and geographic load balancing.
 XDCR addresses the challenges in linking clusters that span across a wide-area network (WAN) rather than simply extending local-cluster replication across a WAN.
 
 == Summary
@@ -145,4 +145,3 @@ Many databases are able to satisfy one or more of these requirements but require
 For example, one solution might deliver data model flexibility but might lack the ability to add or remove nodes without an impact on up-time or performance.
 Another solution might demonstrate good write scalability without being able to index or and change the data model on the fly.
 Couchbase Server is designed to deliver a productive developer and administration experience while also providing performance at scale, whether in the cloud, in a container, on-premise or on an edge device.
-


### PR DESCRIPTION
DOC-10436 release/6.5: Fixed typo

'location' to 'locations'

Backport of #2911 