### PR TITLE
Remove extra blank line in description

### DIFF
--- a/modules/cloud/pages/couchbase-aws-syncgateway-deployment.adoc
+++ b/modules/cloud/pages/couchbase-aws-syncgateway-deployment.adoc
@@ -3,7 +3,6 @@
 
 [abstract]
 {description}
-
 This solution is based on Amazon CloudFormation templates that incorporate the latest features and best practices for deploying Couchbase Server on Amazon Web Services.
 
 Couchbase Sync Gateway on AWS Marketplace provides one of the fastest and easiest ways to get up and running on Amazon Web Services (AWS).


### PR DESCRIPTION
Remove blank line to bring second sentence into the description, mirroring how the Server page looks