### PR TITLE
DOC-11066: Remove prerelease flag

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,6 +1,5 @@
 name: server
 version: '7.2'
-prerelease: Prerelease
 title: Couchbase Server
 start_page: introduction:intro.adoc
 nav:


### PR DESCRIPTION
For release of 7.2.x

See docs issue for other GA release tasks: DOC-11066