### PR TITLE
DOC-10628: remove incorrect info

### DIFF
--- a/modules/learn/pages/services-and-indexes/indexes/storage-modes.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/storage-modes.adoc
@@ -68,7 +68,6 @@ This means the total size of the index can be much bigger than the amount of mem
 In Couchbase Server Enterprise Edition, standard index-storage is supported by the _Plasma_ storage engine.
 In this case, compaction is handled automatically.
 
-However, for installations of Couchbase Server Enterprise Edition running on Linux, note that hole punching is required to enable auto-compaction of Global Secondary Indexes using standard index-storage.
 ****
 
 ****


### PR DESCRIPTION
This is a PR for the ticket https://issues.couchbase.com/browse/DOC-10628
This affects 7.0, 7.1, 7.2 and 7.6.
The fix simply removes the caveat for Linux as there is no such caveat, the behaviour is uniform.

In this page - [docs.couchbase.com/server/7.0/learn/services-and-indexes/indexes/storage-modes.html](https://docs.couchbase.com/server/7.0/learn/services-and-indexes/indexes/storage-modes.html#standard-index-storage) - in the box for enterprise edition, it is mentioned that "note that hole punching is required to enable auto-compaction of Global Secondary Indexes". This is incorrect. Plasma disk compaction is automatic and is enabled by default, irrespective of hole punching. Hole punching just allows plasma disk compaction to reclaim disk space at a finer granularity.