### PR TITLE
DOC-10240 - Added information on 5500 error code to N1QL Error Codes reference

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/n1ql-error-codes.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/n1ql-error-codes.adoc
@@ -602,6 +602,20 @@ Use `scan_vectors` instead.
 | `User [user] has no roles.
 Connecting with this user may not be possible.`
 | User has no roles and may not be possible to connect with.
+
+| *55xx*
+|
+|
+
+| `5500`
+| `Request has exceeded memory quota`
+a| The query request exceeded the set Query Memory Quota.
+
+You can set a memory quota with the Couchbase Server UI, the REST API, or the CLI. For more information, see xref:settings:query-settings.adoc[Query Settings and Parameters].
+
+* To set a memory quota with the UI, see xref:manage:manage-settings/general-settings.adoc#query-settings[Query Settings] in the General settings for Couchbase Server.
+* To set a memory quota with the REST API, see xref:settings:query-settings.adoc#queryMemoryQuota[queryMemoryQuota] in Query Settings and Parameters.
+* To set a memory quota with the CLI, see xref:cli:cbcli/couchbase-cli-setting-query.adoc[setting-query] in the CLI Reference.
 |===
 
 == 10xxx Codes (ds_auth)


### PR DESCRIPTION
Added a new table row for 55xx error codes and added the 5500 error code, with links to existing information about setting memory quotas for understanding what would have caused the error. 