### PR TITLE
DOC-10477: N1QL to SQL++ Rebrand for Query

### DIFF
--- a/modules/n1ql/pages/n1ql-intro/index.adoc
+++ b/modules/n1ql/pages/n1ql-intro/index.adoc
@@ -19,24 +19,24 @@ endif::[]
 
 An overview of common concepts that you will need to understand in order to use the Query service.
 
-* xref:n1ql:n1ql-intro/queriesandresults.adoc[{sqlpp} Queries and Results]
+* xref:n1ql:n1ql-intro/queriesandresults.adoc[]
 
 == Getting System Information
 
 {sqlpp} has a system catalog that stores metadata about a database.
 The system catalog is a namespace called system.
 
-* xref:n1ql:n1ql-intro/sysinfo.adoc[Getting System Information]
+* xref:n1ql:n1ql-intro/sysinfo.adoc[]
 
 == {sqlpp} Error Codes
 
 All of the {sqlpp} error codes, their error messages, and some tips to resolve them.
 
-* xref:n1ql:n1ql-language-reference/n1ql-error-codes.adoc[{sqlpp} Error Codes]
+* xref:n1ql:n1ql-language-reference/n1ql-error-codes.adoc[]
 
 == Related Links
 
 The Query services provides the following tools for running queries:
 
-* xref:tools:cbq-shell.adoc[cbq: The Command Line Shell for {sqlpp}]
-* xref:tools:query-workbench.adoc[Query Workbench]
+* xref:tools:cbq-shell.adoc[]
+* xref:tools:query-workbench.adoc[]

--- a/modules/n1ql/pages/n1ql-intro/sysinfo.adoc
+++ b/modules/n1ql/pages/n1ql-intro/sysinfo.adoc
@@ -1,10 +1,11 @@
 = Getting System Information
-:description: pass:q[{sqlpp} has a system catalog that stores metadata about a database. \
-The system catalog is a namespace called _system_.]
+:description: {sqlpp} has a system catalog that stores metadata about a database. \
+The system catalog is a namespace called system.
 :page-topic-type: concept
 
 [abstract]
-{description}
+{sqlpp} has a system catalog that stores metadata about a database.
+The system catalog is a namespace called _system_.
 
 There is a keyspace for each type of artifact.
 The keyspace names are plural in order to avoid conflicting with {sqlpp} keywords.

--- a/modules/n1ql/pages/n1ql-language-reference/begin-transaction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/begin-transaction.adoc
@@ -32,7 +32,7 @@
 == Purpose
 
 The `BEGIN TRANSACTION` statement enables you to begin a sequence of statements as an ACID transaction.
-Refer to {transactions}[N1QL Support for Couchbase Transactions] for further information.
+Refer to {transactions}[] for further information.
 
 include::partial$n1ql-language-reference/transaction-restrictions.adoc[]
 
@@ -101,9 +101,9 @@ include::example$transactions/results.jsonc[tags=extract;ellipsis]
 
 == Related Links
 
-* For an overview of Couchbase transactions, refer to {overview}[Transactions].
-* To specify transaction settings, refer to {set-transaction}[SET TRANSACTION].
-* To set a savepoint, refer to {savepoint}[SAVEPOINT].
-* To rollback a transaction, refer to {rollback-transaction}[ROLLBACK TRANSACTION].
-* To commit a transaction, refer to {commit-transaction}[COMMIT TRANSACTION].
+* For an overview of Couchbase transactions, refer to {overview}[].
+* To specify transaction settings, refer to {set-transaction}[].
+* To set a savepoint, refer to {savepoint}[].
+* To rollback a transaction, refer to {rollback-transaction}[].
+* To commit a transaction, refer to {commit-transaction}[].
 * Blog post: https://blog.couchbase.com/transactions-n1ql-couchbase-distributed-nosql/[Couchbase Transactions: Elastic, Scalable, and Distributed^].

--- a/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/createindex.adoc
@@ -205,7 +205,7 @@ This constitutes an index-key for the index.
 
 [[index-key-args]]
 expr::
-A {expression}[{sqlpp} expression] over any fields in the document.
+A {sqlpp} {expression}[expression] over any fields in the document.
 This cannot use constant expressions, aggregate functions, or sub-queries.
 
 array-expr::

--- a/modules/n1ql/pages/n1ql-language-reference/curl.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/curl.adoc
@@ -266,20 +266,20 @@ In the second argument, the string concatenation operator (||) cannot be evaluat
 
 == Examples
 
-. <<Ex1,Use Google Maps API to convert static address into coordinates>>
-. <<Ex2,Use Google Maps API to extract geometry (address and geographic location bounds) of a given street address>>
-. <<Ex3,Join two keyspaces on different Couchbase clusters>>
-. <<Ex4,Full text search (FTS) in a {sqlpp} query>>
-. <<Ex5,Use Yahoo Finance API in a WHERE clause to find a stock's lowest value for the day>>
-. <<Ex6,Use CURL() to allow two URLs and disallow one URL>>
-. <<Ex7,Use CURL() to allow all access to all endpoints>>
-. <<Ex8,Use CURL() to turn off access to all endpoints and clear the Allowed and Disallowed lists>>
-. <<Ex9,Use CURL() to turn off access to all endpoints but make no changes to the Allowed and Disallowed lists>>
-. <<Ex10,Use CURL() to turn off access to all endpoints, allow one URL, and clear the Disallowed list>>
-. <<Ex11,Use CURL() to turn off access to all endpoints, disallow one URL, and clear the Allowed list>>
-. <<Ex12,Use CURL() to allow an IP address and port instead of a website name>>
-. <<Ex13,Use CURL() to allow and disallow the same URL -- and get an error>>
-. <<Ex14,Use CURL() with dynamic named parameters>>
+. xref:Ex1[xrefstyle=basic]
+. xref:Ex2[xrefstyle=basic]
+. xref:Ex3[xrefstyle=basic]
+. xref:Ex4[xrefstyle=basic]
+. xref:Ex5[xrefstyle=basic]
+. xref:Ex6[xrefstyle=basic]
+. xref:Ex7[xrefstyle=basic]
+. xref:Ex8[xrefstyle=basic]
+. xref:Ex9[xrefstyle=basic]
+. xref:Ex10[xrefstyle=basic]
+. xref:Ex11[xrefstyle=basic]
+. xref:Ex12[xrefstyle=basic]
+. xref:Ex13[xrefstyle=basic]
+. xref:Ex14[xrefstyle=basic]
 
 The following examples are using CURL in the query projection list.
 

--- a/modules/n1ql/pages/n1ql-language-reference/index.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/index.adoc
@@ -1,5 +1,5 @@
 = {sqlpp} Language Reference
-:description: The {sqlpp} reference guide describes the {sqlpp} language structure and syntax.
+:description: This reference guide describes the syntax and structure of the {sqlpp} language.
 :page-topic-type: concept
 :page-toclevels: 2
 :imagesdir: ../../assets/images
@@ -18,7 +18,8 @@ include::partial$n1ql-language-reference/column-style.adoc[]
 
 [abstract]
 {description}
-It provides reference information about the basic elements in {sqlpp} which can be combined to build {sqlpp} statements.
+It provides information about the basic elements which can be combined to build {sqlpp} statements.
+The Couchbase implementation of {sqlpp} was formerly known as https://www.couchbase.com/products/n1ql[N1QL^].
 
 [[n1ql-language-structure]]
 The {sqlpp} language is composed of <<statements,statements>>, <<N1QL_Expressions,expressions>>, and <<comments,comments>>.

--- a/modules/n1ql/pages/n1ql-language-reference/indexing-arrays.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/indexing-arrays.adoc
@@ -38,7 +38,7 @@ The index definition may also contain other index keys which are not array expre
 
 [[index-key-args]]
 expr::
-A {expression}[{sqlpp} expression] over any fields in the document.
+A {sqlpp} {expression}[expression] over any fields in the document.
 This cannot use constant expressions, aggregate functions, or sub-queries.
 
 array-expr::

--- a/modules/n1ql/pages/n1ql-language-reference/patternmatchingfun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/patternmatchingfun.adoc
@@ -8,8 +8,7 @@ Regular expressions can formally represent various string search patterns using 
 
 For more information on all supported REGEX patterns, see https://golang.org/pkg/regexp/syntax[^].
 
-NOTE: Couchbase Server 4.x {sqlpp} supports regular expressions supported by The Go Programming Language version 1.4.2.
-From Couchbase Server 5.0, The Go Programming Language version 1.8 is supported.
+NOTE: From Couchbase Server 5.0, {sqlpp} supports regular expressions supported by The Go Programming Language version 1.8.
 
 [[section_regex_contains,REGEXP_CONTAINS()]]
 == REGEXP_CONTAINS(`expression`, `pattern`)

--- a/modules/n1ql/pages/n1ql-language-reference/rollback-transaction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/rollback-transaction.adoc
@@ -22,7 +22,7 @@
 
 The `ROLLBACK TRANSACTION` statement enables you to rollback an ACID transaction.
 You can rollback the entire transaction, or rollback to a previous savepoint.
-Refer to {transactions}[{sqlpp} Support for Couchbase Transactions] for further information.
+Refer to {transactions}[] for further information.
 
 This statement may only be used within a transaction.
 
@@ -288,9 +288,9 @@ Notice the booking document no longer exists.
 
 == Related Links
 
-* For an overview of Couchbase transactions, refer to {overview}[Transactions].
-* To begin a transaction, refer to {begin-transaction}[BEGIN TRANSACTION].
-* To specify transaction settings, refer to {set-transaction}[SET TRANSACTION].
-* To set a savepoint, refer to {savepoint}[SAVEPOINT].
-* To commit a transaction, refer to {commit-transaction}[COMMIT TRANSACTION].
+* For an overview of Couchbase transactions, refer to {overview}[].
+* To begin a transaction, refer to {begin-transaction}[].
+* To specify transaction settings, refer to {set-transaction}[].
+* To set a savepoint, refer to {savepoint}[].
+* To commit a transaction, refer to {commit-transaction}[].
 * Blog post: https://blog.couchbase.com/transactions-n1ql-couchbase-distributed-nosql/[Couchbase Transactions: Elastic, Scalable, and Distributed^].

--- a/modules/n1ql/pages/n1ql-language-reference/savepoint.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/savepoint.adoc
@@ -21,7 +21,7 @@
 == Purpose
 
 The `SAVEPOINT` statement enables you to set a savepoint within an ACID transaction.
-Refer to {transactions}[{sqlpp} Support for Couchbase Transactions] for further information.
+Refer to {transactions}[] for further information.
 
 This statement may only be used within a transaction.
 
@@ -70,9 +70,9 @@ include::example$transactions/results.jsonc[tags=!ellipsis]
 
 == Related Links
 
-* For an overview of Couchbase transactions, refer to {overview}[Transactions].
-* To begin a transaction, refer to {begin-transaction}[BEGIN TRANSACTION].
-* To specify transaction settings, refer to {set-transaction}[SET TRANSACTION].
-* To rollback a transaction, refer to {rollback-transaction}[ROLLBACK TRANSACTION].
-* To commit a transaction, refer to {commit-transaction}[COMMIT TRANSACTION].
+* For an overview of Couchbase transactions, refer to {overview}[].
+* To begin a transaction, refer to {begin-transaction}[].
+* To specify transaction settings, refer to {set-transaction}[].
+* To rollback a transaction, refer to {rollback-transaction}[].
+* To commit a transaction, refer to {commit-transaction}[].
 * Blog post: https://blog.couchbase.com/transactions-n1ql-couchbase-distributed-nosql/[Couchbase Transactions: Elastic, Scalable, and Distributed^].

--- a/modules/n1ql/pages/n1ql-language-reference/set-transaction.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/set-transaction.adoc
@@ -30,7 +30,7 @@
 == Purpose
 
 The `SET TRANSACTION` statement enables you to specify settings for an ACID transaction.
-Refer to {transactions}[{sqlpp} Support for Couchbase Transactions] for further information.
+Refer to {transactions}[] for further information.
 
 This statement may only be used within a transaction.
 
@@ -77,9 +77,9 @@ include::example$transactions/results.jsonc[tags=extract;ellipsis]
 
 == Related Links
 
-* For an overview of Couchbase transactions, refer to {overview}[Transactions].
-* To begin a transaction, refer to {begin-transaction}[BEGIN TRANSACTION].
-* To set a savepoint, refer to {savepoint}[SAVEPOINT].
-* To rollback a transaction, refer to {rollback-transaction}[ROLLBACK TRANSACTION].
-* To commit a transaction, refer to {commit-transaction}[COMMIT TRANSACTION].
+* For an overview of Couchbase transactions, refer to {overview}[].
+* To begin a transaction, refer to {begin-transaction}[].
+* To set a savepoint, refer to {savepoint}[].
+* To rollback a transaction, refer to {rollback-transaction}[].
+* To commit a transaction, refer to {commit-transaction}[].
 * Blog post: https://blog.couchbase.com/transactions-n1ql-couchbase-distributed-nosql/[Couchbase Transactions: Elastic, Scalable, and Distributed^].

--- a/modules/n1ql/pages/n1ql-language-reference/statistics-delete.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/statistics-delete.adoc
@@ -117,7 +117,7 @@ index-key::
 [Required] The expression for which you want to delete statistics.
 This may be any expression that is supported as an index key, including, but not limited to:
 
-* A {expression}[{sqlpp} expression] over any fields in the document, as used in a secondary index.
+* A {sqlpp} {expression}[expression] over any fields in the document, as used in a secondary index.
 
 * An {array-expr}[array expression], as used when creating an array index.
 

--- a/modules/n1ql/pages/n1ql-language-reference/statistics-expressions.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/statistics-expressions.adoc
@@ -98,7 +98,7 @@ Refer to the {keyspace-ref}[CREATE INDEX] statement for details of the syntax.
 The expression for which you want to gather statistics.
 This may be any expression that is supported as an index key, including, but not limited to:
 
-* A {expression}[{sqlpp} expression] over any fields in the document, as used in a secondary index.
+* A {sqlpp} {expression}[expression] over any fields in the document, as used in a secondary index.
 
 * An {array-expr}[array expression], as used when creating an array index.
 

--- a/modules/n1ql/pages/n1ql-language-reference/subqueries.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/subqueries.adoc
@@ -195,7 +195,8 @@ WHERE t1.city IN SPLIT((SELECT RAW t2.name
   {
     "city": "Aberdulais",
     "name": "Aberdulais Falls and Tin Works"
-  }...
+  }
+  // ...
 ]
 ----
 ====
@@ -230,7 +231,8 @@ WHERE t1.city IN SPLIT(t1.name);
   {
     "city": "Aberdulais",
     "name": "Aberdulais Falls and Tin Works"
-  }...
+  }
+  // ...
 ]
 ----
 ====
@@ -246,7 +248,7 @@ See xref:n1ql-language-reference/correlated-subqueries.adoc[Correlated Subquerie
 As described in the xref:n1ql-language-reference/from.adoc[FROM clause], the from-term can be a keyspace name or identifier or a {sqlpp} expression:
 
 * Keyspace identifiers are independent sources of data for a query.
-* xref:n1ql-language-reference/index.adoc[{sqlpp} expressions] can be constructed using various {sqlpp} language constructs including subqueries.
+* {sqlpp} xref:n1ql-language-reference/index.adoc#N1QL_Expressions[expressions] can be constructed using various {sqlpp} language constructs including subqueries.
  ** Constant expressions are independent sources of data for a query.
  ** Variable expressions depend on variables in scope and are evaluated to resolve as input data for the query.
 These are applicable to subqueries.
@@ -329,7 +331,7 @@ FROM `travel-sample`.inventory.airport LIMIT 4;
   {
     "$1": 1968
   },
-  ...
+  // ...
 ]
 ----
 ====
@@ -353,7 +355,7 @@ FROM `travel-sample`.inventory.airport t;
   {
     "$1": 1
   },
-  ...
+  // ...
 ]
 ----
 ====
@@ -457,7 +459,8 @@ WHERE t1.city IN (SELECT RAW city
       "type": "landmark",
       "url": "http://www.remuseum.org.uk"
     }
-  }...
+  }
+  // ...
 ]
 ----
 ====
@@ -611,7 +614,8 @@ WHERE (SELECT RAW t2.alt FROM t1.geo t2)[0] > 4000;
   {
     "alt": 5045,
     "city": "Prescott"
-  }, ...
+  },
+  // ...
 ]
 ----
 ====

--- a/modules/n1ql/pages/query.adoc
+++ b/modules/n1ql/pages/query.adoc
@@ -3,6 +3,7 @@
 :page-role: tiles -toc
 :imagesdir: ../assets/images
 :!sectids:
+:keywords: SQL++, N1QL, Query
 :description: The Query Service supports the querying of data by means of the {sqlpp} query language.
 
 // Pass through HTML styles for this page.
@@ -38,23 +39,23 @@ Use the Full Text Search service when you want to take advantage of natural-lang
 == {sqlpp} for Query
 
 Couchbase Server can be queried using {sqlpp}, the Couchbase Server query language.
-{sqlpp} derives its name from the non-first normal form of the data model, which is a superset and generalization of the relational first normal form (1NF).
+The Couchbase implementation of {sqlpp} was formerly known as https://www.couchbase.com/products/n1ql[N1QL^] (pronounced "nickel"), which derives its name from the non-first normal form of the data model.
 
 {sqlpp} is an expressive, powerful, and complete SQL dialect for querying, transforming, and manipulating JSON data.
 Based on SQL, it's immediately familiar to developers who can quickly start developing rich applications.
 
 == What's Next
 
-* xref:n1ql:n1ql-intro/index.adoc[Running Queries]
-* xref:n1ql:tutorial.adoc[Tutorials]
-* xref:tools:tools-ref.adoc[Query Tools]
-* xref:settings:query-settings.adoc[Settings and Parameters]
-* xref:learn:services-and-indexes/indexes/global-secondary-indexes.adoc[Using Indexes]
-* xref:n1ql:advanced.adoc[Advanced Features]
-* xref:n1ql:n1ql-language-reference/index.adoc[{sqlpp} Language Reference]
-* xref:javascript-udfs:javascript-udfs.adoc[JavaScript User-Defined Functions]
+* xref:n1ql:n1ql-intro/index.adoc[]
+* xref:n1ql:tutorial.adoc[]
+* xref:tools:tools-ref.adoc[]
+* xref:settings:query-settings.adoc[]
+* xref:learn:services-and-indexes/indexes/global-secondary-indexes.adoc[]
+* xref:n1ql:advanced.adoc[]
+* xref:n1ql:n1ql-language-reference/index.adoc[]
+* xref:javascript-udfs:javascript-functions-with-couchbase.adoc[]
 
 == Related Links
 
 * xref:learn:services-and-indexes/services/query-service.adoc[Query Service architecture]
-* xref:learn:data/data.adoc[{sqlpp} data model]
+* xref:learn:data/data.adoc[]

--- a/modules/n1ql/pages/tutorial.adoc
+++ b/modules/n1ql/pages/tutorial.adoc
@@ -19,9 +19,15 @@ endif::[]
 
 If you have not done so already, refer to this page to run your first {sqlpp} query.
 
-* xref:getting-started:try-a-query.adoc[Run Your First {sqlpp} Query]
+* xref:getting-started:try-a-query.adoc[]
 
-== {sqlpp} Query Language Tutorial
+== Developer Tutorial
+
+An introductory worked example for developers, showing how to use a software development kit to query a simple database using {sqlpp}.
+
+* xref:tutorials:couchbase-tutorial-student-records.adoc[]
+
+== Interactive {sqlpp} Tutorial
 
 Provides interactive web modules where you can learn about {sqlpp} without having Couchbase Server installed in your own environment.
 The modules are self-contained and let you modify and run sample queries.

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -452,7 +452,7 @@ include::n1ql:partial$n1ql-rest-api/admin/definitions.adoc[tag=settings]
 [#section_nnj_sjk_k1b]
 == Request-Level Parameters
 
-To set a request-level parameter, use the {n1ql-rest-api-index}[{sqlpp} REST API] (`/query/service` endpoint) with a cURL statement, or the {cbq-shell}[cbq] command, or a client program.
+To set a request-level parameter, use the {n1ql-rest-api-index}[] (`/query/service` endpoint) with a cURL statement, or the {cbq-shell}[cbq] command, or a client program.
 You can also set request-level parameters using the {query-preferences}[Run-Time Preferences] window in the Query Workbench.
 
 While `cbq` is a sandbox to test code on your local machine, your production query settings are set with the cURL commands on your server.
@@ -600,10 +600,10 @@ NOTE: Positional Parameters can also be specified in a statement using *?* as an
 
 == Related Links
 
-For more details about the {sqlpp} REST API, refer to {n1ql-rest-api-index}[{sqlpp} REST API].
+For more details about the {sqlpp} REST API, refer to {n1ql-rest-api-index}[].
 
-For more details about the Admin REST API, refer to {n1ql-rest-api-admin}[Admin REST API].
+For more details about the Admin REST API, refer to {n1ql-rest-api-admin}[].
 
-For more details about the Query Settings API, refer to {rest-cluster-query-settings}[Cluster Query Settings API].
+For more details about the Query Settings API, refer to {rest-cluster-query-settings}[].
 
-For more details about API content and settings, refer to {rest-intro}[REST API reference].
+For more details about API content and settings, refer to {rest-intro}[].

--- a/modules/tools/pages/tools-ref.adoc
+++ b/modules/tools/pages/tools-ref.adoc
@@ -19,19 +19,19 @@ endif::[]
 
 [.cmd]`cbq` is the command line shell that you can use to issue {sqlpp} queries on Couchbase Server.
 
-* xref:tools:cbq-shell.adoc[cbq: The Command Line Shell for {sqlpp}]
+* xref:tools:cbq-shell.adoc[]
 
 == Query Workbench
 
 The Query Workbench provides a rich graphical user interface to perform query development.
 
-* xref:tools:query-workbench.adoc[Query Workbench]
+* xref:tools:query-workbench.adoc[]
 
 == Query Monitor
 
 The Query Monitor is a UI that enables you to monitor the current state of the Query service.
 
-* xref:tools:query-monitoring.adoc[Query Monitoring]
+* xref:tools:query-monitoring.adoc[]
 
 == User-Defined Functions
 
@@ -43,17 +43,17 @@ The User-Defined Functions UI enables you to create and manage functions and lib
 
 {sqlpp}-related activities can be audited by Couchbase Server.
 
-* xref:n1ql:n1ql-language-reference/n1ql-auditing.adoc[{sqlpp} Auditing]
+* xref:n1ql:n1ql-language-reference/n1ql-auditing.adoc[]
 
 == Backfill Support for {sqlpp}
 
 You can configure the temporary working space for the {sqlpp} engine and its embedded GSI client via the UI.
 
-* xref:n1ql:n1ql-language-reference/backfill.adoc[Backfill Support for {sqlpp}]
+* xref:n1ql:n1ql-language-reference/backfill.adoc[]
 
 == Related Links
 
 It is also possible to run a query via the {sqlpp} REST API, or programmatically via a software development kit (SDK).
 
-* xref:n1ql:n1ql-rest-api/index.adoc[{sqlpp} REST API]
-* xref:sdk:overview.adoc[SDKs]
+* xref:n1ql:n1ql-rest-api/index.adoc[]
+* xref:sdk:overview.adoc[]


### PR DESCRIPTION
Minor follow-up changes to links and title pages; add "previously known as N1QL"