### PR TITLE
DOC-11391 max ttl changes in server 7.6

### DIFF
--- a/modules/introduction/partials/new-features-76.adoc
+++ b/modules/introduction/partials/new-features-76.adoc
@@ -68,7 +68,7 @@ See xref:manage:monitor/set-up-prometheus-for-monitoring.adoc[Configure Promethe
 ** In earlier versions, you could only set a collection's `maxTTL` setting when creating the collection. 
 You can now change the `maxTTL` setting on a collection after creation.
 ** You can now set a collection's `maxTTL` to -1 to prevent a bucket's non-zero `maxTTL` setting from causing documents in the collection to expire automatically. 
-This new setting is useful if you want most of the documents in a bucket to automatically expire, but want to prevent the documents in one or more buckets from expiring.
+This new setting is useful if you want most of the documents in a bucket to automatically expire, but want to prevent the documents in one or more collections from expiring by default.
 --
 +
 See xref:learn:data/expiration.adoc[] for more information.

--- a/modules/introduction/partials/new-features-76.adoc
+++ b/modules/introduction/partials/new-features-76.adoc
@@ -61,3 +61,15 @@ The new endpoint is able to produce the same output as the old endpoint and has 
 See xref:manage:monitor/set-up-prometheus-for-monitoring.adoc[Configure Prometheus to Collect Couchbase Metrics].
 
 * Disk usage statistics now  include transient files in progress, state files, and configuration files.
+
+* Two changes in Couchbase Server 7.6 affect the `maxTTL` setting for collections:
++
+--
+** In earlier versions, you could only set a collection's `maxTTL` setting when creating the collection. 
+You can now change the `maxTTL` setting on a collection after creation.
+** You can now set a collection's `maxTTL` to -1 to prevent a bucket's non-zero `maxTTL` setting from causing documents in the collection to expire automatically. 
+This new setting is useful if you want most of the documents in a bucket to automatically expire, but want to prevent the documents in one or more buckets from expiring.
+--
++
+See xref:learn:data/expiration.adoc[] for more information.
+

--- a/modules/learn/pages/data/expiration.adoc
+++ b/modules/learn/pages/data/expiration.adoc
@@ -1,6 +1,6 @@
 = Expiration
 :page-edition: Enterprise Edition
-:description: pass:q[The expiration setting for a document determines if and when it expires. When a document expires, Couchbase Server removes it. You can set a _maximum time to live_ (maxTTL) value on buckets and collections that imposes a default expiration on their documents. It also imposes an upper limit on explicitly-set expiration times.]
+:description: pass:q[The expiration setting for a document determines if and when it expires. When a document expires, Couchbase Server removes it. You can set a maximum time to live (maxTTL) value on buckets and collections that imposes a default expiration on their documents. It also imposes an upper limit on explicitly-set expiration times.]
 
 :page-aliases: understanding-couchbase:buckets-memory-and-storage/expiration, learn:buckets-memory-and-storage/expiration
 
@@ -15,7 +15,7 @@ For example, you often want documents that contain user session data to expire s
 Or you may use documents to store cached data. 
 You can have these documents automatically expire so your application knows to refresh the data from its source. 
 
-Couchbase Server Enterprise Edition lets you have documents expire after a period of time, called the document's _Time To Live_ (TTL). 
+Couchbase Server Enterprise Edition lets you have documents expire after a period of time, called the document's Time To Live (TTL). 
 This feature only works in Couchbase and Ephemeral buckets. 
 It does not work in Memcached buckets.
 
@@ -28,16 +28,13 @@ on the documents they contain.
 The `maxTTL` parameter on collections and buckets sets the number of seconds a new or mutated document lasts before expiring. 
 By default, `maxTTL` is 0 for both buckets and collections, meaning that their documents do not automatically expire.
 The `maxTTL` setting also imposes an upper limit on the expiration time you can explicitly set on an individual document in the bucket or collection. 
-If you try to set a document's expiration to a period longer than the non-zero `maxTTL` setting, Couchbase Server sets the expiration to `maxTTL`.  
-
-You can change the `maxTTL` of a bucket at any time. You can only set the `maxTTL` of a collection when you create it. You cannot change it after creation. 
+If you try to set a document's expiration to a period longer than the non-zero `maxTTL` setting, Couchbase Server sets the expiration to the `maxTTL` value.  
 
 Scopes do not support the `maxTTL` setting. 
 
-By Default, when you set `maxTTL` on a collection or bucket, it's applied every time you create or mutate a document.
+By default, when you set `maxTTL` on a collection or bucket, it's applied every time you create or mutate a document.
 This behavior means that Couchbase Server extends the document's life every time you mutate it.
-For use cases such as maintaining user sessions, this works well. 
-In this case, you want the document to exist for some period of time after the last change to it.
+This works well for use cases such as maintaining user sessions where you want the document to exist for some time after its last change.
 
 You can have Couchbase Server preserve the original expiration of the document when you mutate it.
 See xref:manage:manage-expiration.adoc#mutation-expiration[Mutation's Effect on Expiration] for an explanation.
@@ -52,7 +49,9 @@ The three exceptions to this rule are:
 * As mentioned earlier, you cannot set a document's expiration to be longer than a non-zero `maxTTL` setting of the document's collection or bucket.
 If you try to set the document's expiration to be longer than its collection or bucket's `maxTTL` setting, Couchbase Server uses the `maxTTL` setting instead. 
 
-* Setting a collection's `maxTTL` to zero does not override the bucket's `maxTTL` setting. Instead, setting the collection's `maxTTL` to zero has it inherit the `maxTTL` setting from the bucket. 
+* Setting a collection's `maxTTL` to zero does not override the bucket's `maxTTL` setting. 
+Instead, setting the collection's `maxTTL` to zero has it inherit the `maxTTL` setting from the bucket. 
+You can set the collection's `maxTTL` setting to `-1` to prevent the bucket's `maxTTL` from setting a default expiration on the collection's documents.
 
 * Setting a document's expiration to 0 does not prevent it from expiring if its collection or bucket has a `maxTTL` setting that's greater than zero. 
 This behavior means you cannot prevent a document from expiring if its collection or bucket has a `maxTTL` setting that's greater than zero. 
@@ -78,6 +77,11 @@ The following table summarizes the interaction between a document's expiration s
 | `maxTTL` = any value
 | Document expires in `y` seconds.
 
+| Unset or 0
+| `maxTTL = -1`  
+| `maxTTL = z`  (where `z` > 0) 
+| Document does not expire because the collection's -1 setting overrides the bucket's non-zero setting.
+
 | `expiration = x` (where `x` > 0)
 | `maxTTL` = unset, 0, or any value > `x`
 | `maxTTL` = unset, 0, or any value > `x`
@@ -97,13 +101,12 @@ The following table summarizes the interaction between a document's expiration s
 
 == When maxTTL Changes Take Effect
 
-When you change the `maxTTL` setting of a bucket, the change does not have an immediate effect on the documents it contains. 
-The `maxTTL` setting of a bucket only has an effect when you create or mutate a document they contain. 
+When you change the `maxTTL` setting of a bucket or collection, the change does not have an immediate effect on the documents it contains. 
+The `maxTTL` setting on a bucket or collection only has an effect when you create or mutate a document. 
 Any existing expiration set on a document does not change, even if their duration is longer than the `maxTTL` setting.
-Also, documents that are not set to expire do not automatically start expiring after you have set a non-zero `maxTTL` setting on their bucket.
+Also, documents that are not set to expire do not automatically start expiring after you set a non-zero `maxTTL` setting.
 To have the existing documents start expiring, you must mutate them.
 
-Because you can only set the `maxTTL` when creating a collection, it affects all of the documents you add to the collection after creation. The collection cannot contain documents when you initially create it.
 
 [#post-expiration-purging]
 == Post-Expiration Purging
@@ -116,12 +119,12 @@ When the current time is later than the expiration timestamp, Couchbase Server d
 * A query attempts to access it.
 * The xref:learn:buckets-memory-and-storage/memory.adoc#expiry-pager[expiry pager] process runs.
 * The xref:manage:manage-settings/configure-compact-settings.adoc[auto-compaction] process runs.
-For information on performing compaction with the Couchbase CLI, see xref:cli:cbcli/couchbase-cli-bucket-compact.adoc[bucket-compact]; with Couchbase REST APIs, see xref:rest-api:compaction-rest-api.adoc[Compaction API]; with the Couchbase Web Console (as _auto-compaction_), see
+For information about performing compaction with the Couchbase CLI, see xref:cli:cbcli/couchbase-cli-bucket-compact.adoc[bucket-compact]; with Couchbase REST APIs, see xref:rest-api:compaction-rest-api.adoc[Compaction API]; with the Couchbase Server Web Console (as auto-compaction), see
 xref:manage:manage-settings/configure-compact-settings.adoc[Auto-Compaction].
 
-As described in xref:buckets-memory-and-storage/storage.adoc[Storage], Couchbase Server maintains a _tombstone_ for a period of time afterwards for each collection or item that it deletes. 
+As described in xref:buckets-memory-and-storage/storage.adoc[Storage], Couchbase Server maintains a tombstone for a period of time afterwards for each collection or item that it deletes. 
 The tombstone acts as a marker to indicate the item no longer exists. 
-To make sure that no trace of deleted items remain, Couchbase Server removes tombstones during a _Metadata Purge_.
+To make sure that no trace of deleted items remain, Couchbase Server removes tombstones during a Metadata Purge.
 This purge is an automatic, non-disruptive background-process. 
 You can change the schedule of metadata purges using Couchbase Server Web Console.
 See xref:manage:manage-settings/configure-compact-settings.adoc[Auto-Compaction].
@@ -147,7 +150,7 @@ See xref:install:synchronize-clocks-using-ntp.adoc[Clock Sync with NTP].
 [#auditing]
 == Auditing Expiration
 
-When you enable _auditing_, Couchbase Server logs changes to each bucket's `maxTTL` setting.
+When you enable auditing, Couchbase Server logs changes to each bucket's `maxTTL` setting.
 See xref:learn:security/auditing.adoc[Auditing] for more information.
 
 

--- a/modules/manage/pages/manage-expiration.adoc
+++ b/modules/manage/pages/manage-expiration.adoc
@@ -179,7 +179,7 @@ To change a bucket's `maxTTL` setting when creating or editing it:
 . When editing or adding a bucket, expand the *Advanced bucket settings* section.
 . Under *Bucket Max Time-To-Live* select *Enable*.
 . Under *Bucket Max Time-To-Live*, select or clear the *Enable* box to enable or turn off automatic expiration.
-, If you're enabling automatic expiration, enter the number of seconds the documents should exist before expiring in the text field.
+. If you're enabling automatic expiration, enter the number of seconds the documents should exist before expiring in the text field.
 
 To enable expiration when creating a collection using the Web Console, enter a non-zero value in the *Add Collection to _scope name_ Scope* dialog's *Collection Max Time-To-Live* field.
 
@@ -202,7 +202,7 @@ curl -s -X GET -u Administrator:password \
   "maxTTL": 0
 }
 
-curl -X POST -u Administrator:password \
+curl -X PATCH -u Administrator:password \
       http://localhost:8091/pools/default/buckets/user_sessions \
       -d maxTTL=7200
 

--- a/modules/manage/pages/manage-expiration.adoc
+++ b/modules/manage/pages/manage-expiration.adoc
@@ -99,7 +99,6 @@ If you then query the document's expiration metadata, you'll find that it's now 
 ]
 ----
 
-
 You can prevent Couchbase Server from clearing the expiration value by using the xref:settings:query-settings.adoc#preserve_expiry[`preserve_expiry`] request-level parameter. 
 
 You can directly preserve a document's expiration when mutating it. 
@@ -171,31 +170,21 @@ Setting `maxTTL` to a non-zero value has two effects:
 * You cannot explicitly set a document's expiration to be longer than the `maxTTL` setting. 
 If you try to set the expiration to a value larger than the collection or bucket's `maxTTL` setting, Couchbase Server uses the `maxTTL` value instead.
 
-You can set the `maxTTL` setting for buckets and collections when you initially create them. You can change the `maxTTL` setting of a bucket after you create it.
-
 === Set maxTTL Using Couchbase Server Web Console
 
 When you create a new bucket or collection using the Web Console, you can enable the `maxTTL` setting.
 
-To enable automatically expiring documents when creating a bucket using the Web Console:
+To change a bucekt's `maxTTL` setting when creating or editing it:
 
-. In the *Add Data Bucket* dialog, expand the *Advanced bucket settings* section.
+. When edting or adding a bucket, expand the *Advanced bucket settings* section.
 . Under *Bucket Max Time-To-Live* select *Enable*.
-. In the text field, enter the default TTL for documents in seconds.
+. Under *Bucket Max Time-To-Live*, select or clear the *Enable* box to enable or turn off automatic expiration.
+, If you're enabling automatic expiration, enter the number of seconds the documents should exist before expiring in the text field.
 
 To enable expiration when creating a collection using the Web Console, enter a non-zero value in the *Add Collection to _scope name_ Scope* dialog's *Collection Max Time-To-Live* field.
 
-You can also use the Web Console to change the `maxTTL` setting of an existing bucket:
+Once created, you can edit the `maxTTL` setting by clicking *Edit TTL* in the list of collections on the *Scopes & Collections* page.
 
-. Click btn:[Buckets].
-. Click the name of the bucket whose `maxTTL` setting you want to change.
-. Click btn:[Edit].
-. Expand the *Advanced bucket settings* section.
-. Under *Bucket Max Time-To-Live*, select or clear the *Enable* box to enable or turn off automatic expiration.
-, If you're enabling automatic expiration, enter the number of seconds the documents should exist before expiring in the text field.
-. Click btn:[Save Changes].
-
-You cannot change the `maxTTL` of a collection after you create it.
  
 === Set maxTTL Using the REST API
 
@@ -227,7 +216,6 @@ curl -s -X GET -u Administrator:password \
 
 See xref:rest-api:rest-bucket-create.adoc[] for more about editing buckets.
 
-You can only set the `maxTTL` of a collection when creating it. 
 The following example creates a collection named `test_site` in the `store` scope of the `user_sessions` bucket and sets its `maxTTL` to 1 hour:
 
 [source, shell]

--- a/modules/manage/pages/manage-expiration.adoc
+++ b/modules/manage/pages/manage-expiration.adoc
@@ -242,7 +242,7 @@ curl -s -X GET -u Administrator:password \
 []
 ---- 
  
-See xref:rest-api/creating-a-collection.adoc[] for more information about creating collections via the REST-API.
+See xref:rest-api:creating-a-collection.adoc[] for more information about creating collections via the REST-API.
 
 
 === Set maxTTL Using the Command Line Tools and SDKs

--- a/modules/manage/pages/manage-expiration.adoc
+++ b/modules/manage/pages/manage-expiration.adoc
@@ -174,9 +174,9 @@ If you try to set the expiration to a value larger than the collection or bucket
 
 When you create a new bucket or collection using the Web Console, you can enable the `maxTTL` setting.
 
-To change a bucekt's `maxTTL` setting when creating or editing it:
+To change a bucket's `maxTTL` setting when creating or editing it:
 
-. When edting or adding a bucket, expand the *Advanced bucket settings* section.
+. When editing or adding a bucket, expand the *Advanced bucket settings* section.
 . Under *Bucket Max Time-To-Live* select *Enable*.
 . Under *Bucket Max Time-To-Live*, select or clear the *Enable* box to enable or turn off automatic expiration.
 , If you're enabling automatic expiration, enter the number of seconds the documents should exist before expiring in the text field.

--- a/modules/rest-api/pages/creating-a-collection.adoc
+++ b/modules/rest-api/pages/creating-a-collection.adoc
@@ -7,8 +7,8 @@
 
 == Description
 
-Collections are _created_ by means of the `POST /pools/default/buckets/_<bucket_name>_/scopes/_<scope_name>_/collections` HTTP method and URI.
-Collections are _edited_ by means of the `PATCH /pools/default/buckets/_<bucket_name>_/scopes/_<scope_name>_/collections/_<collection_name>_` HTTP method and URI.
+Collections are created by means of the `POST /pools/default/buckets/_<bucket_name>_/scopes/_<scope_name>_/collections` HTTP method and URI.
+Collections are edited by means of the `PATCH /pools/default/buckets/_<bucket_name>_/scopes/_<scope_name>_/collections/_<collection_name>_` HTTP method and URI.
 
 == HTTP Methods and URIs
 
@@ -40,18 +40,20 @@ curl -X PATCH -u [admin]:[password]
 The `<bucket-name>` path-parameter specifies the name of the bucket within which the new collection is to reside.
 The `<scope-name>` path-parameter provides the name of the scope within which the new collection is to reside.
 The `name` parameter specifies the name of the collection to be created: this name cannot subsequently be changed.
-The optional `maxTTL` parameter is a period of time in seconds or -1. It defaults to 0. When you set `maxTTL` to value greater than zero (but less than its maximum value of 2147483647), it has the following effects:  
+The optional `maxTTL` parameter is a period of time in seconds or -1. It defaults to 0. 
+
+When you set `maxTTL` to 0, the collection inherits the `maxTTL` setting of the bucket.
+If the bucket has a `maxTTL` setting greater than 0, documents created or mutated in the collection default to exiring after `maxTTL` seconds.
+
+When you set `maxTTL` to value greater than zero (but less than its maximum value of 2147483647), it has the following effects:  
 +
 --
 * It sets a default expiration time for documents you create or mutate in the collection. 
 * It sets the maximum time in seconds a document can exist before it expires. You can explicitly set a document to expire before this time. Attempting to set a document to expire after this time has Couchbase Server set the document to expire in `maxTTL` seconds.
 --
 +
-When you set `maxTTL` to 0, the collection inherits the `maxTTL` setting of the bucket.
-If the bucket has a `maxTTL` setting greater than 0, documents created or mutated in the collection default to exiring after `maxTTL` seconds. 
-
 When you set `maxTTL` to -1, it overrides the bucket's `maxTTL` setting. 
-Couchbase Server will not apply a default expiration value to new and mutated documents in the collection. 
+Couchbase Server does not apply a default expiration value to new and mutated documents in the collection. 
 
 For more information, see xref:learn:data/expiration.adoc[Expiration].
 

--- a/modules/rest-api/pages/creating-a-collection.adoc
+++ b/modules/rest-api/pages/creating-a-collection.adoc
@@ -46,12 +46,10 @@ When you set `maxTTL` to 0, the collection inherits the `maxTTL` setting of the 
 If the bucket has a `maxTTL` setting greater than 0, documents created or mutated in the collection default to exiring after `maxTTL` seconds.
 
 When you set `maxTTL` to value greater than zero (but less than its maximum value of 2147483647), it has the following effects:  
-+
---
+
 * It sets a default expiration time for documents you create or mutate in the collection. 
 * It sets the maximum time in seconds a document can exist before it expires. You can explicitly set a document to expire before this time. Attempting to set a document to expire after this time has Couchbase Server set the document to expire in `maxTTL` seconds.
---
-+
+
 When you set `maxTTL` to -1, it overrides the bucket's `maxTTL` setting. 
 Couchbase Server does not apply a default expiration value to new and mutated documents in the collection. 
 

--- a/modules/rest-api/pages/creating-a-collection.adoc
+++ b/modules/rest-api/pages/creating-a-collection.adoc
@@ -50,7 +50,7 @@ When you set `maxTTL` to value greater than zero (but less than its maximum valu
 * It sets a default expiration time for documents you create or mutate in the collection. 
 * It sets the maximum time in seconds a document can exist before it expires. You can explicitly set a document to expire before this time. Attempting to set a document to expire after this time has Couchbase Server set the document to expire in `maxTTL` seconds.
 
-When you set `maxTTL` to -1, it overrides the bucket's `maxTTL` setting. By default, when the bucket has a `maxTTL` setting greater than zero, Couchbase Server sets new and mutated documents in the bucket to expire in `maxTTL` seconds. Setting the collection's `maxTTL` to -1 blocks this default behavior for documents in the collection. Couchbase Server does not apply a default expiration to the documents in the collection.
+When you set `maxTTL` to -1, it overrides the bucket's `maxTTL` setting. By default, when the bucket has a `maxTTL` setting greater than zero, Couchbase Server sets new and mutated documents in the bucket to expire in `maxTTL` seconds. Setting the collection's `maxTTL` to -1 blocks this default behavior for documents in the collection. In this case, Couchbase Server does not apply a default expiration to the documents in the collection.
 
 For more information, see xref:learn:data/expiration.adoc[Expiration].
 

--- a/modules/rest-api/pages/creating-a-collection.adoc
+++ b/modules/rest-api/pages/creating-a-collection.adoc
@@ -37,42 +37,55 @@ curl -X PATCH -u [admin]:[password]
   -d history=[ true | false ]
 ----
 
-The `<bucket-name>` path-parameter specifies the name of the bucket within which the new collection is to reside.
-The `<scope-name>` path-parameter provides the name of the scope within which the new collection is to reside.
-The `name` parameter specifies the name of the collection to be created: this name cannot subsequently be changed.
-The optional `maxTTL` parameter is a period of time in seconds or -1. It defaults to 0. 
+== Parameters
 
+bucket-name::
+Specifies the name of the bucket within which the new collection is to reside.
+
+scope-name::
+Provides the name of the scope within which the new collection is to reside.
+
+name::
+Specifies the name of the collection to be created: this name cannot subsequently be changed.
+
+maxTTL:: 
+Optional parameter is a period of time in seconds or -1. 
+It defaults to 0. 
++
 When you set `maxTTL` to 0, the collection inherits the `maxTTL` setting of the bucket.
 If the bucket has a `maxTTL` setting greater than 0, documents created or mutated in the collection default to exiring after `maxTTL` seconds.
-
++
 When you set `maxTTL` to value greater than zero (but less than its maximum value of 2147483647), it has the following effects:  
-
++
+--
 * It sets a default expiration time for documents you create or mutate in the collection. 
 * It sets the maximum time in seconds a document can exist before it expires. You can explicitly set a document to expire before this time. Attempting to set a document to expire after this time has Couchbase Server set the document to expire in `maxTTL` seconds.
-
-When you set `maxTTL` to -1, it overrides the bucket's `maxTTL` setting. By default, when the bucket has a `maxTTL` setting greater than zero, Couchbase Server sets new and mutated documents in the bucket to expire in `maxTTL` seconds. Setting the collection's `maxTTL` to -1 blocks this default behavior for documents in the collection. In this case, Couchbase Server does not apply a default expiration to the documents in the collection.
-
+--
++
+When you set `maxTTL` to -1, it overrides the bucket's `maxTTL` setting. By default, when the bucket has a `maxTTL` setting greater than zero, Couchbase Server sets new and mutated documents in the bucket to expire in `maxTTL` seconds. Setting the collection's `maxTTL` to -1 blocks this behavior so that Couchbase Server does not set a default expiration for documents in the collection. 
++
 For more information, see xref:learn:data/expiration.adoc[Expiration].
 
+history::
 If the value of the optional `history` parameter is:
-
++
+--
 * Not explicitly set by the administrator, the parameter inherits the value of the `historyRetentionCollectionDefault` parameter, used in the creating and editing of buckets.
-
 * Explicitly set by the administrator to `true` or `false`, it potentially overrides, for the current collection, the bucket-wide default established by `historyRetentionCollectionDefault`.
-
+--
++
 If the value of `history` is `true`, change history is recorded for the collection.
 If the value is `false`, change history is _not_ recorded.
-
++
 This parameter is ignored unless the following settings have been made _at bucket level_:
-
++
 * The value of `storageBackend` is `magma`.
-
 * A positive value is established for `historyRetentionSeconds` or `historyRetentionBytes`, or both.
 
-See xref:rest-api:rest-bucket-create.adoc[Creating and Editing Buckets], for information on bucket parameters.
+See xref:rest-api:rest-bucket-create.adoc[Creating and Editing Buckets], for information about bucket parameters.
 For an overview of change history, see xref:learn:data/change-history.adoc[Change History].
 
-Note that `history` is the only parameter that can be edited (by means of the `PATCH` method), subsequent to the collection's creation.
+NOTE: `history` and `maxTTL` are the only parameters that you can edit after you create the collection.
 
 == Responses
 

--- a/modules/rest-api/pages/creating-a-collection.adoc
+++ b/modules/rest-api/pages/creating-a-collection.adoc
@@ -40,10 +40,18 @@ curl -X PATCH -u [admin]:[password]
 The `<bucket-name>` path-parameter specifies the name of the bucket within which the new collection is to reside.
 The `<scope-name>` path-parameter provides the name of the scope within which the new collection is to reside.
 The `name` parameter specifies the name of the collection to be created: this name cannot subsequently be changed.
-The optional `maxTTL` parameter is a period of time in seconds. It defaults to 0. When you set `maxTTL` to value greater than zero (but less than its maximum value of 2147483647), it has the following effects:  
-
+The optional `maxTTL` parameter is a period of time in seconds or -1. It defaults to 0. When you set `maxTTL` to value greater than zero (but less than its maximum value of 2147483647), it has the following effects:  
++
+--
 * It sets a default expiration time for documents you create or mutate in the collection. 
 * It sets the maximum time in seconds a document can exist before it expires. You can explicitly set a document to expire before this time. Attempting to set a document to expire after this time has Couchbase Server set the document to expire in `maxTTL` seconds.
+--
++
+When you set `maxTTL` to 0, the collection inherits the `maxTTL` setting of the bucket.
+If the bucket has a `maxTTL` setting greater than 0, documents created or mutated in the collection default to exiring after `maxTTL` seconds. 
+
+When you set `maxTTL` to -1, it overrides the bucket's `maxTTL` setting. 
+Couchbase Server will not apply a default expiration value to new and mutated documents in the collection. 
 
 For more information, see xref:learn:data/expiration.adoc[Expiration].
 

--- a/modules/rest-api/pages/creating-a-collection.adoc
+++ b/modules/rest-api/pages/creating-a-collection.adoc
@@ -1,5 +1,5 @@
 = Creating and Editing a Collection
-:description: pass:q[Collections can be _created_ by means of the REST API.]
+:description: pass:q[Collections can be created by means of the REST API.]
 :page-topic-type: reference
 
 [abstract]
@@ -7,7 +7,7 @@
 
 == Description
 
-Collections are created by means of the `POST /pools/default/buckets/_<bucket_name>_/scopes/_<scope_name>_/collections` HTTP method and URI.
+Collections are created by means of the `POST /pools/default/buckets/<bucket_name>_/scopes/_<scope_name>_/collections` HTTP method and URI.
 Collections are edited by means of the `PATCH /pools/default/buckets/_<bucket_name>_/scopes/_<scope_name>_/collections/_<collection_name>_` HTTP method and URI.
 
 == HTTP Methods and URIs
@@ -35,6 +35,7 @@ curl -X PATCH -u [admin]:[password]
   http://<hostname-or-ip>:8091/pools/default/buckets/\
     <bucket_name>/scopes/<scope_name>/collections/<collection_name>
   -d history=[ true | false ]
+  -d maxTTL=[integer]
 ----
 
 == Parameters
@@ -53,7 +54,7 @@ Optional parameter is a period of time in seconds or -1.
 It defaults to 0. 
 +
 When you set `maxTTL` to 0, the collection inherits the `maxTTL` setting of the bucket.
-If the bucket has a `maxTTL` setting greater than 0, documents created or mutated in the collection default to exiring after `maxTTL` seconds.
+If the bucket has a `maxTTL` setting greater than 0, documents created or mutated in the collection default to expiring after `maxTTL` seconds.
 +
 When you set `maxTTL` to value greater than zero (but less than its maximum value of 2147483647), it has the following effects:  
 +

--- a/modules/rest-api/pages/creating-a-collection.adoc
+++ b/modules/rest-api/pages/creating-a-collection.adoc
@@ -50,8 +50,7 @@ When you set `maxTTL` to value greater than zero (but less than its maximum valu
 * It sets a default expiration time for documents you create or mutate in the collection. 
 * It sets the maximum time in seconds a document can exist before it expires. You can explicitly set a document to expire before this time. Attempting to set a document to expire after this time has Couchbase Server set the document to expire in `maxTTL` seconds.
 
-When you set `maxTTL` to -1, it overrides the bucket's `maxTTL` setting. 
-Couchbase Server does not apply a default expiration value to new and mutated documents in the collection. 
+When you set `maxTTL` to -1, it overrides the bucket's `maxTTL` setting. By default, when the bucket has a `maxTTL` setting greater than zero, Couchbase Server sets new and mutated documents in the bucket to expire in `maxTTL` seconds. Setting the collection's `maxTTL` to -1 blocks this default behavior for documents in the collection. Couchbase Server does not apply a default expiration to the documents in the collection.
 
 For more information, see xref:learn:data/expiration.adoc[Expiration].
 

--- a/modules/rest-api/pages/rest-bucket-create.adoc
+++ b/modules/rest-api/pages/rest-bucket-create.adoc
@@ -528,7 +528,8 @@ No object is returned.
 [#maxttl]
 === maxTTL
 
-Sets the bucket's _maximum time to live_. The default value is `0`, which does not have documents automatically expire. It also does not affect expiration values you directly set on a document.
+Sets the bucket's _maximum time to live_. The default value is `0`, which does not automatically expire documents. 
+It also does not affect expiration values you directly set on a document.
 
 Setting this parameter to a non-zero value has two effects:
 


### PR DESCRIPTION
These changes cover two new maxTTL-related changes in Server 7.6:

- [DOC-11391](https://issues.couchbase.com/browse/DOC-11391) Document collection maxTTL changes (adds maxTTL=-1 setting for collections to override bucket maxTTL).
- [DOC-11799](https://issues.couchbase.com/browse/DOC-11799) Document how to modify a collection's Max TTL (you can now change the maxTTL of collections after creation).

Changed pages, with links to preview site:

- [What’s New in Version 7.6](https://preview.docs-test.couchbase.com/maxTTL_changes_7.6/server/7.6/introduction/whats-new.html) adds entry at bottom to describe two new maxTTL features.
- [Expiration](https://preview.docs-test.couchbase.com/maxTTL_changes_7.6/server/7.6/learn/data/expiration.html) removes all references to maxTTL not being changeable in collections afyer creations. Adds description of -1 setting to description of setting priorities and the associated logic table.
- [Manage Expiration](https://preview.docs-test.couchbase.com/maxTTL_changes_7.6/server/7.6/manage/manage-expiration.html) similar to the above. Changes reflect new functionality. Also made some changes to limit how much we tell users how to use the UI.
- [Creating and Editing a Collection](https://preview.docs-test.couchbase.com/maxTTL_changes_7.6/server/7.6/rest-api/creating-a-collection.html) Adds the -1 setting for maxTTL and added to the list of parameters that can be changed after creating the collection. Also reformatted the list of parameters to make the presentation easier to read.

Also included are some general changes to meet doc style standards and ease readability.