### PR TITLE
Update intra-cluster-replication.adoc

### DIFF
--- a/modules/learn/pages/clusters-and-availability/intra-cluster-replication.adoc
+++ b/modules/learn/pages/clusters-and-availability/intra-cluster-replication.adoc
@@ -19,7 +19,7 @@ Each replica itself is also implemented as 1024 vBuckets.
 A vBucket that is part of the original implementation of the defined bucket referred to as an _active_ vBucket.
 Therefore, a bucket defined with two replicas has 1024 active vBuckets and 2048 replica vBuckets.
 Typically, only active vBuckets are accessed for read and write operations: although replica vBuckets _are_ able to support _read_ requests.
-Nevertheless, vBuckets receive a continuous stream of mutations from the active vBucket by means of the _Database Change Protocol_ (DCP), and are thereby kept constantly up to date.
+Nevertheless, replica vBuckets receive a continuous stream of mutations from the active vBucket by means of the _Database Change Protocol_ (DCP), and are thereby kept constantly up to date.
 To ensure maximum availability of data in case of node-failures, the _Master Services_ for the cluster calculate and implement the optimal xref:clusters-and-availability/cluster-manager.adoc#vbucket-distribution[vBucket Distribution] across available nodes: consequently, the chance of data-loss through the failure of an individual node is minimized, since replicas are available on the nodes that remain.
 This is shown by the following illustration:
 


### PR DESCRIPTION
The word "replica" is missing whilst explaining that it is the replica vBuckets which receive DCP updates from active vBuckets to keep them updated.