### PR TITLE
DOC-11903 Supported Platforms Doc wrongly mentions RHEL 7 as deprecated in CB 7.2 

### DIFF
--- a/modules/install/pages/install-platforms.adoc
+++ b/modules/install/pages/install-platforms.adoc
@@ -39,7 +39,7 @@ Nodes in a Couchbase cluster should all be running on the same OS, and every eff
 | Red Hat Enterprise Linux (RHEL)
 | 8.x
 
-7.x (Note that this version will be deprecated in Couchbase Server{nbsp}7.2)
+7.x (Note that this version will be deprecated in Couchbase Server{nbsp}7.1)
 
 | SUSE Linux Enterprise Server (SLES)
 | 15.x


### PR DESCRIPTION
change to 'deprecated in 7.1'

