### PR TITLE
[DOC-10478] Page Topic Types Attribute Backport for release/6.5 (#2936)

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/adaptive-indexing.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/adaptive-indexing.adoc
@@ -1,5 +1,6 @@
 = Adaptive Index
 :imagesdir: ../../assets/images
+:page-topic-type: concept
 
 :pairs: xref:n1ql-language-reference/metafun.adoc#pairs
 :logical-hierarchy: xref:n1ql-intro/sysinfo.adoc#logical-hierarchy

--- a/modules/n1ql/pages/n1ql-language-reference/advise.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/advise.adoc
@@ -1,5 +1,5 @@
 = ADVISE
-:page-topic-type: concept
+:page-topic-type: reference
 :page-status: Beta
 :page-edition: Enterprise Edition
 :imagesdir: ../../assets/images

--- a/modules/n1ql/pages/n1ql-language-reference/advisor.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/advisor.adoc
@@ -1,5 +1,5 @@
 = ADVISOR Function
-:page-topic-type: concept
+:page-topic-type: reference
 :page-status: Developer Preview
 :imagesdir: ../../assets/images
 

--- a/modules/n1ql/pages/n1ql-language-reference/aggregatefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/aggregatefun.adoc
@@ -1,5 +1,6 @@
 = Aggregate Functions
 :imagesdir: ../../assets/images
+:page-topic-type: reference
 
 :window: xref:n1ql-language-reference/window.adoc
 :expression: xref:n1ql-language-reference/index.adoc

--- a/modules/n1ql/pages/n1ql-language-reference/alterindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/alterindex.adoc
@@ -1,6 +1,7 @@
 = ALTER INDEX
 :page-edition: Enterprise Edition
 :imagesdir: ../../assets/images
+:page-topic-type: reference
 
 [abstract]
 The ALTER INDEX statement moves the placement of an existing index or replica among different GSI nodes.

--- a/modules/n1ql/pages/n1ql-language-reference/arithmetic.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/arithmetic.adoc
@@ -1,5 +1,6 @@
 = Arithmetic Operators
 :imagesdir: ../../assets/images
+:page-topic-type: reference
 
 Arithmetic operations perform the basic mathematical operations of addition, subtraction, multiplication, division, and modulo within an expression or any numerical value retrieved as part of query clauses.
 Additionally, N1QL provides a negation operation which changes the sign of a value.

--- a/modules/n1ql/pages/n1ql-language-reference/arrayfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/arrayfun.adoc
@@ -1,5 +1,5 @@
 = Array Functions
-:page-topic-type: concept
+:page-topic-type: reference
 
 [abstract]
 You can use array functions to evaluate arrays, perform computations on elements in an array, and to return a new array based on a transformation.

--- a/modules/n1ql/pages/n1ql-language-reference/backfill.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/backfill.adoc
@@ -1,5 +1,6 @@
 = Backfill Support for N1QL
 :page-aliases: settings:backfill
+:page-topic-type: guide
 
 [abstract]
 Configure the temporary working space for the N1QL engine and its embedded GSI client.

--- a/modules/n1ql/pages/n1ql-language-reference/bitwisefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/bitwisefun.adoc
@@ -1,4 +1,5 @@
 = Bitwise Functions
+:page-topic-type: reference
 
 All Bit/Binary functions can only operate on 64-bit signed integers.
 

--- a/modules/n1ql/pages/n1ql-language-reference/booleanlogic.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/booleanlogic.adoc
@@ -1,5 +1,5 @@
 = Boolean Logic
-:page-topic-type: concept
+:page-topic-type: reference
 
 [abstract]
 Some clauses, such as `WHERE`, `WHEN`, and `HAVING`, require values to be interpreted as Boolean values.

--- a/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/build-index.adoc
@@ -1,5 +1,5 @@
 = BUILD INDEX
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 
 [abstract]

--- a/modules/n1ql/pages/n1ql-language-reference/collectionops.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/collectionops.adoc
@@ -1,6 +1,6 @@
 = Collection Operators
 :description: Collection operators enable you to evaluate expressions over every element in an array.
-:page-topic-type: concept
+:page-topic-type: reference
 :page-toclevels: 2
 :imagesdir: ../../assets/images
 :keywords: range condition, quantified expression

--- a/modules/n1ql/pages/n1ql-language-reference/comparisonfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/comparisonfun.adoc
@@ -1,5 +1,5 @@
 = Comparison Functions
-:page-topic-type: concept
+:page-topic-type: reference
 
 Comparison functions determine the greatest or least value from a set of values.
 

--- a/modules/n1ql/pages/n1ql-language-reference/comparisonops.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/comparisonops.adoc
@@ -1,5 +1,5 @@
 = Comparison Operators
-:page-topic-type: concept
+:page-topic-type: reference
 
 Comparison operators enable you to compare two expressions.
 

--- a/modules/n1ql/pages/n1ql-language-reference/condfunnum.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/condfunnum.adoc
@@ -1,5 +1,5 @@
 = Conditional Functions for Numbers
-:page-topic-type: concept
+:page-topic-type: reference
 
 Conditional functions evaluate expressions to determine if the values and formulas meet the specified condition.
 

--- a/modules/n1ql/pages/n1ql-language-reference/condfununknown.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/condfununknown.adoc
@@ -1,5 +1,5 @@
 = Conditional Functions for Unknowns
-:page-topic-type: concept
+:page-topic-type: reference
 
 Conditional functions evaluate expressions to determine if the values and formulas meet the specified condition.
 

--- a/modules/n1ql/pages/n1ql-language-reference/conditionalops.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/conditionalops.adoc
@@ -1,5 +1,5 @@
 = Conditional Operators
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 
 Case expressions evaluate conditional logic in an expression.

--- a/modules/n1ql/pages/n1ql-language-reference/constructionops.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/constructionops.adoc
@@ -1,5 +1,5 @@
 = Construction Operators
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 
 N1QL supports array and object construction operators.

--- a/modules/n1ql/pages/n1ql-language-reference/conventions.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/conventions.adoc
@@ -1,5 +1,5 @@
 = Conventions
-:page-topic-type: concept
+:page-topic-type: reference
 
 [abstract]
 The N1QL syntax descriptions in the documentation use some notational conventions that you need to be familiar with.

--- a/modules/n1ql/pages/n1ql-language-reference/createfunction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createfunction.adoc
@@ -1,5 +1,5 @@
 = CREATE FUNCTION
-:page-topic-type: concept
+:page-topic-type: reference
 :page-status: Developer Preview
 :imagesdir: ../../assets/images
 :page-partial:

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -1,5 +1,5 @@
 = CREATE INDEX
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 :keywords: secondary, index, placement
 :enterprise: https://www.couchbase.com/products/editions[ENTERPRISE EDITION]

--- a/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createprimaryindex.adoc
@@ -1,4 +1,5 @@
 = CREATE PRIMARY INDEX
+:page-topic-type: reference
 
 The `CREATE PRIMARY INDEX` statement allows you to create a primary index.
 Primary indexes contain a full set of keys in a given keyspace.

--- a/modules/n1ql/pages/n1ql-language-reference/curl.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/curl.adoc
@@ -1,5 +1,5 @@
 = CURL Function
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 
 :url-wiki-curl: https://en.wikipedia.org/wiki/CURL

--- a/modules/n1ql/pages/n1ql-language-reference/datatypes.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/datatypes.adoc
@@ -1,5 +1,5 @@
 = Data Types
-:page-topic-type: concept
+:page-topic-type: reference
 
 [abstract]
 N1QL supports many data types: MISSING, NULL, Boolean values, numeric values, string values, arrays, objects, and binary.

--- a/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/datefun.adoc
@@ -1,5 +1,5 @@
 = Date Functions
-:page-topic-type: concept
+:page-topic-type: reference
 
 [abstract]
 N1QL date functions return the system clock value or manipulate the datetime values, which are represented as a string or an integer.

--- a/modules/n1ql/pages/n1ql-language-reference/delete.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/delete.adoc
@@ -1,5 +1,5 @@
 = DELETE
-:page-topic-type: concept
+:page-topic-type: reference
 
 DELETE immediately removes the specified document from your keyspace.
 DELETE uses the following syntax:

--- a/modules/n1ql/pages/n1ql-language-reference/dropfunction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropfunction.adoc
@@ -1,10 +1,5 @@
 = DROP FUNCTION
-<<<<<<< HEAD
 :page-topic-type: reference
-=======
-:description: pass:q[The `DROP FUNCTION` statement enables you to delete a user-defined function.]
-:page-topic-type: reference
->>>>>>> f54cfb1a ([DOC-10478] Adding files unique to release/6.6...)
 :page-status: Developer Preview
 :imagesdir: ../../assets/images
 :page-partial:

--- a/modules/n1ql/pages/n1ql-language-reference/dropfunction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropfunction.adoc
@@ -1,5 +1,10 @@
 = DROP FUNCTION
-:page-topic-type: concept
+<<<<<<< HEAD
+:page-topic-type: reference
+=======
+:description: pass:q[The `DROP FUNCTION` statement enables you to delete a user-defined function.]
+:page-topic-type: reference
+>>>>>>> f54cfb1a ([DOC-10478] Adding files unique to release/6.6...)
 :page-status: Developer Preview
 :imagesdir: ../../assets/images
 :page-partial:

--- a/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropindex.adoc
@@ -1,5 +1,5 @@
 = DROP INDEX
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 
 The DROP INDEX statement allows you to drop a named primary index or a secondary index.

--- a/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/dropprimaryindex.adoc
@@ -1,5 +1,5 @@
 = DROP PRIMARY INDEX
-:page-topic-type: concept
+:page-topic-type: reference
 
 The DROP PRIMARY INDEX statement allows you to drop an unnamed primary indexes.
 

--- a/modules/n1ql/pages/n1ql-language-reference/execfunction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/execfunction.adoc
@@ -1,5 +1,5 @@
 = EXECUTE FUNCTION
-:page-topic-type: concept
+:page-topic-type: reference
 :page-status: Developer Preview
 :imagesdir: ../../assets/images
 :page-partial:

--- a/modules/n1ql/pages/n1ql-language-reference/execute.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/execute.adoc
@@ -1,5 +1,5 @@
 = EXECUTE
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 
 [abstract]

--- a/modules/n1ql/pages/n1ql-language-reference/explain.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/explain.adoc
@@ -1,5 +1,5 @@
 = EXPLAIN
-:page-topic-type: concept
+:page-topic-type: reference
 
 [abstract]
 The EXPLAIN statement when used before any N1QL statement, provides information about the execution plan for the statement.

--- a/modules/n1ql/pages/n1ql-language-reference/from.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/from.adoc
@@ -1,5 +1,6 @@
 = FROM Clause
 :imagesdir: ../../assets/images
+:page-topic-type: reference
 
 [abstract]
 The `FROM` clause specifies the documents to be used as the input for a query.

--- a/modules/n1ql/pages/n1ql-language-reference/functions.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/functions.adoc
@@ -1,5 +1,5 @@
 = Functions Overview
-:page-topic-type: concept
+:page-topic-type: reference
 
 [abstract]
 Function names are used to apply a function to values, to values at a specified path, or to values derived from a DISTINCT clause.

--- a/modules/n1ql/pages/n1ql-language-reference/grant.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/grant.adoc
@@ -1,5 +1,5 @@
 = GRANT
-:page-topic-type: concept
+:page-topic-type: reference
 
 [abstract]
 The GRANT statement allows granting any RBAC roles to a specific user.

--- a/modules/n1ql/pages/n1ql-language-reference/groupby-aggregate-performance.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/groupby-aggregate-performance.adoc
@@ -1,6 +1,7 @@
 = Group By and Aggregate Performance
 :page-edition: enterprise edition
 :imagesdir: ../../assets/images
+:page-topic-type: concept
 
 [abstract]
 N1QL Pushdowns optimize the performance of N1QL queries by supporting GROUP BY and Aggregate expressions.

--- a/modules/n1ql/pages/n1ql-language-reference/groupby.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/groupby.adoc
@@ -1,5 +1,6 @@
 = GROUP BY Clause
 :imagesdir: ../../assets/images
+:page-topic-type: reference
 
 [abstract]
 The GROUP BY clause arranges aggregate values into groups, based on one or more fields.

--- a/modules/n1ql/pages/n1ql-language-reference/hints.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/hints.adoc
@@ -1,5 +1,6 @@
 = USE Clause
 :imagesdir: ../../assets/images
+:page-topic-type: reference
 
 [abstract]
 The `USE` clause enables you to specify that the query should use particular keys, or a particular index.

--- a/modules/n1ql/pages/n1ql-language-reference/identifiers.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/identifiers.adoc
@@ -1,5 +1,5 @@
 = Identifiers
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 
 [abstract]

--- a/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/index-partitioning.adoc
@@ -1,7 +1,7 @@
 = Index Partitioning
 :page-edition: Enterprise Edition
 :imagesdir: ../../assets/images
-
+:page-topic-type: reference
 :expression: xref:n1ql-language-reference/index.adoc
 :logical-hierarchy: xref:n1ql-intro/sysinfo.adoc#logical-hierarchy
 :identifiers: xref:n1ql-language-reference/identifiers.adoc

--- a/modules/n1ql/pages/n1ql-language-reference/indexing-arrays.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/indexing-arrays.adoc
@@ -1,5 +1,6 @@
 = Array Indexing
 :imagesdir: ../../assets/images
+:page-topic-type: reference
 :logical-hierarchy: xref:n1ql-intro/sysinfo.adoc#logical-hierarchy
 :expression: xref:n1ql-language-reference/index.adoc
 :createindex: xref:n1ql-language-reference/createindex.adoc

--- a/modules/n1ql/pages/n1ql-language-reference/indexing-meta-info.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/indexing-meta-info.adoc
@@ -1,4 +1,5 @@
 = Indexing Metadata Information
+:page-topic-type: reference
 
 Couchbase Server allows indexing on selected metadata fields, for example the expiration and CAS properties.
 This improves performance of queries involving predicates on the metadata fields, such as expired documents or recently modified documents.

--- a/modules/n1ql/pages/n1ql-language-reference/infer.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/infer.adoc
@@ -1,5 +1,6 @@
 = INFER
 :imagesdir: ../../assets/images
+:page-topic-type: reference
 
 The INFER statement enables you to infer the metadata of documents in a keyspace, for example the structure of documents, data types of various attributes, sample values, and so on.
 Since a keyspace or bucket can contain documents with varying structures, the INFER statement is statistical in nature rather than deterministic.

--- a/modules/n1ql/pages/n1ql-language-reference/insert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/insert.adoc
@@ -1,5 +1,6 @@
 = INSERT
 :imagesdir: ../../assets/images
+:page-topic-type: reference
 
 [abstract]
 Use the INSERT statement to insert one or more new documents into an existing keyspace.

--- a/modules/n1ql/pages/n1ql-language-reference/join.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/join.adoc
@@ -1,6 +1,7 @@
 = JOIN Clause
 :imagesdir: ../../assets/images
 :clause: JOIN
+:page-topic-type: reference
 
 [abstract]
 The `JOIN` clause enables you to create new input objects by combining two or more source objects.

--- a/modules/n1ql/pages/n1ql-language-reference/jsonfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/jsonfun.adoc
@@ -1,5 +1,5 @@
 = JSON Functions
-:page-topic-type: concept
+:page-topic-type: reference
 
 DECODE_JSON(expression)
 

--- a/modules/n1ql/pages/n1ql-language-reference/let.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/let.adoc
@@ -1,5 +1,6 @@
 = LET clause
 :imagesdir: ../../assets/images
+:page-topic-type: reference
 
 [abstract]
 Use `LET` to create variables for later use within a query.

--- a/modules/n1ql/pages/n1ql-language-reference/limit.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/limit.adoc
@@ -1,4 +1,5 @@
 = LIMIT clause
+:page-topic-type: reference
 
 [abstract]
 The `LIMIT` clause specifies the maximum number of documents to be returned in a resultset by a `SELECT` statement.

--- a/modules/n1ql/pages/n1ql-language-reference/literals.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/literals.adoc
@@ -1,5 +1,5 @@
 = Literals
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 
 [abstract]

--- a/modules/n1ql/pages/n1ql-language-reference/logicalops.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/logicalops.adoc
@@ -1,5 +1,5 @@
 = Logical Operators
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 
 Logical terms let you combine other expressions using xref:n1ql-language-reference/booleanlogic.adoc[Boolean logic].

--- a/modules/n1ql/pages/n1ql-language-reference/merge.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/merge.adoc
@@ -1,5 +1,5 @@
 = MERGE
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 
 [abstract]

--- a/modules/n1ql/pages/n1ql-language-reference/metafun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/metafun.adoc
@@ -1,5 +1,5 @@
 = Miscellaneous Utility Functions
-:page-topic-type: concept
+:page-topic-type: reference
 :page-partial:
 
 Meta functions retrieve information about the document or item as well as perform base64 encoding.

--- a/modules/n1ql/pages/n1ql-language-reference/n1ql-auditing.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/n1ql-auditing.adoc
@@ -1,4 +1,5 @@
 = N1QL Auditing
+:page-topic-type: reference
 
 [abstract]
 N1QL-related activities can be audited, by Couchbase Server.

--- a/modules/n1ql/pages/n1ql-language-reference/n1ql-error-codes.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/n1ql-error-codes.adoc
@@ -1,4 +1,5 @@
 = N1QL Error Codes
+:page-topic-type: reference
 
 [abstract]
 The following table lists all of the N1QL error codes, their error message, and some tips to resolve them.

--- a/modules/n1ql/pages/n1ql-language-reference/nest.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/nest.adoc
@@ -1,6 +1,7 @@
 = NEST Clause
 :imagesdir: ../../assets/images
 :clause: NEST
+:page-topic-type: reference
 
 [abstract]
 The `NEST` clause creates an input object by producing a single result of nesting keyspaces.

--- a/modules/n1ql/pages/n1ql-language-reference/nestedops.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/nestedops.adoc
@@ -1,5 +1,5 @@
 = Nested Operators and Expressions
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 
 In N1QL, nested operators and paths indicate expressions to access nested sub-documents within a JSON document or expression and follow the syntax:

--- a/modules/n1ql/pages/n1ql-language-reference/numericfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/numericfun.adoc
@@ -1,5 +1,5 @@
 = Number Functions
-:page-topic-type: concept
+:page-topic-type: reference
 
 Number functions are functions that are performed on a numeric field.
 

--- a/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/objectfun.adoc
@@ -1,5 +1,5 @@
 = Object Functions
-:page-topic-type: concept
+:page-topic-type: reference
 
 == OBJECT_ADD()
 

--- a/modules/n1ql/pages/n1ql-language-reference/offset.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/offset.adoc
@@ -1,4 +1,5 @@
 = OFFSET clause
+:page-topic-type: reference
 
 [abstract]
 The `OFFSET` clause specifies the number of resultset objects to skip in a `SELECT` query.

--- a/modules/n1ql/pages/n1ql-language-reference/operators.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/operators.adoc
@@ -1,5 +1,5 @@
 = Operators Overview
-:page-topic-type: concept
+:page-topic-type: reference
 
 [abstract]
 Operators perform a specific operation on the input values or expressions.

--- a/modules/n1ql/pages/n1ql-language-reference/orderby.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/orderby.adoc
@@ -1,5 +1,6 @@
 = ORDER BY clause
 :imagesdir: ../../assets/images
+:page-topic-type: reference
 
 [abstract]
 The `ORDER BY` clause sorts the result-set by one or more columns, in ascending or descending order.

--- a/modules/n1ql/pages/n1ql-language-reference/patternmatchingfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/patternmatchingfun.adoc
@@ -1,5 +1,5 @@
 = Pattern-Matching Functions
-:page-topic-type: concept
+:page-topic-type: reference
 
 Pattern-matching functions allow you to find regular expression patterns in strings or attributes.
 Regular expressions can formally represent various string search patterns using different special characters to indicate wildcards, positional characters, repetition, optional or mandatory sequences of letters, etc.

--- a/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/prepare.adoc
@@ -1,5 +1,5 @@
 = PREPARE
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 
 [abstract]

--- a/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/reservedwords.adoc
@@ -1,5 +1,5 @@
 = Reserved Words
-:page-topic-type: concept
+:page-topic-type: reference
 
 [abstract]
 N1QL defines an extensive list of keywords that are reserved words.

--- a/modules/n1ql/pages/n1ql-language-reference/revoke.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/revoke.adoc
@@ -1,5 +1,5 @@
 = REVOKE
-:page-topic-type: concept
+:page-topic-type: reference
 
 [abstract]
 The REVOKE statement allows revoking of any RBAC roles from specific users.

--- a/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/searchfun.adoc
@@ -1,5 +1,5 @@
 = Search Functions
-:page-topic-type: concept
+:page-topic-type: reference
 :page-status: Couchbase Server 6.5
 :imagesdir: ../../assets/images
 :underscore: _

--- a/modules/n1ql/pages/n1ql-language-reference/select-syntax.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/select-syntax.adoc
@@ -1,6 +1,7 @@
 = SELECT Syntax
 :idprefix: _
 :imagesdir: ../../assets/images
+:page-topic-type: reference
 
 [abstract]
 This page enables you to drill down through the syntax of a SELECT query.

--- a/modules/n1ql/pages/n1ql-language-reference/selectclause.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/selectclause.adoc
@@ -1,6 +1,7 @@
 = SELECT Clause
 :description: The SELECT clause determines the result set.
 :imagesdir: ../../assets/images
+:page-topic-type: reference
 
 [abstract]
 The `SELECT` clause determines the result set.

--- a/modules/n1ql/pages/n1ql-language-reference/selectintro.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/selectintro.adoc
@@ -1,4 +1,5 @@
 = Overview
+:page-topic-type: reference
 
 [abstract]
 With the SELECT statement, you can query and manipulate JSON data.

--- a/modules/n1ql/pages/n1ql-language-reference/stringfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/stringfun.adoc
@@ -1,5 +1,5 @@
 = String Functions
-:page-topic-type: concept
+:page-topic-type: reference
 
 String functions perform operations on a string input value and returns a string or other value.
 

--- a/modules/n1ql/pages/n1ql-language-reference/stringops.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/stringops.adoc
@@ -1,5 +1,5 @@
 = String Operators
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 
 N1QL provides the concatenation string operator.

--- a/modules/n1ql/pages/n1ql-language-reference/subqueries.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/subqueries.adoc
@@ -1,5 +1,5 @@
 = Subqueries
-:page-topic-type: concept
+:page-topic-type: reference
 
 [abstract]
 In N1QL, a subquery is a SELECT query that is a constituent part of another N1QL query or subquery.

--- a/modules/n1ql/pages/n1ql-language-reference/subquery-examples.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/subquery-examples.adoc
@@ -1,5 +1,5 @@
 = Examples
-:page-topic-type: concept
+:page-topic-type: reference
 
 == Example1
 

--- a/modules/n1ql/pages/n1ql-language-reference/tokenfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/tokenfun.adoc
@@ -1,5 +1,5 @@
 = Token Functions
-:page-topic-type: concept
+:page-topic-type: reference
 
 Tokenization is the process of breaking a stream of text up into words, phrases, symbols, or other meaningful elements called tokens.
 The list of tokens becomes input for further processing such as parsing or text mining.

--- a/modules/n1ql/pages/n1ql-language-reference/typefun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/typefun.adoc
@@ -1,6 +1,6 @@
 = Type Functions
 :description: Type functions perform operations that check or convert expressions.
-:page-topic-type: concept
+:page-topic-type: reference
 
 [abstract]
 {description}

--- a/modules/n1ql/pages/n1ql-language-reference/union.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/union.adoc
@@ -1,4 +1,5 @@
 = UNION, INTERSECT, and EXCEPT
+:page-topic-type: reference
 
 [abstract]
 The `UNION`, `INTERSECT`, and `EXCEPT` operators combine the resultsets of two or more `SELECT` statements.

--- a/modules/n1ql/pages/n1ql-language-reference/unnest.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/unnest.adoc
@@ -1,6 +1,7 @@
 = UNNEST clause
 :imagesdir: ../../assets/images
 :clause: UNNEST
+:page-topic-type: reference
 
 [abstract]
 The `UNNEST` clause creates an input object by flattening an array in the parent document.

--- a/modules/n1ql/pages/n1ql-language-reference/update.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/update.adoc
@@ -1,5 +1,5 @@
 = UPDATE
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 
 [abstract]

--- a/modules/n1ql/pages/n1ql-language-reference/updatestatistics.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/updatestatistics.adoc
@@ -1,5 +1,5 @@
 = UPDATE STATISTICS
-:page-topic-type: concept
+:page-topic-type: reference
 :page-status: Developer Preview
 :imagesdir: ../../assets/images
 

--- a/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/upsert.adoc
@@ -1,5 +1,5 @@
 = UPSERT
-:page-topic-type: concept
+:page-topic-type: reference
 :imagesdir: ../../assets/images
 
 [abstract]

--- a/modules/n1ql/pages/n1ql-language-reference/userfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/userfun.adoc
@@ -1,5 +1,5 @@
 = User-Defined Functions
-:page-topic-type: concept
+:page-topic-type: reference
 :page-status: Developer Preview
 :imagesdir: ../../assets/images
 :page-partial:

--- a/modules/n1ql/pages/n1ql-language-reference/where.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/where.adoc
@@ -1,4 +1,5 @@
 = WHERE clause
+:page-topic-type: reference
 
 [abstract]
 The `WHERE` clause filters resultsets based specified conditions.

--- a/modules/n1ql/pages/n1ql-language-reference/window.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/window.adoc
@@ -1,5 +1,5 @@
 = OVER clause and Window Functions
-:page-topic-type: concept
+:page-topic-type: reference
 :page-edition: enterprise edition
 :page-status: Couchbase Server 6.5
 :imagesdir: ../../assets/images

--- a/modules/n1ql/pages/n1ql-language-reference/windowfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/windowfun.adoc
@@ -1,5 +1,5 @@
 = Window Functions
-:page-topic-type: concept
+:page-topic-type: reference
 :page-edition: enterprise edition
 :page-status: Couchbase Server 6.5
 :imagesdir: ../../assets/images

--- a/modules/n1ql/pages/n1ql-language-reference/with.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/with.adoc
@@ -1,5 +1,6 @@
 = WITH clause
 :page-status: Couchbase Server 6.5
+:page-topic-type: reference
 
 [abstract]
 Use `WITH` to create a *common table expression*.

--- a/modules/n1ql/pages/query.adoc
+++ b/modules/n1ql/pages/query.adoc
@@ -4,6 +4,7 @@
 :page-role: tiles
 :imagesdir: ../assets/images
 :!sectids:
+:page-topic-type: concept
 
 = Query: Fundamentals
 ++++


### PR DESCRIPTION
Backported changes from 7.1 release branch to 6.5.

The page topic tags were inconsistent across pages in the Query section of the server docs. These changes resolve the inconsistency in tag assignments.