### PR TITLE
DOC-11234: Deprecate SQL++ operations on buckets without password

### DIFF
--- a/modules/learn/pages/buckets-memory-and-storage/buckets.adoc
+++ b/modules/learn/pages/buckets-memory-and-storage/buckets.adoc
@@ -211,8 +211,8 @@ See
 xref:learn:security/authorization-overview.adoc[Authorization] and
 xref:learn:security/authentication.adoc[Authentication] for details.
 
-Legacy buckets, defined on releases of Couchbase Server prior to 5.0, may continue to be accessible without password-specification.
-However, you are strongly recommended ensuring that all buckets are fully protected by RBAC, especially for production purposes.
+From release 7.6, Couchbase Server no longer supports {sqlpp} operations on buckets without password specification -- for instance, legacy buckets which have been upgraded to use RBAC.
+Users must authenticate to connect to the Query service and execute a {sqlpp} statement, and must be authorized to access all required buckets and collections.
 
 == Bucket Storage
 Couchbase supports two different backends for the underlying storage of bucket data:

--- a/modules/learn/pages/security/authentication-domains.adoc
+++ b/modules/learn/pages/security/authentication-domains.adoc
@@ -15,13 +15,15 @@ This includes:
 
  ** The _Full Administrator_ for Couchbase Server.
 
-** _Locally Defined Users_, which are explicitly created by a Couchbase Server  administrator; and each feature a username and password unique within the Local domain.
+ ** _Locally Defined Users_, which are explicitly created by a Couchbase Server administrator; and each feature a username and password unique within the Local domain.
 
  ** _Internal Components_ within Couchbase Server that support core  functionality (for example, indexing, searching, and replicating), and run  with full administrative privileges.
 
  ** _Generated Users_, which are created by Couchbase Server as part of the  upgrade process from pre-5.0 to 5.0 and post-5.0 versions; each in  correspondence with a legacy bucket.
 Each Generated User is assigned a _username_ that is identical to the bucket-name; and either a _password_ that is identical to the bucket's pre-5.0 password, or _no password_, if the bucket did not feature a password.
 Generated Users are created to ensure that legacy applications can continue to access legacy buckets after upgrade to 5.0 or post-5.0, with the same username-password combination being used for authentication.
++
+Note that from release 7.6, Couchbase Server no longer supports {sqlpp) operations on buckets without password specification.
 
 * _External_: Contains either or both of the following:
 

--- a/modules/learn/pages/security/upgrading-to-rbac.adoc
+++ b/modules/learn/pages/security/upgrading-to-rbac.adoc
@@ -42,3 +42,5 @@ Each new user that has been defined to correspond to a legacy bucket that featur
 This role (which in RBAC-enabled versions of Couchbase Server prior to 5.5 was referred to as *Full Bucket Access*) allows the new user the same bucket-access privileges (including read-write on bucket-data) as were previously possible by means of the bucket-password; and is visible in association with the user in the *Security* screen of the Couchbase Web Console.
 
 * Applications that continue to attempt bucket-access by specifying the legacy bucket-name and (where appropriate) bucket-password _do not fail_; since the bucket-name is interpreted as a username, and the bucket-password as a corresponding user-password; and the bucket access-privilege thereby attained is identical to that attained under previous releases of Couchbase Server.
+
+Note that from release 7.6, Couchbase Server no longer supports {sqlpp} operations on buckets without password specification.


### PR DESCRIPTION
Docs issue: DOC-11234

Preview documentation:

* [Buckets › Bucket Security](https://github.com/couchbase/docs-server/blob/b1cc964aa5ede013438299dd6fcdf041e4a01449/modules/learn/pages/buckets-memory-and-storage/buckets.adoc#bucket-security)
* [Authentication Domains › Understanding Authentication Domains](https://github.com/couchbase/docs-server/blob/b1cc964aa5ede013438299dd6fcdf041e4a01449/modules/learn/pages/security/authentication-domains.adoc#introduction-to-externally-based-authentication)
* [Upgrading to RBAC › Legacy Buckets on the Standard Port](https://github.com/couchbase/docs-server/blob/b1cc964aa5ede013438299dd6fcdf041e4a01449/modules/learn/pages/security/upgrading-to-rbac.adoc#legacy-buckets-on-the-standard-port)