### PR TITLE
Release/7.1 FTS minor fixes

### DIFF
--- a/modules/fts/pages/fts-queryshape-circle.adoc
+++ b/modules/fts/pages/fts-queryshape-circle.adoc
@@ -338,8 +338,7 @@ The output of five (5) hits (from a total of 842 matching docs) is as follows
 
 = Example Circle Query (against Circles)
 
-[NOTE]
-It is assumed that you have run the example xref:fts-creating-index-from-REST-geojson.adoc[Creating a GeoJSON Index via the REST API] to ensure your cluster has a GeoJSON dataset and a GeoJSON index on the dataset prior to running this example.
+include::partial$fts-geoshape-prereq-common.adoc[]
 
 Matches if the document circle resides within the query circle.
 

--- a/modules/fts/pages/fts-queryshape-envelope.adoc
+++ b/modules/fts/pages/fts-queryshape-envelope.adoc
@@ -325,8 +325,7 @@ The output of five (5) hits (from a total of 2024 matching docs) is as follows
 
 = Example Envelope Query (against Circles)
 
-[NOTE]
-It is assumed that you have run the example xref:fts-creating-index-from-REST-geojson.adoc[Creating a GeoJSON Index via the REST API] to ensure your cluster has a GeoJSON dataset and a GeoJSON index on the dataset prior to running this example.
+include::partial$fts-geoshape-prereq-common.adoc[]
 
 Matches if the area of the query rectangle overlaps the document circle.
 

--- a/modules/fts/pages/fts-queryshape-geometrycollection.adoc
+++ b/modules/fts/pages/fts-queryshape-geometrycollection.adoc
@@ -398,8 +398,7 @@ The output of five (5) hits (from a total of 47 matching docs) is as follows
 
 = Example GeometryCollection Query (against Circles)
 
-[NOTE]
-It is assumed that you have run the example xref:fts-creating-index-from-REST-geojson.adoc[Creating a GeoJSON Index via the REST API] to ensure your cluster has a GeoJSON dataset and a GeoJSON index on the dataset prior to running this example.
+include::partial$fts-geoshape-prereq-common.adoc[]
 
 Intersects when the query geometrycollection intersects the circular region in the document.
 

--- a/modules/fts/pages/fts-queryshape-linestring.adoc
+++ b/modules/fts/pages/fts-queryshape-linestring.adoc
@@ -246,8 +246,7 @@ The output of two (2) hits (from a total of 2 matching docs) is as follows
 
 = Example LineString Query (against Circles)
 
-[NOTE]
-It is assumed that you have run the example xref:fts-creating-index-from-REST-geojson.adoc[Creating a GeoJSON Index via the REST API] to ensure your cluster has a GeoJSON dataset and a GeoJSON index on the dataset prior to running this example.
+include::partial$fts-geoshape-prereq-common.adoc[]
 
 Intersects when the query point lies within the area of the circular region in the document.
 

--- a/modules/fts/pages/fts-queryshape-multilinestring.adoc
+++ b/modules/fts/pages/fts-queryshape-multilinestring.adoc
@@ -215,8 +215,7 @@ The output of three (3) hits (from a total of 3 matching docs) is as follows
 
 = Example MultiLineString Query (against Circles)
 
-[NOTE]
-It is assumed that you have run the example xref:fts-creating-index-from-REST-geojson.adoc[Creating a GeoJSON Index via the REST API] to ensure your cluster has a GeoJSON dataset and a GeoJSON index on the dataset prior to running this example.
+include::partial$fts-geoshape-prereq-common.adoc[]
 
 Intersects when the query multilinestring intersects the circular region in the document.
 

--- a/modules/fts/pages/fts-queryshape-multipoint.adoc
+++ b/modules/fts/pages/fts-queryshape-multipoint.adoc
@@ -299,8 +299,7 @@ The output of two (2) hits (from a total of 2 matching docs) is as follows
 
 = Example MultiPoint Query (against Circles)
 
-[NOTE]
-It is assumed that you have run the example xref:fts-creating-index-from-REST-geojson.adoc[Creating a GeoJSON Index via the REST API] to ensure your cluster has a GeoJSON dataset and a GeoJSON index on the dataset prior to running this example.
+include::partial$fts-geoshape-prereq-common.adoc[]
 
 Intersects when any of the query points lies within the area of the circular region in the document.
 

--- a/modules/fts/pages/fts-queryshape-multipolygon.adoc
+++ b/modules/fts/pages/fts-queryshape-multipolygon.adoc
@@ -331,8 +331,7 @@ The output of five (5) hits (from a total of 45 matching docs) is as follows
 
 = Example MultiPolygon Query (against Circles)
 
-[NOTE]
-It is assumed that you have run the example xref:fts-creating-index-from-REST-geojson.adoc[Creating a GeoJSON Index via the REST API] to ensure your cluster has a GeoJSON dataset and a GeoJSON index on the dataset prior to running this example.
+include::partial$fts-geoshape-prereq-common.adoc[]
 
 The MultiPolygon contains a two polygons one for Utah and one for Colorado. Intersects when the query multipolygon intersects the circular region in the document.
 

--- a/modules/fts/pages/fts-queryshape-point.adoc
+++ b/modules/fts/pages/fts-queryshape-point.adoc
@@ -213,8 +213,7 @@ The output of one (1) hit (from a total of 1 matching docs) is as follows
 
 = Example Point Query (against Circles)
 
-[NOTE]
-It is assumed that you have run the example xref:fts-creating-index-from-REST-geojson.adoc[Creating a GeoJSON Index via the REST API] to ensure your cluster has a GeoJSON dataset and a GeoJSON index on the dataset prior to running this example.
+include::partial$fts-geoshape-prereq-common.adoc[]
 
 Matches when the query point lies within the area of the circular region in the document.
 

--- a/modules/fts/pages/fts-queryshape-polygon.adoc
+++ b/modules/fts/pages/fts-queryshape-polygon.adoc
@@ -373,8 +373,7 @@ The output of five (5) hits (from a total of 18 matching docs) is as follows
 
 = Example Polygon Query (against Circles)
 
-[NOTE]
-It is assumed that you have run the example xref:fts-creating-index-from-REST-geojson.adoc[Creating a GeoJSON Index via the REST API] to ensure your cluster has a GeoJSON dataset and a GeoJSON index on the dataset prior to running this example.
+include::partial$fts-geoshape-prereq-common.adoc[]
 
 Intersects when the query polygon intersects the circular region in the document.
 

--- a/modules/fts/pages/fts-supported-queries-geojson-spatial.adoc
+++ b/modules/fts/pages/fts-supported-queries-geojson-spatial.adoc
@@ -950,7 +950,9 @@ This example quickly creates the same index as xref:fts-creating-index-from-REST
 
 == Final GeoJSON Search index
 
-Note, for the samples above that return actual airportname and name fields and also the nine (9) QueryShape examples referenced in xref:fts-supported-queries-geojson-spatial.adoc[#detailed-geojson-examples] the Search index used is as follows:
+Note, for the samples above that return actual airportname and name fields and also the nine (9) QueryShape examples referenced in <<detailed-geojson-examples,Detailed examples for every QueryShape>>
+
+the Search index used is as follows:
 
 [source, json]
 ----


### PR DESCRIPTION
1. Fixed bad internal link
2. Updated nine (9) examples to use the partial include for the [NOTE] blocks - this was an oversight on my part as the 2 includes for the NOTEs should be identical.

FYI the partial is as follows (and already used for the first example in each of the nine files) it should be used for both examples that is why it is a partial:

[NOTE]
It is assumed that you your cluster has 1) a modified xref:fts-supported-queries-geojson-spatial.adoc#prerequisites-dataset[travel-sample with GeoJSON data] and 2) a Search index as per xref:fts-creating-index-from-REST-geojson.adoc[Creating a GeoJSON Index via the REST API] prior to running this example.
