### PR TITLE
DOC-10482 n1ql feature controller

### DIFF
--- a/modules/manage/pages/manage-settings/general-settings.adoc
+++ b/modules/manage/pages/manage-settings/general-settings.adoc
@@ -208,7 +208,7 @@ image::manage-settings/query-settings-bottom.png["The bottom half of the Query S
 * *Max Parallelism*: The maximum number of index partitions for parallel aggregation-computing.
 
 * *N1QL Feature Controller*: Enables or disables features in the Query engine. 
-
++
 WARNING: Do not change the *N1QL Feature Controller* setting without guidance from technical support.
 
 * *Transaction Timeout*: The number of milliseconds to elapse before a transaction times out.

--- a/modules/manage/pages/manage-settings/general-settings.adoc
+++ b/modules/manage/pages/manage-settings/general-settings.adoc
@@ -207,7 +207,9 @@ image::manage-settings/query-settings-bottom.png["The bottom half of the Query S
 
 * *Max Parallelism*: The maximum number of index partitions for parallel aggregation-computing.
 
-* *N1QL Feature Controller*: Provided for technical support only.
+* *N1QL Feature Controller*: Enables or disables features in the Query engine. 
+
+WARNING: Do not change the *N1QL Feature Controller* setting without guidance from technical support.
 
 * *Transaction Timeout*: The number of milliseconds to elapse before a transaction times out.
 


### PR DESCRIPTION
...description in general-settings.adoc to specify what the setting....

...does in a general sense and emphasize that the user shouldn't...

...change the setting without technical support guidance.

I decided on an admonition here because it's just an <ul> element - and if we're elaborating, at least generally, on what the feature does, we should be a little more strong on not modifying it without assistance. 