### PR TITLE
DOC-11436: Document new Query service settings

### DIFF
--- a/modules/n1ql/pages/n1ql-rest-api/admin.adoc
+++ b/modules/n1ql/pages/n1ql-rest-api/admin.adoc
@@ -12,6 +12,6 @@ include::partial$n1ql-rest-api/admin/security.adoc[]
 
 == See Also
 
-* [[queryCleanupClientAttempts]][[queryCleanupLostAttempts]][[queryCleanupWindow]][[queryCompletedLimit]][[queryCompletedThreshold]][[queryLogLevel]][[queryMaxParallelism]][[queryMemoryQuota]][[queryNumAtrs]][[queryN1qlFeatCtrl]][[queryPipelineBatch]][[queryPipelineCap]][[queryPreparedLimit]][[queryScanCap]][[queryTimeout]][[queryTxTimeout]][[queryUseCBO]][[queryUseReplica]]For cluster-level settings, see the xref:rest-api:rest-cluster-query-settings.adoc#_settings[Cluster Query Settings API].
+* [[queryCleanupClientAttempts]][[queryCleanupLostAttempts]][[queryCleanupWindow]][[queryCompletedLimit]][[queryCompletedMaxPlanSize]][[queryCompletedThreshold]][[queryLogLevel]][[queryMaxParallelism]][[queryMemoryQuota]][[queryNodeQuota]][[queryNodeQuotaValPercent]][[queryNumAtrs]][[queryNumCpus]][[queryN1qlFeatCtrl]][[queryPipelineBatch]][[queryPipelineCap]][[queryPreparedLimit]][[queryScanCap]][[queryTimeout]][[queryTxTimeout]][[queryUseCBO]][[queryUseReplica]]For cluster-level settings, see the xref:rest-api:rest-cluster-query-settings.adoc#_settings[Cluster Query Settings API].
 
 * [[atrcollection_req]][[client_context_id]][[controls_req]][[max_parallelism_req]][[memory_quota_req]][[numatrs_req]][[pipeline_batch_req]][[pipeline_cap_req]][[pretty_req]][[profile_req]][[scan_cap_req]][[timeout_req]][[tximplicit]][[use_cbo_req]][[use_replica_req]]For request-level parameters, see the xref:n1ql:n1ql-rest-api/index.adoc#_request_parameters[Query Service REST API].

--- a/modules/rest-api/pages/rest-cluster-query-settings.adoc
+++ b/modules/rest-api/pages/rest-cluster-query-settings.adoc
@@ -12,6 +12,6 @@ include::partial$query-settings/security.adoc[]
 
 == See Also
 
-* [[cleanupclientattempts]][[cleanuplostattempts]][[cleanupwindow]][[completed-limit]][[completed-threshold]][[loglevel]][[max-parallelism-srv]][[memory-quota-srv]][[n1ql-feat-ctrl]][[numatrs-srv]][[pipeline-batch-srv]][[pipeline-cap-srv]][[prepared-limit]][[scan-cap-srv]][[timeout-srv]][[txtimeout-srv]][[use-cbo-srv]][[use-replica-srv]]For node-level settings, see the xref:n1ql:n1ql-rest-api/admin.adoc#_settings[Admin REST API].
+* [[cleanupclientattempts]][[cleanuplostattempts]][[cleanupwindow]][[completed-limit]][[completed-max-plan-size]][[completed-threshold]][[loglevel]][[max-parallelism-srv]][[memory-quota-srv]][[node-quota]][[node-quota-val-percent]][[num-cpus]][[numatrs-srv]][[n1ql-feat-ctrl]][[pipeline-batch-srv]][[pipeline-cap-srv]][[prepared-limit]][[scan-cap-srv]][[timeout-srv]][[txtimeout-srv]][[use-cbo-srv]][[use-replica-srv]]For node-level settings, see the xref:n1ql:n1ql-rest-api/admin.adoc#_settings[Admin REST API].
 
 * [[max_parallelism_req]][[memory_quota_req]][[numatrs_req]][[pipeline_batch_req]][[pipeline_cap_req]][[scan_cap_req]][[timeout_req]][[tximplicit]][[txtimeout_req]][[use_cbo_req]][[use_replica_req]]For request-level parameters, see the xref:n1ql:n1ql-rest-api/index.adoc#_request_parameters[Query Service REST API].

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -181,8 +181,12 @@ a| [%hardbreaks]
 <<queryCleanupLostAttempts,queryCleanupLostAttempts>>
 <<queryCleanupWindow,queryCleanupWindow>>
 <<queryCompletedLimit,queryCompletedLimit>>
+<<queryCompletedMaxPlanSize,queryCompletedMaxPlanSize>>
 <<queryCompletedThreshold,queryCompletedThreshold>>
 <<queryLogLevel,queryLogLevel>>
+<<queryNodeQuota,queryNodeQuota>>
+<<queryNodeQuotaValPercent,queryNodeQuotaValPercent>>
+<<queryNumCpus,queryNumCpus>>
 <<queryN1qlFeatCtrl,queryN1qlFeatCtrl>>
 <<queryPreparedLimit,queryPreparedLimit>>
 
@@ -191,8 +195,12 @@ a| [%hardbreaks]
 <<cleanuplostattempts,cleanuplostattempts>>
 <<cleanupwindow,cleanupwindow>>
 <<completed-limit,completed-limit>>
+<<completed-max-plan-size,completed-max-plan-size>>
 <<completed-threshold,completed-threshold>>
 <<loglevel,loglevel>>
+<<node-quota,node-quota>>
+<<node-quota-val-percent,node-quota-val-percent>>
+<<num-cpus,num-cpus>>
 <<n1ql-feat-ctrl,n1ql-feat-ctrl>>
 <<prepared-limit,prepared-limit>>
 


### PR DESCRIPTION
Docs issue: DOC-11436

This PR documents 4 new query settings, at cluster-level and node-level:

| Cluster-level | Node-level |
| :---- | :---- |
| `queryNodeQuota` | `node-quota` |
| `queryNodeQuotaValPercent` | `node-quota-val-percent` |
| `queryNumCpus` | `num-cpus` |
| `queryCompletedMaxPlanSize` | `completed-max-plan-size` |

Draft documentation:

* [Settings and Parameters](https://ia.docs-test.couchbase.com/server/current/settings/query-settings.html)
* [Query Settings REST API](https://ia.docs-test.couchbase.com/server/current/rest-api/rest-cluster-query-settings.html#_settings)
* [Query Admin REST API](https://ia.docs-test.couchbase.com/server/current/n1ql/n1ql-rest-api/admin.html#_settings)

Credentials for the preview docs: [Information Architecture changes](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Information-Architecture-changes) &mdash; N.B. not the usual preview credentials!

Depends on the following upstream PR, which must be merged before this one:

* https://github.com/couchbaselabs/cb-swagger/pull/110