### PR TITLE
DOC-9838-7.2 Non root install: 7.0.2 fails with:open files for the couchbase user is set too low (70000)

### DIFF
--- a/modules/install/pages/non-root.adoc
+++ b/modules/install/pages/non-root.adoc
@@ -40,7 +40,7 @@ To do this, follow the instructions provided in xref:install:install-swap-space.
 === Establish Limits for User Processes and File Descriptors
 
 The maximum permitted number of _concurrent user processes_, and the maximum permitted number of _currently open file descriptors_, are both established on Linux systems with default values that are too low for running Couchbase Server with optimal performance and scale.
-The maximum number of user processes must therefore be reset to at least 10,000; and the maximum number of file descriptors to at least 70,000.
+The maximum number of user processes must therefore be reset to at least 10,000; and the maximum number of file descriptors to at least 200,000.
 
 Note that Linux establishes such limits _per user_; and that since Couchbase Server will not, following non-root install, run as a _service_, but as a user process, the limits must be established separately for each user or group designated to run the non-root Couchbase Server.
 
@@ -72,7 +72,7 @@ The response indicates the maximum number of file descriptors currently permitte
 1024
 ----
 +
-Again, in this case, the number, `1024`, is lower than the Couchbase-Server requirement of `70000`.
+Again, in this case, the number, `1024`, is lower than the Couchbase-Server requirement of `200000`.
 
 . Raise the current limits on user processes and file descriptors, for the user or group designated to perform non-root install and then run Couchbase Server.
 To do this, access `/etc/security/limits.conf`, and add `hard` and `soft` lines for the `nproc` and `nofile` types, specifying appropriate values.
@@ -84,8 +84,8 @@ Following these additions, the lines should appear as follows:
 nameofuserorgroup       soft    nproc           10000
 nameofuserorgroup       hard    nproc           10000
 
-nameofuserorgroup       soft    nofile          70000
-nameofuserorgroup       hard    nofile          70000
+nameofuserorgroup       soft    nofile          200000
+nameofuserorgroup       hard    nofile          200000
 ----
 +
 Save the file and exit.
@@ -108,7 +108,7 @@ file size               (blocks, -f) unlimited
 pending signals                 (-i) 3829
 max locked memory       (kbytes, -l) 64
 max memory size         (kbytes, -m) unlimited
-open files                      (-n) 70000
+open files                      (-n) 200000
 pipe size            (512 bytes, -p) 8
 POSIX message queues     (bytes, -q) 819200
 real-time priority              (-r) 0


### PR DESCRIPTION
 – Upped file limit to 200,000

https://issues.couchbase.com/browse/DOC-9838