### PR TITLE
DOC-10449 release/7.2: Changes N1QL to SQL++ for the FTS module in the docs server repo

### DIFF
--- a/modules/fts/pages/fts-analyzers-search-functions.adoc
+++ b/modules/fts/pages/fts-analyzers-search-functions.adoc
@@ -1,15 +1,15 @@
 = Analyzers - Search Functions
 
-xref:n1ql:n1ql-language-reference/searchfun.adoc[Search functions] allow users to execute full text search requests within a N1QL query.
+xref:n1ql:n1ql-language-reference/searchfun.adoc[Search functions] allow users to execute full text search requests within a {sqlpp} query.
 
-In the context of N1QL queries, a full text search index can be described as one of the following :
+In the context of {sqlpp} queries, a full text search index can be described as one of the following :
 
 * xref:n1ql:n1ql-language-reference/covering-indexes.adoc[Covering index]
 
 * Non-covering index
 
 This characterization depends on the extent to which it could answer all aspects of the SELECT predicate and the WHERE clauses of a N1Q1 query.
-An N1QL query against a non-covering index will go through a "Verification phase.” In this phase  documents are fetched from the query service based on the results of the search index, and the documents are validated as per the clauses defined in the query.
+An {sqlpp} query against a non-covering index will go through a "Verification phase.” In this phase  documents are fetched from the query service based on the results of the search index, and the documents are validated as per the clauses defined in the query.
 
 For example, an index with only the field `field1` configured is considered a non-covering index for a query `field1=abc` and `field2=xyz`.
 

--- a/modules/fts/pages/fts-analyzers-search-functions.adoc
+++ b/modules/fts/pages/fts-analyzers-search-functions.adoc
@@ -8,7 +8,7 @@ In the context of {sqlpp} queries, a full text search index can be described as 
 
 * Non-covering index
 
-This characterization depends on the extent to which it could answer all aspects of the SELECT predicate and the WHERE clauses of a N1Q1 query.
+This characterization depends on the extent to which it could answer all aspects of the SELECT predicate and the WHERE clauses of a {sqlpp} query.
 An {sqlpp} query against a non-covering index will go through a "Verification phase.” In this phase  documents are fetched from the query service based on the results of the search index, and the documents are validated as per the clauses defined in the query.
 
 For example, an index with only the field `field1` configured is considered a non-covering index for a query `field1=abc` and `field2=xyz`.

--- a/modules/fts/pages/fts-analyzers-search-functions.adoc
+++ b/modules/fts/pages/fts-analyzers-search-functions.adoc
@@ -9,7 +9,7 @@ In the context of {sqlpp} queries, a full text search index can be described as 
 * Non-covering index
 
 This characterization depends on the extent to which it could answer all aspects of the SELECT predicate and the WHERE clauses of a {sqlpp} query.
-An {sqlpp} query against a non-covering index will go through a "Verification phase.” In this phase  documents are fetched from the query service based on the results of the search index, and the documents are validated as per the clauses defined in the query.
+A {sqlpp} query against a non-covering index will go through a "Verification phase". In this phase documents are fetched from the query service based on the results of the search index, and the documents are validated as per the clauses defined in the query.
 
 For example, an index with only the field `field1` configured is considered a non-covering index for a query `field1=abc` and `field2=xyz`.
 

--- a/modules/fts/pages/fts-flex.adoc
+++ b/modules/fts/pages/fts-flex.adoc
@@ -1,4 +1,4 @@
-= FTS FLEX (FTS + N1QL Extended Support For Collections)
+= FTS FLEX (FTS + {sqlpp} Extended Support For Collections)
 
 FTS is capable of supporting multiple collections within a single index definition. 
 
@@ -8,7 +8,7 @@ If the user wants to set up an index definition to subscribe to just a few colle
 
 The type mappings will now take the form of either "scope_name.collection_name" (to index all documents within that scope.collection) or "scope_name.collection_name.type_name" (to index only those documents within that scope.collection that match "type" = "type_name") . We will refer to FTS index definitions in this mode as collection-aware FTS indexes.
 
-NOTE: The type expression check within N1QL queries becomes unnecessary with collection-aware FTS indexes.
+NOTE: The type expression check within {sqlpp} queries becomes unnecessary with collection-aware FTS indexes.
 
 == Example
 
@@ -76,7 +76,7 @@ When you set up an FTS index definition to stream from 2 collections: landmark, 
 }
 ----
 
-Below are some N1QL queries targeting the above index definition. 
+Below are some {sqlpp} queries targeting the above index definition. 
 
 ----
 SELECT META().id

--- a/modules/fts/pages/fts-index-analyzers.adoc
+++ b/modules/fts/pages/fts-index-analyzers.adoc
@@ -412,16 +412,16 @@ Additionally, a range of analyzers is provided for the specific support of certa
 
 == Analyzers - Search Functions
 
-xref:n1ql:n1ql-language-reference/searchfun.adoc[Search functions] allow users to execute full text search requests within a N1QL query.
+xref:n1ql:n1ql-language-reference/searchfun.adoc[Search functions] allow users to execute full text search requests within a {sqlpp} query.
 
-In the context of N1QL queries, a full text search index can be described as one of the following :
+In the context of {sqlpp} queries, a full text search index can be described as one of the following :
 
 * xref:n1ql:n1ql-language-reference/covering-indexes.adoc[Covering index]
 
 * Non-covering index
 
 This characterization depends on the extent to which it could answer all aspects of the SELECT predicate and the WHERE clauses of a N1Q1 query.
-An N1QL query against a non-covering index will go through a "verification phase.” In this phase,  documents are fetched from the query service based on the results of the search index, and the documents are validated as per the clauses defined in the query.
+An {sqlpp} query against a non-covering index will go through a "verification phase.” In this phase,  documents are fetched from the query service based on the results of the search index, and the documents are validated as per the clauses defined in the query.
 
 For example, an index with only the field `field1` configured is considered a non-covering index for a query `field1=abc` and `field2=xyz`.
 

--- a/modules/fts/pages/fts-perform-searches.adoc
+++ b/modules/fts/pages/fts-perform-searches.adoc
@@ -16,6 +16,6 @@ Refer to the SDK's xref:java-sdk:concept-docs:full-text-search-overview.adoc[Ful
 
 NOTE: The xref:java-sdk:howtos:full-text-searching-with-sdk.adoc[Searching from the SDK] page for the _Java_ SDK provides an extensive code-example that demonstrates multiple options for performing full text searches.
 
-* The N1QL Search functions.
-These enable you to perform a full text search as part of a N1QL query.
+* The {sqlpp} Search functions.
+These enable you to perform a full text search as part of a {sqlpp} query.
 Refer to xref:n1ql:n1ql-language-reference/searchfun.adoc[Search Functions] for information.

--- a/modules/fts/pages/fts-quickstart-guide.adoc
+++ b/modules/fts/pages/fts-quickstart-guide.adoc
@@ -39,8 +39,8 @@ This supports several languages, and allows full text searches to be performed w
 Refer to the SDK's xref:java-sdk:concept-docs:full-text-search-overview.adoc[Full Text Search] page for information.
 Note that the xref:java-sdk:howtos:full-text-searching-with-sdk.adoc[Searching from the SDK] page for the _Java_ SDK provides an extensive code-example that demonstrates multiple options for performing full text searches.
 //(Refer to <<establishing-demonstration-indexes>> below for more information.)
-* The N1QL Search functions.
-These enable you to perform a full text search as part of a N1QL query.
+* The {sqlpp} Search functions.
+These enable you to perform a full text search as part of a {sqlpp} query.
 Refer to xref:n1ql:n1ql-language-reference/searchfun.adoc[Search Functions] for information.
 
 [#establishing-demonstration-indexes]

--- a/modules/fts/pages/fts-searching-from-N1QL.adoc
+++ b/modules/fts/pages/fts-searching-from-N1QL.adoc
@@ -1,6 +1,6 @@
-= Searching from N1QL
+= Searching from {sqlpp}
 
-Search functions enable you to use full text search queries directly within a N1QL query.
+Search functions enable you to use full text search queries directly within a {sqlpp} query.
 
 == Prerequisites
 
@@ -20,9 +20,9 @@ For information on creating users and assigning roles, see xref:learn:security/a
 
 === When to Use Search Functions
 
-The search functions are useful when you need to combine a full text search with the power of a N1QL query; for example, combining joins and natural-language search in the same query.
+The search functions are useful when you need to combine a full text search with the power of a {sqlpp} query; for example, combining joins and natural-language search in the same query.
 
-If you only need to use the capabilities of a full text search without any N1QL features, consider making use of the Search service directly, through the user interface, the REST API, or an SDK.
+If you only need to use the capabilities of a full text search without any {sqlpp} features, consider making use of the Search service directly, through the user interface, the REST API, or an SDK.
 
 [[search,SEARCH()]]
 == SEARCH(`identifier`, `query`[, `options`])
@@ -58,12 +58,12 @@ If the path is omitted, the default field is set to `{underscore}all`.
 If the _query_ argument is a query string which specifies a field, this field takes priority, and the path in the identifier is ignored.
 Similarly, if the _query_ argument is a query object, the path is ignored.
 
-* The path must use Search syntax rather than N1QL syntax; in other words, you cannot specify array locations such as `[*]` or `[3]` in the path.
+* The path must use Search syntax rather than {sqlpp} syntax; in other words, you cannot specify array locations such as `[*]` or `[3]` in the path.
 
 * If the keyspace, keyspace alias, or path contains any characters such as `-`, you must surround that part of the identifier with backticks `{backtick}{backtick}`.
 --
 +
-The _identifier_ argument cannot be replaced by a N1QL query parameter.
+The _identifier_ argument cannot be replaced by a {sqlpp} query parameter.
 
 query::
 [Required] The full text search query.
@@ -88,13 +88,13 @@ For more details, refer to xref:fts:fts-sorting.adoc[Sorting Query Results].
 
 [NOTE]
 ====
-When specifying a complete full text search request with the N1QL SEARCH() function, if the value of the `size` parameter is greater than the maximum number of full text search results, the query ignores the `size` parameter and returns all matching results.
+When specifying a complete full text search request with the {sqlpp} SEARCH() function, if the value of the `size` parameter is greater than the maximum number of full text search results, the query ignores the `size` parameter and returns all matching results.
 
 This is different to the behavior of a complete full text search request in the Search service, where the query returns an error if the value of the `size` parameter is greater than the maximum number of full text search results.
 ====
 |===
 +
-The _query_ argument may be replaced by a N1QL query parameter, as long as the query parameter resolves to a string or an object.
+The _query_ argument may be replaced by a {sqlpp} query parameter, as long as the query parameter resolves to a string or an object.
 
 options::
 [Optional] A JSON object containing options for the search.
@@ -154,11 +154,11 @@ If this field is omitted, the name of this full text search operation defaults t
 [Optional]
 | (any)
 | Other fields are ignored by the Query engine and are passed on to the Search engine as options.
-The values of these options may be replaced with N1QL query parameters, such as `"analyzer": $analyzer`.
+The values of these options may be replaced with {sqlpp} query parameters, such as `"analyzer": $analyzer`.
 |===
 
 +
-The _options_ argument cannot be replaced by a N1QL query parameter, but it may contain N1QL query parameters.
+The _options_ argument cannot be replaced by a {sqlpp} query parameter, but it may contain {sqlpp} query parameters.
 
 === Return Value
 
@@ -200,14 +200,14 @@ Group aggregates and projection are not pushed.
 ====
 The following queries are equivalent:
 
-[source,n1ql]
+[source,{sqlpp}]
 ----
 SELECT META(t1).id
 FROM `travel-sample`.inventory.airline AS t1
 WHERE SEARCH(t1.country, "+United +States");
 ----
 
-[source,n1ql]
+[source,{sqlpp}]
 ----
 SELECT META(t1).id
 FROM `travel-sample`.inventory.airline AS t1
@@ -218,7 +218,7 @@ WHERE SEARCH(t1, "country:\"United States\"");
 [source,json]
 ----
 [
- 
+
   {
     "id": "airline_10"
   },
@@ -240,7 +240,7 @@ The results are unordered, so they may be returned in a different order each tim
 
 .Search using a query object
 ====
-[source,n1ql]
+[source,{sqlpp}]
 ----
 SELECT t1.name
 FROM `travel-sample`.inventory.hotel AS t1
@@ -273,7 +273,7 @@ The results are unordered, so they may be returned in a different order each tim
 
 .Search using a complete full text search request
 ====
-[source,n1ql]
+[source,{sqlpp}]
 ----
 SELECT t1.name
 FROM `travel-sample`.inventory.hotel AS t1
@@ -318,12 +318,12 @@ WHERE SEARCH(t1, {
 ----
 
 This query returns 5 results, and the results are ordered, as specified by the search options.
-As an alternative, you could limit the number of results and order them using the N1QL xref:n1ql-language-reference/limit.adoc[LIMIT] and xref:n1ql-language-reference/orderby.adoc[ORDER BY] clauses.
+As an alternative, you could limit the number of results and order them using the {sqlpp} xref:n1ql-language-reference/limit.adoc[LIMIT] and xref:n1ql-language-reference/orderby.adoc[ORDER BY] clauses.
 ====
 
 .Search against a full text search index that carries a custom type mapping
 ====
-[source,n1ql]
+[source,{sqlpp}]
 ----
 SELECT META(t1).id
 FROM `travel-sample`.inventory.hotel AS t1
@@ -354,8 +354,8 @@ If the full text search index being queried has its default mapping disabled and
 //The above query uses the demonstration index xref:fts:fts-demonstration-indexes.adoc#travel-sample-index-hotel-description[travel-sample-index-hotel-description], which has the custom type mapping "hotel".
 
 For more information on defining custom type mappings within the full text search index, refer to xref:fts:fts-type-mappings.adoc[Type Mappings].
-Note that for N1QL queries, only full text search indexes with one type mapping are searchable.
-Also the supported type identifiers at the moment are "type_field" and "docid_prefix"; "docid_regexp" isn't supported yet for SEARCH queries via N1QL.
+Note that for {sqlpp} queries, only full text search indexes with one type mapping are searchable.
+Also the supported type identifiers at the moment are "type_field" and "docid_prefix"; "docid_regexp" isn't supported yet for SEARCH queries via {sqlpp}.
 ====
 
 [[search_meta,SEARCH_META()]]
@@ -396,7 +396,7 @@ It may also include other metadata requested by advanced search options, such as
 
 .Select search metadata
 ====
-[source,n1ql]
+[source,{sqlpp}]
 ----
 SELECT SEARCH_META() AS meta -- <1>
 FROM `travel-sample`.inventory.hotel AS t1
@@ -405,7 +405,7 @@ WHERE SEARCH(t1, {
     "match": "bathrobes",
     "field": "reviews.content",
     "analyzer": "standard"
-  }, 
+  },
   "includeLocations": true -- <2>
 })
 LIMIT 3;
@@ -487,7 +487,7 @@ LIMIT 3;
 
 .Select the search metadata by outname
 ====
-[source,n1ql]
+[source,{sqlpp}]
 ----
 SELECT t1.name, SEARCH_META(s1) AS meta -- <1>
 FROM `travel-sample`.inventory.hotel AS t1
@@ -555,7 +555,7 @@ A number reflecting the score of the result.
 .Select the search score
 ====
 
-[source,n1ql]
+[source,{sqlpp}]
 ----
 SELECT name, description, SEARCH_SCORE() AS score -- <1>
 FROM `travel-sample`.inventory.hotel AS t1
@@ -586,17 +586,17 @@ LIMIT 3;
 
 <1> There is only one <<search>> function in this query, so the SEARCH_SCORE() function does not need to specify the outname.
 
-== FTS FLEX (FTS + N1QL Extended Support For Collections)
+== FTS FLEX (FTS + {sqlpp} Extended Support For Collections)
 
-FTS is capable of supporting multiple collections within a single index definition. 
+FTS is capable of supporting multiple collections within a single index definition.
 
 Pre Couchbase Server 7.0 index definitions will continue to be supported with 7.0 FTS.
 
-If the user wants to set up an index definition to subscribe to just a few collections within a single scope, they will be able to do so by toggling the "doc_config.mode" to either of ["scope.collection.type_field", "scope.collection.docid_prefix"]. 
+If the user wants to set up an index definition to subscribe to just a few collections within a single scope, they will be able to do so by toggling the "doc_config.mode" to either of ["scope.collection.type_field", "scope.collection.docid_prefix"].
 
 The type mappings will now take the form of either "scope_name.collection_name" (to index all documents within that scope.collection) or "scope_name.collection_name.type_name" (to index only those documents within that scope.collection that match "type" = "type_name") . We will refer to FTS index definitions in this mode as collection-aware FTS indexes.
 
-NOTE: The type expression check within N1QL queries becomes unnecessary with collection-aware FTS indexes.
+NOTE: The type expression check within {sqlpp} queries becomes unnecessary with collection-aware FTS indexes.
 
 === Example
 
@@ -664,7 +664,7 @@ When you set up an FTS index definition to stream from 2 collections: landmark, 
 }
 ----
 
-Below are some N1QL queries targeting the above index definition. 
+Below are some {sqlpp} queries targeting the above index definition.
 
 ----
 SELECT META().id

--- a/modules/fts/pages/fts-supported-queries.adoc
+++ b/modules/fts/pages/fts-supported-queries.adoc
@@ -2,7 +2,7 @@
 :page-aliases: query-types.adoc
 
 [abstract]
-With Full Text Search you can perform queries on Full Text Indexes. You can perform the queries either by using Couchbase Web Console, the Couchbase REST API, N1QL (using search functions in the Query service), or the Couchbase SDK.
+With Full Text Search you can perform queries on Full Text Indexes. You can perform the queries either by using Couchbase Web Console, the Couchbase REST API, {sqlpp} (using search functions in the Query service), or the Couchbase SDK.
 
 [#query-specification-options]
 == Query-Specification Options

--- a/modules/fts/pages/fts-system-indexes.adoc
+++ b/modules/fts/pages/fts-system-indexes.adoc
@@ -1,12 +1,12 @@
-= System:indexes - FTS indexes which are eligible to be queried from N1QL
+= System:indexes - FTS indexes which are eligible to be queried from {sqlpp}
 
-Use the following command to find all the FTS indexes in the system table that can be queried from N1QL.
+Use the following command to find all the FTS indexes in the system table that can be queried from {sqlpp}.
 
 ----
 SELECT * FROM system:indexes
 ----
 
-An additional link describes various scenarios in which the FTS Index becomes ineligible to be queried by N1QL.
+An additional link describes various scenarios in which the FTS Index becomes ineligible to be queried by {sqlpp}.
 
 xref:n1ql/pages/n1ql-language-reference/searchfun.adoc#limitations[Scenarios where FTS Index becomes ineligible to be queried by N1QL]
  


### PR DESCRIPTION
Changes N1QL to SQL++ for the FTS module in the docs-server repo.

**Does** Change N1QL to {sqlpp} in running text
**Does** Change [source,n1ql] to [source,sqlpp]

**Do not** change n1ql in file names, directory names, extensions, links, or anchors
**Do not** change n1ql in commands, options, UI text, or output text