### PR TITLE
DOC-10436 release/6.0: Fixed typo

### DIFF
--- a/modules/introduction/pages/intro.adoc
+++ b/modules/introduction/pages/intro.adoc
@@ -151,7 +151,7 @@ Couchbase Server replicates data across multiple nodes to support failover.
 Ensuring that additional copies of the data are available is automated to deal with the inevitable failures that large distributed systems are designed to recover from.
 All of this is done automatically without need for manual intervention or downtime.
 
-Entire Couchbase Server clusters can be replicated to one or more alternate geographical location using Cross Data Center Replication (XDCR), a technology that delivers increased high availability, disaster recovery and geographic load balancing.
+Entire Couchbase Server clusters can be replicated to one or more alternate geographical locations using Cross Data Center Replication (XDCR), a technology that delivers increased high availability, disaster recovery and geographic load balancing.
 XDCR addresses the unique challenges inherent in linking clusters that span across a wide-area network (WAN) rather than simply extending local-cluster replication across a WAN.
 
 == Summary


### PR DESCRIPTION
DOC-10436 release/6.0: Fixed typo

'location' to 'locations'

Backport of #2911 