### PR TITLE
DOC-11903 Supported Platforms Doc wrongly mentions RHEL 7 as deprecated in CB 7.2 

### DIFF
--- a/modules/install/pages/install-platforms.adoc
+++ b/modules/install/pages/install-platforms.adoc
@@ -43,7 +43,7 @@ ARM64 support requires ARMv8 CPUs, such as the Amazon Graviton series.
 9.x
 
 | Red Hat Enterprise Linux (RHEL)
-| 7.x (deprecated in Couchbase Server{nbsp}7.2)
+| 7.x (unsupported in Couchbase Server{nbsp}7.2)
 
 8.x
 


### PR DESCRIPTION
Changed to say 'unsupported in 7.2'

https://issues.couchbase.com/browse/DOC-11903