### PR TITLE
Fixing typo

### DIFF
--- a/modules/rest-api/pages/rest-list-node-services.adoc
+++ b/modules/rest-api/pages/rest-list-node-services.adoc
@@ -119,4 +119,4 @@ The output may include information on ports used by:
 [#see-also]
 == See Also
 
-A complete list of Couchbase Services and the ports they occupy, along with infomration on custom port mapping, is provided in xref:install:install-ports.adoc[Couchbase Server Ports].
+A complete list of Couchbase Services and the ports they occupy, along with information on custom port mapping, is provided in xref:install:install-ports.adoc[Couchbase Server Ports].


### PR DESCRIPTION
(cherry picked from commit 399ace1ce8365fabf7f78029d1438e61ff38b867)