### PR TITLE
DOC-10510 Marks backup to Azure blob storage as GA in 7.1.2

### DIFF
--- a/modules/introduction/pages/whats-new.adoc
+++ b/modules/introduction/pages/whats-new.adoc
@@ -237,8 +237,8 @@ Resume option for cbbackupmgr restore::
 The --resume option for cbbackupmgr restore allows you to resume a restore that has failed due to a temporary environmental issue.
 See xref:backup-restore:cbbackupmgr-restore.adoc[].
 
-[Developer Preview] Direct Backup to Azure Blob Containers::
-The cbbackupmgr CLI direct backup to Azure blob containers is available for Developer Preview in 7.1.
+[GA in 7.1.2] Direct Backup to Azure Blob Containers::
+The cbbackupmgr CLI direct backup to Azure blob containers is available for Developer Preview in 7.1 (GA in 7.1.2).
 See xref:backup-restore:cbbackupmgr-cloud.adoc[].
 
 [Developer Preview] Encrypted Backups::

--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -40,6 +40,9 @@ See xref:rest-api:rest-cluster-email-notifications.adoc[Setting Alerts].
 * The Eventing Services now allows multiple collections to be listened to.
 See xref:eventing:eventing-Terminologies.adoc#eventing-keyspaces[Eventing Keyspaces].
 
+* Direct backup to Azure blob store using cbbackupmgr CLI or the Backup Service is GA in 7.1.2.
+See xref:backup-restore:cbbackupmgr-cloud.adoc[Cloud Backup].
+
 === New Supported Platforms
 
 This release adds support for the following platforms:


### PR DESCRIPTION
The `cbbackupmgr` backup to Azure functionality will be generally available in 7.1.2. Updates the documentation to indicate this and adds an entry to the release log so that people are aware.