### PR TITLE
 DOC-10609 release/7.1.2: Changes to {sqlpp} instead of N1QL in running text

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/metafun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/metafun.adoc
@@ -152,7 +152,7 @@ Returns the https://en.wikipedia.org/wiki/Base64[base64^] encoding of the given 
 
 === Arguments
 
-expression:: An expression representing any supported N1QL datatype.
+expression:: An expression representing any supported {sqlpp} datatype.
 
 === Return Value
 
@@ -311,7 +311,7 @@ A general function to return the length of an item.
 
 === Arguments
 
-expression:: An expression representing any supported N1QL datatype.
+expression:: An expression representing any supported {sqlpp}  datatype.
 
 === Return Value
 


### PR DESCRIPTION
Changes to {sqlpp} instead of N1QL in running text. But leaves N1QL in the output of the VERSION() function.