### PR TITLE
DOC-10628: remove linux caveat

### DIFF
--- a/modules/manage/pages/manage-settings/configure-compact-settings.adoc
+++ b/modules/manage/pages/manage-settings/configure-compact-settings.adoc
@@ -17,7 +17,6 @@ Auto-compaction settings affect _on-disk_ data, and therefore do not apply to Ep
 Full and Cluster administrators can configure compaction settings with xref:manage:manage-settings/configure-compact-settings.adoc#configure-auto-compaction-with-the-ui[Couchbase Web Console], the Couchbase xref:manage:manage-settings/configure-compact-settings.adoc#configure-auto-compaction-with-the-cli[CLI], or the xref:manage:manage-settings/configure-compact-settings.adoc#configure-auto-compaction-with-the-rest-api[REST] API.
 
 Note that in Couchbase Server Enterprise Edition, auto-compaction does not apply to memory-optimized index storage, and there are no settings necessary for configuring the auto-compaction of Global Secondary Indexes using standard index storage.
-However, for installations of Couchbase Server Enterprise Edition running on Linux, note that hole punching is required to enable auto-compaction of Global Secondary Indexes using standard index storage.
 See xref:learn:services-and-indexes/indexes/storage-modes.adoc#standard-index-storage[Standard Index Storage], for information.
 
 [#configure-auto-compaction-with-the-ui]


### PR DESCRIPTION
This is a PR for the ticket https://issues.couchbase.com/browse/DOC-10628
This affects 7.0, 7.1, 7.2 and 7.6.
The fix simply removes the caveat for Linux as there is no such caveat, the behaviour is uniform.

In this page - [docs.couchbase.com/server/7.0/learn/services-and-indexes/indexes/storage-modes.html](https://docs.couchbase.com/server/7.0/learn/services-and-indexes/indexes/storage-modes.html#standard-index-storage) - in the box for enterprise edition, it is mentioned that "note that hole punching is required to enable auto-compaction of Global Secondary Indexes". This is incorrect. Plasma disk compaction is automatic and is enabled by default, irrespective of hole punching. Hole punching just allows plasma disk compaction to reclaim disk space at a finer granularity.