### PR TITLE
Add search nav partial from devex-docs

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -56,6 +56,8 @@
     *** xref:guides:create-javascript-library.adoc[]
     *** xref:guides:create-user-defined-function.adoc[]
     *** xref:guides:call-user-defined-function.adoc[]
+include::search:partial$nav.adoc[]
+
 * xref:home:ROOT:sdk.adoc[SDKs]
   ** xref:sdk-extensions::distributed-acid-transactions.adoc[Distributed ACID Transactions]
   ** xref:sdk-extensions::field-level-encryption.adoc[Field Level Encryption]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -56,7 +56,12 @@
     *** xref:guides:create-javascript-library.adoc[]
     *** xref:guides:create-user-defined-function.adoc[]
     *** xref:guides:call-user-defined-function.adoc[]
+
+
++
+--
 include::search:partial$nav.adoc[]
+--
 
 * xref:home:ROOT:sdk.adoc[SDKs]
   ** xref:sdk-extensions::distributed-acid-transactions.adoc[Distributed ACID Transactions]


### PR DESCRIPTION
Part of striping and branching investigation:

* Playbook: [couchbase/docs-site#639](https://github.com/couchbase/docs-site/pull/639)
* Devex Capella branch: [couchbaselabs/docs-devex#1](https://github.com/couchbaselabs/docs-devex/pull/1)
* Devex Server branch: [couchbaselabs/docs-devex#2](https://github.com/couchbaselabs/docs-devex/pull/2)
* Server nav: this PR

There would be a similar inclusion in the Couchbase Cloud nav &mdash; there is no PR for that change.