### PR TITLE
Doc 11652 prune audit logs

### DIFF
--- a/modules/introduction/partials/new-features-72.adoc
+++ b/modules/introduction/partials/new-features-72.adoc
@@ -66,8 +66,6 @@ See xref:cli:cli-intro.adoc#server-tools-packages[Server Tools Packages].
 * _Capella_ databases use Certificate Authorities (CAs), to establish secure connections: these CAs are now automatically trusted when you use Couchbase Web Console or the REST API to establish _fully secure_ XDCR connections between Capella databases and Couchbase Enterprise Server 7.2+.
 See xref:manage:manage-xdcr/secure-xdcr-replication.adoc#capella-trusted-cas[Capella Trusted CAs].
 
-== New in Version 7.2.4
-
 * You can now have Couchbase Server prune rotated audit logs after a period of time. 
 You set how long  Couchbase Server should keep audit logs by using the new `pruneAge` parameter for the `/settings/audit` endpoint. 
 The default value of 0 means that Couchbase Server does not prune audit logs. 

--- a/modules/introduction/partials/new-features-72.adoc
+++ b/modules/introduction/partials/new-features-72.adoc
@@ -65,3 +65,10 @@ See xref:cli:cli-intro.adoc#server-tools-packages[Server Tools Packages].
 
 * _Capella_ databases use Certificate Authorities (CAs), to establish secure connections: these CAs are now automatically trusted when you use Couchbase Web Console or the REST API to establish _fully secure_ XDCR connections between Capella databases and Couchbase Enterprise Server 7.2+.
 See xref:manage:manage-xdcr/secure-xdcr-replication.adoc#capella-trusted-cas[Capella Trusted CAs].
+
+== New in Version 7.2.4
+
+* You can now have Couchbase Server prune rotated audit logs after a period of time. 
+You set how long  Couchbase Server should keep audit logs by using the new `pruneAge` parameter for the `/settings/audit` endpoint. 
+The default value of 0 means that Couchbase Server does not prune audit logs. 
+See xref:rest-api:rest-auditing.adoc[Configure Auditing].

--- a/modules/learn/pages/security/auditing.adoc
+++ b/modules/learn/pages/security/auditing.adoc
@@ -69,7 +69,7 @@ For example, `"Unsuccessful attempt to login to couchbase cluster"`, `"Node was 
 |===
 
 [#saving-audit-records]
-== Saving Audit Records
+== Saving and Pruning Audit Records
 
 When auditing is enabled, logged events are written to a default file, named `audit.log`.
 After an administrator-specified period — which must be a minimum of 15 minutes and a maximum of 7 days — this file is closed, and is saved under a modified name that features a timestamp corresponding to the time of saving.
@@ -77,7 +77,10 @@ A new, empty `audit.log` file is created and saved when a new audit event is gen
 Note that this _rotation_ may happen earlier if the file reaches its maximum size of 20MB.
 For instructions on configuring the file's _rotation time_, see xref:manage:manage-security/manage-auditing.adoc[Manage Auditing].
 
-Note that audit log-files are not automatically deleted: their eventual deletion is the responsibility of the administrator.
+By default, Couchbase Server does not automatically delete rotated audit log files.
+Over time, these log files can consume disk space on your nodes. 
+You can choose to have Couchbase Server remove rotated audit logs after a period of time by using the xref:rest-api:rest-auditing.adoc[Configure Auditing] REST-API's `pruneAge` parameter. 
+You can also use an external tool or script to periodically remove audit files directly from the log directory. 
 
 == Sample Audit Records
 

--- a/modules/manage/pages/manage-security/manage-auditing.adoc
+++ b/modules/manage/pages/manage-security/manage-auditing.adoc
@@ -235,6 +235,7 @@ http://10.143.192.101:8091/settings/audit \
 -d rotateSize=524288000 \
 -d rotateInterval=7200 \
 -d logPath='/opt/couchbase/var/lib/couchbase/logs'
+-d pruneAge=10800
 ----
 
 Here, auditing for the node is enabled, by specifying a value of `true` for the `auditEnabled` parameter.
@@ -243,5 +244,6 @@ Likewise, a list of `disabledUsers` is specified.
 See xref:manage:manage-security/manage-auditing.adoc#ignoring-events-by-user[Ignoring Filterable Events By User], above, for information.
 Note, however, that when specified using the REST API, local and internal usernames take the `/local`, rather than the `/couchbase` suffix.
 The `rotateSize` is specified in bytes, and the `rotateInterval` in seconds.
+The `pruneAge` parameter tells Couchbase Server to automatically delete rotated audit logs after 10800 minutes (1 week). 
 
 See xref:rest-api:rest-auditing.adoc[Configure Auditing], for more detailed information; including use of the `GET /settings/audit` method and URI to retrieve the current audit configuration.

--- a/modules/rest-api/pages/rest-auditing.adoc
+++ b/modules/rest-api/pages/rest-auditing.adoc
@@ -36,6 +36,7 @@ curl -X GET -u Administrator:password http://<host>:<port>/settings/audit
 curl -X POST -u Administrator:password http://<host>:<port>/settings/audit
   -d auditdEnabled=[ true | false ]
   -d logPath=[ pathname ]
+  -d pruneAge=[ integer ]
   -d rotateInterval=[ integer ]
   -d rotateSize=[ integer ]
   -d disabled=[ *{ event-id }, ]
@@ -52,6 +53,11 @@ Other values can still be configured, even if `auditdEnabled` is set to `false`.
 When auditing is enabled, all _non-filterable_ events are audited; and none can be individually disabled.
 
 * The `logPath` parameter specifies the pathname of the directory to which the `audit.log` file is written.
+
+* The `pruneAge` parameter sets the number of minutes Couchbase Server keeps rotated audit logs. 
+When set to the minimum value 0 (the default), Couchbase Server does not prune rotated audit logs. 
+If set to a value greater than 0, Couchbase Server deletes rotated audit logs that are older than this value in minutes.  
+The maximum value for this setting is 35791394 (4085 years).
 
 * The `rotateInterval` parameter specifies the maximum time-period that is to elapse between log-rotations.
 Its value must be a number of seconds, in the range of 900 (15 minutes) to 604800 (7 days), inclusive.
@@ -113,6 +119,8 @@ The `GET /settings/audit` method and URI return an object that contains the foll
 Each member is an object of two elements, which are the _name_ of the disabled user and their _domain_.
 
 * _logPath_: The current value of the pathname to which the `audit.log` file is being written.
+
+* _pruneAge_: The number of minutes Couchbase Server keeps rotated audit logs. The value `0` means Couchbase Server does not automatically prune these logs.  
 
 * _rotateInterval_: An integer that is the number of seconds in the maximum time-period on whose elapse the log file is rotated.
 
@@ -204,6 +212,7 @@ If the call is successful, the output resembles the following:
     }
   ],
   "logPath": "/opt/couchbase/var/lib/couchbase/logs",
+  "pruneAge": 0,
   "rotateInterval": 7200,
   "rotateSize": 524288000
 }
@@ -226,11 +235,13 @@ http://10.143.192.101:8091/settings/audit \
 -d rotateSize=524288000 \
 -d rotateInterval=7200 \
 -d logPath='/opt/couchbase/var/lib/couchbase/logs'
+-d pruneAge=10080
 ----
 
 This call enables event auditing for the current node, by setting `auditdEnabled` to `true`.
 It specifies a list of filterable-event ids as `disabled`; and specifies one local user and two internal users as `disabledUser`, ensuring filterable events from these users will not be audited.
-It also specifies values for `rotateSize`, `rotateInterval`, and `logPath`.
+It also specifies values for `rotateSize`, `rotateInterval`, and `logPath`. 
+It sets the period of time that Couchbase Server keeps audit logs to 1 week (60 minutes &Cross; 24 hours &Cross; 7 days = 10080).
 
 == See Also
 


### PR DESCRIPTION
PR for pruneAge feature, which was pulled because it was merged too early. This PR will merge just before we publish 7.2.4.