### PR TITLE
DOC-10299: Documentation on query context

### DIFF
--- a/modules/getting-started/pages/look-at-the-results.adoc
+++ b/modules/getting-started/pages/look-at-the-results.adoc
@@ -64,7 +64,7 @@ To see the collections that are contained within a given scope, left-click on th
 [#travel_sample_collections_screen]
 image::travelSampleCollectionsScreen.png["The travel-sample Scopes screen, showing the inventory collections",720]
 
-Starting with this release, all documents must be contained in a scope and collection.
+In Couchbase Server 7.0 and later, all documents must be contained in a scope and collection.
 If you import a dataset that was created in earlier versions of Couchbase Server, the documents are automatically saved within a `_default` scope and a `_default` collection.
 For your initial work with the system, this will be fine.
 But as you continue, and you create more documents, your will benefit from using scopes and collections to organize those documents in the best way: this will make data-access intuitive and clear.

--- a/modules/guides/pages/prep-statements.adoc
+++ b/modules/guides/pages/prep-statements.adoc
@@ -240,7 +240,9 @@ N1QL::
 --
 To create a prepared statement, use the `PREPARE` statement.
 
-Use the FROM / AS clause to specify a name for the prepared statement, if required.
+1. If necessary, set the xref:n1ql:n1ql-intro/sysinfo.adoc#query-context[query context] to the bucket and scope where you want to create the prepared statement.
+
+2. Use the FROM / AS clause to specify a name for the prepared statement, if required.
 If you don't, a name is generated automatically.
 
 '''
@@ -368,9 +370,11 @@ N1QL::
 --
 To execute a prepared statement, use the `EXECUTE` statement.
 
-1. Supply the name of the prepared statement, as provided when you created the prepared statement.
+1. If necessary, set the xref:n1ql:n1ql-intro/sysinfo.adoc#query-context[query context] to the bucket and scope where you created the prepared statement.
 
-2. If necessary, use the USING clause to supply the values for parameters in the prepared statement.
+2. Supply the name of the prepared statement, as provided when you created the prepared statement.
+
+3. If necessary, use the USING clause to supply the values for parameters in the prepared statement.
 
   ** Specify positional parameters using an array of values.
 

--- a/modules/learn/pages/data/scopes-and-collections.adoc
+++ b/modules/learn/pages/data/scopes-and-collections.adoc
@@ -86,6 +86,13 @@ For information on RBAC, see xref:learn:security/authorization-overview.adoc[Aut
 For a list of roles, see xref:learn:security/roles.adoc[Roles].
 For examples of how to assign roles to scopes and collections, see xref:manage:manage-security/manage-users-and-roles.adoc[Manage Users, Groups, and Roles].
 
+[#tenant-separation]
+== Tenant Separation
+
+A query may refer to a collection using an absolute _keyspace path_; or a relative _partial keyspace reference_, which must be resolved by means of the _query context_.
+The use of partial keyspace references and query context supports the separation of tenant data in a multi-tenancy environment.
+For details, refer to xref:n1ql:n1ql-intro/sysinfo.adoc#query-context[Query Context].
+
 [#expiration-and-collections]
 == Expiration and Collections
 

--- a/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
+++ b/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
@@ -917,9 +917,10 @@ Currently, only the `default` namespace is available.
 |===
 
 A prepared statement is created and stored relative to the current xref:n1ql:n1ql-intro/sysinfo.adoc#query-context[query context].
-This enables you to create multiple prepared statements with the same name, each stored relative to a different query context.
+You can create multiple prepared statements with the same name, each stored relative to a different query context.
+This enables you to run multiple instances of the same application against different datasets.
 
-When this is the case, the name of the prepared statement in the `system:prepareds` catalog includes the associated query context in brackets, to distinguish between prepared statements with the same name.
+When there are multiple prepared statements with the same name in different query contexts, the name of the prepared statement in the `system:prepareds` catalog includes the associated query context in brackets.
 
 [[sys-prepared-get]]
 === Get Prepared Statements

--- a/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
+++ b/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
@@ -899,7 +899,7 @@ For each prepared statement, this catalog provides information such as name, sta
 
 For field names and meanings, refer to xref:n1ql:n1ql-rest-api/admin.adoc#_statements[Statements].
 The `system:prepareds` catalog returns all the properties that the N1QL Admin REST API would return for a specific prepared statement.
-In addition, the `system:prepareds` catalog also returns the following property.
+In addition, the `system:prepareds` catalog also returns the following properties.
 
 [options="header", cols=".^3a,.^11a,.^4a"]
 |===
@@ -916,7 +916,7 @@ Currently, only the `default` namespace is available.
 |string
 |===
 
-A prepared statement is created and stored relative to the current _query context_.
+A prepared statement is created and stored relative to the current xref:n1ql:n1ql-intro/sysinfo.adoc#query-context[query context].
 This enables you to create multiple prepared statements with the same name, each stored relative to a different query context.
 
 When this is the case, the name of the prepared statement in the `system:prepareds` catalog includes the associated query context in brackets, to distinguish between prepared statements with the same name.

--- a/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
+++ b/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
@@ -105,11 +105,14 @@ You need to provide correct credentials, IP address, and port details of your se
 
 . Get the current query settings:
 +
-[source,console]
+[source,sh]
 ----
-include::settings:example$save-node-level-settings.txt[]
-
-$ cat  ./query_settings.json
+include::settings:example$save-node-level-settings.sh[tag=curl]
+----
++
+[source,sh]
+----
+cat  ./query_settings.json
 ----
 +
 [source,json]
@@ -120,27 +123,27 @@ include::settings:example$node-level-settings.jsonc[]
 . Set current query settings profile:
  .. To set the query settings saved in a file [.path]_./query_settings.json_, enter the following query:
 +
-[source,console]
+[source,sh]
 ----
-$ curl http://localhost:8093/admin/settings -u user:pword \
+curl http://localhost:8093/admin/settings -u user:pword \
   -X POST \
   -d@./query_settings.json
 ----
 
  .. To explicitly specify the settings, enter the following query:
 +
-[source,console]
+[source,sh]
 ----
-$ curl http://localhost:8093/admin/settings -u user:pword \
+curl http://localhost:8093/admin/settings -u user:pword \
   -H 'Content-Type: application/json' \
   -d '{"profile": "phases"}'
 ----
 
 . Verify the settings are changed as specified:
 +
-[source,console]
+[source,sh]
 ----
-include::settings:example$node-level-settings.txt[]
+include::settings:example$node-level-settings.sh[tag=curl]
 ----
 +
 [source,json]
@@ -162,10 +165,14 @@ include::settings:example$node-level-settings.txt[]
 You can enable monitoring and profiling settings for each query statement.
 To set query settings using the cbq shell, use the `\SET` command:
 
-[source,console]
+[source,n1ql]
 ----
-cbq> \set -profile "timings";
-cbq> \set;
+\set -profile "timings";
+\set;
+----
+
+[source,text]
+----
  Query Parameters :
  Parameter name : profile
  Value : ["timings"]
@@ -174,9 +181,9 @@ cbq> \set;
 
 To set query settings using the REST API, specify the parameters in the request body:
 
-[source,console]
+[source,sh]
 ----
-$ curl http://localhost:8093/query/service -u user:pword \
+curl http://localhost:8093/query/service -u user:pword \
   -d 'profile=timings&statement=SELECT * FROM "world" AS hello'
 ----
 
@@ -295,7 +302,7 @@ a|
 [source,json]
 ----
 "executionTimings": {
-  …
+  // …
   [{
     "#operator": "Fetch",
     "#stats": {
@@ -319,7 +326,8 @@ a|
     "execTime": "449.944µs",
     "kernTime": "14.625524ms"
     }
-  }, …]
+  // …
+  ]}
 ----
 
 |===
@@ -333,17 +341,17 @@ These statistics (`kernTime`, `servTime`, and `execTime`) can be very helpful in
 ====
 The cbq engine must be started with authorization, for example:
 
-[source,console]
+[source,sh]
 ----
-$ ./cbq  -engine=http://localhost:8091/ -u Administrator -p pword
+./cbq -engine=http://localhost:8091/ -u Administrator -p pword
 ----
 
-Show the statistics collected when the `profile` is set to `phases`:
+Using the cbq shell, show the statistics collected when the `profile` is set to `phases`:
 
-[source,console]
+[source,n1ql]
 ----
-cbq> \set -profile "phases";
-cbq> SELECT * FROM `travel-sample`.inventory.airline LIMIT 1;
+\set -profile "phases";
+SELECT * FROM `travel-sample`.inventory.airline LIMIT 1;
 ----
 
 [source,json]
@@ -402,12 +410,12 @@ cbq> SELECT * FROM `travel-sample`.inventory.airline LIMIT 1;
 
 .Timings Profile
 ====
-Show the statistics collected when `profile` is set to `timings`:
+Using the cbq shell, show the statistics collected when `profile` is set to `timings`:
 
-[source,console]
+[source,n1ql]
 ----
-cbq> \set -profile "timings";
-cbq> SELECT * FROM `travel-sample`.inventory.airline LIMIT 1;
+\set -profile "timings";
+SELECT * FROM `travel-sample`.inventory.airline LIMIT 1;
 ----
 
 [source,json]
@@ -626,9 +634,9 @@ For field names and meanings, refer to xref:n1ql:n1ql-rest-api/admin.adoc#_vital
 
 === Get System Vitals
 
-[source,console]
+[source,sh]
 ----
-$ curl -u Administrator:pword http://localhost:8093/admin/vitals
+curl -u Administrator:pword http://localhost:8093/admin/vitals
 ----
 
 [source,json]
@@ -674,9 +682,9 @@ The profile related attributes are described in the section <<profile,Attribute 
 
 To view active requests with Admin REST API:
 
-[source,console]
+[source,sh]
 ----
-$ curl -u Administrator:pword http://localhost:8093/admin/active_requests
+curl -u Administrator:pword http://localhost:8093/admin/active_requests
 ----
 
 To view active requests with N1QL, including the query plan:
@@ -693,9 +701,9 @@ The DELETE command can be used to terminate an active request, for instance, a n
 
 To terminate an active request [.var]`uuid` with the Admin REST API:
 
-[source,console]
+[source,sh]
 ----
-$ curl -u Administrator:pword -X DELETE http://localhost:8093/admin/active_requests/uuid
+curl -u Administrator:pword -X DELETE http://localhost:8093/admin/active_requests/uuid
 ----
 
 To terminate an active request [.var]`uuid` with N1QL:
@@ -905,9 +913,9 @@ __required__|The node on which the prepared statement is stored.|string
 
 To get a list of all known prepared statements, you can use the Admin REST API or a N1QL query:
 
-[source,console]
+[source,sh]
 ----
-$ curl -u Administrator:pword http://localhost:8093/admin/prepareds
+curl -u Administrator:pword http://localhost:8093/admin/prepareds
 ----
 
 [source,n1ql]
@@ -917,9 +925,9 @@ SELECT * FROM system:prepareds;
 
 To get information about a specific prepared statement [.var]`example1`, you can use the Admin REST API or a N1QL query:
 
-[source,console]
+[source,sh]
 ----
-$ curl -u Administrator:pword http://localhost:8093/admin/prepareds/example1
+curl -u Administrator:pword http://localhost:8093/admin/prepareds/example1
 ----
 
 [source,n1ql]
@@ -932,9 +940,9 @@ SELECT * FROM system:prepareds WHERE name = "example1";
 
 To delete a specific prepared statement [.var]`p1`, you can use the Admin REST API or a N1QL query:
 
-[source,console]
+[source,sh]
 ----
-$ curl -u Administrator:pword -X DELETE http://localhost:8093/admin/prepareds/p1
+curl -u Administrator:pword -X DELETE http://localhost:8093/admin/prepareds/p1
 ----
 
 [source,n1ql]
@@ -1230,9 +1238,9 @@ Running only one of them continuously has no noticeable affect on performance.
 
 To get a list of all logged completed requests using the Admin REST API:
 
-[source,console]
+[source,sh]
 ----
-$ curl -u Administrator:pword http://localhost:8093/admin/completed_requests
+curl -u Administrator:pword http://localhost:8093/admin/completed_requests
 ----
 
 To get a list of all logged completed requests using N1QL, including the query plan:
@@ -1247,9 +1255,9 @@ SELECT *, meta().plan FROM system:completed_requests;
 
 To purge a completed request [.var]`uuid` with the Admin REST API:
 
-[source,console]
+[source,sh]
 ----
-$ curl -u Administrator:pword -X DELETE http://localhost:8093/admin/completed_requests/uuid
+curl -u Administrator:pword -X DELETE http://localhost:8093/admin/completed_requests/uuid
 ----
 
 To purge a completed request [.var]`uuid` with N1QL:
@@ -1276,9 +1284,11 @@ In Couchbase Server 6.5 and later, you can specify the conditions for completed 
 This field takes a JSON object containing the names and values of logging qualifiers.
 Completed requests that meet the defined qualifiers are logged.
 
-[source,console]
+[source,sh]
 ----
-$ curl http://localhost:8093/admin/settings -u Administrator:password -H 'Content-Type: application/json' -d '{"completed": {"user": "marco", "error": 12003}}'
+curl http://localhost:8093/admin/settings -u Administrator:password \
+  -H 'Content-Type: application/json' \
+  -d '{"completed": {"user": "marco", "error": 12003}}'
 ----
 
 ==== Logging Qualifiers
@@ -1304,16 +1314,20 @@ To remove a qualifier, use a minus sign (`-`) before the qualifier name, e.g. `-
 
 For example, the following request will add user `simon` to those tracked, and remove error `12003`.
 
-[source,console]
+[source,sh]
 ----
-$ curl http://localhost:8093/admin/settings -u Administrator:password -H 'Content-Type: application/json' -d '{"completed": {"+user": "simon", "-error": 12003}}'
+curl http://localhost:8093/admin/settings -u Administrator:password \
+  -H 'Content-Type: application/json' \
+  -d '{"completed": {"+user": "simon", "-error": 12003}}'
 ----
 
 Similarly, you could remove all logging by execution time with the following request, as long as the value matches the existing threshold.
 
-[source,console]
+[source,sh]
 ----
-$ curl http://localhost:8093/admin/settings -u Administrator:password -H 'Content-Type: application/json' -d '{"completed": {"-threshold": 1000}}'
+curl http://localhost:8093/admin/settings -u Administrator:password \
+  -H 'Content-Type: application/json' \
+  -d '{"completed": {"-threshold": 1000}}'
 ----
 
 ==== Tagged Sets
@@ -1322,9 +1336,11 @@ You can also specify qualifiers that have to be met as a group for the completed
 
 To do this, specify the `tag` field along with a set of qualifiers, like so:
 
-[source,console]
+[source,sh]
 ----
-$ curl http://localhost:8093/admin/settings -u Administrator:password -H 'Content-Type: application/json' -d '{"completed": {"user": "marco", "error": 12003, "tag": "both_user_and_error"}}'
+curl http://localhost:8093/admin/settings -u Administrator:password \
+  -H 'Content-Type: application/json' \
+  -d '{"completed": {"user": "marco", "error": 12003, "tag": "both_user_and_error"}}'
 ----
 
 In this case, the request will be logged when both user and error match.
@@ -1334,9 +1350,11 @@ Requests that match a tagged set of conditions are logged with a field `~tag`, w
 
 To add a qualifier to a tagged set, specify the tag name again along with the new qualifier:
 
-[source,console]
+[source,sh]
 ----
-$ curl http://localhost:8093/admin/settings -u Administrator:password -H 'Content-Type: application/json' -d '{"completed": {"client": "172.1.2.3",  "tag": "both_user_and_error"}}'
+curl http://localhost:8093/admin/settings -u Administrator:password \
+  -H 'Content-Type: application/json' \
+  -d '{"completed": {"client": "172.1.2.3", "tag": "both_user_and_error"}}'
 ----
 
 You cannot add a new instance of an existing qualifier to a tagged set using a plus sign (`+`) before the qualifier name.
@@ -1365,9 +1383,11 @@ Specify [.in]`0` to log all requests and [.in]`-1` to not log any requests to th
 
 To specify a different value, use:
 
-[source,console]
+[source,sh]
 ----
-$ curl http://localhost:port/admin/settings -H 'Content-Type: application/json' -d '{"completed-threshold":0}' -u user:pword
+curl http://localhost:port/admin/settings -u user:pword \
+  -H 'Content-Type: application/json' \
+  -d '{"completed-threshold":0}'
 ----
 
 ==== Completed Limit
@@ -1378,9 +1398,11 @@ Specify [.in]`0` to not track any requests and [.in]`-1` to set no limit.
 
 To specify a different value, use:
 
-[source,console]
+[source,sh]
 ----
-$ curl http://localhost:port/admin/settings -H 'Content-Type: application/json' -d '{"completed-limit":1000}' -u user:pword
+curl http://localhost:port/admin/settings -u user:pword \
+  -H 'Content-Type: application/json' \
+  -d '{"completed-limit":1000}'
 ----
 
 [[sys-completed-examples]]
@@ -1389,30 +1411,30 @@ $ curl http://localhost:port/admin/settings -H 'Content-Type: application/json' 
 [[example-2]]
 .Completed Request
 ====
-First, we set `profile = "timings"` and run a long query which takes at least 1000ms (the default value of the `completed-threshold` query setting) to get registered in the `system:completed_requests` keyspace:
+First, using the cbq shell, we set `profile = "timings"` and run a long query which takes at least 1000ms (the default value of the `completed-threshold` query setting) to get registered in the `system:completed_requests` keyspace:
 
 .Query 1
-[source,console]
+[source,n1ql]
 ----
-cbq> \set -profile "timings";
-cbq> SELECT * FROM `travel-sample`.inventory.route ORDER BY sourceairport;
+\set -profile "timings";
+SELECT * FROM `travel-sample`.inventory.route ORDER BY sourceairport;
 ----
 
-Now, we change the profile setting to "phases" and rerun another long query:
+Now, using the cbq shell, we change the profile setting to "phases" and rerun another long query:
 
 .Query 2
-[source,console]
+[source,n1ql]
 ----
-cbq> \set -profile "phases";
-cbq> SELECT * FROM `travel-sample`.inventory.route ORDER BY destinationairport;
+\set -profile "phases";
+SELECT * FROM `travel-sample`.inventory.route ORDER BY destinationairport;
 ----
 
 Run a query `system:completed_requests` keyspace with `meta().plan`.
 
 .Query 3
-[source,console]
+[source,n1ql]
 ----
-cbq> SELECT meta().plan, * from system:completed_requests;
+SELECT meta().plan, * from system:completed_requests;
 ----
 
 .Result

--- a/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
+++ b/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
@@ -171,7 +171,7 @@ To set query settings using the cbq shell, use the `\SET` command:
 \set;
 ----
 
-[source,text]
+[source,none]
 ----
  Query Parameters :
  Parameter name : profile
@@ -894,7 +894,7 @@ The root operator is a Sequence, which itself has a collection of child operator
 [#sys-prepared]
 == system:prepareds
 
-This catalog provides data about the known prepared statements and their state in a query engine’s prepared statement cache.
+This catalog provides data about the known prepared statements and their state in a query engine's prepared statement cache.
 For each prepared statement, this catalog provides information such as name, statement, query plan, last use time, number of uses, and so on.
 
 For field names and meanings, refer to xref:n1ql:n1ql-rest-api/admin.adoc#_statements[Statements].
@@ -905,8 +905,21 @@ In addition, the `system:prepareds` catalog also returns the following property.
 |===
 |Name|Description|Schema
 |**node** +
-__required__|The node on which the prepared statement is stored.|string
+__required__
+|The node on which the prepared statement is stored.
+|string
+
+|**namespace** +
+__required__
+|The namespace in which the prepared statement is stored.
+Currently, only the `default` namespace is available.
+|string
 |===
+
+A prepared statement is created and stored relative to the current _query context_.
+This enables you to create multiple prepared statements with the same name, each stored relative to a different query context.
+
+When this is the case, the name of the prepared statement in the `system:prepareds` catalog includes the associated query context in brackets, to distinguish between prepared statements with the same name.
 
 [[sys-prepared-get]]
 === Get Prepared Statements
@@ -962,15 +975,17 @@ DELETE FROM system:prepareds;
 
 .Get Prepared
 ====
+.Prepared statement with default query context -- using cbq
 [source,n1ql]
 ----
+\UNSET -query_context;
 PREPARE p1 AS SELECT * FROM `travel-sample`.inventory.airline WHERE iata = "U2";
 ----
 
 [source,json]
 ----
 {
-  "requestID": "06819475-e1f6-48a6-8b78-41a6fbac7810",
+  "requestID": "64069886-eb17-4fa6-8cc8-e60ebe93d97c",
   "signature": "json",
   "results": [
     {
@@ -1058,45 +1073,38 @@ PREPARE p1 AS SELECT * FROM `travel-sample`.inventory.airline WHERE iata = "U2";
   ],
   "status": "success",
   "metrics": {
-    "elapsedTime": "60.560801ms",
-    "executionTime": "60.291394ms",
+    "elapsedTime": "105.814848ms",
+    "executionTime": "105.648798ms",
     "resultCount": 1,
     "resultSize": 3301,
     "serviceLoad": 12
-  },
-  "profile": {
-    "phaseTimes": {
-      "authorize": "21.597µs",
-      "instantiate": "14.64µs",
-      "parse": "1.718303ms",
-      "plan": "1.658632ms",
-      "run": "56.817557ms"
-    },
-    "phaseOperators": {
-      "authorize": 1
-    },
-    "requestTime": "2021-04-30T21:46:33.972Z",
-    "servicingHost": "127.0.0.1:8091"
   }
 }
 ----
 
+.Prepared statement with specified query context -- using cbq
 [source,n1ql]
 ----
-SELECT *, meta().plan FROM system:prepareds;
+\SET -query_context travel-sample.inventory;
+PREPARE p1 AS SELECT * FROM airline WHERE iata = "U2";
 ----
 
 [source,json]
 ----
 {
-  "requestID": "42adcc5e-3d7f-4228-8da1-035093a93406",
-  "signature": {
-    "*": "*",
-    "plan": "json"
-  },
+  "requestID": "1c90603e-5e42-42b4-9362-4fc96bf895ac",
+  "signature": "json",
   "results": [
     {
-      "plan": {
+      "encoded_plan": "H4sIAAAAAAAA/wEAAP//AAAAAAAAAAA=",
+      "featureControls": 76,
+      "indexApiVersion": 4,
+      "indexScanKeyspaces": {
+        "default:travel-sample.inventory.airline": false
+      },
+      "name": "[127.0.0.1:8091]p1",
+      "namespace": "default",
+      "operator": {
         "#operator": "Authorize",
         "privileges": {
           "List": [
@@ -1161,53 +1169,93 @@ SELECT *, meta().plan FROM system:prepareds;
           ]
         }
       },
+      "queryContext": "travel-sample.inventory",
+      "reqType": "SELECT",
+      "signature": {
+        "*": "*"
+      },
+      "text": "PREPARE p1 AS SELECT * FROM airline WHERE iata = \"U2\";",
+      "useCBO": true
+    }
+  ],
+  "status": "success",
+  "metrics": {
+    "elapsedTime": "17.476424ms",
+    "executionTime": "17.187836ms",
+    "resultCount": 1,
+    "resultSize": 3298,
+    "serviceLoad": 12
+  }
+}
+----
+
+.List prepared statements
+[source,n1ql]
+----
+SELECT *, meta().plan FROM system:prepareds;
+----
+
+[source,json]
+----
+{
+  "requestID": "d976e59a-d74e-4350-b0df-fa137099d594",
+  "signature": {
+    "*": "*",
+    "plan": "json"
+  },
+  "results": [
+    {
+      "plan": {
+        // ...
+      },
       "prepareds": {
-        "encoded_plan": "H4sIAAAAAAAA/6RT3W7UPBB9leh8N23lr6KAqGTExVJtBaKo0W6BC1olJpndmnptd+ysGlbh2ZGTtFW3CIR6l9gzZ86PZwOylaupLrxRFhIQWJCKDdORs5GdCZCHrwS0relm4vVn4qCdhXw5ns0rZT9QG7yqKEBuUNNCNSbKyGpN5v+gVt7QvrZrstFxu680G20JcqFMoE7AqhVBwh9g+O6hIG+BIOA8sYqOE/x/9z+YNPHSsf5BEPCs19rQciBxokOE/LrBmeIlxXu0v9ISyFmvIQ/Th/MB8ll30Qn8rC61qbcZzOm6IVultqGAyfZz/7koZ71S3CY7X0DgW1Nd9bwf8MVo+qCnuGNfjOwLP6Dc1hWe3XeqYp/YBuNtcUUtZOQmuX81ZgeJewt+H0OonE8nd2Mh0ARtl5BYBo1OPJR0TLG6/JOWJ83enpYrVsaQwZOyOtYmEkOgcrbWg3HY2SlHfuV+qVVU5W72JjvHp+fn2H1E5L3VUSuTD9ZDgCk0JhaReBX6gXTjU2Egs0jSouIxjovuokuvbYt4ZFIrpDuB64a4TbtJN3HYV6brs7Y3Zz49mR6dJUi9tP0SJw/2ILGHTmBsyWfTfDKbZv4gm8yzoSfby45npx+z8kFE5eP9yL68m86mWTLhzoLX/Tugo7eno4xfAQAA//83PgrgVgQAAA==",
+        "encoded_plan": "H4sIAAAAAAAA/6RTUW/TPBT9K9H5XrbJ30QBMcmIhzJ1AjG0qh3wwKbEJLedmWt71061UIXfjpxkndYhENpbYt97z7nn+GxAtnQVVbk3ykICAgtSsWY6djayMwHy6JWAthXdjr3+TBy0s5Avh7N5qewHaoJXJQXIDSpaqNpEGVmtyfwf1MobOtR2TTY6bg6VZqMtQS6UCdQKWLUiSPgR+u9uFOTdIAg4T6yi4zT+v/sfjOt45Vj/IAh41mttaNmTONUhQn7d4FzxkuL9tL/SEpiyXkMepQ/nA+Sz9rIV+FleaVPtMpjTTU22TG19AZPtcP+5aMp6pbhJcr6AwLe6vO54P+CLQfR+n3zLPh/Y576fcleXe3bfqYydYxsMt/k1NZCR66T+9eAdJO4l+L0NoXQ+nWxhIVAHbZeQWAaNVjxc6YRiefWnXZ6EvYs2VayMIYMneXWiTSSGQOlspXvhsLdXDPyKw0KrqIr97E12gU/PL7D/iMh7q6NWZtpLDwGmUJuYR+JV6ADp1qfCQGaRVouKBzsu28s2vbYd4pFJrZDuBFJOtyE8Go0EbmriJqWVbmOfYKab86aTaz45nRyfJxC9tF2skyoHkDhAKzC0TGeT6Xg2yfwoG8+zvic7yE5mZx+z4oFpxePEZF/eTWaTLMmyFeV19zLo+O3ZsNivAAAA//+q+jhuaAQAAA==",
         "featuresControl": 76,
         "indexApiVersion": 4,
         "indexScanKeyspaces": {
           "default:travel-sample.inventory.airline": false
         },
-        "name": "p1",
+        "name": "p1", // <1>
         "namespace": "default",
         "node": "127.0.0.1:8091",
         "statement": "PREPARE p1 AS SELECT * FROM `travel-sample`.inventory.airline WHERE iata = \"U2\";",
+        "uses": 0
+      }
+    },
+    {
+      "plan": {
+        // ...
+      },
+      "prepareds": {
+        "encoded_plan": "H4sIAAAAAAAA/6STT28TMRDFv8rqcWkrExFAVDLiEKpUIIoaJQUOtNqY3Ulq6tju2Bt1iZbPjry7TWmKQKg3/xnPvPk9zwZkC1dSmXujLCQgsCAVK6YjZyM7EyAPXwloW9LNyOvPxEE7C/myP5sVyn6gOnhVUIDcoKSFqkyUkdWazNOgVt7QQNs12ei4HijNRluCXCgTqBGwakWQ8EN06zYV5G0iCDhPrKLjlP7J3QajKl461j8IAp71WhtadiJOdIiQXzc4U7ykeJftn7IEJqzXkIdp4XyAfNZcNAI/i0ttyl0FM7quyBbpWRfAZNu6/x00Yb1SXCecLyDwrSquWt339KKH3vWTb9Xnvfrcd1lu43LP7jsVsXVsg/42v6IaMnKV6F/13kHiDsGfbQiF8+lkWxYCVdB2CYll0GjE/ZaOKRaXf+vlUbV3q00UK2PI4FFeHWsTiSFQOFvqDhz29ua9vvlgrlVU8/3sTXaOT8/Psf9AyHuro1Zm0qGHAFOoTMwj8Sq0BenGp8BAZpFai4p7Oy6aiyb9th3hkUmtkO4E0pxuh/BwOBS4rojrNK108wDy4HevmK7P6pbibHwyPjpLtfXSttOeYB1A4gCNQJ9pMh1PRtNx5ofZaJZ1b7KD7Hh6+jHreWRf3o2n4ywx2RJ53X4LOnp72nf1KwAA////9+bsZQQAAA==",
+        "featuresControl": 76,
+        "indexApiVersion": 4,
+        "indexScanKeyspaces": {
+          "default:travel-sample.inventory.airline": false
+        },
+        "name": "p1(travel-sample.inventory)", // <2>
+        "namespace": "default",
+        "node": "127.0.0.1:8091",
+        "statement": "PREPARE p1 AS SELECT * FROM airline WHERE iata = \"U2\";",
         "uses": 0
       }
     }
   ],
   "status": "success",
   "metrics": {
-    "elapsedTime": "74.38189ms",
-    "executionTime": "74.238983ms",
-    "resultCount": 1,
-    "resultSize": 3936,
+    "elapsedTime": "25.323496ms",
+    "executionTime": "25.173646ms",
+    "resultCount": 2,
+    "resultSize": 7891,
     "serviceLoad": 12
-  },
-  "profile": {
-    "phaseTimes": {
-      "authorize": "18.115µs",
-      "fetch": "17.331889ms",
-      "instantiate": "18.856µs",
-      "parse": "673.255µs",
-      "plan": "99.23µs",
-      "primaryScan": "55.468539ms",
-      "run": "73.429071ms"
-    },
-    "phaseCounts": {
-      "fetch": 1,
-      "primaryScan": 1
-    },
-    "phaseOperators": {
-      "authorize": 1,
-      "fetch": 1,
-      "primaryScan": 1
-    },
-    "requestTime": "2021-04-30T21:47:56.814Z",
-    "servicingHost": "127.0.0.1:8091"
   }
 }
 ----
+
+Note that the names of the prepared statements are identical, but they are associated with different query contexts.
+
+<.> The name of the prepared statement for the default query context
+<.> The name of the prepared statement showing the associated query context
 ====
 
 [#sys-completed-req]

--- a/modules/n1ql/pages/n1ql-intro/queriesandresults.adoc
+++ b/modules/n1ql/pages/n1ql-intro/queriesandresults.adoc
@@ -19,6 +19,13 @@ Because data can be irregular, you can specify conditions in the `WHERE` clause 
 
 You can use standard `GROUP BY`, `ORDER BY`, `LIMIT`, and `OFFSET` clauses as well as a rich set of functions to transform the results as needed.
 
+Queries access data, which is be stored within a logical hierarchy of buckets, scopes and collections.
+For details, refer to xref:learn:data/scopes-and-collections.adoc[Scopes and Collections].
+
+A query may refer to a collection using an absolute _keyspace path_; or a relative _partial keyspace reference_, which must be resolved by means of the _query context_.
+The use of partial keyspace references and query context supports the separation of tenant data in a multi-tenancy environment.
+For details, refer to xref:n1ql:n1ql-intro/sysinfo.adoc#query-context[Query Context].
+
 == Results
 
 The result for each query is a set of JSON documents.

--- a/modules/n1ql/pages/n1ql-intro/sysinfo.adoc
+++ b/modules/n1ql/pages/n1ql-intro/sysinfo.adoc
@@ -1,10 +1,11 @@
 = Getting System Information
-:description: pass:q[N1QL has a system catalog that stores metadata about a database. \
-The system catalog is a namespace called _system_.]
 :page-topic-type: concept
+:description: N1QL has a system catalog that stores metadata about a database. \
+The system catalog is a namespace called system.
 
 [abstract]
-{description}
+N1QL has a system catalog that stores metadata about a database.
+The system catalog is a namespace called _system_.
 
 There is a keyspace for each type of artifact.
 The keyspace names are plural in order to avoid conflicting with N1QL keywords.
@@ -78,6 +79,13 @@ When the query context is not set, it defaults to the `default` namespace, with 
 * To set the query context in the Query Workbench, use the the xref:tools:query-workbench.adoc#query-context[query context] drop-down menu in the Query Editor.
 
 * To set the query context from the cbq shell or the REST API, use the xref:settings:query-settings.adoc#query_context[query_context] request-level parameter.
+
+.Tenant separation
+[IMPORTANT]
+--
+By using queries with partial keyspace references, which are resolved using the query context, a database application can be switched from one scope to another simply by changing the query context.
+This can be used to support the separation of tenant data in a multi-tenancy environment.
+--
 
 [#querying-datastores]
 == Querying Datastores

--- a/modules/n1ql/pages/n1ql-language-reference/execute.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/execute.adoc
@@ -49,7 +49,8 @@ _(Introduced in Couchbase Server 7.0)_
 endif::[]
 
 A prepared statement is created and stored relative to the current _query context_.
-This enables you to create multiple prepared statements with the same name, each stored relative to a different query context.
+You can create multiple prepared statements with the same name, each stored relative to a different query context.
+This enables you to run multiple instances of the same application against different datasets.
 
 To execute a prepared statement, the query context must be the same as it was when the prepared statement was created; otherwise the prepared statement will not be found.
 

--- a/modules/n1ql/pages/n1ql-language-reference/execute.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/execute.adoc
@@ -41,16 +41,18 @@ This may be:
 
 For more details, refer to <<parameters>> below.
 
-[[usage]]
-== Usage
+[[query-context]]
+== Query Context
 
-You can execute a prepared statement in three ways:
+A prepared statement is created and stored relative to the current _query context_.
+This enables you to create multiple prepared statements with the same name, each stored relative to a different query context.
 
-* Using the EXECUTE statement in the Query Workbench.
+To execute a prepared statement, the query context must be the same as it was when the prepared statement was created; otherwise the prepared statement will not be found.
 
-* Using the EXECUTE statement in the the xref:tools:cbq-shell.adoc[cbq] command line shell.
+You must therefore set the required query context, or unset the query context if necessary, before executing the prepared statement.
+If you do not set the query context, it defaults to the empty string.
 
-* Using the xref:n1ql:n1ql-rest-api/index.adoc[Query REST API] (`/query/service` endpoint).
+For further information, refer to xref:n1ql:n1ql-intro/sysinfo.adoc#query-context[Query Context].
 
 [[statement-retrieval]]
 == Statement Retrieval
@@ -263,3 +265,9 @@ curl -v http://localhost:8093/query/service -d 'prepared="fave_tweets"&$r=9.5'
 == Related
 
 * For information on preparing a statement for execution, refer to xref:n1ql-language-reference/prepare.adoc[PREPARE].
+
+* For information on using prepared statements with the `cbq` command line shell, refer to xref:tools:cbq-shell.adoc[].
+
+* For information on using prepared statements with the Query REST API (`/query/service` endpoint), refer to xref:n1ql:n1ql-rest-api/index.adoc[].
+
+* For information on using prepared statements with an SDK, refer to xref:java-sdk:concept-docs:n1ql-query.adoc#prepared-statements-for-query-optimization[Querying with N1QL] and xref:java-sdk:howtos:n1ql-queries-with-sdk.adoc#parameterized-queries[N1QL from the SDK].

--- a/modules/n1ql/pages/n1ql-language-reference/execute.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/execute.adoc
@@ -44,6 +44,10 @@ For more details, refer to <<parameters>> below.
 [[query-context]]
 == Query Context
 
+ifeval::['{page-component-version}' == '7.0']
+_(Introduced in Couchbase Server 7.0)_
+endif::[]
+
 A prepared statement is created and stored relative to the current _query context_.
 This enables you to create multiple prepared statements with the same name, each stored relative to a different query context.
 

--- a/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
@@ -48,6 +48,10 @@ For more details, refer to <<result>> below.
 [[query-context]]
 == Query Context
 
+ifeval::['{page-component-version}' == '7.0']
+_(Introduced in Couchbase Server 7.0)_
+endif::[]
+
 A prepared statement is created and stored relative to the current _query context_.
 This enables you to create multiple prepared statements with the same name, each stored relative to a different query context.
 

--- a/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
@@ -53,7 +53,8 @@ _(Introduced in Couchbase Server 7.0)_
 endif::[]
 
 A prepared statement is created and stored relative to the current _query context_.
-This enables you to create multiple prepared statements with the same name, each stored relative to a different query context.
+You can create multiple prepared statements with the same name, each stored relative to a different query context.
+This enables you to run multiple instances of the same application against different datasets.
 
 To execute a prepared statement, the query context must be the same as it was when the prepared statement was created; otherwise the prepared statement will not be found.
 

--- a/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
@@ -45,18 +45,18 @@ A local name for the prepared statement.
 If you do not specify a local name for the prepared statement, the query engine generates a UUID from the statement text.
 For more details, refer to <<result>> below.
 
-[[usage]]
-== Usage
+[[query-context]]
+== Query Context
 
-You can prepare a statement in three ways:
+A prepared statement is created and stored relative to the current _query context_.
+This enables you to create multiple prepared statements with the same name, each stored relative to a different query context.
 
-* Using the PREPARE statement in the Query Workbench.
+To execute a prepared statement, the query context must be the same as it was when the prepared statement was created; otherwise the prepared statement will not be found.
 
-* Using the PREPARE statement in the the xref:tools:cbq-shell.adoc[cbq] command line shell.
+You must therefore set the required query context, or unset the query context if necessary, before creating the prepared statement.
+If you do not set the query context, it defaults to the empty string.
 
-* Using the xref:n1ql:n1ql-rest-api/index.adoc[Query REST API] (`/query/service` endpoint).
-
-For information on how to use prepared statements with various SDKs, refer to xref:java-sdk:concept-docs:n1ql-query.adoc#prepared-statements-for-query-optimization[Querying with N1QL] and xref:java-sdk:howtos:n1ql-queries-with-sdk.adoc#parameterized-queries[N1QL from the SDK].
+For further information, refer to xref:n1ql:n1ql-intro/sysinfo.adoc#query-context[Query Context].
 
 [[parameters]]
 == Parameters
@@ -118,8 +118,8 @@ signature:: The signature of the statement being prepared.
 text:: The full PREPARE statement text.
 
 encoded_plan:: The full prepared statement in encoded format.
-This is included in Couchbase Server 6.5 for for compatibility with previous versions.
-In previous versions of Couchbase Server, you can use the encoded plan in a request to execute a prepared statement.
+This is included for backward compatibility.
+In versions of Couchbase Server prior to Couchbase Server 6.5, you can use the encoded plan in a request to execute a prepared statement.
 
 [[cache]]
 == Statement Cache
@@ -337,3 +337,9 @@ WHERE airline = "FL";
 == Related
 
 * For information on executing the prepared statement, refer to xref:n1ql-language-reference/execute.adoc[EXECUTE].
+
+* For information on using prepared statements with the `cbq` command line shell, refer to xref:tools:cbq-shell.adoc[].
+
+* For information on using prepared statements with the Query REST API (`/query/service` endpoint), refer to xref:n1ql:n1ql-rest-api/index.adoc[].
+
+* For information on using prepared statements with an SDK, refer to xref:java-sdk:concept-docs:n1ql-query.adoc#prepared-statements-for-query-optimization[Querying with N1QL] and xref:java-sdk:howtos:n1ql-queries-with-sdk.adoc#parameterized-queries[N1QL from the SDK].

--- a/modules/settings/examples/node-level-settings.sh
+++ b/modules/settings/examples/node-level-settings.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# tag::curl[]
+curl http://localhost:8093/admin/settings -u user:pword
+# end::curl[]

--- a/modules/settings/examples/node-level-settings.txt
+++ b/modules/settings/examples/node-level-settings.txt
@@ -1,1 +1,0 @@
-$ curl http://localhost:8093/admin/settings -u user:pword

--- a/modules/settings/examples/save-node-level-settings.sh
+++ b/modules/settings/examples/save-node-level-settings.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# tag::curl[]
+curl http://localhost:8093/admin/settings -u user:pword -o ./query_settings.json
+# end::curl[]

--- a/modules/settings/examples/save-node-level-settings.txt
+++ b/modules/settings/examples/save-node-level-settings.txt
@@ -1,1 +1,0 @@
-$ curl http://localhost:8093/admin/settings -u user:pword -o ./query_settings.json

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -422,9 +422,9 @@ These settings cannot be set by `cbq`.
 ====
 To see a list of the current Query Settings, while the Query Service is running, enter:
 
-[source,shell]
+[source,sh]
 ----
-include::example$node-level-settings.txt[]
+include::example$node-level-settings.sh[tag=curl]
 ----
 
 This will output the entire list of node-level query settings:
@@ -437,9 +437,9 @@ include::example$node-level-settings.jsonc[]
 To output to a file for editing multiple settings at a single time, add the [.var]`-o filename` option.
 For example:
 
-[source,shell]
+[source,sh]
 ----
-include::example$save-node-level-settings.txt[]
+include::example$save-node-level-settings.sh[tag=curl]
 ----
 ====
 


### PR DESCRIPTION
The following draft documentation is ready for review:

* [Scopes and Collections](https://simon-dew.github.io/docs-site/DOC-10299/server/current/learn/data/scopes-and-collections.html#tenant-separation) — added section on query context and multi-tenancy
* [N1QL Queries and Results](https://simon-dew.github.io/docs-site/DOC-10299/server/current/n1ql/n1ql-intro/queriesandresults.html) — added paragraph on query context and multi-tenancy
* [Getting System Information › Logical Hierarchy › Query Context](https://simon-dew.github.io/docs-site/DOC-10299/server/current/n1ql/n1ql-intro/sysinfo.html#query-context) — added note on multi-tenancy
* [PREPARE](https://simon-dew.github.io/docs-site/DOC-10299/server/current/n1ql/n1ql-language-reference/prepare.html#query-context) and [EXECUTE](https://simon-dew.github.io/docs-site/DOC-10299/server/current/n1ql/n1ql-language-reference/execute.html#query-context) — added sections on query context
* [Prepared Statements](https://simon-dew.github.io/docs-site/DOC-10299/server/current/guides/prep-statements.html) How-To Guide — added steps to set query context
* [Monitor Queries › system:prepareds](https://simon-dew.github.io/docs-site/DOC-10299/server/current/manage/monitor/monitoring-n1ql-query.html#sys-prepared) — added notes on query context, updated examples

Docs issue: [DOC-10299](https://issues.couchbase.com/browse/DOC-10299)