### PR TITLE
Update fts-supported-queries-date-range.adoc

### DIFF
--- a/modules/fts/pages/fts-supported-queries-date-range.adoc
+++ b/modules/fts/pages/fts-supported-queries-date-range.adoc
@@ -21,3 +21,43 @@ The [.param]`inclusive_start` and [.param]`inclusive_end` properties in the quer
  "field": "review_date"
 }
 ----
+
+The default datetime parser is *dateTimeOptional* which contaings the following layouts s per the syntax in https://pkg.go.dev/time :
+
+[cols="<,<", options="header"]
+|===
+|Format |Name
+
+|2006-01-02T15:04:05.999999999Z07:00 |time.RFC3339Nano
+|2006-01-02T15:04:05Z07:00 |time.RFC3339
+|2006-01-02T15:04:05 |rfc3339NoTimezone
+|2006-01-02 15:04:05 |rfc3339NoTimezoneNoT
+|2006-01-02 |rfc3339NoTime
+|===
+
+Other formats such as *reviews.date* in *travel-sample.inventory.hotel* keyspace will need a "Custom Date/Time Parser" as default *dateTimeOptional* will not match the data values or strings like "date": "2013-06-22 18:33:50 +0300"
+
+If you create a "Custom Date/Time Parser" all layout template should be defined as per the syntax in https://pkg.go.dev/time :
+
+[cols="<,<", options="header"]
+|===
+|Type |Options
+
+|Year |06, 2006
+|Month |01, 1, Jan, January
+|Day |02, 2, _2
+|Weekday |Mon, Monday
+|Hours |03, 3, 15
+|Minutes |04, 4
+|Seconds |05, 5
+|ms μs ns |.000, .000000, .000000000
+|ms μs ns |.999, .999999, .999999999 (trailing zeros removed)
+|am/pm |PM, pm
+|Timezone |MST
+|Offset |-0700, -07, -07:00, Z0700, Z07:00
+|===
+
+The layout template needed for a "Custom Date/Time Parser" that will recognize  travel-sample fields with strings like "2013-06-22 18:33:50 +0300" is "2006-01-02 15:04:05 -0700" as per the table above.
+
+NOTE: It is important that you follow the syntax in the above table derived from https://pkg.go.dev/time you cannot just past in a random date.  For example only 06 or 2006 in the layout template will be a year.
+


### PR DESCRIPTION
The documentation was completely missing for this complex feature/syntax - this is valid for all 7.X version and most likely 6.X versions of the documentation.

This is a recurring problem no one (our own staff) knows how to make Custom DateTime Parsers becuase they don't know that the templates have to be in Golang syntax.