### PR TITLE
DOC-11412 Backporting change from 7.2 to 7.1

### DIFF
--- a/modules/install/pages/install-oracle.adoc
+++ b/modules/install/pages/install-oracle.adoc
@@ -38,14 +38,14 @@ This method involves downloading and installing a small meta package from Couchb
 +
 [source,console]
 ----
-curl -O https://packages.couchbase.com/releases/couchbase-release/couchbase-release-1.0-6-x86_64.rpm
+curl -O https://packages.couchbase.com/releases/couchbase-release/couchbase-release-1.0.noarch.rpm
 ----
 
 . Install the meta package.
 +
 [source,console]
 ----
-sudo rpm -i ./couchbase-release-1.0-6-x86_64.rpm
+sudo rpm -i ./couchbase-release-1.0.noarch.rpm
 ----
 +
 The meta package installs the necessary information for `yum` to be able to retrieve all of the necessary Couchbase Server installation packages and dependencies.

--- a/modules/install/pages/rhel-suse-install-intro.adoc
+++ b/modules/install/pages/rhel-suse-install-intro.adoc
@@ -36,14 +36,14 @@ This method involves downloading and installing a small meta package from Couchb
 +
 [source,console]
 ----
-curl -O https://packages.couchbase.com/releases/couchbase-release/couchbase-release-1.0-x86_64.rpm
+curl -O https://packages.couchbase.com/releases/couchbase-release/couchbase-release-1.0.noarch.rpm
 ----
 
 . Install the meta package.
 +
 [source,console]
 ----
-sudo rpm -i ./couchbase-release-1.0-x86_64.rpm
+sudo rpm -i ./couchbase-release-1.0.noarch.rpm
 ----
 +
 The meta package installs the necessary information for `yum` to be able to retrieve all of the necessary Couchbase Server installation packages and dependencies.

--- a/modules/install/pages/ubuntu-debian-install.adoc
+++ b/modules/install/pages/ubuntu-debian-install.adoc
@@ -36,14 +36,14 @@ This method involves downloading and installing a small meta package from Couchb
 +
 [source,console]
 ----
-curl -O https://packages.couchbase.com/releases/couchbase-release/couchbase-release-1.0-amd64.deb
+curl -O https://packages.couchbase.com/releases/couchbase-release/couchbase-release-1.0-noarch.deb
 ----
 
 . Install the meta package.
 +
 [source,console]
 ----
-sudo dpkg -i ./couchbase-release-1.0-amd64.deb
+sudo dpkg -i ./couchbase-release-1.0-noarch.deb
 ----
 +
 The meta package installs the necessary information for `apt` to be able to retrieve all of the necessary Couchbase Server installation packages and dependencies.


### PR DESCRIPTION
Backporting change from 7.2 to 7.1 as requested in [DOC-11412](https://issues.couchbase.com/browse/DOC-11412) by @ceejatec. 


Changed the pages mentioned in the bug, plus the Oracle Linux page which also had the old x86 package name. (#3374)