### PR TITLE
DOC-10609 release/7.2: Adds two N1QL functions

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/metafun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/metafun.adoc
@@ -1062,4 +1062,72 @@ SELECT UUID() AS uuid;
 ----
 ====
 
+[[VERSION,VERSION()]]
+== VERSION()
+
+=== Description
+
+Returns SQL++ version.
+
+=== Arguments
+
+None.
+
+=== Return Value
+
+Returns string containing the SQL++ version.
+
+=== Example
+
+.Query
+[source,sqlpp]
+----
+SELECT VERSION() as language_version;
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "language_version": "7.1.1-N1QL"
+  }
+]
+----
+
+
+[[DS_VERSION,VERSION()]]
+== DS_VERSION()
+
+=== Description
+
+Returns the Couchbase Server version.
+
+=== Arguments
+
+None.
+
+=== Return Value
+
+Returns string containing the Couchbase Server version.
+
+=== Example
+
+.Query
+[source,sqlpp]
+----
+SELECT DS_VERSION() as server_version;
+----
+
+.Results
+[source,json]
+----
+[
+  {
+    "server_version": "7.1.1-3175-enterprise"
+  }
+]
+----
+====
+
 For further examples using `UUID()`, refer to the xref:n1ql-language-reference/insert.adoc[INSERT] and xref:n1ql-language-reference/merge.adoc[MERGE] statements.

--- a/modules/n1ql/pages/n1ql-language-reference/metafun.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/metafun.adoc
@@ -1090,7 +1090,7 @@ SELECT VERSION() as language_version;
 ----
 [
   {
-    "language_version": "7.1.1-N1QL"
+    "language_version": "7.0.2-N1QL"
   }
 ]
 ----
@@ -1124,7 +1124,7 @@ SELECT DS_VERSION() as server_version;
 ----
 [
   {
-    "server_version": "7.1.1-3175-enterprise"
+    "server_version": "7.0.4-7279-enterprise"
   }
 ]
 ----


### PR DESCRIPTION
 - Adds two N1QL functions to the Miscellaneous utility Functions page!
 - Updates JSON results from examples given in the Jira (DOC-10609) ticket using the Capella workbench.
 
 (the {sqlpp} updates are already present in this version)
 
 