### PR TITLE
DOC-9599: Update release note for MB-43232

### DIFF
--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -84,7 +84,13 @@ Couchbase Server 6.5.2, released in February 2021, is the second maintenance rel
 | *Summary*: The index service now sets a more contextual user-agent in HTTP requests to the cluster manager(ns_server).
 
 | https://issues.couchbase.com/browse/MB-43232[MB-43232^]
-| *Summary*: Starting with version 6.5.0, VbSeqnosReader has been updated to process two types of requests: VbSeqnosRequest and VbMinSeqnosRequest. When processing VbSeqnosRequest, if there are any VbMinSeqnosRequest’s, then the VbMinSeqnosRequest’s will be queued back into the requestCh of VbSeqnosReader. However, if the VbSeqnosReader closed by this time, then enqueue would fail and the caller would be waiting for a response indefinitely. This has been fixed to respond to outstanding requests upon exit of VbSeqnosReader.
+a| *Summary*: Fixed a rare race condition in the Index Service that can be triggered when the network connection to the Data Service is terminated.
+This can cause the following problems:
+
+. The Index Service stops persisting snapshots for the index(es) affected.
+This means if the Index service was to restart, the recovery of indexes would be slow and in extreme cases it will have to rebuild the index completely.
+
+. The Index Service can end up in deadlock state which will causes Index rebalances to fail or stall and can slow down indexing.
 
 | https://issues.couchbase.com/browse/MB-43132[MB-43132^]
 | *Summary*: During index definition operations, the cluster info cache is updated multiple times. In a cluster with large number of buckets, refreshing the cluster info cache took a long time and slowed down these operations. This has been fixed.


### PR DESCRIPTION
Server 6.5 is unsupported, but this may be useful for users of older versions or anyone who wants to know when the ticket was fixed. As the text was already provided it seems like a quick win.