### PR TITLE
DOC-10321 release/7.0: Deleted text

### DIFF
--- a/modules/eventing/pages/eventing-faq.adoc
+++ b/modules/eventing/pages/eventing-faq.adoc
@@ -26,15 +26,15 @@ Yes, the Eventing Service node can be co-located with other MDS-enabled services
 
 
 * Is it supported for both text and binary formats of the documents?
-+ 
++
 *Yes* only for versions 6.6.2+
 +
-For versions 6.6.2 and later, the value or the document can be either text or binary. Starting with version 6.6.2, Eventing processes binary documents. Eventing Functions can read a binary value from a bucket alias or via an Advanced Accessor. The documents are based on a key-value format where the value can be arbitrary text or binary data. However, in practice the value is typically a well formatted JSON text payload.  Note, Eventing Functions via the curl() function can also handle binary data to and from an external REST endpoint. Furthermore, every mutation OnUpdate(doc,meta) will now have a property "datatype" set to either "binary" or "json", however this information is not available via OnDelete(meta,options) or Basic Bucket Ops.  
+For versions 6.6.2 and later, the value or the document can be either text or binary. Starting with version 6.6.2, Eventing processes binary documents. Eventing Functions can read a binary value from a bucket alias or via an Advanced Accessor. The documents are based on a key-value format where the value can be arbitrary text or binary data. However, in practice the value is typically a well formatted JSON text payload.  Note, Eventing Functions via the curl() function can also handle binary data to and from an external REST endpoint. Furthermore, every mutation OnUpdate(doc,meta) will now have a property "datatype" set to either "binary" or "json", however this information is not available via OnDelete(meta,options) or Basic Bucket Ops.
 +
 *No* for versions 6.6.1 and earlier.
 +
 For versions 6.6.1 and earlier, the value or the document must always be text. Eventing currently doesn't process binary documents (binary documents will not generate mutations). Additionally, an Eventing Function can’t currently read a binary value from a bucket alias. The documents are based on a key-value format where the value can be arbitrary text. However, in practice the value is typically a well formatted JSON text payload.  There is one exception, Eventing Functions via the curl() function can handle binary data to and from an external REST endpoint.
-+ 
++
 
 
 == Change Capture
@@ -112,17 +112,17 @@ Since DCP is valid for the Data Service, and Eventing Functions only operate on 
 * Can Functions interact with external processes?
 +
 Yes.
-Functions support a cURL API as a way of interacting with external entities or REST endpoints using HTTP. This functionality 
-allows propagation of data changes to other systems, notifying the application about interesting events, enriching documents 
-with data from external resources, and so on. The native cURL that lets users propagate events of interest to other APIs when 
+Functions support a cURL API as a way of interacting with external entities or REST endpoints using HTTP. This functionality
+allows propagation of data changes to other systems, notifying the application about interesting events, enriching documents
+with data from external resources, and so on. The native cURL that lets users propagate events of interest to other APIs when
 mutation rates are low.
 
 
 * Can a Function be debugged and what happens when a Function is debugged?
 +
 Yes.
-Functions offer multiple diagnosability solutions (debugger, logs, and statistics), all designed to have minimal impact on overall 
-performance and scalability. 
+Functions offer multiple diagnosability solutions (debugger, logs, and statistics), all designed to have minimal impact on overall
+performance and scalability.
 When debugging a function a single mutation is blocked and handed off to the debugger session, while the rest of the mutations continue to be serviced by the Eventing Function, refer to the xref:eventing:eventing-debugging-and-diagnosability.adoc[Debugging and Diagnosability] section.
 
 
@@ -134,7 +134,7 @@ Functions can be "paused, edited and resumed" without losing a single mutation; 
 
 * How do I perform a Function's lifecycle operations from CI/CD?
 +
-To perform Functions lifecycle operations from CI/CD, refer to the xref:cli:cbcli/couchbase-cli-eventing-function-setup.adoc[CLI Eventing] section. 
+To perform Functions lifecycle operations from CI/CD, refer to the xref:cli:cbcli/couchbase-cli-eventing-function-setup.adoc[CLI Eventing] section.
 
 
 * How to invoke a REST endpoint from inside the Function?
@@ -166,8 +166,8 @@ Functions do not allow global variables, this restriction is mandatory for the F
 
 * What is in the "meta" Function parameter (OnUpdate, OnDelete)? Is this the metadata we currently write in order to figure out what has changed in the document?
 +
-No, the meta parameter does not include information on what fields changed or mutated in the document. 
-This parameter is composed of the meta fields associated with the document. For more information, refer to the https://docs.couchbase.com/server/6.5/learn/data/data.html#metadata[metadata] section.  
+No, the meta parameter does not include information on what fields changed or mutated in the document.
+This parameter is composed of the meta fields associated with the document. For more information, refer to the https://docs.couchbase.com/server/6.5/learn/data/data.html#metadata[metadata] section.
 +
 It should be noted, “document metadata” is different from the "Eventing Storage" keyspace (metadata collection), described in the next section, used by the Eventing Service to maintain state and checkpoints.
 
@@ -178,16 +178,16 @@ More than one Function can be defined for the same source collection.
 This lets you process the change according to the business logic that you enforce.
 But there is no enforced ordering; for example, if collection 'wine' has three different Functions, which are FunctionA, FunctionB, and FunctionC, you cannot enforce the order in which these Functions are executed.
 +
-However, for each Function you start a set of DCP streams so for a busy system you will get better performance by coalescing  multiple Eventing Functions that have the same source collection into a single Function.  
+However, for each Function you start a set of DCP streams so for a busy system you will get better performance by coalescing  multiple Eventing Functions that have the same source collection into a single Function.
 This merging is easy to do with a JavaScript switch statement or a simple if-then-else block.
 
-* Is it possible to get additional state during a Function execution? 
+* Is it possible to get additional state during a Function execution?
 +
 Yes.
-For example, you can fetch related data from another document (using a document id) from any other collection that is exposed to the Function via a "bucket binding".  
+For example, you can fetch related data from another document (using a document id) from any other collection that is exposed to the Function via a "bucket binding".
 It is also possible to utilize the cURL API to read additional state from an external REST endpoint.
 
-* Is it possible to update state (or change a document) during a Function execution? 
+* Is it possible to update state (or change a document) during a Function execution?
 +
 Yes.
 For example, you can your enrich or update a document with data from another document (using a document id) from any other collection that is exposed to the Function via a binding with access level of "Read Write" inclusive of the source collection.
@@ -208,31 +208,20 @@ Some additional requirements of the metadata collection are as follows:
 ** You should reserve the metadata collection solely for Eventing housekeeping.
 It shouldn't be used for any other data storage.
 ** Each Eventing function always requires a fixed amount of space of about 2MB (1024 docs * 1884 bytes).
-** If an Eventing function uses timers, then an additional fixed amount of space of about 0.2MB (1024 * docs of 196 bytes) is needed. 
+** If an Eventing function uses timers, then an additional fixed amount of space of about 0.2MB (1024 * docs of 196 bytes) is needed.
 From version 6.6.1 on only 0.04MB (256 docs * 196 bytes) is needed if the function uses timers.
 ** If an Eventing function uses timers, then for each active timer, an additional amount of space between 832 and 1856 bytes (832 bytes + sizeof(context)) is needed.
 Where by default the context cannot be larger than 1024 bytes and the maximum number of active timers is based on both the business logic and the mutation rate.
-Note, the "timer_context_size" can be overridden on a per function bases via the xref:eventing-api.adoc[Eventing: REST API]. 
+Note, the "timer_context_size" can be overridden on a per function bases via the xref:eventing-api.adoc[Eventing: REST API].
 It is best to keep the size of the context small by using a reference rather than passing and storing a massive document in the timer.
-** Every timer requires up to three documents (_root_, _alarm_, and _context_) which are stored in the Eventing Storage (or metadata collection). 
+** Every timer requires up to three documents (_root_, _alarm_, and _context_) which are stored in the Eventing Storage (or metadata collection).
 Note sometimes only two (2) additional documents are needed if the timer shares the same scan interval or _root_ document with a previous timer.
 
 * Why is the metadata collection not getting cleared when I cancel a timer or a set of timers.
 +
-When a timer is canceled the _context_ document is removed immediately, however the _root_ and _alarm_ documents are removed in a lazy fashion when the canceled timer was originally scheduled to fire.  
-Thus is 100K timers are scheduled to fire one (1) year in the future and canceled up to 2 additional documents will persist for one (1) year. 
+When a timer is canceled the _context_ document is removed immediately, however the _root_ and _alarm_ documents are removed in a lazy fashion when the canceled timer was originally scheduled to fire.
+Thus is 100K timers are scheduled to fire one (1) year in the future and canceled up to 2 additional documents will persist for one (1) year.
 Note the _cancelTimer()_ function was introduced in version 6.6.0.
-
-* When I undeploy all Eventing Functions the metadata collection is not fully cleared (this is a regression in 6.6.1 only).
-+
-This issue, https://issues.couchbase.com/browse/MB-43272[MB-43272], will happen when a Function is paused and then undeployed from the paused state (without resuming it again). 
-There are two solutions to avoid this issue 
-+
-** In version 6.6.1 never undeploy from the paused state.
-** After this issue occurs in version 6.6.1 (deploying from the passed state) you can clean things up via an Export, Delete and Import of the impacted Function after this issue occurs. 
-+
-Note the Export, Delete and Import actions won't actually delete the orphaned documents in metadata collection but this sequence will create a new functionUUID for the Eventing function and this function will only concern with the document (timer doc and checkpoint docs) created by the new functionUUID.  
-If this is an issue in your specific deployment please ask for a patch release.
 
 == Timer Behavior
 
@@ -240,10 +229,10 @@ If this is an issue in your specific deployment please ask for a patch release.
 +
 The timer implementation is designed to handle large numbers of distributed timers (i.e., millions of timers) and the only promise is to run timers as soon as possible, e.g. no timers lost.
 +
-In a steady state you may see a 3-4 second delay from the scheduled time, however if scheduling timers close to the system wall-clock this delay may increase to about 14 seconds.  
+In a steady state you may see a 3-4 second delay from the scheduled time, however if scheduling timers close to the system wall-clock this delay may increase to about 14 seconds.
 For more details on Timer scheduling refer to xref:eventing-timers.adoc#wall-clock-accuracy[Timers: Wall-clock Accuracy] section.
 
-* Can I cancel a Timer? 
+* Can I cancel a Timer?
 +
 Yes.
 As of the release 6.6.0 Eventing Timers can be cancelled using _cancelTimer()_ function, or by creating a new Timer with the same reference as an existing Timer refer to xref:eventing-timers.adoc#limitations[Timers: Limitations].
@@ -289,35 +278,35 @@ No. Functions do not lose any mutations during a rebalance operation.
 
 * I have Functions deployed on my cluster, when can I perform an Eventing rebalance operation?
 +
-The Function lifecycle operations (deploying, undeploying, pausing, resuming, and deleting) and the Eventing rebalance operation are mutually exclusive. 
-The Eventing rebalance  operation fails when a Function lifecycle operation is currently in progress. 
+The Function lifecycle operations (deploying, undeploying, pausing, resuming, and deleting) and the Eventing rebalance operation are mutually exclusive.
+The Eventing rebalance  operation fails when a Function lifecycle operation is currently in progress.
 Likewise, when the Eventing rebalance operation is in progress, you cannot perform a Function lifecycle operation.
 +
-Due to a regression, https://issues.couchbase.com/browse/MB-43343[MB-43343], impacting only 6.6.1 during a rebalance in of an Eventing node a race can occur resulting in Eventing functions becoming hung in deploying state. 
-Users can run into this issue when they have multiple functions deployed against the same source collection and they try to rebalance-in an eventing node.  
+Due to a regression, https://issues.couchbase.com/browse/MB-43343[MB-43343], impacting only 6.6.1 during a rebalance in of an Eventing node a race can occur resulting in Eventing functions becoming hung in deploying state.
+Users can run into this issue when they have multiple functions deployed against the same source collection and they try to rebalance-in an eventing node.
 The workaround is to ensure that you pause all Eventing Functions before any rebalance.
 
 * How do I increase performance of an Eventing Function?
 +
-You can scale up vertically by adding additional workers (in the Eventing Function's settings) to increase performance for a specific Function. 
-You can also scale out horizontally via Couchbase’s elastic scaling option by adding another node and rebalancing.  
+You can scale up vertically by adding additional workers (in the Eventing Function's settings) to increase performance for a specific Function.
+You can also scale out horizontally via Couchbase’s elastic scaling option by adding another node and rebalancing.
 In this case each eventing node is assigned a subset of vBuckets. Note this sharding increases overall performance for all Functions.
 +
 In 7.0.0 the default number of workers for new Eventing Functions is now one (1), previously it was one (3).  Thus pay attention to your performance and adjust the number of works to fit your application. Note, all upgrades of existing Functions will keep the number of workers they were created with.
 +
-However keep in mind that sometimes the Function is limited by the overall performance of the Data Service. 
+However keep in mind that sometimes the Function is limited by the overall performance of the Data Service.
 In this case it is appropriate to scale the Data service.
 
 * When I maximize the workers Eventing Function I sometimes see a stall in processing?
 +
-When scaling up vertically by adding additional workers (in the Eventing Function's settings) typically above 48 workers (_the issues is workload 
-dependent and occurs typically on source collection updates_) you may see a stall in Eventing Function's progress.  This is typically related 
-to resources given to the Eventing service and can be solved by adding additional Memory Quota to Eventing in the Cluster Settings.  By 
+When scaling up vertically by adding additional workers (in the Eventing Function's settings) typically above 48 workers (_the issues is workload
+dependent and occurs typically on source collection updates_) you may see a stall in Eventing Function's progress.  This is typically related
+to resources given to the Eventing service and can be solved by adding additional Memory Quota to Eventing in the Cluster Settings.  By
 default Eventing allocates 256 MB, raising this value to 512 MB will typically solve this resource issue (this is one of the rare instances
 that you may need to raise the Memory Quota for Eventing).
 +
-However keep in mind that sometimes the Function is limited by both the number of cores in the Eventing instance the overall 
-performance of the Data Service.  In these cases it is appropriate to either scale compute power of the Eventing node, scale the 
+However keep in mind that sometimes the Function is limited by both the number of cores in the Eventing instance the overall
+performance of the Data Service.  In these cases it is appropriate to either scale compute power of the Eventing node, scale the
 Eventing service, or scale the Data service.
 
 * Does Eventing support node-to-node encryption ?
@@ -326,5 +315,3 @@ Yes, node-to-node encryption is  available in the Couchbase Server for the Event
 Therefore, on earlier versions (in either train), when _all_ is specified, the data passed to and from all other Couchbase Services is passed in encrypted form, whereas the data passed to and from the Eventing Service continues to be passed in _unencrypted_ form.
 +
 When node-to-node encryption is enabled or disabled all deployed Eventing Functions need to be temporarily paused and can be resumed after the necessary changes have been made (to prevents the potential loss of mutations during the encryption change.)
-
-


### PR DESCRIPTION
DOC-10321 release/7.0: Deleted text

Deleted everything from "When I undeploy all Eventing Functions the metadata collection is not fully cleared..." up to and including "... If this is an issue in your specific deployment please ask for a patch release."

Backport of #2914 

(Enrico Pagayucan is not available as a reviewer)