### PR TITLE
Added missing What's New entries for SAML and storage migration.

### DIFF
--- a/modules/introduction/partials/new-features-76.adoc
+++ b/modules/introduction/partials/new-features-76.adoc
@@ -4,6 +4,12 @@ See xref:rest-api:setting-minimum-replicas.adoc[Setting a Replica-Minimum].
 * In each user-created or sample bucket, a `_system` scope is created and maintained by default. This scope contains collections used by Couchbase services, for service-specific data.
 See xref:learn:data/scopes-and-collections.adoc#system-scope-and-its-collections[_system Scope and its Collections].
 
+* You can now migrate buckets from one storage backend to another. 
+This feature supports migrating buckets from Couchstore to Magma and from Magma to Couchstore. 
+You can migrate buckets while the database continues running.
+To complete the migration you must trigger a swap rebalance or a graceful failover followed by a full recovery on each node that contains the bucket.
+See xref:manage:manage-buckets/migrate-bucket.adoc[].
+
 * Node-connectivity can be checked, prior to the creation of an XDCR reference.
 See xref:rest-api:rest-xdcr-connection-precheck.adoc[Checking Connections].
 
@@ -34,6 +40,11 @@ You can supply multiple regular expressions that Couchbase attempts to match aga
 This feature gives you greater flexibility when authenticating users. 
 For example, you can use a regular expression to map the domain name in an email address to an LDAP organization. 
 See xref:manage:manage-security/configure-ldap.adoc#ldap-advanced-mapping[Advanced Query] under xref:manage:manage-security/configure-ldap.adoc#enable-ldap-user-authentication[User Authentication Enablement].
+
+* The Couchbase Server Web Console now supports using _Structured Authentication Markup Language_ (SAML) for authentication. 
+When you enable SAML authentication, a btn:[Sign In Using SSO] button appears on the Web Console login screen. 
+This button lets users who have already authenticated with the SAML identity provider (Okta, for example) to skip having to enter credentials.  
+See xref:learn:security/authentication-domains.adoc#saml-authentication[SAML Authentication] for more information.
 
 * You can now have Couchbase Server prune rotated audit logs after a period of time. 
 You set how long  Couchbase Server should keep audit logs by using the new `pruneAge` parameter for the `/settings/audit` endpoint. 

--- a/modules/learn/pages/security/authentication-domains.adoc
+++ b/modules/learn/pages/security/authentication-domains.adoc
@@ -184,7 +184,7 @@ SAML authentication offers these features:
 
 * _Single Sign On_ (SSO) lets users avoid repeated username and password prompts for every service they sign in to. Instead, the user authenticates once with the IdP when first connecting to a service. This initial authentication starts a session for the user with the IdP. While the session is active, when the user connects to a service that uses the IdP, it authenticates them without prompting for a username and password. SSO also means users have fewer usernames and passwords to memorize.
 * Most IdPs implement _Two-Factor Authentication_ (2FA). 2FA increases security by requiring users to prove their identity with more than just a username and password. For example, 2FA can require users to enter a number sent to them via a mobile text message or from an authentication app on their mobile phone. 
-* SAML lets administrators centralize user authentication by defining users once in the IdP, instead of having to create an account for each service. They cab assign the users privileges for any service that uses the IdP for authentication. When an administrator removes a user's privileges, services automatically end the user's active sessions. 
+* SAML lets administrators centralize user authentication by defining users once in the IdP, instead of having to create an account for each service. They can assign the users privileges for any service that uses the IdP for authentication. When an administrator removes a user's privileges, services automatically end the user's active sessions. 
 
 === Mapping of Groups and Roles With SAML Authentication
 


### PR DESCRIPTION
I didn't add What's New entries for two of my 7.6 features because I was unaware the topic existed. This PR adds the missing entries.

Here's the preview for the updated [What's New ](https://preview.docs-test.couchbase.com/DOC-11694_add_missing_whats_new/server/7.6/introduction/whats-new.html) page.

Also added a bonus typo fix I found in the SAML documentation.