### PR TITLE
DOC-10628: Remove incorrect information

### DIFF
--- a/modules/learn/pages/services-and-indexes/indexes/storage-modes.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/storage-modes.adoc
@@ -67,8 +67,6 @@ This means the total size of the index can be much bigger than the amount of mem
 
 In Couchbase Server Enterprise Edition, standard index-storage is supported by the _Plasma_ storage engine.
 In this case, compaction is handled automatically.
-
-However, for installations of Couchbase Server Enterprise Edition running on Linux, note that hole punching is required to enable auto-compaction of Global Secondary Indexes using standard index-storage.
 ****
 
 ****


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-10628

This PR addresses some information that is no longer correct, there will be similar PRs for all supported versions and 7.6.

In this page - [docs.couchbase.com/server/7.0/learn/services-and-indexes/indexes/storage-modes.html](https://docs.couchbase.com/server/7.0/learn/services-and-indexes/indexes/storage-modes.html#standard-index-storage) - in the box for enterprise edition, it is mentioned that "note that hole punching is required to enable auto-compaction of Global Secondary Indexes". This is incorrect. Plasma disk compaction is automatic and is enabled by default, irrespective of hole punching. Hole punching just allows plasma disk compaction to reclaim disk space at a finer granularity.