### PR TITLE
DOC-11183 platform support matrix for 7.6

### DIFF
--- a/modules/install/pages/install-platforms.adoc
+++ b/modules/install/pages/install-platforms.adoc
@@ -9,7 +9,7 @@
 
 Make sure that your chosen operating system is listed below, before you install Couchbase Server.
 
-Note that Couchbase clusters on mixed platforms are not supported.
+NOTE: Couchbase clusters on mixed platforms are not supported.
 Nodes in a Couchbase cluster should all be running on the same OS, and every effort should be made to apply the same OS patches across the entire cluster.
 
 ARM64 support requires ARMv8 CPUs, such as the Amazon Graviton series.
@@ -20,7 +20,7 @@ ARM64 support requires ARMv8 CPUs, such as the Amazon Graviton series.
 | Operating System | Supported Versions (64-bit)
 
 | Amazon Linux 2
-| LTS (x86-64, ARM64)
+| LTS (x86-64, ARM64) (deprecated in Couchbase Server 7.6)
 
 | Amazon Linux 2023
 | AL2023 (x86-64, ARM64)
@@ -45,17 +45,17 @@ ARM64 support requires ARMv8 CPUs, such as the Amazon Graviton series.
 | SUSE Linux Enterprise Server (SLES)
 | 15.x
 
-NOTE: Versions earlier than SP2 are no longer supported in Couchbase Server 7.2 and later.
+NOTE: versions earlier than SP2 are no longer supported in Couchbase Server 7.2 and later.
 
 | Ubuntu
-| 20.04 LTS (x86, ARM64)
+| 20.04 LTS (x86, ARM64) (deprecated in Couchbase Server 7.6)
 
 22.x LTS (x86, ARM64)
 
 | Windows Server
 | 2022
 
-2019
+2019 (deprecated in Couchbase Server 7.6)
 
 |===
 
@@ -65,11 +65,11 @@ NOTE: Versions earlier than SP2 are no longer supported in Couchbase Server 7.2 
 | Operating System | Supported Versions (64-bit)
 
 | macOS
-| 14 "Sonoma" (x86-64 and Apple Silicon ARM64)
+| 14 "Sonoma"
 
 13 "Ventura"
 
-12 "Monterey" 
+12 "Monterey" (x86-64 and Apple Silicon ARM64) (deprecated in Couchbase Server 7.6)
  
 | Windows Desktop
 | 10 (requires Anniversary Update)

--- a/modules/install/pages/install-platforms.adoc
+++ b/modules/install/pages/install-platforms.adoc
@@ -117,32 +117,36 @@ Couchbase Web Console is supported on a variety of modern Web browsers.
 | Apple Safari
 | macOS
 | 11.1+
-| 7.2 +
+| 7.6 +
+7.2 +
 7.1 +
 7.0
 
 | Google Chrome
 | macOS, Windows
 | 67+
-| 7.2 +
+| 7.6 +
+7.2 +
 7.1 +
 7.0 +
 
 | Microsoft Edge
 | Windows
 | 80+
-| 7.2 +
+| 7.6 +
+7.2 +
 7.1 +
 7.0 +
 
 | Mozilla Firefox
 | macOS, Windows
 | 67+
-| 7.2 +
+| 7.6 +
+7.2 +
 7.1 +
 7.0 +
 |===
 
 == Capella Browser Support
 
-A list of the supported web browsers for Capella is provided xref:cloud:reference:browser-compatibility.adoc[here].
+See xref:cloud:reference:browser-compatibility.adoc[Supported Web Browsers] for a list of the web browsers that Capella supports.

--- a/modules/install/pages/install-platforms.adoc
+++ b/modules/install/pages/install-platforms.adoc
@@ -26,9 +26,9 @@ ARM64 support requires ARMv8 CPUs, such as the Amazon Graviton series.
 | AL2023 (x86-64, ARM64)
 
 | Debian
-| 11.x
+| 12.x
 
-10.x (deprecated in 7.2)
+11.x
 
 
 | Oracle Linux{empty}footnote:[Only the Red Hat Compatible Kernel (RHCK) is supported. The Unbreakable Enterprise Kernel (UEK) is not supported.]
@@ -45,7 +45,7 @@ ARM64 support requires ARMv8 CPUs, such as the Amazon Graviton series.
 | SUSE Linux Enterprise Server (SLES)
 | 15.x
 
-(Note that versions earlier than SP2 are no longer supported in Couchbase Server 7.2.)
+NOTE: Versions earlier than SP2 are no longer supported in Couchbase Server 7.2 and later.
 
 | Ubuntu
 | 20.04 LTS (x86, ARM64)
@@ -65,10 +65,12 @@ ARM64 support requires ARMv8 CPUs, such as the Amazon Graviton series.
 | Operating System | Supported Versions (64-bit)
 
 | macOS
-| 11 "Big Sur" (deprecated in 7.2)
+| 14 "Sonoma" (x86-64 and Apple Silicon ARM64)
 
-12 "Monterey" (x86-64 and Apple Silicon ARM64)
+13 "Ventura"
 
+12 "Monterey" 
+ 
 | Windows Desktop
 | 10 (requires Anniversary Update)
 |===

--- a/modules/introduction/partials/new-features-76.adoc
+++ b/modules/introduction/partials/new-features-76.adoc
@@ -1,3 +1,13 @@
+* Couchbase Server 7.6 adds support for the following platforms:
++
+--
+** Debian Linux 12 (Bookworm)
+** macOS 13 "Ventura"
+** macOS 14 "Sonoma"
+--
++
+See xref:install:install-platforms.adoc[] for a full list of supported platforms.
+
 * A required minimum can be established for the number of replicas configured for a bucket.
 See xref:rest-api:setting-minimum-replicas.adoc[Setting a Replica-Minimum].
 


### PR DESCRIPTION
This PR covers updating the Server supported platforms matrix for 7.6. See the [doc plan for these updates](https://docs.google.com/document/d/1mcQrE3UBNe6ykxJB1m3xRAcR7XTajmQHTyYMBrk88Ow/edit).

 Two pages were edited (links lead to the preview site):

- [What's New](https://preview.docs-test.couchbase.com/support-martix-7.6/server/7.6/introduction/whats-new.html) lists support for Debian 12 and macOS 13 & 14 as new features.
-  [Supported Platforms](https://preview.docs-test.couchbase.com/support-martix-7.6/server/7.6/install/install-platforms.html#cloud:reference:browser-compatibility.adoc) adds the new Debian and MacOS versions, removes obsolete Debian and MacOS versions, and added 7.6 to the supported browser list.
