### PR TITLE
document Eventing REST call resetStatsCounters

### DIFF
--- a/modules/eventing/pages/eventing-api.adoc
+++ b/modules/eventing/pages/eventing-api.adoc
@@ -866,6 +866,24 @@ curl -XGET http://Administrator:password@192.168.1.5:8096/getFailureStats?name=[
 curl -XGET 'http://anyAuthedUser:password@192.168.1.5:8096/getFailureStats?name=[function_name]&bucket=[fs_bucket]&scope=[fs_scope]'
 ----
 
+| GET
+| [.path]_/resetStatsCounters?appName=[function_name]_
+a| Reset an Application's statistics.
+This will reset the subset of statistics related to the specific Function.
+
+|
+2+a|
+Sample API:
+
+[source,console]
+----
+curl -XGET http://Administrator:password@192.168.1.5:8096/resetStatsCounters?appName=[function_name]
+----
+[source,console]
+----
+curl -XGET 'http://anyAuthedUser:password@192.168.1.5:8096/resetStatsCounters?appName=[function_name]&bucket=[fs_bucket]&scope=[fs_scope]'
+----
+
 |===
 
 .Eventing Functions API (*deprecated activation/deactivation*)


### PR DESCRIPTION
Unlike in 7.0.2 when introduced in 7.1 we show the "function scope variant" for a non-admin user