### PR TITLE
DOC-10440: Fix inconsistent use of tabs and spaces in Transactions docs

### DIFF
--- a/modules/learn/pages/data/transactions.adoc
+++ b/modules/learn/pages/data/transactions.adoc
@@ -62,20 +62,20 @@ transactions.run((txnctx) -> {
     int andyBalance = andyContent.getInt("account_balance");
     var beth = txnctx.get(collection, "Beth");
 
-	var bethContent = beth.contentAsObject();
+    var bethContent = beth.contentAsObject();
     int bethBalance = bethContent.getInt("account_balance");
 
     // if Beth has sufficient funds, make the transfer
     if (bethBalance > transferAmount) {
-	 	andyContent.put("account_balance", andyBalance + transferAmount);
+        andyContent.put("account_balance", andyBalance + transferAmount);
         txnctx.replace(andy, andyContent);
 
         bethContent.put("account_balance", bethBalance - transferAmount);
         txnctx.replace(beth, bethContent)
-        }
-        else throw new InsufficientFunds();
-   	// commit transaction - optional, can be omitted
-   	txnctx.commit();
+    } else
+        throw new InsufficientFunds();
+   // commit transaction - optional, can be omitted
+   txnctx.commit();
 });
 ----
 


### PR DESCRIPTION
Transactions code snippet had inconsistent use of tabs and spaces, which resulted in some lines being over-indented