### PR TITLE
Fixed a few typos in the FTS Docs -> Dynamic Index

### DIFF
--- a/modules/fts/pages/fts-creating-index-from-UI-classic-editor-dynamic.adoc
+++ b/modules/fts/pages/fts-creating-index-from-UI-classic-editor-dynamic.adoc
@@ -48,11 +48,11 @@ image::fts-select-dynamic-scope-collections.png[,450,align=left]
 
 * You will see a newly visible pull-down menu provided for the *Scope* field, under the *[X] Use non-default scope/collections* checkbox, and select a bucket that you are allowed to access to via the cluster's RBAC settings.
 +
-For this example leave the setting as *_default* which which is used to migrate bucket based data into the collections paradigm. 
+For this example leave the setting as *_default* which is used to migrate bucket based data into the collections paradigm. 
 
-* Under *Type Mapings*, unselect the checkbox *[ ]  default | dynamic*.
+* Under *Type Mappings*, unselect the checkbox *[ ]  default | dynamic*.
 +
-This is required as this type mapping (the default mapping) is only valid for the <bucket>._default._default which is typically used to upgrade a 6.X server from a bucket into a more powerful collections paradigm.  In this example we will do the equivlent but on a per collections basis.
+This is required as this type mapping (the default mapping) is only valid for the <bucket>._default._default which is typically used to upgrade a 6.X server from a bucket into a more powerful collections paradigm.  In this example we will do the equivalent but on a per collections basis.
 +
 image::fts-uncheck-default-mapping.png[,600,align=left]
 
@@ -68,7 +68,7 @@ image::fts-index-menu1-geopoint-filled.png[,600,align=left]
 
 ** Leave the *[{nbsp}{nbsp}] only index specified fields* checkbox blank or unset.
 +
-This will index all fields in the scope *_default* collection *_default*, howver not this is not recommended for large production datasets.
+This will index all fields in the scope *_default* collection *_default*, however not this is not recommended for large production datasets.
 
 ** Click on the blue *ok* at the right of the section to save this mapping.
 


### PR DESCRIPTION
A few (4) typos are there in the Couchbase Documentation -> Search -> Create Search Indexes -> Classic editor and examples -> Collections -> Dynamic Index. I have fixed them 