### PR TITLE
DOC-10466 - Add Information on Minimum Memory Resident Ratio

### DIFF
--- a/modules/learn/pages/buckets-memory-and-storage/memory.adoc
+++ b/modules/learn/pages/buckets-memory-and-storage/memory.adoc
@@ -9,13 +9,9 @@
 [#service-memory-quotas]
 == Service Memory Quotas
 
-You must configure your memory quota allocations for each service in Couchbase Server, except for the xref:services-and-indexes/services/query-service.adoc[Query Service] and xref:services-and-indexes/services/backup-service.adoc[Backup Service]. You can tune the availability of memory resources according to how you assign your services for each node.
+You must configure your memory quota allocations for each service in Couchbase Server, except for the xref:services-and-indexes/services/query-service.adoc[Query Service] and xref:services-and-indexes/services/backup-service.adoc[Backup Service]. You can change the availability of memory resources in your cluster based on how you assign your services to each node.
 
-The xref:services-and-indexes/services/data-service.adoc[Data Service] must run on at least one node in a cluster. Every bucket created on a node has its own memory quota. The memory quota for a bucket comes from the quota you assign to the Data Service. For more information on bucket memory quotas, see the <<bucket-memory,Bucket Memory Quotas section>>.
-
-The memory quota you allocate for a service applies to every instance of that service across your cluster.
-
-For example, if you allocate 2048 MB to the xref:services-and-indexes/services/analytics-service.adoc[Analytics Service], and you run the Analytics Service on three of a cluster's five nodes, each instance of the service has 2048 MB of memory.
+The memory quota you allocate for a service applies to every instance of that service across your cluster. For example, if you allocate 2048 MB to the xref:services-and-indexes/services/analytics-service.adoc[Analytics Service], and you run the Analytics Service on three of a cluster's five nodes, each instance of the service has 2048 MB of memory.
 
 NOTE: You can't allocate different amounts of memory for different instances of the same service in a cluster. 
 
@@ -23,7 +19,9 @@ Couchbase recommends that you allocate no more than 90% of a node's memory (80% 
 
 The firm limits for server memory allocation can be calculated by: stem:[max(total\_memory - 1, 80\% \times total\_memory)] where `total_memory` is the maximum memory on the node in GiB.
 
-When you add a new node to a cluster, you can choose to use the same configuration from the cluster's first node. If this default configuration exceeds the memory available for the node, you can customize the new node's settings and change services on that node. You can add more nodes to a cluster to add more services. 
+The xref:services-and-indexes/services/data-service.adoc[Data Service] must run on at least one node in any cluster. Every xref:buckets.adoc[bucket] you create on a node has its own memory quota. The available memory for a bucket comes from the quota you assign to the Data Service. For more information on bucket memory quotas, see the <<bucket-memory,Bucket Memory Quotas section>>.
+
+When you add a new node, you can choose to use the same configuration from the first node in the cluster. If this default configuration exceeds the memory available for the node, you can customize the new node's settings and change its assigned services. You can add more nodes to a cluster to add more services. 
 
 For more information about how to add nodes and allocate memory to a service when you initialize a cluster, see xref:manage:manage-nodes/create-cluster.adoc[].
 
@@ -56,14 +54,14 @@ The Query Service and the Backup Service don't require an administrator-specifie
 [#bucket-memory]
 == Bucket Memory Quotas 
 
-You must specify a memory quota for each bucket you create. This quota is allocated for the bucket on a per node basis and must be less than the RAM quota for the cluster. 
+You must specify a memory quota for each bucket you create. This quota is allocated for the bucket on a per node basis and must be less than the total memory quota for the cluster. 
 
 Set the memory quota based on the expected size of your dataset. The memory quota for a bucket must support the minimum memory resident ratio of its xref:learn:buckets-memory-and-storage/storage-engines.adoc[storage engine]: 
 
 * *Couchstore*: The memory quota is recommended to be at least 10-20% of your expected dataset size. 
 * *Magma*: The memory quota is recommended to be at least 2% of your expected dataset size. 
 
-For example, if you expect to have about 2TBs of data per node and use the *Magma* engine, you could set the memory quota for a bucket to 40GB. 
+For example, if you expect to have about 2TBs of data per node in your cluster and want to use the *Magma* engine, you could set the memory quota for a bucket to 40GB. 
 
 NOTE: These values are recommendations only. The specific memory quota requirements for your bucket are dependent on access patterns, data density, and other factors.
 

--- a/modules/learn/pages/buckets-memory-and-storage/memory.adoc
+++ b/modules/learn/pages/buckets-memory-and-storage/memory.adoc
@@ -57,6 +57,22 @@ Minimum-required memory-quotas (which are the quota-defaults initially provided 
 
 Note that neither the Query Service nor the Backup Service requires an administrator-specified memory quota.
 
+[#bucket-memory]
+== Bucket Memory Quotas 
+
+You must specify a Memory Quota for each bucket you create. This quota is allocated for the bucket on a per node basis and must be less than the RAM quota for the cluster. 
+
+Set the Memory Quota based on the expected size of your dataset. The Memory Quota for a bucket must support the minimum memory resident ratio of its xref:learn:buckets-memory-and-storage/storage-engines.adoc[storage engine]: 
+
+* *Couchstore*: The Memory Quota is recommended to be at least 10-20% of your expected dataset size. 
+* *Magma*: The Memory Quota is recommended to be at least 2% of your expected dataset size. 
+
+For example, if you expect to have about 2TBs of data per node and use the *Magma* engine, you could set the Memory Quota for a bucket to 40GB. 
+
+NOTE: These values are recommendations only. The specific Memory Quota requirements for your bucket are dependent on access patterns, data density, and other factors.
+
+For more information on how to create a bucket and configure a Memory Quota, see xref:manage:manage-buckets/create-bucket.adoc[].
+
 [#initialization-and-warmup]
 == Initialization and Warmup
 
@@ -88,9 +104,22 @@ See xref:cli:cbepctl/set-flush_param.adoc[set flush_param].
 == Ejection
 
 If a bucket's memory quota is exceeded, items may be _ejected_ from the bucket by the Data Service.
-Different _ejection methods_ are available, and are configured per bucket.
-Note that in some cases, ejection is configured _not_ to occur.
-For detailed information, see xref:buckets-memory-and-storage/buckets.adoc[Buckets].
+
+Different ejection methods are available, and are configured per bucket. Note that in some cases, ejection is configured _not_ to occur.
+
+For a Couchbase bucket, you can choose betweeen a *Value-only* or *Full* ejection method: 
+
+* *Value-only*: The bucket only ejects data when it removes a document from memory. Choose this method if you need better performance rather than memory. 
+* *Full*: The bucket ejects data, metadata, keys, and values when it removes a document from memory. Choose this method if performance isn't a concern. 
+
+For an Ephemeral bucket, you can choose between a *No ejection* or *NRU ejection* ejection policy. : 
+
+* *No ejection*: The bucket doesn't eject any existing data and attempts to cache new data fail. 
+* *NRU ejection*: The bucket ejects any documents markes as *Not Recently Used*. 
+
+NOTE: Ejection from Ephemeral buckets removes data without persistence because Ephemeral buckets have no presence on disk. 
+
+For more information about buckets and bucket types, see xref:buckets-memory-and-storage/buckets.adoc[Buckets].
 
 For each bucket, available memory is managed according to two _watermarks_, which are `mem_low_wat` and `mem_high_wat`.
 If data is continuously loaded into the bucket, its quantity eventually increases to the value indicated by the `mem_low_wat` watermark.

--- a/modules/learn/pages/buckets-memory-and-storage/memory.adoc
+++ b/modules/learn/pages/buckets-memory-and-storage/memory.adoc
@@ -11,7 +11,8 @@
 
 You must configure your memory quota allocations for each service in Couchbase Server, except for the xref:services-and-indexes/services/query-service.adoc[Query Service] and xref:services-and-indexes/services/backup-service.adoc[Backup Service]. You can change the availability of memory resources in your cluster based on how you assign your services to each node.
 
-The memory quota you allocate for a service applies to every instance of that service across your cluster. For example, if you allocate 2048 MB to the xref:services-and-indexes/services/analytics-service.adoc[Analytics Service], and you run the Analytics Service on three of a cluster's five nodes, each instance of the service has 2048 MB of memory.
+The memory quota you allocate for a service applies to every instance of that service across your cluster. 
+For example, if you allocate 2048 MB to the xref:services-and-indexes/services/analytics-service.adoc[Analytics Service], and you run the Analytics Service on three of a cluster's five nodes, each instance of the service has 2048 MB of memory.
 
 NOTE: You can't allocate different amounts of memory for different instances of the same service in a cluster. 
 
@@ -19,13 +20,20 @@ Couchbase recommends that you allocate no more than 90% of a node's memory (80% 
 
 The firm limits for server memory allocation can be calculated by: stem:[max(total\_memory - 1, 80\% \times total\_memory)] where `total_memory` is the maximum memory on the node in GiB.
 
-The xref:services-and-indexes/services/data-service.adoc[Data Service] must run on at least one node in any cluster. Every xref:buckets.adoc[bucket] you create on a node has its own memory quota. The available memory for a bucket comes from the quota you assign to the Data Service. For more information on bucket memory quotas, see the <<bucket-memory,Bucket Memory Quotas section>>.
+The xref:services-and-indexes/services/data-service.adoc[Data Service] must run on at least one node in any cluster. Every xref:buckets.adoc[bucket] you create on a node has its own memory quota. 
+The available memory for a bucket comes from the quota you assign to the Data Service. 
+For more information on bucket memory quotas, see the <<bucket-memory,Bucket Memory Quotas section>>.
 
-When you add a new node, you can choose to use the same configuration from the first node in the cluster. If this default configuration exceeds the memory available for the node, you can customize the new node's settings and change its assigned services. You can add more nodes to a cluster to add more services. 
+When you add a new node, you can choose to use the same configuration from the first node in the cluster. 
+If this default configuration exceeds the memory available for the node, you can customize the new node's settings and change its assigned services. 
+You can add more nodes to a cluster to add more services. 
 
 For more information about how to add nodes and allocate memory to a service when you initialize a cluster, see xref:manage:manage-nodes/create-cluster.adoc[].
 
-The *Memory Quotas* panel in the xref:manage:manage-settings/general-settings.adoc[General settings screen] of the Couchbase Server Web Console lists all the services running on a cluster. It also shows the memory allocated to each service. You can use the panel to change the memory allocations in your cluster. If a change doesn't meet the required minimum or exceeds the available memory for a cluster, the Memory Quotas panel displays an error. 
+The *Memory Quotas* panel in the xref:manage:manage-settings/general-settings.adoc[General settings screen] of the Couchbase Server Web Console lists all the services running on a cluster. 
+It also shows the memory allocated to each service. 
+You can use the panel to change the memory allocations in your cluster. 
+If a change doesn't meet the required minimum or exceeds the available memory for a cluster, the Memory Quotas panel displays an error. 
 
 The following table contains the minimum required memory quotas for each service in Couchbase Server:
 
@@ -54,16 +62,19 @@ The Query Service and the Backup Service don't require an administrator-specifie
 [#bucket-memory]
 == Bucket Memory Quotas 
 
-You must specify a memory quota for each bucket you create. This quota is allocated for the bucket on a per node basis and must be less than the total memory quota for the cluster. 
+You must specify a memory quota for each bucket you create. 
+This quota is allocated for the bucket on a per node basis and must be less than the total memory quota for the cluster. 
 
-Set the memory quota based on the expected size of your dataset. The memory quota for a bucket must support the minimum memory resident ratio of its xref:learn:buckets-memory-and-storage/storage-engines.adoc[storage engine]: 
+Set the memory quota based on the expected size of your dataset. 
+The memory quota for a bucket must support the minimum memory resident ratio of its xref:learn:buckets-memory-and-storage/storage-engines.adoc[storage engine]: 
 
 * *Couchstore*: The memory quota is recommended to be at least 10-20% of your expected dataset size. 
 * *Magma*: The memory quota is recommended to be at least 2% of your expected dataset size. 
 
 For example, if you expect to have about 2TBs of data per node in your cluster and want to use the *Magma* engine, you could set the memory quota for a bucket to 40GB. 
 
-NOTE: These values are recommendations only. The specific memory quota requirements for your bucket are dependent on access patterns, data density, and other factors.
+NOTE: These values are recommendations only. 
+The specific memory quota requirements for your bucket are dependent on access patterns, data density, and other factors.
 
 For more information on how to create a bucket and configure its memory quota, see xref:manage:manage-buckets/create-bucket.adoc[].
 
@@ -99,12 +110,15 @@ See xref:cli:cbepctl/set-flush_param.adoc[set flush_param].
 
 If a bucket's memory quota is exceeded, items may be _ejected_ from the bucket by the Data Service.
 
-Different ejection methods are available, and are configured per bucket. Note that in some cases, ejection is configured _not_ to occur.
+Different ejection methods are available, and are configured per bucket. 
+Note that in some cases, ejection is configured _not_ to occur.
 
 For a Couchbase bucket, you can choose betweeen a *Value-only* or *Full* ejection method: 
 
-* *Value-only*: The bucket only ejects data when it removes a document from memory. Choose this method if you need better performance, but be aware that it uses more system memory. 
-* *Full*: The bucket ejects data, metadata, keys, and values when it removes a document from memory. Choose this method if you want to reduce your memory overhead requirement. 
+* *Value-only*: The bucket only ejects data when it removes a document from memory. 
+Choose this method if you need better performance, but be aware that it uses more system memory. 
+* *Full*: The bucket ejects data, metadata, keys, and values when it removes a document from memory. 
+Choose this method if you want to reduce your memory overhead requirement. 
 
 For an Ephemeral bucket, you can choose between a *No ejection* or *Eject data when RAM is full* ejection policy: 
 

--- a/modules/learn/pages/buckets-memory-and-storage/memory.adoc
+++ b/modules/learn/pages/buckets-memory-and-storage/memory.adoc
@@ -29,8 +29,7 @@ The available memory for a bucket comes from the quota you assign to the Data Se
 For more information on bucket memory quotas, see the <<bucket-memory,Bucket Memory Quotas>> section.
 
 When you add a new node, you can use the same configuration and services from the first node in the cluster. 
-You can also choose to customize the new node's settings and change its assigned services. 
-You can add more nodes to a cluster to add more services. 
+You can also choose to customize the new node's settings and change its assigned services.
 
 For more information about how to add nodes and allocate memory to a service when you initialize a cluster, see xref:manage:manage-nodes/create-cluster.adoc[].
 

--- a/modules/learn/pages/buckets-memory-and-storage/memory.adoc
+++ b/modules/learn/pages/buckets-memory-and-storage/memory.adoc
@@ -18,14 +18,18 @@ NOTE: You can't allocate different amounts of memory for different instances of 
 
 Couchbase recommends that you allocate no more than 90% of a node's memory (80% on nodes with a small amount of total memory) to a server and its services. 
 
-The firm limits for server memory allocation can be calculated by: stem:[max(total\_memory - 1, 80\% \times total\_memory)] where `total_memory` is the maximum memory on the node in GiB.
+The firm limits for server memory allocation can be calculated by: 
+
+stem:[max(total\_memory - 1, 80\% \times total\_memory)] 
+
+where `total_memory` is the maximum memory on the node in GiB.
 
 The xref:services-and-indexes/services/data-service.adoc[Data Service] must run on at least one node in any cluster. Every xref:buckets.adoc[bucket] you create on a node has its own memory quota. 
 The available memory for a bucket comes from the quota you assign to the Data Service. 
-For more information on bucket memory quotas, see the <<bucket-memory,Bucket Memory Quotas section>>.
+For more information on bucket memory quotas, see the <<bucket-memory,Bucket Memory Quotas>> section.
 
-When you add a new node, you can choose to use the same configuration from the first node in the cluster. 
-If this default configuration exceeds the memory available for the node, you can customize the new node's settings and change its assigned services. 
+When you add a new node, you can use the same configuration and services from the first node in the cluster. 
+You can also choose to customize the new node's settings and change its assigned services. 
 You can add more nodes to a cluster to add more services. 
 
 For more information about how to add nodes and allocate memory to a service when you initialize a cluster, see xref:manage:manage-nodes/create-cluster.adoc[].

--- a/modules/learn/pages/buckets-memory-and-storage/memory.adoc
+++ b/modules/learn/pages/buckets-memory-and-storage/memory.adoc
@@ -9,31 +9,27 @@
 [#service-memory-quotas]
 == Service Memory Quotas
 
-Memory-quota allocation on Couchbase Server occurs _per service_ (except in the cases of the xref:services-and-indexes/services/query-service.adoc[Query Service] and xref:services-and-indexes/services/backup-service.adoc[Backup Service], which do not require specific allocations).
-This allows the availability of memory-resources to be tuned according to the assignment of services, node by node.
-Note that the xref:services-and-indexes/services/data-service.adoc[Data Service] must run on at least one node; and that on each of those nodes, quotas for buckets, specified at the time of bucket-creation, are subtracted from the quota allocated to the Data Service.
+You must configure your memory quota allocations for each service in Couchbase Server, except for the xref:services-and-indexes/services/query-service.adoc[Query Service] and xref:services-and-indexes/services/backup-service.adoc[Backup Service]. You can tune the availability of memory resources according to how you assign your services for each node.
 
-The memory-quota allocation specified for a given service applies to every instance of that service across the cluster.
-For example, if 2048 MB is specified for the xref:services-and-indexes/services/analytics-service.adoc[Analytics Service], and the Analytics Service is run on three of a cluster's five nodes, each of the three instances of the service is duly allocated 2048 MB.
-Note that it is not possible to have different memory allocations across multiple instances of the same service within a single cluster.
+The xref:services-and-indexes/services/data-service.adoc[Data Service] must run on at least one node in a cluster. Every bucket created on a node has its own memory quota. The memory quota for a bucket comes from the quota you assign to the Data Service. For more information on bucket memory quotas, see the <<bucket-memory,Bucket Memory Quotas section>>.
 
-As a guideline, Couchbase recommends that no more than 90% of a node's memory (80% on nodes with a small amount of total memory) be allocated to the server and its services. 
-The firm limits on server memory allocation are: stem:[max(total\_memory - 1, 80\% \times total\_memory)] where `total_memory` is the maximum memory on the node in GiB.
+The memory quota you allocate for a service applies to every instance of that service across your cluster.
 
-Instructions on how to allocate memory quotas to services when initializing a new cluster can be found in the section xref:manage:manage-nodes/create-cluster.adoc[Create a Cluster].
+For example, if you allocate 2048 MB to the xref:services-and-indexes/services/analytics-service.adoc[Analytics Service], and you run the Analytics Service on three of a cluster's five nodes, each instance of the service has 2048 MB of memory.
 
-When a node is added to a cluster, the _Default Configuration_, as established by the set-up of the first node in the cluster, is available: this covers all configurable elements, including memory quotas.
-However, if insufficient memory for the default configuration is available on the new node, the default configuration is prohibited: in such cases, settings for the new node can be custom-configured, allowing an appropriate subset of services to be specified.
+NOTE: You can't allocate different amounts of memory for different instances of the same service in a cluster. 
 
-If, when the initial node of a cluster is set up, only a subset of services is assigned, additional nodes can subsequently be added, in order to host additional services: in which case, each new service can be given its initial memory allocation as its node is added.
+Couchbase recommends that you allocate no more than 90% of a node's memory (80% on nodes with a small amount of total memory) to a server and its services. 
 
-Instructions on how to add a new node to a cluster can be found in the section xref:manage:manage-nodes/create-cluster.adoc[Create a Cluster].
+The firm limits for server memory allocation can be calculated by: stem:[max(total\_memory - 1, 80\% \times total\_memory)] where `total_memory` is the maximum memory on the node in GiB.
 
-The *Memory Quotas* panel on the xref:manage:manage-settings/general-settings.adoc[General] settings screen of Couchbase Web Console lists all services running on the cluster, and specifies the memory allocation for each.
-The panel is interactive, and allows the memory allocations to be changed and saved.
-If a modification attemptedly exceeds a permitted minimum-required or maximum-available level, a notification of the error is displayed, and the modification is disallowed.
+When you add a new node to a cluster, you can choose to use the same configuration from the cluster's first node. If this default configuration exceeds the memory available for the node, you can customize the new node's settings and change services on that node. You can add more nodes to a cluster to add more services. 
 
-Minimum-required memory-quotas (which are the quota-defaults initially provided by Couchbase Server) are:
+For more information about how to add nodes and allocate memory to a service when you initialize a cluster, see xref:manage:manage-nodes/create-cluster.adoc[].
+
+The *Memory Quotas* panel in the xref:manage:manage-settings/general-settings.adoc[General settings screen] of the Couchbase Server Web Console lists all the services running on a cluster. It also shows the memory allocated to each service. You can use the panel to change the memory allocations in your cluster. If a change doesn't meet the required minimum or exceeds the available memory for a cluster, the Memory Quotas panel displays an error. 
+
+The following table contains the minimum required memory quotas for each service in Couchbase Server:
 
 [#memory_quota_mimumums,cols="3,5"]
 |===
@@ -55,23 +51,23 @@ Minimum-required memory-quotas (which are the quota-defaults initially provided 
 | 256
 |===
 
-Note that neither the Query Service nor the Backup Service requires an administrator-specified memory quota.
+The Query Service and the Backup Service don't require an administrator-specified memory quota.
 
 [#bucket-memory]
 == Bucket Memory Quotas 
 
-You must specify a Memory Quota for each bucket you create. This quota is allocated for the bucket on a per node basis and must be less than the RAM quota for the cluster. 
+You must specify a memory quota for each bucket you create. This quota is allocated for the bucket on a per node basis and must be less than the RAM quota for the cluster. 
 
-Set the Memory Quota based on the expected size of your dataset. The Memory Quota for a bucket must support the minimum memory resident ratio of its xref:learn:buckets-memory-and-storage/storage-engines.adoc[storage engine]: 
+Set the memory quota based on the expected size of your dataset. The memory quota for a bucket must support the minimum memory resident ratio of its xref:learn:buckets-memory-and-storage/storage-engines.adoc[storage engine]: 
 
-* *Couchstore*: The Memory Quota is recommended to be at least 10-20% of your expected dataset size. 
-* *Magma*: The Memory Quota is recommended to be at least 2% of your expected dataset size. 
+* *Couchstore*: The memory quota is recommended to be at least 10-20% of your expected dataset size. 
+* *Magma*: The memory quota is recommended to be at least 2% of your expected dataset size. 
 
-For example, if you expect to have about 2TBs of data per node and use the *Magma* engine, you could set the Memory Quota for a bucket to 40GB. 
+For example, if you expect to have about 2TBs of data per node and use the *Magma* engine, you could set the memory quota for a bucket to 40GB. 
 
-NOTE: These values are recommendations only. The specific Memory Quota requirements for your bucket are dependent on access patterns, data density, and other factors.
+NOTE: These values are recommendations only. The specific memory quota requirements for your bucket are dependent on access patterns, data density, and other factors.
 
-For more information on how to create a bucket and configure a Memory Quota, see xref:manage:manage-buckets/create-bucket.adoc[].
+For more information on how to create a bucket and configure its memory quota, see xref:manage:manage-buckets/create-bucket.adoc[].
 
 [#initialization-and-warmup]
 == Initialization and Warmup
@@ -109,13 +105,13 @@ Different ejection methods are available, and are configured per bucket. Note th
 
 For a Couchbase bucket, you can choose betweeen a *Value-only* or *Full* ejection method: 
 
-* *Value-only*: The bucket only ejects data when it removes a document from memory. Choose this method if you need better performance rather than memory. 
-* *Full*: The bucket ejects data, metadata, keys, and values when it removes a document from memory. Choose this method if performance isn't a concern. 
+* *Value-only*: The bucket only ejects data when it removes a document from memory. Choose this method if you need better performance, but be aware that it uses more system memory. 
+* *Full*: The bucket ejects data, metadata, keys, and values when it removes a document from memory. Choose this method if you want to reduce your memory overhead requirement. 
 
-For an Ephemeral bucket, you can choose between a *No ejection* or *NRU ejection* ejection policy. : 
+For an Ephemeral bucket, you can choose between a *No ejection* or *Eject data when RAM is full* ejection policy: 
 
-* *No ejection*: The bucket doesn't eject any existing data and attempts to cache new data fail. 
-* *NRU ejection*: The bucket ejects any documents markes as *Not Recently Used*. 
+* *No ejection*: If the bucket reaches its memory quota, the bucket doesn't eject any existing data and attempts to cache new data fail. 
+* *Eject data when RAM is full*: If the bucket reaches its memory quota, the bucket ejects older documents from RAM to make space for new data. 
 
 NOTE: Ejection from Ephemeral buckets removes data without persistence because Ephemeral buckets have no presence on disk. 
 

--- a/modules/manage/pages/manage-buckets/create-bucket.adoc
+++ b/modules/manage/pages/manage-buckets/create-bucket.adoc
@@ -230,7 +230,7 @@ For more information about XDCR conflict resolution, see xref:learn:clusters-and
 Bucket Priority sets the priority of the bucket's background tasks relative to the background tasks of other buckets on the cluster. 
 
 Background tasks may involve DCP stream-processing, item-paging, and more. 
-Specifying High might result in faster processing for the current bucket's tasks. T
+Specifying High might result in faster processing for the current bucket's tasks.
 This setting only takes effect when there is more than one bucket defined for the cluster, and the buckets are assigned different Bucket Priority values.
 
 . Choose an *Ejection Policy* for the bucket: 

--- a/modules/manage/pages/manage-buckets/create-bucket.adoc
+++ b/modules/manage/pages/manage-buckets/create-bucket.adoc
@@ -1,192 +1,185 @@
 = Create a Bucket
 :description: pass:q[_Full_ and _Cluster_ Administrators can use Couchbase Web Console, the CLI, or the REST API to create a bucket.]
 :page-aliases: clustersetup:create-bucket
+:page-topic-type: guide
 
 [abstract]
 {description}
 
-[#examples-on-this-pages]
-== Examples on This Page
+You can create a bucket with the xref:manage:manage-buckets/create-bucket.adoc#create-bucket-using-couchbase-web-console[UI], xref:manage:manage-buckets/create-bucket.adoc#create-bucket-with-the-cli[CLI] or the xref:manage:manage-buckets/create-bucket.adoc#create-bucket-with-the-rest-api[REST API].
 
-The examples in the subsections below show how to create a bucket by means of the xref:manage:manage-buckets/create-bucket.adoc#create-bucket-using-couchbase-web-console[UI], xref:manage:manage-buckets/create-bucket.adoc#create-bucket-with-the-cli[CLI] and xref:manage:manage-buckets/create-bucket.adoc#create-bucket-with-the-rest-api[REST API].
-Note that a maximum of 30 buckets can be created per cluster.
+You can create a maximum of 30 buckets per cluster.
 
 [#create-bucket-using-couchbase-web-console]
 == Create a Bucket with The UI
 
-To create a bucket, access Couchbase Web Console, and left-click on the [.ui]*Buckets* tab, in the vertical navigation-bar at the left-hand side:
+To create a bucket with the Couchbase UI: 
 
-[#access_bucket_tab]
-image::manage-buckets/accessBucketTab.png[,100,align=left]
-
-The [.ui]*Buckets* screen now appears, showing the buckets that have already been defined for your system.
-If you are accessing this screen immediately after setting up the cluster, no buckets are yet defined:
-
-[#buckets_view_initial]
-image::manage-buckets/bucketsViewInitial.png[,880,align=left]
-
-To create a new bucket, left-click on *ADD BUCKET*, at the upper-right:
-
-[#add-bucket-button]
-image::manage-buckets/addBucketButton.png[,110,align=left]
-
-This brings up the [.ui]*Add Data Bucket* dialog, which appears as follows:
+. Log in to the Couchbase Web Console.
+. Go to [.ui]*Buckets*.
+. Select btn:[Add Bucket].
++
+The [.ui]*Add Data Bucket* dialog appears:
 
 [#add-data-bucket-dialog-initial]
 image::manage-buckets/addDataBucketDialogInitial.png[,320,align=left]
 
-Enter a bucket name into the interactive [.ui]*Name* text-field.
-A bucket name can only contain characters in the ranges of A-Z, a-z, and 0-9; with the addition of the underscore, period, dash and percent characters; and can be no more than 100 characters in length.
+[start="4"]
+. In the *Name* field, enter a name for the new bucket.
 
-Specify the [.ui]*Storage Backend* for the bucket, which can be `Couchstore` or `Magma`.
+[NOTE]
+====
+A bucket name can only be up to 100 characters in length and contain:
 
---
-include::partial$backend-description-section.adoc[]
---
+* Uppercase and lowercase characters (A-Z and a-z)
+* Digits (0-9)
+* Underscores (_), periods (.), dashes (-), and percent symbols (%)
+====
+[start="5"]
+. Choose a *Bucket Type* for the bucket: *Couchbase*, *Memcached*, or *Ephemeral*.
++
+For more information on bucket types, see xref:learn:buckets-memory-and-storage/buckets.adoc[].
+. Choose a *Storage Backend* for the bucket: *CouchStore* or *Magma*.
++
+For more information on the available storage engines, see xref:learn:buckets-memory-and-storage/storage-engines.adoc[Storage Engines].
 
-See xref:learn:buckets-memory-and-storage/storage-engines.adoc[Storage Engines], for more information.
+. In the *Memory Quota* field, enter a value in MiB per node for the total RAM available for the bucket. This value can't exceed the total RAM quota for your cluster. 
 
-Next, specify an appropriate memory quota for your bucket, in the [.ui]*Memory Quota* field: either enter a figure by typing at the keyboard; or, with the mouse, access the arrow-icons at the right-hand side of the interactive text-field, to increment or decrement the default value.
-The quota you specify is allocated for your bucket on a per node basis.
-The value you enter must fit with the overall cluster RAM quota.
-The cluster quota is displayed as a figure; and also graphically, as a horizontal display-bar.
-The bar provides size-information for the bucket you are creating, for the amount of memory already added to other buckets, and for the amount currently free.
+NOTE: Your memory quota needs to match the minimum memory resident ratio required by your chosen storage engine. For more information, see xref:learn:buckets-memory-and-storage/memory.adoc#bucket-memory[Bucket Memory Quotas].
 
-Note that the bucket RAM-quota you have established can be dynamically altered after bucket-creation, provided that cluster-resources are sufficient.
+[start="8"]
+. Expand *Advanced bucket settings*. See <<advanced-bucket-settings>>.
+. Select btn:[Add Bucket].
 
-Now, proceed to establish _advanced settings_ for your bucket.
+The bucket appears on the *Buckets* screen: 
 
-== Establish Advanced Bucket Settings
+image::manage-buckets/bucketsViewWithCreatedBucket.png[,750,align=left]
 
-Three [.ui]*Bucket Type* options are displayed: which are [.ui]*Couchbase*, [.ui]*Memcached*, and [.ui]*Ephemeral*.
-For information on the differences between these bucket-types, see
-xref:learn:buckets-memory-and-storage/buckets.adoc[Buckets].
+You can view the following information for the bucket: 
 
-Selection of each bucket-type provides a different set of advanced settings, which can be used to configure the bucket.
-The bucket-type selected by default is [.ui]*Couchbase*.
-Therefore, to see the advanced settings associated with this bucket-type, left-click on the right-pointing arrowhead labelled [.ui]*Advanced bucket settings*.
-This causes the [.ui]*Add Data Bucket* dialog to expand vertically, as shown below.
+* The number of items the bucket contains. 
+* The percentage of items in the bucket that are currently resident. 
+* The number of operations per second being performed on the bucket. 
+* The amount of RAM the bucekt is currently using, compared to its memory quota. 
+* The amount of disk space used by the bucket. 
 
-== Couchbase Bucket-Settings
+You can also view the xref:manage:manage-ui/manage-ui.adoc#console-documents[Documents] in the bucket and create xref:learn:data/scopes-and-collections.adoc[Scopes and Collections]. For information on how to import documents into a bucket, see xref:manage:import-documents/import-documents.adoc[Import Documents].
 
-The advanced bucket-settings for the [.ui]*Couchbase* bucket-type are as follows:
+[#advanced-bucket-settings]
+=== Set Advanced Bucket Settings
+
+The available advanced settings for your bucket change based on your selected *Bucket Type*. 
+
+==== Couchbase Bucket Settings
+
+To configure advanced settings for a Couchbase bucket: 
+
+. To enable xref:learn:clusters-and-availability/intra-cluster-replication.adoc[replica creation and management], under *Replicas*, select the btn:[Enable] checkbox. 
+
+.. In the *Number of replica (backup) copies* list, select the number of replicas for the bucket. 
+
+.. To replicate view indexes and data from the bucket, select the btn:[Replicate view indexes] checkbox.
+
+. To set a xref:learn:data/expiration.adoc[document expiration] for documents in the bucket, under *Bucket Max Time-To-Live*, select the btn:[Enable] checkbox.
+
+.. In the *Seconds* field, enter the maximum number of seconds a document can exist in the bucket before it's deleted. 
++
+TIP: The maximum allowed value is 2147483648 seconds (68.096 years). You can only apply this setting to documents created after you change the configuration. 
+
+. Choose a *Compression Mode* for the bucket: *Off*, *Passive*, or *Active*. 
++
+For more information on the available compression modes, see xref:learn:buckets-memory-and-storage/compression.adoc[].
+
+. Choose a *Conflict Resolution* method for Cross Datacenter Replication (XDCR) on this bucket: *Sequence number* or *Timestamp*. 
++
+For more information on XDCR conflict resolution, see xref:learn:clusters-and-availability/xdcr-conflict-resolution.adoc[].
+
+. Choose an *Ejection Method* for the bucket: *Value-only* or *Full*. 
++
+For more information on ejection, see the xref:learn:buckets-memory-and-storage/memory.adoc#ejection[Ejection section in Memory].
+
+include::learn:partial$full-ejection-note.adoc[]
+
+[#bucket-priority, start="6"]
+. Choose a *Bucket Priority* for the bucket: *Default* or *High*. 
++
+Bucket Priority sets the priority of the bucket's background tasks relative to the background tasks of other buckets on the cluster. 
++
+Background tasks may involve disk I/O, DCP stream-processing, item-paging, and more. Specifying High might result in faster processing for the current bucket's tasks. This setting only takes effect when there is more than one bucket defined for the cluster, and the buckets are assigned different Bucket Priority values.
+
+[#durability-level, start="7"]
+. In the *Minimum Durability Level* list, select a durability level for the bucket: *none*, *majority*, *majorityAndPersistActive*, or *persistToMajority*.
++
+For more information on durability, see xref:learn:data/durability.adoc[].
+
+. To enable automatic compaction of data and indexes to save space, select the btn:[Auto-Compaction] checkbox. 
+
+.. To override the default Auto-Compaction settings, select the btn:[Override the default auto-compaction settings?] checkbox. 
++
+For more information on how to configure Auto-Compaction, see xref:manage:manage-settings/configure-compact-settings.adoc[].
+
+. To enable flushing for the bucket, under *Flush*, select the btn:[Enable] checkbox.
++
+For more information on flushing, see xref:manage-buckets/flush-bucket.adoc[Flush a Bucket].
 
 [#add-data-bucket-dialog-expanded]
 image::manage-buckets/addBucketWithMagmaOption.png[,400,align=left]
 
-The fields are as follows:
+==== Memcached Bucket Settings
 
-* [.ui]*Replicas*: Allows replica-creation to be enabled and managed.
-To enable, check the [.ui]*Enable* checkbox.
-The number of replica-copies to be created and maintained is determined by means of the [.ui]*Number of replica (backup) copies* pulldown menu, which allows a value from 1 to 3 to be selected.
+CAUTION: Memcached buckets are deprecated. Use a *Couchbase* or *Ephemeral* bucket, instead. 
+
+To configure advanced settings for a Memcached bucket:
+
+. To enable flushing for the bucket, under *Flush*, select the btn:[Enable] checkbox.
 +
-By checking the [.ui]*Replicate view indexes* checkbox, you ensure that view indexes, as well as data, are replicated.
-+
-For detailed information on replication, see xref:learn:clusters-and-availability/intra-cluster-replication.adoc[Intra-Cluster Replication].
-
-* [.ui]*Bucket Max Time-To-Live*: If the [.ui]*Enable* checkbox is checked, the integer specified in the [.ui]*seconds* field determines the maximum time a document can exist, following its creation within this bucket, before being deleted.
-The maximum time that can be specified is 2147483648 (68.096 years).
-The setting is applied to all documents created after the setting is itself established.
-+
-For detailed information, see
-xref:learn:data/expiration.adoc[Expiration].
-
-* [.ui]*Compression Mode*: Controls whether and how compression is applied to data within the bucket.
-For detailed information, see xref:learn:buckets-memory-and-storage/compression.adoc[Compression].
-
-* [.ui]*Conflict Resolution*: A _conflict_ occurs during XDCR, when a document has been modified in different ways in different locations; necessitating that one of the versions be chosen for retention, and the other discarded.
-There are two methods for making this choice: these are represented by the [.ui]*Sequence number* and [.ui]*Timestamp* checkboxes.
-The method you choose is permanently established for the current bucket: it cannot subsequently be changed.
-For information on the significance of each method, see xref:learn:clusters-and-availability/xdcr-conflict-resolution.adoc[XDCR Conflict Resolution].
-+
-Note that you can also set the conflict resolution method using the CLI xref:cli:cbcli/couchbase-cli-bucket-create.adoc[bucket-create] command, or the xref:rest-api:rest-bucket-create.adoc[REST API].
-
-* [.ui]*Ejection Method*: For Couchbase buckets, the options are [.ui]*Value-only* and [.ui]*Full*.
-If [.ui]*Full* is selected, everything (including data, metadata, key, and value) is ejected.
-If [.ui]*Value-only* is selected, only data is ejected.
-Generally, Value-only ejection favors performance at the expense of memory; and Full ejection vice versa.
-See xref:learn:buckets-memory-and-storage/memory.adoc#ejection[Ejection], for more information.
-Note that _ejection_ in the context of a Couchbase bucket means removal from memory, with continued persistence on disk.
-+
-include::learn:partial$full-ejection-note.adoc[]
-
-[#bucket-priority]
-* [.ui]*Bucket Priority*: Allows you to specify the priority of the current Couchbase bucket's background tasks, relative to the background tasks of other buckets on the cluster.
-Background tasks may involve disk I/O, DCP stream-processing, item-paging, and more.
-+
-Radio-buttons allow [.ui]*Default* or [.ui]*High* to be chosen.
-These settings determine whether the bucket's tasks are enqueued in low or high priority task-queues.
-Specifying High _may_ result in faster processing for the current bucket's tasks.
-However, the specification only makes a difference when there is more than one bucket defined for the cluster, and when those buckets are assigned different priority-values.
-See xref:learn:services-and-indexes/services/data-service.adoc[Data Service], for further information.
-
-[#durability-level]
-* [.ui]*Minimum Durability Level*: Allows an appropriate durability level to be assigned to the bucket.
-Levels are accessed by means of a pull-down menu.
-The options are *none*, *majority*, *majorityAndPersistActive*, and *persistToMajority*.
-For information, see xref:learn:data/durability.adoc[Durability].
-
-* [.ui]*Auto-Compaction*: Allows triggering of the process whereby data and indexes are compacted automatically on a system-defined schedule, to save space.
-To override the default settings, check the checkbox marked [.ui]*Override the default auto-compation settings?* If you do so, the dialog goes through a further vertical expansion; and additional fields are displayed, whereby you can specify your own compaction-settings.
-For information on the defaults, and on the options provided for overriding them, see
-xref:manage:manage-settings/configure-compact-settings.adoc[Configuring Auto-Compaction].
-* [.ui]*Flush*: This section allows flushing to be enabled.
-If it is enabled, and flushing is performed, items in the bucket are removed as soon as possible.
-See
-xref:manage-buckets/flush-bucket.adoc[Flush a Bucket], for details.
-
-== Memcached Bucket-Settings
-
-Use of memcached buckets is now _deprecated_.
-New buckets should therefore be specified as _Couchbase_ or _Ephemeral_.
-
-To see advanced settings for a Memcached bucket, check the [.ui]*Memcached* checkbox.
-The advanced settings now appear as follows:
+For more information on flushing, see xref:manage-buckets/flush-bucket.adoc[Flush a Bucket].
 
 [#add-data-bucket-dialog-expanded-for-memcached]
 image::manage-buckets/addDataBucketDialogExpandedForMemcached.png[,350,align=left]
 
-The only advanced setting that applies to Memcached is [.ui]*Flush*, whose function is identical to that described above for Couchbase buckets.
+==== Ephemeral Bucket Settings
 
-== Ephemeral Bucket-Settings
+To configure advanced settings for an Ephemeral bucket: 
 
-To see advanced settings for an Ephemeral bucket, check the [.ui]*Ephemeral* checkbox.
-The advanced settings now appear as follows:
+. To enable xref:learn:clusters-and-availability/intra-cluster-replication.adoc[replica creation and management], under *Replicas*, select the btn:[Enable] checkbox. 
+
+.. In the *Number of replica (backup) copies* list, select the number of replicas for the bucket. 
+
+. . To set a xref:learn:data/expiration.adoc[document expiration] for documents in the bucket, under *Bucket Max Time-To-Live*, select the btn:[Enable] checkbox.
+
+.. In the *Seconds* field, enter the maximum number of seconds a document can exist in the bucket before it's deleted. 
++
+TIP: The maximum allowed value is 2147483648 seconds (68.096 years). You can only apply this setting to documents created after you change the configuration. 
+
+. Choose a *Compression Mode* for the bucket: *Off*, *Passive*, or *Active*. 
++
+For more information on the available compression modes, see xref:learn:buckets-memory-and-storage/compression.adoc[].
+
+. Choose a *Conflict Resolution* method for Cross Datacenter Replication (XDCR) on this bucket: *Sequence number* or *Timestamp*. 
++
+For more information on XDCR conflict resolution, see xref:learn:clusters-and-availability/xdcr-conflict-resolution.adoc[].
+
+. Choose a *Bucket Priority*: *Default* or *High*. Bucket Priority sets the priority of the bucket's background tasks relative to the background tasks of other buckets on the cluster. 
++
+Background tasks may involve DCP stream-processing, item-paging, and more. Specifying High might result in faster processing for the current bucket's tasks. This setting only takes effect when there is more than one bucket defined for the cluster, and the buckets are assigned different Bucket Priority values.
+
+. Choose an *Ejection Policy* for the bucket: *No ejection* or *NRU ejection*. 
++
+For more information on ejection, see the xref:learn:buckets-memory-and-storage/memory.adoc#ejection[Ejection section in Memory].
+
+. In the *Minimum Durability Level* list, select a durability level for the bucket: *none* or *majority*.
++
+For more information on durability, see xref:learn:data/durability.adoc[].
 
 [#add-data-bucket-dialog-expanded-for-ephemeral]
 image::manage-buckets/addDataBucketDialogExpandedForEphemeral.png[,350,align=left]
-
-The settings [.ui]*Conflict Resolution*, [.ui]*Bucket Max Time-to-Live*, [.ui]*Compression Mode*, and [.ui]*Flush* are identical in functionality for both Ephemeral and Couchbase buckets.
-
-The following settings are different for Ephemeral buckets:
-
-* [.ui]*Replicas*: The [.ui]*Replicate view indexes* checkbox is not available for Ephemeral buckets: it is available for Couchbase buckets only.
-* [.ui]*Bucket Priority*: Background tasks exclude disk I/0, since this is not applicable to Ephemeral buckets.
-* [.ui]*Ejection Policy*: For Ephemeral buckets, the options are [.ui]*No ejection* and [.ui]*NRU ejection*.
-If [.ui]*No ejection* is selected, no ejection of existing data occurs, and attempts to cache new data fail.
-If [.ui]*NRU ejection* is selected, existing data is ejected, with _Not Recently Used_ documents being those removed.
-Note that _ejection_ when applied to an Ephemeral bucket means removal of bucket-data from memory without persistence (since ephemeral buckets have no presence on disk).
-
-* [.ui]*Metadata Purge Interval*: This setting, here provided at the top level of the user interface for Ephemeral buckets, was made visible for Couchbase buckets only by checking the [.ui]*Auto-Compaction* checkbox.
-Note that other auto-compaction settings do not apply to Ephemeral buckets, since such settings are for data that reside on disk: however, the Metadata Purge Interval applies both to Couchbase _and_ to Ephemeral buckets.
-* *Durability Level*: Only the *None* and *Majority* settings are available (since persistence is not supported by Ephemeral buckets).
-
-When all fields have been appropriately filled, left-click on the *Add Bucket* button, at the bottom right of the dialog:
-
-image::manage-buckets/addBucketButtonOnDialog.png[,150,align=left]
-
-The bucket is now added to Couchbase Server, and can be viewed on the *Buckets* screen:
-
-image::manage-buckets/bucketsViewWithCreatedBucket.png[,750,align=left]
-
-The row for the created bucket provides data on the number of items the bucket contains and how many are currently resident; on how many operations per second are being performed on the bucket; on the amount of RAM currently being used by the bucket, in comparison to its maximum quota; and the amount of disk space used by the bucket. To the right hand side of the row are tabs that allow examination of the xref:manage:manage-ui/manage-ui.adoc#console-documents[Documents] within the bucket; and creation of xref:learn:data/scopes-and-collections.adoc[Scopes and Collections], into which documents can be organized.
-
-For information on importing documents into a bucket, see xref:manage:import-documents/import-documents.adoc[Import Documents].
 
 [#create-bucket-with-the-cli]
 == Create a Bucket with the CLI
 
 To create a bucket with the Couchbase CLI, use the `bucket-create` command.
+
 For example:
 
 ----
@@ -202,17 +195,15 @@ For example:
 --enable-flush 0
 ----
 
-This creates a _Couchbase_ bucket named `testBucket`, with a RAM size of `1024`; specifying a maximum time-to-live, and disabling flush.
-Note that a minimum durability level of `persistToMajority` is specified: other permitted settings for this parameter are `none` (the default), `majorityAndPersistActive`, and `majority`.
-For details on the significance of these settings, see xref:learn:data/durability.adoc[Durability].
-(Note that an _Ephemeral_ bucket, when created, can only use the `none` and `majority` settings, for this parameter.)
+The preceding example creates a `Couchbase` bucket named `testBucket`, with a RAM size of `1024`. It sets a Maximum Time-to-Live and disables Flush. It also sets a Minimum Durability Level of `persistToMajority`. 
 
-For further information on `bucket-create` and its additional parameters, see the reference page for xref:cli:cbcli/couchbase-cli-bucket-create.adoc[bucket-create].
+For more information on `bucket-create` and its parameters, see xref:cli:cbcli/couchbase-cli-bucket-create.adoc[bucket-create] in the Couchbase CLI reference.
 
 [#create-bucket-with-the-rest-api]
 == Create a Bucket with the REST API
 
 To create a bucket with the Couchbase REST API, use the `POST` http method, with the `/pools/default/buckets` endpoint.
+
 For example:
 
 ----
@@ -224,9 +215,6 @@ curl -v -X POST http://10.143.201.101:8091/pools/default/buckets \
 -d durabilityMinLevel=majorityAndPersistActive
 ----
 
-This creates a _Couchbase_ bucket named `testBucket`, with a RAM size of `512`.
-Note that a minimum durability level of `majorityAndPersistActive` is specified: other permitted settings for this parameter are `none` (the default), `majority`, and `persistToMajority`.
-For details on the significance of these settings, see xref:learn:data/durability.adoc[Durability].
-(Note that an _Ephemeral_ bucket, when created, can only use the `none` and `majority` settings, for this parameter.)
+The preceding example creates a `Couchbase` bucket named `testBucket`, with a RAM size of `512`. It sets a Minimum Durability Level of `majorityAndPersistActive`.
 
-For further information, see the REST API reference page xref:rest-api:rest-bucket-create.adoc[Creating and Editing Buckets].
+For more information on the `/pools/default/buckets` endpoint and its parameters, see xref:rest-api:rest-bucket-create.adoc[Creating and Editing Buckets] in the Buckets API reference.

--- a/modules/manage/pages/manage-buckets/create-bucket.adoc
+++ b/modules/manage/pages/manage-buckets/create-bucket.adoc
@@ -45,16 +45,16 @@ A bucket name can be up to 100 characters in length and contain:
 * *Couchbase*
 * *Memcached*
 * *Ephemeral*
-+
 
++
 For more information about bucket types, see xref:learn:buckets-memory-and-storage/buckets.adoc[].
 
 . Choose a *Storage Backend* for the bucket:
 +
 * *Couchstore*
 * *Magma*
-+
 
++
 For more information about the available storage engines, see xref:learn:buckets-memory-and-storage/storage-engines.adoc[Storage Engines].
 
 . In the *Memory Quota* field, enter a value in MiB per node for the total RAM available for the bucket. This value can't exceed the total RAM quota for your cluster. 
@@ -115,26 +115,26 @@ You can only apply this setting to documents created after you change the config
 * *Off* 
 * *Passive*
 * *Active*
-+
 
++
 For more information about the available compression modes, see xref:learn:buckets-memory-and-storage/compression.adoc[].
 
 . Choose a *Conflict Resolution* method for Cross Datacenter Replication (XDCR) on this bucket: 
 +
 * *Sequence number* 
 * *Timestamp*
-+
 
++
 For more information about XDCR conflict resolution, see xref:learn:clusters-and-availability/xdcr-conflict-resolution.adoc[].
 
 . Choose an *Ejection Method* for the bucket: 
 +
 * *Value-only*
 * *Full*
-+
 
-For more information about ejection, see the xref:learn:buckets-memory-and-storage/memory.adoc#ejection[Ejection section in Memory].
 +
+For more information about ejection, see the xref:learn:buckets-memory-and-storage/memory.adoc#ejection[Ejection] section in Memory.
+
 include::learn:partial$full-ejection-note.adoc[]
 
 [#bucket-priority, start="6"]
@@ -142,9 +142,10 @@ include::learn:partial$full-ejection-note.adoc[]
 +
 * *Default*
 * *High*
+
 +
 Bucket Priority sets the priority of the bucket's background tasks relative to the background tasks of other buckets on the cluster. 
-+
+
 Background tasks may involve disk I/O, DCP stream-processing, item-paging, and more. 
 Specifying High might result in faster processing for the current bucket's tasks. 
 This setting only takes effect when there is more than one bucket defined for the cluster, and you have assigned different Bucket Priority values.
@@ -156,8 +157,8 @@ This setting only takes effect when there is more than one bucket defined for th
 * *majority*
 * *majorityAndPersistActive*
 * *persistToMajority*
-+
 
++
 For more information about durability, see xref:learn:data/durability.adoc[].
 
 . To enable automatic compaction of data and indexes to save space, select the *Auto-Compaction* checkbox. 
@@ -208,25 +209,26 @@ You can only apply this setting to documents created after you change the config
 * *Off*
 * *Passive*
 * *Active* 
-+
 
++
 For more information about the available compression modes, see xref:learn:buckets-memory-and-storage/compression.adoc[].
 
 . Choose a *Conflict Resolution* method for Cross Datacenter Replication (XDCR) on this bucket: 
 +
 * *Sequence number*
 * *Timestamp* 
-+
 
++
 For more information about XDCR conflict resolution, see xref:learn:clusters-and-availability/xdcr-conflict-resolution.adoc[].
 
 . Choose a *Bucket Priority*: 
 +
 * *Default*
 * *High*
+
 +
 Bucket Priority sets the priority of the bucket's background tasks relative to the background tasks of other buckets on the cluster. 
-+
+
 Background tasks may involve DCP stream-processing, item-paging, and more. 
 Specifying High might result in faster processing for the current bucket's tasks. T
 This setting only takes effect when there is more than one bucket defined for the cluster, and the buckets are assigned different Bucket Priority values.
@@ -235,8 +237,8 @@ This setting only takes effect when there is more than one bucket defined for th
 +
 * *No ejection* 
 * *Eject data when RAM is full* 
-+
 
++
 For more information about ejection, see the xref:learn:buckets-memory-and-storage/memory.adoc#ejection[Ejection section in Memory].
 
 . In the *Metadata Purge Interval* field, enter a value between `0.0007-60` to set how often a node purges metadata on deleted items.
@@ -250,8 +252,8 @@ If set too low, data might be inconsistent in XDCR or Views.
 +
 * *none*
 * *majority*
-+
 
++
 For more information about durability, see xref:learn:data/durability.adoc[].
 
 [#add-data-bucket-dialog-expanded-for-ephemeral]

--- a/modules/manage/pages/manage-buckets/create-bucket.adoc
+++ b/modules/manage/pages/manage-buckets/create-bucket.adoc
@@ -15,7 +15,7 @@ You can create a maximum of 30 buckets per cluster.
 * You must be a Full or Cluster Administrator.
 
 [#create-bucket-using-couchbase-web-console]
-== Create a Bucket with The UI
+== Create a Bucket with the UI
 
 To create a bucket with the Couchbase UI: 
 
@@ -26,7 +26,7 @@ To create a bucket with the Couchbase UI:
 The [.ui]*Add Data Bucket* dialog appears:
 
 [#add-data-bucket-dialog-initial]
-image::manage-buckets/addDataBucketDialogInitial.png[,320,align=left]
+image::manage-buckets/addDataBucketDialogInitial.png[,320,align=center, alt="An image that displays the Add Data Bucket dialog. The Name field is empty. Bucket Type is set to Couchbase, and the Storage Backend is set to CouchStore. The Memory Quota is set to 18488MiB. The Advanced bucket settings are collapsed."]
 
 [start="4"]
 . In the *Name* field, enter a name for the new bucket.
@@ -46,16 +46,18 @@ A bucket name can be up to 100 characters in length and contain:
 * *Memcached*
 * *Ephemeral*
 +
+
 For more information about bucket types, see xref:learn:buckets-memory-and-storage/buckets.adoc[].
 . Choose a *Storage Backend* for the bucket:
 +
 * *Couchstore*
 * *Magma*
 +
+
 For more information about the available storage engines, see xref:learn:buckets-memory-and-storage/storage-engines.adoc[Storage Engines].
 
 . In the *Memory Quota* field, enter a value in MiB per node for the total RAM available for the bucket. This value can't exceed the total RAM quota for your cluster. 
-
++
 NOTE: Your memory quota needs to match the minimum memory resident ratio required by your chosen storage engine. 
 For more information, see xref:learn:buckets-memory-and-storage/memory.adoc#bucket-memory[Bucket Memory Quotas].
 
@@ -64,16 +66,16 @@ For more information, see xref:learn:buckets-memory-and-storage/memory.adoc#buck
 . Set any advanced settings for your bucket. See <<advanced-bucket-settings>>.
 . Select btn:[Add Bucket].
 
-The bucket appears on the *Buckets* screen: 
+The bucket appears on the *Buckets* screen. 
 
-image::manage-buckets/bucketsViewWithCreatedBucket.png[,750,align=left]
+image::manage-buckets/bucketsViewWithCreatedBucket.png[,750,align=center, alt="An image that displays the bucket list on the Buckets screen, and the search bar for filtering the available buckets. A single bucket, called testBucket, displays in the table. It has no items, and uses 27MiB out of the 256MiB RAM quota available. It uses 4.08MiB of disk space."]
 
 You can view the following information for the bucket: 
 
 * The number of items the bucket contains. 
 * The percentage of items in the bucket that are currently resident. 
 * The number of operations per second being performed on the bucket. 
-* The amount of RAM the bucekt is currently using, compared to its memory quota. 
+* The amount of RAM the bucket is currently using, compared to its memory quota. 
 * The amount of disk space used by the bucket. 
 
 You can also view the xref:manage:manage-ui/manage-ui.adoc#console-documents[Documents] in the bucket and create xref:learn:data/scopes-and-collections.adoc[Scopes and Collections]. 
@@ -94,13 +96,13 @@ The available advanced settings for your bucket change based on your selected *B
 
 To configure advanced settings for a Couchbase bucket: 
 
-. To enable xref:learn:clusters-and-availability/intra-cluster-replication.adoc[replica creation and management], under *Replicas*, select the btn:[Enable] checkbox. 
+. To enable xref:learn:clusters-and-availability/intra-cluster-replication.adoc[replica creation and management], under *Replicas*, select the *Enable* checkbox. 
 
 .. In the *Number of replica (backup) copies* list, select the number of replicas for the bucket. 
 
-.. To replicate view indexes and data from the bucket, select the btn:[Replicate view indexes] checkbox.
+.. To replicate view indexes and data from the bucket, select the *Replicate view indexes* checkbox.
 
-. To set a xref:learn:data/expiration.adoc[document expiration] for documents in the bucket, under *Bucket Max Time-To-Live*, select the btn:[Enable] checkbox.
+. To set a xref:learn:data/expiration.adoc[document expiration] for documents in the bucket, under *Bucket Max Time-To-Live*, select the *Enable* checkbox.
 
 .. In the *Seconds* field, enter the maximum time in seconds that a document can exist in the bucket before it's deleted. 
 +
@@ -113,6 +115,7 @@ You can only apply this setting to documents created after you change the config
 * *Passive*
 * *Active*
 +
+
 For more information about the available compression modes, see xref:learn:buckets-memory-and-storage/compression.adoc[].
 
 . Choose a *Conflict Resolution* method for Cross Datacenter Replication (XDCR) on this bucket: 
@@ -120,6 +123,7 @@ For more information about the available compression modes, see xref:learn:bucke
 * *Sequence number* 
 * *Timestamp*
 +
+
 For more information about XDCR conflict resolution, see xref:learn:clusters-and-availability/xdcr-conflict-resolution.adoc[].
 
 . Choose an *Ejection Method* for the bucket: 
@@ -127,6 +131,7 @@ For more information about XDCR conflict resolution, see xref:learn:clusters-and
 * *Value-only*
 * *Full*
 +
+
 For more information about ejection, see the xref:learn:buckets-memory-and-storage/memory.adoc#ejection[Ejection section in Memory].
 +
 include::learn:partial$full-ejection-note.adoc[]
@@ -151,20 +156,21 @@ This setting only takes effect when there is more than one bucket defined for th
 * *majorityAndPersistActive*
 * *persistToMajority*
 +
+
 For more information about durability, see xref:learn:data/durability.adoc[].
 
-. To enable automatic compaction of data and indexes to save space, select the btn:[Auto-Compaction] checkbox. 
+. To enable automatic compaction of data and indexes to save space, select the *Auto-Compaction* checkbox. 
 
 .. To override the default Auto-Compaction settings, select the btn:[Override the default auto-compaction settings?] checkbox. 
 +
 For more information about how to configure Auto-Compaction, see xref:manage:manage-settings/configure-compact-settings.adoc[].
 
-. To enable flushing for the bucket, under *Flush*, select the btn:[Enable] checkbox.
+. To enable flushing for the bucket, under *Flush*, select the *Enable* checkbox.
 +
 For more information about flushing, see xref:manage-buckets/flush-bucket.adoc[Flush a Bucket].
 
 [#add-data-bucket-dialog-expanded]
-image::manage-buckets/addBucketWithMagmaOption.png[,400,align=left]
+image::manage-buckets/addBucketWithMagmaOption.png[,400,align=center, alt="An image that displays the Add Data Bucket dialog, with a Couchbase Bucket Type and CouchStore Storage Backend selected. The Advanced bucket settings are expanded and to show the default selections for a Couchbase and Couchstore bucket."]
 
 [#memcached-bucket-settings]
 ==== Memcached Bucket Settings
@@ -173,23 +179,23 @@ CAUTION: Memcached buckets are deprecated. Use a *Couchbase* or *Ephemeral* buck
 
 To configure advanced settings for a Memcached bucket:
 
-. To enable flushing for the bucket, under *Flush*, select the btn:[Enable] checkbox.
+. To enable flushing for the bucket, under *Flush*, select the *Enable* checkbox.
 +
 For more information about flushing, see xref:manage-buckets/flush-bucket.adoc[Flush a Bucket].
 
 [#add-data-bucket-dialog-expanded-for-memcached]
-image::manage-buckets/addDataBucketDialogExpandedForMemcached.png[,350,align=left]
+image::manage-buckets/addDataBucketDialogExpandedForMemcached.png[,350,align=center, alt="An image that displays the Add Data Bucket dialog. The Memcached Bucket Type and CouchStore Storage Backend are selected. The bucket Name has been set to mySecondTestBucket."]
 
 [#ephemeral-bucket-settings]
 ==== Ephemeral Bucket Settings
 
 To configure advanced settings for an Ephemeral bucket: 
 
-. To enable xref:learn:clusters-and-availability/intra-cluster-replication.adoc[replica creation and management], under *Replicas*, select the btn:[Enable] checkbox. 
+. To enable xref:learn:clusters-and-availability/intra-cluster-replication.adoc[replica creation and management], under *Replicas*, select the *Enable* checkbox. 
 
 .. In the *Number of replica (backup) copies* list, select the number of replicas for the bucket. 
 
-. . To set a xref:learn:data/expiration.adoc[document expiration] for documents in the bucket, under *Bucket Max Time-To-Live*, select the btn:[Enable] checkbox.
+. To set a xref:learn:data/expiration.adoc[document expiration] for documents in the bucket, under *Bucket Max Time-To-Live*, select the *Enable* checkbox.
 
 .. In the *Seconds* field, enter the maximum number of seconds a document can exist in the bucket before it's deleted. 
 +
@@ -202,6 +208,7 @@ You can only apply this setting to documents created after you change the config
 * *Passive*
 * *Active* 
 +
+
 For more information about the available compression modes, see xref:learn:buckets-memory-and-storage/compression.adoc[].
 
 . Choose a *Conflict Resolution* method for Cross Datacenter Replication (XDCR) on this bucket: 
@@ -209,6 +216,7 @@ For more information about the available compression modes, see xref:learn:bucke
 * *Sequence number*
 * *Timestamp* 
 +
+
 For more information about XDCR conflict resolution, see xref:learn:clusters-and-availability/xdcr-conflict-resolution.adoc[].
 
 . Choose a *Bucket Priority*: 
@@ -220,13 +228,14 @@ Bucket Priority sets the priority of the bucket's background tasks relative to t
 +
 Background tasks may involve DCP stream-processing, item-paging, and more. 
 Specifying High might result in faster processing for the current bucket's tasks. T
-his setting only takes effect when there is more than one bucket defined for the cluster, and the buckets are assigned different Bucket Priority values.
+This setting only takes effect when there is more than one bucket defined for the cluster, and the buckets are assigned different Bucket Priority values.
 
 . Choose an *Ejection Policy* for the bucket: 
 +
 * *No ejection* 
 * *Eject data when RAM is full* 
 +
+
 For more information about ejection, see the xref:learn:buckets-memory-and-storage/memory.adoc#ejection[Ejection section in Memory].
 
 . In the *Metadata Purge Interval* field, enter a value between `0.0007-60` to set how often a node purges metadata on deleted items.
@@ -241,10 +250,11 @@ If set too low, data might be inconsistent in XDCR or Views.
 * *none*
 * *majority*
 +
+
 For more information about durability, see xref:learn:data/durability.adoc[].
 
 [#add-data-bucket-dialog-expanded-for-ephemeral]
-image::manage-buckets/addDataBucketDialogExpandedForEphemeral.png[,350,align=left]
+image::manage-buckets/addDataBucketDialogExpandedForEphemeral.png[,350,align=center, alt="An image that displays the Add Data Bucket dialog, with the Bucket Type set to Ephemeral and the Storage Backend set to CouchStore. The Advanced bucket settings are expanded to show the default selections for a Ephemeral and Couchstore bucket."]
 
 [#create-bucket-with-the-cli]
 == Create a Bucket with the CLI
@@ -253,6 +263,7 @@ To create a bucket with the Couchbase CLI, use the `bucket-create` command.
 
 For example:
 
+[source, sh]
 ----
 ./couchbase-cli bucket-create \
 --cluster 10.143.201.101:8091 \
@@ -279,6 +290,7 @@ To create a bucket with the Couchbase REST API, use the `POST` http method, with
 
 For example:
 
+[source, sh]
 ----
 curl -v -X POST http://10.143.201.101:8091/pools/default/buckets \
 -u Administrator:password \

--- a/modules/manage/pages/manage-buckets/create-bucket.adoc
+++ b/modules/manage/pages/manage-buckets/create-bucket.adoc
@@ -30,7 +30,7 @@ image::manage-buckets/addDataBucketDialogInitial.png[,320,align=center, alt="An 
 
 [start="4"]
 . In the *Name* field, enter a name for the new bucket.
-
++
 [NOTE]
 ====
 A bucket name can be up to 100 characters in length and contain:
@@ -48,6 +48,7 @@ A bucket name can be up to 100 characters in length and contain:
 +
 
 For more information about bucket types, see xref:learn:buckets-memory-and-storage/buckets.adoc[].
+
 . Choose a *Storage Backend* for the bucket:
 +
 * *Couchstore*
@@ -161,7 +162,7 @@ For more information about durability, see xref:learn:data/durability.adoc[].
 
 . To enable automatic compaction of data and indexes to save space, select the *Auto-Compaction* checkbox. 
 
-.. To override the default Auto-Compaction settings, select the btn:[Override the default auto-compaction settings?] checkbox. 
+.. To override the default Auto-Compaction settings, select the *Override the default auto-compaction settings?* checkbox. 
 +
 For more information about how to configure Auto-Compaction, see xref:manage:manage-settings/configure-compact-settings.adoc[].
 

--- a/modules/manage/pages/manage-buckets/create-bucket.adoc
+++ b/modules/manage/pages/manage-buckets/create-bucket.adoc
@@ -6,16 +6,20 @@
 [abstract]
 {description}
 
-You can create a bucket with the xref:manage:manage-buckets/create-bucket.adoc#create-bucket-using-couchbase-web-console[UI], xref:manage:manage-buckets/create-bucket.adoc#create-bucket-with-the-cli[CLI] or the xref:manage:manage-buckets/create-bucket.adoc#create-bucket-with-the-rest-api[REST API].
+You can create a bucket with the xref:manage:manage-buckets/create-bucket.adoc#create-bucket-using-couchbase-web-console[Couchbase Server UI], xref:manage:manage-buckets/create-bucket.adoc#create-bucket-with-the-cli[CLI] or the xref:manage:manage-buckets/create-bucket.adoc#create-bucket-with-the-rest-api[REST API].
 
 You can create a maximum of 30 buckets per cluster.
+
+== Prerequisites
+
+* You must be a Full or Cluster Administrator.
 
 [#create-bucket-using-couchbase-web-console]
 == Create a Bucket with The UI
 
 To create a bucket with the Couchbase UI: 
 
-. Log in to the Couchbase Web Console.
+. Log in to the Couchbase Server Web Console.
 . Go to [.ui]*Buckets*.
 . Select btn:[Add Bucket].
 +
@@ -29,26 +33,34 @@ image::manage-buckets/addDataBucketDialogInitial.png[,320,align=left]
 
 [NOTE]
 ====
-A bucket name can only be up to 100 characters in length and contain:
+A bucket name can be up to 100 characters in length and contain:
 
 * Uppercase and lowercase characters (A-Z and a-z)
 * Digits (0-9)
 * Underscores (_), periods (.), dashes (-), and percent symbols (%)
 ====
 [start="5"]
-. Choose a *Bucket Type* for the bucket: *Couchbase*, *Memcached*, or *Ephemeral*.
+. Choose a *Bucket Type* for the bucket: 
 +
-For more information on bucket types, see xref:learn:buckets-memory-and-storage/buckets.adoc[].
-. Choose a *Storage Backend* for the bucket: *CouchStore* or *Magma*.
+* *Couchbase*
+* *Memcached*
+* *Ephemeral*
 +
-For more information on the available storage engines, see xref:learn:buckets-memory-and-storage/storage-engines.adoc[Storage Engines].
+For more information about bucket types, see xref:learn:buckets-memory-and-storage/buckets.adoc[].
+. Choose a *Storage Backend* for the bucket:
++
+* *Couchstore*
+* *Magma*
++
+For more information about the available storage engines, see xref:learn:buckets-memory-and-storage/storage-engines.adoc[Storage Engines].
 
 . In the *Memory Quota* field, enter a value in MiB per node for the total RAM available for the bucket. This value can't exceed the total RAM quota for your cluster. 
 
 NOTE: Your memory quota needs to match the minimum memory resident ratio required by your chosen storage engine. For more information, see xref:learn:buckets-memory-and-storage/memory.adoc#bucket-memory[Bucket Memory Quotas].
 
 [start="8"]
-. Expand *Advanced bucket settings*. See <<advanced-bucket-settings>>.
+. Expand *Advanced bucket settings*. 
+. Set any advanced settings for your bucket. See <<advanced-bucket-settings>>.
 . Select btn:[Add Bucket].
 
 The bucket appears on the *Buckets* screen: 
@@ -63,13 +75,20 @@ You can view the following information for the bucket:
 * The amount of RAM the bucekt is currently using, compared to its memory quota. 
 * The amount of disk space used by the bucket. 
 
-You can also view the xref:manage:manage-ui/manage-ui.adoc#console-documents[Documents] in the bucket and create xref:learn:data/scopes-and-collections.adoc[Scopes and Collections]. For information on how to import documents into a bucket, see xref:manage:import-documents/import-documents.adoc[Import Documents].
+You can also view the xref:manage:manage-ui/manage-ui.adoc#console-documents[Documents] in the bucket and create xref:learn:data/scopes-and-collections.adoc[Scopes and Collections]. 
+
+For information about how to import documents into a bucket, see xref:manage:import-documents/import-documents.adoc[Import Documents].
 
 [#advanced-bucket-settings]
 === Set Advanced Bucket Settings
 
-The available advanced settings for your bucket change based on your selected *Bucket Type*. 
+The available advanced settings for your bucket change based on your selected *Bucket Type*:
 
+* <<couchbase-bucket-settings>>
+* <<memcached-bucket-settings>>
+* <<ephemeral-bucket-settings>>
+
+[#couchbase-bucket-settings]
 ==== Couchbase Bucket Settings
 
 To configure advanced settings for a Couchbase bucket: 
@@ -82,49 +101,68 @@ To configure advanced settings for a Couchbase bucket:
 
 . To set a xref:learn:data/expiration.adoc[document expiration] for documents in the bucket, under *Bucket Max Time-To-Live*, select the btn:[Enable] checkbox.
 
-.. In the *Seconds* field, enter the maximum number of seconds a document can exist in the bucket before it's deleted. 
+.. In the *Seconds* field, enter the maximum time in seconds that a document can exist in the bucket before it's deleted. 
 +
 TIP: The maximum allowed value is 2147483648 seconds (68.096 years). You can only apply this setting to documents created after you change the configuration. 
 
-. Choose a *Compression Mode* for the bucket: *Off*, *Passive*, or *Active*. 
+. Choose a *Compression Mode* for the bucket: 
 +
-For more information on the available compression modes, see xref:learn:buckets-memory-and-storage/compression.adoc[].
-
-. Choose a *Conflict Resolution* method for Cross Datacenter Replication (XDCR) on this bucket: *Sequence number* or *Timestamp*. 
+* *Off* 
+* *Passive*
+* *Active*
 +
-For more information on XDCR conflict resolution, see xref:learn:clusters-and-availability/xdcr-conflict-resolution.adoc[].
+For more information about the available compression modes, see xref:learn:buckets-memory-and-storage/compression.adoc[].
 
-. Choose an *Ejection Method* for the bucket: *Value-only* or *Full*. 
+. Choose a *Conflict Resolution* method for Cross Datacenter Replication (XDCR) on this bucket: 
 +
-For more information on ejection, see the xref:learn:buckets-memory-and-storage/memory.adoc#ejection[Ejection section in Memory].
+* *Sequence number* 
+* *Timestamp*
++
+For more information about XDCR conflict resolution, see xref:learn:clusters-and-availability/xdcr-conflict-resolution.adoc[].
 
+. Choose an *Ejection Method* for the bucket: 
++
+* *Value-only*
+* *Full*
++
+For more information about ejection, see the xref:learn:buckets-memory-and-storage/memory.adoc#ejection[Ejection section in Memory].
++
 include::learn:partial$full-ejection-note.adoc[]
 
 [#bucket-priority, start="6"]
-. Choose a *Bucket Priority* for the bucket: *Default* or *High*. 
+. Choose a *Bucket Priority* for the bucket: 
++
+* *Default*
+* *High*
 +
 Bucket Priority sets the priority of the bucket's background tasks relative to the background tasks of other buckets on the cluster. 
 +
-Background tasks may involve disk I/O, DCP stream-processing, item-paging, and more. Specifying High might result in faster processing for the current bucket's tasks. This setting only takes effect when there is more than one bucket defined for the cluster, and the buckets are assigned different Bucket Priority values.
+Background tasks may involve disk I/O, DCP stream-processing, item-paging, and more. Specifying High might result in faster processing for the current bucket's tasks. This setting only takes effect when there is more than one bucket defined for the cluster, and you have assigned different Bucket Priority values.
 
 [#durability-level, start="7"]
-. In the *Minimum Durability Level* list, select a durability level for the bucket: *none*, *majority*, *majorityAndPersistActive*, or *persistToMajority*.
+. In the *Minimum Durability Level* list, select a durability level for the bucket: 
 +
-For more information on durability, see xref:learn:data/durability.adoc[].
+* *none*
+* *majority*
+* *majorityAndPersistActive*
+* *persistToMajority*
++
+For more information about durability, see xref:learn:data/durability.adoc[].
 
 . To enable automatic compaction of data and indexes to save space, select the btn:[Auto-Compaction] checkbox. 
 
 .. To override the default Auto-Compaction settings, select the btn:[Override the default auto-compaction settings?] checkbox. 
 +
-For more information on how to configure Auto-Compaction, see xref:manage:manage-settings/configure-compact-settings.adoc[].
+For more information about how to configure Auto-Compaction, see xref:manage:manage-settings/configure-compact-settings.adoc[].
 
 . To enable flushing for the bucket, under *Flush*, select the btn:[Enable] checkbox.
 +
-For more information on flushing, see xref:manage-buckets/flush-bucket.adoc[Flush a Bucket].
+For more information about flushing, see xref:manage-buckets/flush-bucket.adoc[Flush a Bucket].
 
 [#add-data-bucket-dialog-expanded]
 image::manage-buckets/addBucketWithMagmaOption.png[,400,align=left]
 
+[#memcached-bucket-settings]
 ==== Memcached Bucket Settings
 
 CAUTION: Memcached buckets are deprecated. Use a *Couchbase* or *Ephemeral* bucket, instead. 
@@ -133,11 +171,12 @@ To configure advanced settings for a Memcached bucket:
 
 . To enable flushing for the bucket, under *Flush*, select the btn:[Enable] checkbox.
 +
-For more information on flushing, see xref:manage-buckets/flush-bucket.adoc[Flush a Bucket].
+For more information about flushing, see xref:manage-buckets/flush-bucket.adoc[Flush a Bucket].
 
 [#add-data-bucket-dialog-expanded-for-memcached]
 image::manage-buckets/addDataBucketDialogExpandedForMemcached.png[,350,align=left]
 
+[#ephemeral-bucket-settings]
 ==== Ephemeral Bucket Settings
 
 To configure advanced settings for an Ephemeral bucket: 
@@ -152,25 +191,47 @@ To configure advanced settings for an Ephemeral bucket:
 +
 TIP: The maximum allowed value is 2147483648 seconds (68.096 years). You can only apply this setting to documents created after you change the configuration. 
 
-. Choose a *Compression Mode* for the bucket: *Off*, *Passive*, or *Active*. 
+. Choose a *Compression Mode* for the bucket: 
 +
-For more information on the available compression modes, see xref:learn:buckets-memory-and-storage/compression.adoc[].
-
-. Choose a *Conflict Resolution* method for Cross Datacenter Replication (XDCR) on this bucket: *Sequence number* or *Timestamp*. 
+* *Off*
+* *Passive*
+* *Active* 
 +
-For more information on XDCR conflict resolution, see xref:learn:clusters-and-availability/xdcr-conflict-resolution.adoc[].
+For more information about the available compression modes, see xref:learn:buckets-memory-and-storage/compression.adoc[].
 
-. Choose a *Bucket Priority*: *Default* or *High*. Bucket Priority sets the priority of the bucket's background tasks relative to the background tasks of other buckets on the cluster. 
+. Choose a *Conflict Resolution* method for Cross Datacenter Replication (XDCR) on this bucket: 
++
+* *Sequence number*
+* *Timestamp* 
++
+For more information about XDCR conflict resolution, see xref:learn:clusters-and-availability/xdcr-conflict-resolution.adoc[].
+
+. Choose a *Bucket Priority*: 
++
+* *Default*
+* *High*
++
+Bucket Priority sets the priority of the bucket's background tasks relative to the background tasks of other buckets on the cluster. 
 +
 Background tasks may involve DCP stream-processing, item-paging, and more. Specifying High might result in faster processing for the current bucket's tasks. This setting only takes effect when there is more than one bucket defined for the cluster, and the buckets are assigned different Bucket Priority values.
 
-. Choose an *Ejection Policy* for the bucket: *No ejection* or *NRU ejection*. 
+. Choose an *Ejection Policy* for the bucket: 
 +
-For more information on ejection, see the xref:learn:buckets-memory-and-storage/memory.adoc#ejection[Ejection section in Memory].
+* *No ejection* 
+* *Eject data when RAM is full* 
++
+For more information about ejection, see the xref:learn:buckets-memory-and-storage/memory.adoc#ejection[Ejection section in Memory].
 
-. In the *Minimum Durability Level* list, select a durability level for the bucket: *none* or *majority*.
+. In the *Metadata Purge Interval* field, enter a value between `0.0007-60` to set how often a node purges metadata on deleted items.
 +
-For more information on durability, see xref:learn:data/durability.adoc[].
+A value of `0.0007` equals a minute. A value of `0.5` equals 12 hours. If this value is too high, the node might have a delay when reclaiming memory. If set too low, data might be inconsistent in XDCR or Views. 
+
+. In the *Minimum Durability Level* list, select a durability level for the bucket: 
++
+* *none*
+* *majority*
++
+For more information about durability, see xref:learn:data/durability.adoc[].
 
 [#add-data-bucket-dialog-expanded-for-ephemeral]
 image::manage-buckets/addDataBucketDialogExpandedForEphemeral.png[,350,align=left]
@@ -197,7 +258,7 @@ For example:
 
 The preceding example creates a `Couchbase` bucket named `testBucket`, with a RAM size of `1024`. It sets a Maximum Time-to-Live and disables Flush. It also sets a Minimum Durability Level of `persistToMajority`. 
 
-For more information on `bucket-create` and its parameters, see xref:cli:cbcli/couchbase-cli-bucket-create.adoc[bucket-create] in the Couchbase CLI reference.
+For more information about `bucket-create` and its parameters, see xref:cli:cbcli/couchbase-cli-bucket-create.adoc[bucket-create] in the Couchbase CLI reference.
 
 [#create-bucket-with-the-rest-api]
 == Create a Bucket with the REST API
@@ -217,4 +278,4 @@ curl -v -X POST http://10.143.201.101:8091/pools/default/buckets \
 
 The preceding example creates a `Couchbase` bucket named `testBucket`, with a RAM size of `512`. It sets a Minimum Durability Level of `majorityAndPersistActive`.
 
-For more information on the `/pools/default/buckets` endpoint and its parameters, see xref:rest-api:rest-bucket-create.adoc[Creating and Editing Buckets] in the Buckets API reference.
+For more information about the `/pools/default/buckets` endpoint and its parameters, see xref:rest-api:rest-bucket-create.adoc[Creating and Editing Buckets] in the Buckets API reference.

--- a/modules/manage/pages/manage-buckets/create-bucket.adoc
+++ b/modules/manage/pages/manage-buckets/create-bucket.adoc
@@ -56,7 +56,8 @@ For more information about the available storage engines, see xref:learn:buckets
 
 . In the *Memory Quota* field, enter a value in MiB per node for the total RAM available for the bucket. This value can't exceed the total RAM quota for your cluster. 
 
-NOTE: Your memory quota needs to match the minimum memory resident ratio required by your chosen storage engine. For more information, see xref:learn:buckets-memory-and-storage/memory.adoc#bucket-memory[Bucket Memory Quotas].
+NOTE: Your memory quota needs to match the minimum memory resident ratio required by your chosen storage engine. 
+For more information, see xref:learn:buckets-memory-and-storage/memory.adoc#bucket-memory[Bucket Memory Quotas].
 
 [start="8"]
 . Expand *Advanced bucket settings*. 
@@ -103,7 +104,8 @@ To configure advanced settings for a Couchbase bucket:
 
 .. In the *Seconds* field, enter the maximum time in seconds that a document can exist in the bucket before it's deleted. 
 +
-TIP: The maximum allowed value is 2147483648 seconds (68.096 years). You can only apply this setting to documents created after you change the configuration. 
+TIP: The maximum allowed value is 2147483648 seconds (68.096 years). 
+You can only apply this setting to documents created after you change the configuration. 
 
 . Choose a *Compression Mode* for the bucket: 
 +
@@ -137,7 +139,9 @@ include::learn:partial$full-ejection-note.adoc[]
 +
 Bucket Priority sets the priority of the bucket's background tasks relative to the background tasks of other buckets on the cluster. 
 +
-Background tasks may involve disk I/O, DCP stream-processing, item-paging, and more. Specifying High might result in faster processing for the current bucket's tasks. This setting only takes effect when there is more than one bucket defined for the cluster, and you have assigned different Bucket Priority values.
+Background tasks may involve disk I/O, DCP stream-processing, item-paging, and more. 
+Specifying High might result in faster processing for the current bucket's tasks. 
+This setting only takes effect when there is more than one bucket defined for the cluster, and you have assigned different Bucket Priority values.
 
 [#durability-level, start="7"]
 . In the *Minimum Durability Level* list, select a durability level for the bucket: 
@@ -189,7 +193,8 @@ To configure advanced settings for an Ephemeral bucket:
 
 .. In the *Seconds* field, enter the maximum number of seconds a document can exist in the bucket before it's deleted. 
 +
-TIP: The maximum allowed value is 2147483648 seconds (68.096 years). You can only apply this setting to documents created after you change the configuration. 
+TIP: The maximum allowed value is 2147483648 seconds (68.096 years). 
+You can only apply this setting to documents created after you change the configuration. 
 
 . Choose a *Compression Mode* for the bucket: 
 +
@@ -213,7 +218,9 @@ For more information about XDCR conflict resolution, see xref:learn:clusters-and
 +
 Bucket Priority sets the priority of the bucket's background tasks relative to the background tasks of other buckets on the cluster. 
 +
-Background tasks may involve DCP stream-processing, item-paging, and more. Specifying High might result in faster processing for the current bucket's tasks. This setting only takes effect when there is more than one bucket defined for the cluster, and the buckets are assigned different Bucket Priority values.
+Background tasks may involve DCP stream-processing, item-paging, and more. 
+Specifying High might result in faster processing for the current bucket's tasks. T
+his setting only takes effect when there is more than one bucket defined for the cluster, and the buckets are assigned different Bucket Priority values.
 
 . Choose an *Ejection Policy* for the bucket: 
 +
@@ -224,7 +231,10 @@ For more information about ejection, see the xref:learn:buckets-memory-and-stora
 
 . In the *Metadata Purge Interval* field, enter a value between `0.0007-60` to set how often a node purges metadata on deleted items.
 +
-A value of `0.0007` equals a minute. A value of `0.5` equals 12 hours. If this value is too high, the node might have a delay when reclaiming memory. If set too low, data might be inconsistent in XDCR or Views. 
+A value of `0.0007` equals a minute. 
+A value of `0.5` equals 12 hours. 
+If this value is too high, the node might have a delay when reclaiming memory. 
+If set too low, data might be inconsistent in XDCR or Views. 
 
 . In the *Minimum Durability Level* list, select a durability level for the bucket: 
 +
@@ -256,7 +266,9 @@ For example:
 --enable-flush 0
 ----
 
-The preceding example creates a `Couchbase` bucket named `testBucket`, with a RAM size of `1024`. It sets a Maximum Time-to-Live and disables Flush. It also sets a Minimum Durability Level of `persistToMajority`. 
+The preceding example creates a `Couchbase` bucket named `testBucket`, with a RAM size of `1024`.
+ It sets a Maximum Time-to-Live and disables Flush. 
+ It also sets a Minimum Durability Level of `persistToMajority`. 
 
 For more information about `bucket-create` and its parameters, see xref:cli:cbcli/couchbase-cli-bucket-create.adoc[bucket-create] in the Couchbase CLI reference.
 
@@ -276,6 +288,7 @@ curl -v -X POST http://10.143.201.101:8091/pools/default/buckets \
 -d durabilityMinLevel=majorityAndPersistActive
 ----
 
-The preceding example creates a `Couchbase` bucket named `testBucket`, with a RAM size of `512`. It sets a Minimum Durability Level of `majorityAndPersistActive`.
+The preceding example creates a `Couchbase` bucket named `testBucket`, with a RAM size of `512`. 
+It sets a Minimum Durability Level of `majorityAndPersistActive`.
 
 For more information about the `/pools/default/buckets` endpoint and its parameters, see xref:rest-api:rest-bucket-create.adoc[Creating and Editing Buckets] in the Buckets API reference.


### PR DESCRIPTION
The goal of this ticket was to add information on the minimum memory resident ratio for assigning a memory quota to a bucket during bucket creation. 

The Create a Bucket page hadn't been updated in 4 years, so I took the liberty of turning it into a full procedure. It includes the new information about how to assign the memory quota. 

The full explanation of the minimum memory resident ratio is inside the Memory topic. I rewrote the Service Memory Quotas section, added a new Bucket Memory Quotas section, and added to the Ejection section to support the changes to Create a Bucket. 

(I had to do a small rebase because I missed the ticket number in one of my commits :)) 