### PR TITLE
Update best practices with new section.

### DIFF
--- a/modules/eventing/pages/troubleshooting-best-practices.adoc
+++ b/modules/eventing/pages/troubleshooting-best-practices.adoc
@@ -220,3 +220,15 @@ The above bare regular expression should be written with the quotes escaped via 
 ----
 mystring.match(/(\S+)[^=]=[\"\']?((?:.(?![\"\']?\s+(?:\S+)[^=]=|[>\"\']))+.)[\"\']?/g);
 ----
+
+== Why do some of my functions dealing with large datasets take so long to undeploy?
+
+Undeployment depends on the size of the Eventing metadata collection (or scratchpad) and not the source or destination. 
+If any Eventing Function is undeployed on a collection with lots of tombstones the Eventing service has to re-stream these documents for any Eventing Function during undeployment phase. 
+If we have an Eventing function that generates a billion timers which have all fired (relatively quickly say an hour or two) the Eventing Function might take minutes or even an hour to undeploy due to the tombstones of deleted items in this case timers remaining on disk. 
+In fact any Eventing Function that shares the same metadata collection will also experience the same slow undeployment.
+
+Workarounds (best practice) is to have a separate metadata collection for non-timer Eventing Functions which will stream 1024 documents each. 
+Eventing Functions that generate a massive amount of timers (1000+/sec.) should use a private collection for metadata and not share this area with other Eventing Functions.  
+Note the tombstones will remain by default for 3 days unless the Metadata Purge Interval is adjusted. 
+By lowering the bucket's Metadata Purge Interval  (it can be set to a low as 0.4 hours) the potential for accumulating a massive number of tombstones can be avoided.

--- a/modules/eventing/pages/troubleshooting-best-practices.adoc
+++ b/modules/eventing/pages/troubleshooting-best-practices.adoc
@@ -221,14 +221,14 @@ The above bare regular expression should be written with the quotes escaped via 
 mystring.match(/(\S+)[^=]=[\"\']?((?:.(?![\"\']?\s+(?:\S+)[^=]=|[>\"\']))+.)[\"\']?/g);
 ----
 
-== Why do some of my functions dealing with large datasets take so long to undeploy?
+== Why does my function take so long to undeploy?
 
-Undeployment depends on the size of the Eventing metadata collection (or scratchpad) and not the source or destination. 
-If any Eventing Function is undeployed on a collection with lots of tombstones the Eventing service has to re-stream these documents for any Eventing Function during undeployment phase. 
-If we have an Eventing function that generates a billion timers which have all fired (relatively quickly say an hour or two) the Eventing Function might take minutes or even an hour to undeploy due to the tombstones of deleted items in this case timers remaining on disk. 
-In fact any Eventing Function that shares the same metadata collection will also experience the same slow undeployment.
+Undeployment time depends on the size of the Eventing metadata collection or scratchpad, not the source or destination. 
+If you undeploy an Eventing Function on a collection with lots of tombstones, the Eventing service has to re-stream these documents during the undeployment phase. 
+If you have an Eventing function that generates a billion timers, which have all fired quickly, the Eventing Function might take minutes or an hour to undeploy because of the tombstones remaining on disk. 
+Any Eventing Function that shares the same metadata collection will also be slow to undeploy.
 
-Workarounds (best practice) is to have a separate metadata collection for non-timer Eventing Functions which will stream 1024 documents each. 
-Eventing Functions that generate a massive amount of timers (1000+/sec.) should use a private collection for metadata and not share this area with other Eventing Functions.  
-Note the tombstones will remain by default for 3 days unless the Metadata Purge Interval is adjusted. 
-By lowering the bucket's Metadata Purge Interval  (it can be set to a low as 0.4 hours) the potential for accumulating a massive number of tombstones can be avoided.
+It's recommended to have a separate metadata collection for non-timer Eventing Functions, which will stream 1024 documents each. 
+An Eventing Function that generates more than 1000 timers per second should use a private collection for metadata and not share this area with other Eventing Functions.  
+By default, tombstones remain on disk for 3 days. 
+Adjust the Metadata Purge Interval to reduce the number of accumulated tombstones. 


### PR DESCRIPTION
As per https://issues.couchbase.com/browse/MB-56113 it is important to warn Eventing power uses of corner cases that result in slow undeployment.