### PR TITLE
DOC-11214-7.2 Feedback on Supported Platforms | Couchbase Docs – Noted that 7.2 OS versions are no longer supported.

### DIFF
--- a/modules/install/pages/install-platforms.adoc
+++ b/modules/install/pages/install-platforms.adoc
@@ -27,6 +27,10 @@ ARM64 support requires ARMv8 CPUs, such as the Amazon Graviton series.
 | Amazon Linux 2023
 | AL2023 (x86-64, ARM64)
 
+| CentOS
+| 7.x (deprecated in Couchbase Server{nbsp}7.2)
+
+
 | Debian
 | 11.x
 
@@ -39,7 +43,9 @@ ARM64 support requires ARMv8 CPUs, such as the Amazon Graviton series.
 9.x
 
 | Red Hat Enterprise Linux (RHEL)
-| 8.x
+| 7.x (deprecated in Couchbase Server{nbsp}7.2)
+
+8.x
 
 9.x
 


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-11214