### PR TITLE
DOC-11646 user backup  of user and user groups with --enable-users

### DIFF
--- a/modules/backup-restore/pages/enterprise-backup-restore.adoc
+++ b/modules/backup-restore/pages/enterprise-backup-restore.adoc
@@ -44,9 +44,13 @@ When you use this flag, `cbbackupmgr` backs up just the following:
 * eventing functions
 * full-text Search indexes and aliases
 * GSI indexes
-* query UDFs 
+* Query SQL++ UDFs 
 * scopes and collections definitions (Couchbase Server version 7.6 and later)
 * views
+
+
+NOTE: `cbbackupmgr` does not back up query function libraries such as user-created JavaScript libraries.
+You must back up these libraries separately. 
 
 Another useful flag is `--enable-users` which backs up users and user groups. Users and groups are not backed up by default. This option is useful for preventing the loss of users and groups in case of disaster. 
 

--- a/modules/backup-restore/pages/enterprise-backup-restore.adoc
+++ b/modules/backup-restore/pages/enterprise-backup-restore.adoc
@@ -33,9 +33,6 @@ Each backup job in the [.term]_Backup Repository_ stores its backup in two ways:
 === What's Backed Up
 
 By default, backups include your database's data and metadata. 
-Since Couchbase Server version 7.6 and later, `cbbackupmgr` also backs up users and user groups. 
-
-NOTE: Backups that include users contain the user's hashed passwords. 
 
 You can change what the tool backs up and restores by using arguments to the `cbbackupmgr config` command. 
 For example, if you only want to back up your cluster's metadata, use the `--disable-data` command line flag when configuring your backup repository. 
@@ -49,24 +46,24 @@ When you use this flag, `cbbackupmgr` backs up just the following:
 * GSI indexes
 * query UDFs 
 * scopes and collections definitions (Couchbase Server version 7.6 and later)
-* users (Couchbase Server version 7.6 and later)
-* user groups (Couchbase Server version 7.6 and later)
 * views
+
+Another useful flag is `--enable-users` which backs up users and user groups. Users and groups are not backed up by default. This option is useful for preventing the loss of users and groups in case of disaster. 
+
+NOTE: Backups that include users contain the user's hashed passwords. 
 
 Other flags let you exclude specific metadata, or select a subset of data to back up.
 See xref:backup-restore:cbbackupmgr-config.adoc[cbbackupmgr config] for a list of the arguments you can use to control what `cbbackupmgr` backs up.
 
-You can also use command line flags to control what data the `cbbackupmgr restore` command restores.  
-For example, use `--disable-users` to prevent `cbbackupmgr` from restoring users and groups. 
-You can also use the `--overwrite-users` to have `cbbackupmgr` overwrite existing users and groups in the database if the backup contains a matching user or group. 
+You can also use command line flags to control how the `cbbackupmgr restore` command restores data.  
+For example, use `--overwrite-users` to have `cbbackupmgr` overwrite existing users and groups in the database if the backup contains a matching user or group. 
 By default, `cbbackupmgr` does not overwrite existing users in the database.
 Instead, it restores just the users in the backup that do not exist in database.
 See xref:backup-restore:cbbackupmgr-restore.adoc[cbbackupmgr restore] for a list of the arguments you can use to control what `cbbackupmgr` restores.
 
-
 === Tool Locations
 
-The `cbbackupmgr` tool is installed, with all other tools, in the following _per platform_ locations:
+When installed as part of the Couchbase Server install,  `cbbackupmgr` tool is stored with all other tools in the following _per platform_ locations:
 
 .Backup Tool Locations
 [cols="1,5"]
@@ -114,6 +111,7 @@ Unless otherwise specified, backup and restore apply both to _local_ and to _clo
 [cols="5,3,3,3,3,3,3,3,3"]
 |===
 | *cbbackupmgr version*
+| *7.6*
 | *7.2*
 | *7.1*
 | *7.0*
@@ -121,57 +119,70 @@ Unless otherwise specified, backup and restore apply both to _local_ and to _clo
 | *6.5.x*
 | *6.0.x*
 | *5.5.x*
-| *5.0.x*
 
-| 7.2
+| 7.6
+| ✓
 | ✓
 | ✓
 | ✓
 | ✓
 |
+|
+|
+
+| 7.2
+| 
+| ✓
+| ✓
+| ✓
+| ✓
 |
 |
 |
 
 | 7.1
 |
+| 
 | ✓
 | ✓
 | ✓
 | ✓*
 |
 |
-|
+
 
 | 7.0
 |
 |
+|
 | ✓
 | ✓
 | ✓*
 | ✓*
 |
-|
+
 
 | 6.6.0 and above
 |
 |
 |
+|
 | ✓
 | ✓*
 | ✓*
 | ✓*
-|
+
 
 | 6.5
 |
 |
 |
 |
-| ✓
-| ✓
-| ✓
 |
+| ✓
+| ✓
+| ✓
+
 
 | 6.0.x
 |
@@ -179,9 +190,10 @@ Unless otherwise specified, backup and restore apply both to _local_ and to _clo
 |
 |
 |
+|
 | ✓
 |
-|
+
 
 | 5.5.x
 |
@@ -190,18 +202,9 @@ Unless otherwise specified, backup and restore apply both to _local_ and to _clo
 |
 |
 |
-| ✓
 |
+| ✓
 
-| 5.0.x
-|
-|
-|
-|
-|
-|
-|
-| ✓
 
 |===
 

--- a/modules/introduction/partials/new-features-76.adoc
+++ b/modules/introduction/partials/new-features-76.adoc
@@ -27,7 +27,11 @@ See xref:rest-api:rest-setting-security.adoc[Configure On-the-Wire Security].
 * Credentials for Couchbase-Server internal users can now be rotated at any time, by means of the REST API.
 See xref:rest-api:rest-rotate-internal-credentials.adoc[Rotate Internal Credentials].
 
-* By default, `cbbackupmgr` now backs up and restores user groups and users, including roles and permissions. User passwords are saved in the backup in a hashed format. When restoring a backup, `cbbackupmgr` defaults to not overwriting existing users in the database with identically named users in the backup. You can change these default `cbbackupmgr` behaviors using the new `--disable-users` and `--overwrite-users` command-line arguments. See  xref:backup-restore:cbbackupmgr-config.adoc[cbbackupmgr config] and xref:backup-restore:cbbackupmgr-restore.adoc[cbbackupmgr restore] for more about these new arguments.
+* The `cbbackupmgr` command has a new `--enable-users` flag that backs up user groups and users including roles and permissions. 
+When you supply the new argument, `cbbackupmgr` saves user passwords in the backup in a hashed format. 
+When restoring a backup, `cbbackupmgr` defaults to not overwriting existing users in the database with identically named users in the backup. 
+You can change this default behavior using the new `--overwrite-users` command-line argument. 
+See  xref:backup-restore:cbbackupmgr-config.adoc[cbbackupmgr config] and xref:backup-restore:cbbackupmgr-restore.adoc[cbbackupmgr restore] for more about user backup.
 
 * The Role-Based Access Control (RBAC) REST API has a new `backup` endpoint that lets you backup and restore user and user groups. See xref:rest-api:rbac.adoc#backup-and-restore-users-and-groups[Backup and Restore Users and Groups]. 
 
@@ -41,7 +45,7 @@ This feature gives you greater flexibility when authenticating users.
 For example, you can use a regular expression to map the domain name in an email address to an LDAP organization. 
 See xref:manage:manage-security/configure-ldap.adoc#ldap-advanced-mapping[Advanced Query] under xref:manage:manage-security/configure-ldap.adoc#enable-ldap-user-authentication[User Authentication Enablement].
 
-* The Couchbase Server Web Console now supports using _Structured Authentication Markup Language_ (SAML) for authentication. 
+* The Couchbase Server Web Console now supports using Structured Authentication Markup Language (SAML) for authentication. 
 When you enable SAML authentication, a btn:[Sign In Using SSO] button appears on the Web Console login screen. 
 This button lets users who have already authenticated with the SAML identity provider (Okta, for example) to skip having to enter credentials.  
 See xref:learn:security/authentication-domains.adoc#saml-authentication[SAML Authentication] for more information.


### PR DESCRIPTION
Edits to cover making user backups non-default and requiring the --enable-users flag.

Also additional edits requested by Hyun-Ju.

Affected pages (with links to the docs preview site):

- [What's New](https://preview.docs-test.couchbase.com/enable-users-flag/server/7.6/introduction/whats-new.html)
- [cbbackupmgr](https://preview.docs-test.couchbase.com/enable-users-flag/server/7.6/backup-restore/enterprise-backup-restore.html)
