### PR TITLE
DOC-9838-7.0 Non root install: 7.0.2 fails with:open files for the couchbase user is set too low (70000)

### DIFF
--- a/modules/install/pages/non-root.adoc
+++ b/modules/install/pages/non-root.adoc
@@ -69,7 +69,7 @@ The response indicates the maximum number of file descriptors currently permitte
 1024
 ----
 +
-Again, in this case, the number, `1024`, is lower than the Couchbase-Server requirement of `70000`.
+Again, in this case, the number, `1024`, is lower than the Couchbase-Server requirement of `200000`.
 
 . Raise the current limits on user processes and file descriptors, for the user or group designated to perform non-root install and then run Couchbase Server.
 To do this, access `/etc/security/limits.conf`, and add `hard` and `soft` lines for the `nproc` and `nofile` types, specifying appropriate values.
@@ -81,8 +81,8 @@ Following these additions, the lines should appear as follows:
 nameofuserorgroup       soft    nproc           10000
 nameofuserorgroup       hard    nproc           10000
 
-nameofuserorgroup       soft    nofile          70000
-nameofuserorgroup       hard    nofile          70000
+nameofuserorgroup       soft    nofile          200000
+nameofuserorgroup       hard    nofile          200000
 ----
 +
 Save the file and exit.
@@ -105,7 +105,7 @@ file size               (blocks, -f) unlimited
 pending signals                 (-i) 3829
 max locked memory       (kbytes, -l) 64
 max memory size         (kbytes, -m) unlimited
-open files                      (-n) 70000
+open files                      (-n) 200000
 pipe size            (512 bytes, -p) 8
 POSIX message queues     (bytes, -q) 819200
 real-time priority              (-r) 0


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-9838