### PR TITLE
DOC-10887: Add documentation about the "completed" state

### DIFF
--- a/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
+++ b/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
@@ -1274,7 +1274,7 @@ Most field names and meanings match exactly those of `system:active_requests`.
 Note that the `completed` state means that the request was started and completed by the Query service, but it does not mean that it was necessarily successful.
 The request could have been successful, or completed with errors.
 
-To find requests that completed successfully, search for completed requests whose `errorCount` field has the value `0`.
+To find requests that completed successfully, search for completed requests whose `state` is `completed` and whose `errorCount` field has the value `0`.
 
 [NOTE]
 ====
@@ -1297,11 +1297,19 @@ To get a list of all logged completed requests using the Admin REST API:
 curl -u Administrator:pword http://localhost:8093/admin/completed_requests
 ----
 
+To get a list of all logged completed requests using {sqlpp}, including the query plan:
+
+[source,sqlpp]
+----
+SELECT *, meta().plan FROM system:completed_requests;
+----
+
 To get a list of all logged completed requests using {sqlpp}, including only successful requests:
 
 [source,sqlpp]
 ----
-SELECT * FROM system:completed_requests WHERE errorCount = 0;
+SELECT * FROM system:completed_requests
+WHERE state = "completed" AND errorCount = 0;
 ----
 
 [[sys-completed-delete]]

--- a/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
+++ b/modules/manage/pages/monitor/monitoring-n1ql-query.adoc
@@ -1269,7 +1269,12 @@ For each completed request, this catalog maintains information such as requestId
 This information provides a general insight into the health and performance of the query engine and the cluster.
 
 For field names and meanings, refer to xref:n1ql:n1ql-rest-api/admin.adoc#_requests[Requests].
-Note that most field names and meanings match exactly those of `system:active_requests`.
+Most field names and meanings match exactly those of `system:active_requests`.
+
+Note that the `completed` state means that the request was started and completed by the Query service, but it does not mean that it was necessarily successful.
+The request could have been successful, or completed with errors.
+
+To find requests that completed successfully, search for completed requests whose `errorCount` field has the value `0`.
 
 [NOTE]
 ====
@@ -1292,11 +1297,11 @@ To get a list of all logged completed requests using the Admin REST API:
 curl -u Administrator:pword http://localhost:8093/admin/completed_requests
 ----
 
-To get a list of all logged completed requests using {sqlpp}, including the query plan:
+To get a list of all logged completed requests using {sqlpp}, including only successful requests:
 
 [source,sqlpp]
 ----
-SELECT *, meta().plan FROM system:completed_requests;
+SELECT * FROM system:completed_requests WHERE errorCount = 0;
 ----
 
 [[sys-completed-delete]]


### PR DESCRIPTION
This pull request adds information about successfully completed requests to the [system:completed_requests](https://docs.couchbase.com/server/current/manage/monitor/monitoring-n1ql-query.html#sys-completed-req) documentation.

See [couchbaselabs/cb-swagger#99](https://github.com/couchbaselabs/cb-swagger/pull/99) for changes to the Admin REST API documentation.

Docs issue: DOC-10887