### PR TITLE
[DOC-10478] Page Topic Types Attribute Backport for release/6.6 (#2936)

### DIFF
--- a/modules/n1ql/pages/advanced.adoc
+++ b/modules/n1ql/pages/advanced.adoc
@@ -1,6 +1,7 @@
 = Advanced Features
 :page-role: tiles -toc
 :!sectids:
+:page-topic-type: reference
 
 // Pass through HTML styles for this page.
 

--- a/modules/n1ql/pages/n1ql-language-reference/adaptive-indexing.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/adaptive-indexing.adoc
@@ -1,6 +1,7 @@
 = Adaptive Index
 :description: Adaptive Indexes are a special type of GSI array index that can index all or specified fields of a document.
 :imagesdir: ../../assets/images
+:page-topic-type: concept
 
 :pairs: xref:n1ql-language-reference/metafun.adoc#pairs
 :logical-hierarchy: xref:n1ql-intro/sysinfo.adoc#logical-hierarchy

--- a/modules/n1ql/pages/n1ql-language-reference/advise.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/advise.adoc
@@ -1,6 +1,6 @@
 = ADVISE
 :description: The ADVISE statement provides index recommendations to optimize query response time.
-:page-topic-type: concept
+:page-topic-type: reference
 :page-edition: Enterprise Edition
 :imagesdir: ../../assets/images
 

--- a/modules/n1ql/pages/n1ql-language-reference/advisor.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/advisor.adoc
@@ -1,7 +1,7 @@
 = ADVISOR Function
 :description: pass:q[The `ADVISOR` function provides index recommendations to optimize query response time. \
 There are two main scenarios for using this function.]
-:page-topic-type: concept
+:page-topic-type: reference
 :page-status: Developer Preview
 :imagesdir: ../../assets/images
 

--- a/modules/n1ql/pages/n1ql-language-reference/aggregatefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/aggregatefun.adoc
@@ -2,6 +2,7 @@
 :description: Aggregate functions take multiple values from documents, perform calculations, and return a single value as the result. \
 The function names are case insensitive.
 :imagesdir: ../../assets/images
+:page-topic-type: reference
 
 :window: xref:n1ql-language-reference/window.adoc
 :expression: xref:n1ql-language-reference/index.adoc

--- a/modules/n1ql/pages/n1ql-language-reference/alterindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/alterindex.adoc
@@ -2,6 +2,7 @@
 :description: The ALTER INDEX statement moves the placement of an existing index or replica among different GSI nodes.
 :page-edition: Enterprise Edition
 :imagesdir: ../../assets/images
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/arithmetic.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/arithmetic.adoc
@@ -1,6 +1,7 @@
 = Arithmetic Operators
 :description: Arithmetic operations perform the basic mathematical operations of addition, subtraction, multiplication, division, and modulo within an expression or any numerical value retrieved as part of query clauses.
 :imagesdir: ../../assets/images
+:page-topic-type: reference
 
 {description}
 Additionally, N1QL provides a negation operation which changes the sign of a value.

--- a/modules/n1ql/pages/n1ql-language-reference/arrayfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/arrayfun.adoc
@@ -1,6 +1,6 @@
 = Array Functions
 :description: You can use array functions to evaluate arrays, perform computations on elements in an array, and to return a new array based on a transformation.
-:page-topic-type: concept
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/backfill.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/backfill.adoc
@@ -1,6 +1,7 @@
 = Backfill Support for N1QL
 :description: Configure the temporary working space for the N1QL engine and its embedded GSI client.
 :page-aliases: settings:backfill
+:page-topic-type: guide
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/bitwisefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/bitwisefun.adoc
@@ -1,5 +1,6 @@
 = Bitwise Functions
 :description: All Bit/Binary functions can only operate on 64-bit signed integers.
+:page-topic-type: reference
 
 {description}
 

--- a/modules/n1ql/pages/n1ql-language-reference/booleanlogic.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/booleanlogic.adoc
@@ -1,6 +1,6 @@
 = Boolean Logic
 :description: pass:q[Some clauses, such as `WHERE`, `WHEN`, and `HAVING`, require values to be interpreted as Boolean values.]
-:page-topic-type: concept
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
@@ -1,6 +1,6 @@
 = BUILD INDEX
 :description: The BUILD INDEX statement enables you to build one or more GSI indexes that are marked for deferred building all at once.
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 
 [abstract]

--- a/modules/n1ql/pages/n1ql-language-reference/collectionops.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/collectionops.adoc
@@ -1,6 +1,6 @@
 = Collection Operators
 :description: Collection operators enable you to evaluate expressions over every element in an array.
-:page-topic-type: concept
+:page-topic-type: reference
 :page-toclevels: 2
 :imagesdir: ../../assets/images
 :keywords: range condition, quantified expression

--- a/modules/n1ql/pages/n1ql-language-reference/comparisonfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/comparisonfun.adoc
@@ -1,6 +1,6 @@
 = Comparison Functions
 :description: Comparison functions determine the greatest or least value from a set of values.
-:page-topic-type: concept
+:page-topic-type: reference
 
 {description}
 

--- a/modules/n1ql/pages/n1ql-language-reference/comparisonops.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/comparisonops.adoc
@@ -1,6 +1,6 @@
 = Comparison Operators
 :description: Comparison operators enable you to compare expressions.
-:page-topic-type: concept
+:page-topic-type: reference
 
 {description}
 

--- a/modules/n1ql/pages/n1ql-language-reference/condfunnum.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/condfunnum.adoc
@@ -1,6 +1,6 @@
 = Conditional Functions for Numbers
 :description: Conditional functions evaluate expressions to determine if the values and formulas meet the specified condition.
-:page-topic-type: concept
+:page-topic-type: reference
 
 {description}
 

--- a/modules/n1ql/pages/n1ql-language-reference/condfununknown.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/condfununknown.adoc
@@ -1,6 +1,6 @@
 = Conditional Functions for Unknowns
 :description: Conditional functions evaluate expressions to determine if the values and formulas meet the specified condition.
-:page-topic-type: concept
+:page-topic-type: reference
 
 {description}
 

--- a/modules/n1ql/pages/n1ql-language-reference/conditionalops.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/conditionalops.adoc
@@ -1,6 +1,6 @@
 = Conditional Operators
 :description: Case expressions evaluate conditional logic in an expression.
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/constructionops.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/constructionops.adoc
@@ -1,6 +1,6 @@
 = Construction Operators
 :description: N1QL supports array and object construction operators.
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/conventions.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/conventions.adoc
@@ -1,6 +1,6 @@
 = Conventions
 :description: The N1QL syntax descriptions in the documentation use some notational conventions that you need to be familiar with.
-:page-topic-type: concept
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/createfunction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createfunction.adoc
@@ -1,6 +1,6 @@
 = CREATE FUNCTION
 :description: pass:q[The `CREATE FUNCTION` statement enables you to create a user-defined function.]
-:page-topic-type: concept
+:page-topic-type: reference
 :page-status: Developer Preview
 :imagesdir: ../../assets/images
 :page-partial:

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -1,7 +1,7 @@
 = CREATE INDEX
 :description: pass:q[The `CREATE INDEX` statement allows you to create a secondary index. \
 Secondary indexes contain a filtered or a full set of keys in a given bucket.]
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 :keywords: secondary, index, placement
 :enterprise: https://www.couchbase.com/products/editions[ENTERPRISE EDITION]

--- a/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
@@ -1,6 +1,7 @@
 = CREATE PRIMARY INDEX
 :description: pass:q[The `CREATE PRIMARY INDEX` statement allows you to create a primary index. \
 Primary indexes contain a full set of keys in a given keyspace.]
+:page-topic-type: reference
 
 {description}
 Primary indexes are optional and are only required for running ad hoc queries on a keyspace that is not supported by a secondary index.

--- a/modules/n1ql/pages/n1ql-language-reference/curl.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/curl.adoc
@@ -1,6 +1,6 @@
 = CURL Function
 :description: pass:a,q[The `CURL()` function implements a subset of {url-wiki-curl}[cURL^] functionality and enables N1QL queries to interact and integrate with external JSON data sources available over HTTP/REST.]
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 
 :url-wiki-curl: https://en.wikipedia.org/wiki/CURL

--- a/modules/n1ql/pages/n1ql-language-reference/datatypes.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/datatypes.adoc
@@ -1,6 +1,6 @@
 = Data Types
 :description: N1QL supports many data types: MISSING, NULL, Boolean values, numeric values, string values, arrays, objects, and binary.
-:page-topic-type: concept
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
@@ -1,6 +1,6 @@
 = Date Functions
 :description: N1QL date functions return the system clock value or manipulate the datetime values, which are represented as a string or an integer.
-:page-topic-type: concept
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/delete.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/delete.adoc
@@ -1,7 +1,7 @@
 = DELETE
 :description: DELETE immediately removes the specified document from your keyspace. \
 DELETE uses the following syntax:
-:page-topic-type: concept
+:page-topic-type: reference
 
 {description}
 

--- a/modules/n1ql/pages/n1ql-language-reference/dropfunction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropfunction.adoc
@@ -1,6 +1,6 @@
 = DROP FUNCTION
 :description: pass:q[The `DROP FUNCTION` statement enables you to delete a user-defined function.]
-:page-topic-type: concept
+:page-topic-type: reference
 :page-status: Developer Preview
 :imagesdir: ../../assets/images
 :page-partial:

--- a/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
@@ -1,6 +1,6 @@
 = DROP INDEX
 :description: The DROP INDEX statement allows you to drop a named primary index or a secondary index.
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
@@ -1,6 +1,6 @@
 = DROP PRIMARY INDEX
 :description: The DROP PRIMARY INDEX statement allows you to drop an unnamed primary indexes.
-:page-topic-type: concept
+:page-topic-type: reference
 
 {description}
 

--- a/modules/n1ql/pages/n1ql-language-reference/execfunction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/execfunction.adoc
@@ -1,6 +1,6 @@
 = EXECUTE FUNCTION
 :description: pass:q[The `EXECUTE FUNCTION` statement enables you to execute a user-defined function.]
-:page-topic-type: concept
+:page-topic-type: reference
 :page-status: Developer Preview
 :imagesdir: ../../assets/images
 :page-partial:

--- a/modules/n1ql/pages/n1ql-language-reference/execute.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/execute.adoc
@@ -1,6 +1,6 @@
 = EXECUTE
 :description: The EXECUTE statement executes a prepared statement.
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 
 [abstract]

--- a/modules/n1ql/pages/n1ql-language-reference/explain.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/explain.adoc
@@ -1,6 +1,6 @@
 = EXPLAIN
 :description: The EXPLAIN statement when used before any N1QL statement, provides information about the execution plan for the statement.
-:page-topic-type: concept
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/from.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/from.adoc
@@ -1,6 +1,7 @@
 = FROM Clause
 :description: pass:q[The `FROM` clause specifies the documents to be used as the input for a query.]
 :imagesdir: ../../assets/images
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/functions.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/functions.adoc
@@ -1,6 +1,6 @@
 = Functions Overview
 :description: Function names are used to apply a function to values, to values at a specified path, or to values derived from a DISTINCT clause.
-:page-topic-type: concept
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/grant.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/grant.adoc
@@ -1,6 +1,6 @@
 = GRANT
 :description: The GRANT statement allows granting any RBAC roles to a specific user.
-:page-topic-type: concept
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/groupby-aggregate-performance.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/groupby-aggregate-performance.adoc
@@ -2,6 +2,7 @@
 :description: N1QL Pushdowns optimize the performance of N1QL queries by supporting GROUP BY and Aggregate expressions.
 :page-edition: enterprise edition
 :imagesdir: ../../assets/images
+:page-topic-type: concept
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/groupby.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/groupby.adoc
@@ -1,6 +1,7 @@
 = GROUP BY Clause
 :description: The GROUP BY clause arranges aggregate values into groups, based on one or more fields.
 :imagesdir: ../../assets/images
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/hints.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/hints.adoc
@@ -1,6 +1,7 @@
 = USE Clause
 :description: pass:q[The `USE` clause enables you to specify that the query should use particular keys, or a particular index.]
 :imagesdir: ../../assets/images
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/identifiers.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/identifiers.adoc
@@ -1,6 +1,6 @@
 = Identifiers
 :description: An identifier is a symbolic reference to a value in the current context of a query.
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 
 [abstract]

--- a/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
@@ -2,7 +2,7 @@
 :description: Index Partitioning enables you to increase aggregate query performance by dividing and spreading a large index of documents across multiple nodes, horizontally scaling out an index as needed.
 :page-edition: Enterprise Edition
 :imagesdir: ../../assets/images
-
+:page-topic-type: reference
 :expression: xref:n1ql-language-reference/index.adoc
 :logical-hierarchy: xref:n1ql-intro/sysinfo.adoc#logical-hierarchy
 :identifiers: xref:n1ql-language-reference/identifiers.adoc

--- a/modules/n1ql/pages/n1ql-language-reference/indexing-arrays.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/indexing-arrays.adoc
@@ -1,6 +1,7 @@
 = Array Indexing
 :description: Array Indexing adds the capability to create global indexes on array elements and optimizes the execution of queries involving array elements.
 :imagesdir: ../../assets/images
+:page-topic-type: reference
 :logical-hierarchy: xref:n1ql-intro/sysinfo.adoc#logical-hierarchy
 :expression: xref:n1ql-language-reference/index.adoc
 :createindex: xref:n1ql-language-reference/createindex.adoc

--- a/modules/n1ql/pages/n1ql-language-reference/indexing-meta-info.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/indexing-meta-info.adoc
@@ -1,5 +1,6 @@
 = Indexing Metadata Information
 :description: Couchbase Server allows indexing on selected metadata fields, for example the expiration and CAS properties.
+:page-topic-type: reference
 
 {description}
 This improves performance of queries involving predicates on the metadata fields, such as expired documents or recently modified documents.

--- a/modules/n1ql/pages/n1ql-language-reference/infer.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/infer.adoc
@@ -1,6 +1,7 @@
 = INFER
 :description: The INFER statement enables you to infer the metadata of documents in a keyspace, for example the structure of documents, data types of various attributes, sample values, and so on.
 :imagesdir: ../../assets/images
+:page-topic-type: reference
 
 {description}
 Since a keyspace or bucket can contain documents with varying structures, the INFER statement is statistical in nature rather than deterministic.

--- a/modules/n1ql/pages/n1ql-language-reference/insert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/insert.adoc
@@ -1,6 +1,7 @@
 = INSERT
 :description: Use the INSERT statement to insert one or more new documents into an existing keyspace.
 :imagesdir: ../../assets/images
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/join.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/join.adoc
@@ -2,6 +2,7 @@
 :description: pass:q[The `JOIN` clause enables you to create new input objects by combining two or more source objects.]
 :imagesdir: ../../assets/images
 :clause: JOIN
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/jsonfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/jsonfun.adoc
@@ -1,6 +1,6 @@
 = JSON Functions
 :description: DECODE_JSON(expression)
-:page-topic-type: concept
+:page-topic-type: reference
 
 {description}
 

--- a/modules/n1ql/pages/n1ql-language-reference/let.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/let.adoc
@@ -1,6 +1,7 @@
 = LET clause
 :description: pass:q[Use `LET` to create variables for later use within a query.]
 :imagesdir: ../../assets/images
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/limit.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/limit.adoc
@@ -1,5 +1,6 @@
 = LIMIT clause
 :description: pass:q[The `LIMIT` clause specifies the maximum number of documents to be returned in a resultset by a `SELECT` statement.]
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/literals.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/literals.adoc
@@ -1,6 +1,6 @@
 = Literals
 :description: Literal values include strings, numbers, TRUE, FALSE, NULL, and MISSING.
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 
 [abstract]

--- a/modules/n1ql/pages/n1ql-language-reference/logicalops.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/logicalops.adoc
@@ -1,6 +1,6 @@
 = Logical Operators
 :description: Logical terms let you combine other expressions using Boolean logic.
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 
 Logical terms let you combine other expressions using xref:n1ql-language-reference/booleanlogic.adoc[Boolean logic].

--- a/modules/n1ql/pages/n1ql-language-reference/merge.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/merge.adoc
@@ -1,6 +1,6 @@
 = MERGE
 :description: A MERGE statement provides the ability to update, insert into, or delete from a keyspace based on the results of a join with another keyspace or subquery.
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 
 [abstract]

--- a/modules/n1ql/pages/n1ql-language-reference/metafun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/metafun.adoc
@@ -1,6 +1,6 @@
 = Miscellaneous Utility Functions
 :description: Meta functions retrieve information about the document or item as well as perform base64 encoding.
-:page-topic-type: concept
+:page-topic-type: reference
 :page-partial:
 
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/n1ql-auditing.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/n1ql-auditing.adoc
@@ -1,5 +1,6 @@
 = N1QL Auditing
 :description: N1QL-related activities can be audited, by Couchbase Server.
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/n1ql-error-codes.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/n1ql-error-codes.adoc
@@ -1,5 +1,6 @@
 = N1QL Error Codes
 :description: The following table lists all of the N1QL error codes, their error message, and some tips to resolve them.
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/nest.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/nest.adoc
@@ -2,6 +2,7 @@
 :description: pass:q[The `NEST` clause creates an input object by producing a single result of nesting keyspaces.]
 :imagesdir: ../../assets/images
 :clause: NEST
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/nestedops.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/nestedops.adoc
@@ -1,6 +1,6 @@
 = Nested Operators and Expressions
 :description: In N1QL, nested operators and paths indicate expressions to access nested sub-documents within a JSON document or expression.
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/numericfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/numericfun.adoc
@@ -1,6 +1,6 @@
 = Number Functions
 :description: Number functions are functions that are performed on a numeric field.
-:page-topic-type: concept
+:page-topic-type: reference
 
 {description}
 

--- a/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
@@ -1,5 +1,5 @@
 = Object Functions
-:page-topic-type: concept
+:page-topic-type: reference
 
 == OBJECT_ADD()
 

--- a/modules/n1ql/pages/n1ql-language-reference/offset.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/offset.adoc
@@ -1,5 +1,6 @@
 = OFFSET clause
 :description: pass:q[The `OFFSET` clause specifies the number of resultset objects to skip in a `SELECT` query.]
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/operators.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/operators.adoc
@@ -1,6 +1,6 @@
 = Operators Overview
 :description: Operators perform a specific operation on the input values or expressions.
-:page-topic-type: concept
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/orderby.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/orderby.adoc
@@ -1,6 +1,7 @@
 = ORDER BY clause
 :description: pass:q[The `ORDER BY` clause sorts the result-set by one or more columns, in ascending or descending order.]
 :imagesdir: ../../assets/images
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/patternmatchingfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/patternmatchingfun.adoc
@@ -1,6 +1,6 @@
 = Pattern-Matching Functions
 :description: Pattern-matching functions allow you to find regular expression patterns in strings or attributes.
-:page-topic-type: concept
+:page-topic-type: reference
 
 {description}
 Regular expressions can formally represent various string search patterns using different special characters to indicate wildcards, positional characters, repetition, optional or mandatory sequences of letters, etc.

--- a/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
@@ -1,6 +1,6 @@
 = PREPARE
 :description: The PREPARE statement prepares a query for repeated execution.
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 
 [abstract]

--- a/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
@@ -1,7 +1,7 @@
 = Reserved Words
 :description: N1QL defines an extensive list of keywords that are reserved words. \
 You cannot use these keywords as identifiers unless you escape them.
-:page-topic-type: concept
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/revoke.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/revoke.adoc
@@ -1,6 +1,6 @@
 = REVOKE
 :description: The REVOKE statement allows revoking of any RBAC roles from specific users.
-:page-topic-type: concept
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
@@ -1,6 +1,6 @@
 = Search Functions
 :description: Search functions enable you to use full text search (xref:fts:full-text-intro.adoc[FTS]) queries directly within a N1QL query.
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 :underscore: _
 

--- a/modules/n1ql/pages/n1ql-language-reference/select-syntax.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/select-syntax.adoc
@@ -2,6 +2,7 @@
 :description: This page enables you to drill down through the syntax of a SELECT query.
 :idprefix: _
 :imagesdir: ../../assets/images
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/selectclause.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/selectclause.adoc
@@ -1,6 +1,7 @@
 = SELECT Clause
 :description: The SELECT clause determines the result set.
 :imagesdir: ../../assets/images
+:page-topic-type: reference
 
 [abstract]
 The `SELECT` clause determines the result set.

--- a/modules/n1ql/pages/n1ql-language-reference/selectintro.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/selectintro.adoc
@@ -1,6 +1,7 @@
 = Overview
 :description: With the SELECT statement, you can query and manipulate JSON data. \
 You can select, join, project, nest, unnest, group, and sort in a single SELECT statement.
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/stringfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/stringfun.adoc
@@ -1,6 +1,6 @@
 = String Functions
 :description: String functions perform operations on a string input value and returns a string or other value.
-:page-topic-type: concept
+:page-topic-type: reference
 
 {description}
 

--- a/modules/n1ql/pages/n1ql-language-reference/stringops.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/stringops.adoc
@@ -1,6 +1,6 @@
 = String Operators
 :description: N1QL provides the concatenation string operator.
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/subqueries.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/subqueries.adoc
@@ -1,6 +1,6 @@
 = Subqueries
 :description: In N1QL, a subquery is a SELECT query that is a constituent part of another N1QL query or subquery.
-:page-topic-type: concept
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/subquery-examples.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/subquery-examples.adoc
@@ -1,5 +1,5 @@
 = Examples
-:page-topic-type: concept
+:page-topic-type: reference
 
 == Example1
 

--- a/modules/n1ql/pages/n1ql-language-reference/tokenfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/tokenfun.adoc
@@ -1,6 +1,6 @@
 = Token Functions
 :description: Tokenization is the process of breaking a stream of text up into words, phrases, symbols, or other meaningful elements called tokens.
-:page-topic-type: concept
+:page-topic-type: reference
 
 {description}
 The list of tokens becomes input for further processing such as parsing or text mining.

--- a/modules/n1ql/pages/n1ql-language-reference/typefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/typefun.adoc
@@ -1,6 +1,6 @@
 = Type Functions
 :description: Type functions perform operations that check or convert expressions.
-:page-topic-type: concept
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/union.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/union.adoc
@@ -1,5 +1,6 @@
 = UNION, INTERSECT, and EXCEPT
 :description: pass:q[The `UNION`, `INTERSECT`, and `EXCEPT` operators combine the resultsets of two or more `SELECT` statements.]
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/unnest.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/unnest.adoc
@@ -2,6 +2,7 @@
 :description: pass:q[The `UNNEST` clause creates an input object by flattening an array in the parent document.]
 :imagesdir: ../../assets/images
 :clause: UNNEST
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/update.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/update.adoc
@@ -1,6 +1,6 @@
 = UPDATE
 :description: UPDATE replaces a document that already exists with updated values.
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 
 [abstract]

--- a/modules/n1ql/pages/n1ql-language-reference/updatestatistics.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/updatestatistics.adoc
@@ -1,6 +1,6 @@
 = UPDATE STATISTICS
 :description: pass:q[The `UPDATE STATISTICS` statement collects statistics on expressions over a named keyspace.]
-:page-topic-type: concept
+:page-topic-type: reference
 :page-status: Developer Preview
 :imagesdir: ../../assets/images
 

--- a/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
@@ -2,7 +2,7 @@
 :description: Used to insert a new record or update an existing one. \
 If the document doesn’t exist it will be created. \
 UPSERT is a combination of INSERT and UPDATE.
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 
 [abstract]

--- a/modules/n1ql/pages/n1ql-language-reference/userfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/userfun.adoc
@@ -1,6 +1,6 @@
 = User-Defined Functions
 :description: You can call a user-defined function in any expression where you can call a built-in function.
-:page-topic-type: concept
+:page-topic-type: reference
 :page-status: Developer Preview
 :imagesdir: ../../assets/images
 :page-partial:

--- a/modules/n1ql/pages/n1ql-language-reference/where.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/where.adoc
@@ -1,5 +1,6 @@
 = WHERE clause
 :description: pass:q[The `WHERE` clause filters resultsets based specified conditions.]
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/window.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/window.adoc
@@ -1,6 +1,6 @@
 = OVER clause and Window Functions
 :description: pass:q[The `OVER` clause defines the window for a window function.]
-:page-topic-type: concept
+:page-topic-type: reference
 :page-edition: enterprise edition
 :page-status: Couchbase Server 6.5
 :imagesdir: ../../assets/images

--- a/modules/n1ql/pages/n1ql-language-reference/windowfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/windowfun.adoc
@@ -1,6 +1,6 @@
 = Window Functions
 :description: Window functions are used to compute cumulative, moving, and reporting aggregations.
-:page-topic-type: concept
+:page-topic-type: reference
 :page-edition: enterprise edition
 :imagesdir: ../../assets/images
 

--- a/modules/n1ql/pages/n1ql-language-reference/with.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/with.adoc
@@ -1,6 +1,7 @@
 = WITH clause
 :description: pass:q[Use `WITH` to create a *common table expression*.]
 :page-status: Couchbase Server 6.5
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/query.adoc
+++ b/modules/n1ql/pages/query.adoc
@@ -4,6 +4,7 @@
 :page-role: tiles
 :imagesdir: ../assets/images
 :!sectids:
+:page-topic-type: concept
 
 = Query: Fundamentals
 ++++


### PR DESCRIPTION
Backported changes from 7.1 release branch to 6.6. 

The page topic tags were inconsistent across pages in the Query section of the server docs. These changes resolve the inconsistency in tag assignments. 