### PR TITLE
Correct bucket create eviction parameter

### DIFF
--- a/modules/rest-api/pages/rest-bucket-create.adoc
+++ b/modules/rest-api/pages/rest-bucket-create.adoc
@@ -45,7 +45,7 @@ curl -X POST -u <administrator>:<password>
   -d ramQuota=<integer>
   -d storageBackend=[ couchstore | magma ]
   -d evictionPolicy=[
-          [ valueOnly | full ] |
+          [ valueOnly | fullEviction ] |
           [ noEviction | nruEviction ]
         ]
   -d durabilityMinLevel=[


### PR DESCRIPTION
It should be "fullEviction" rather than "full". The following error message is given when creating a bucket with "full" evictionPolicy:

"evictionPolicy":"Eviction policy must be either 'valueOnly' or 'fullEviction' for couchbase buckets"

The rest of the page appears to correctly list the parameter as "fullEviction".

Unsure if this is the correct branch.