### PR TITLE
DOC-11917: Query Release Notes for Server 7.6

### DIFF
--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -36,6 +36,9 @@ The stats now also include the transient files in progress, state files, and con
 | https://issues.couchbase.com/browse/MB-22424[MB-22424]
 | The {sqlpp} language adds support for sequences.
 
+| https://issues.couchbase.com/browse/MB-38696[MB-38696]
+| The CREATE COLLECTION statement adds support for maxTTL.
+
 | https://issues.couchbase.com/browse/MB-53472[MB-53472]
 | The cbq shell adds a `-query_context` command line option.
 

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -27,6 +27,9 @@ The stats now also include the transient files in progress, state files, and con
 | https://issues.couchbase.com/browse/MB-57496[MB-57496]
 | The SORT BY and GROUP BY operations overspill to disk if they exceed the Query service memory quota.
 
+| https://issues.couchbase.com/browse/MB-53384[MB-53384]
+| Correlated subqueries can use primary index or sequential scan.
+
 |===
 
 [#deprecated-features-and-platforms-760]

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -40,7 +40,7 @@ The stats now also include the transient files in progress, state files, and con
 | The {sqlpp} language adds support for sequences.
 
 | https://issues.couchbase.com/browse/MB-54197[MB-54197]
-| The {sqlpp} language adds support for the LATERAL keyword in ANSI joins, ANSI nests, and comma-separated joins.
+| The {sqlpp} language adds a LATERAL keyword to ANSI joins, ANSI nests, and comma-separated joins.
 
 | https://issues.couchbase.com/browse/MB-56524[MB-56524]
 | The {sqlpp} language adds an EXPLAIN FUNCTION statement.
@@ -60,6 +60,9 @@ The stats now also include the transient files in progress, state files, and con
 | https://issues.couchbase.com/browse/MB-56743[MB-56743]
 | The Query Admin REST API adds an `/admin/gc` endpoint to run the garbage collector.
 
+| https://issues.couchbase.com/browse/MB-57931[MB-57931]
+| The `/clusterInit` endpoint in the Nodes and Clusters REST API adds support for Query memory quotas.
+
 | https://issues.couchbase.com/browse/MB-56372[MB-56372]
 | When a query executes a user-defined function, profiling information is now available for any queries within the UDF.
 
@@ -68,9 +71,6 @@ The stats now also include the transient files in progress, state files, and con
 
 | https://issues.couchbase.com/browse/MB-51250[MB-51250]
 | Users can now create a JavaScript function and the corresponding {sqlpp} function in a single statement.
-
-| https://issues.couchbase.com/browse/MB-57537[MB-57537]
-| The Query service adds new command line and UI parameters to support node quotas.
 
 | https://issues.couchbase.com/browse/MB-55036[MB-55036]
 | The Query service adds new cluster-level, node-level, and request-level parameters to support reading from replica vBuckets.
@@ -84,6 +84,9 @@ The stats now also include the transient files in progress, state files, and con
 | https://issues.couchbase.com/browse/MB-56367[MB-56367]
 | The Query service adds cluster-level and node-level parameters to support node quotas.
 
+| https://issues.couchbase.com/browse/MB-57537[MB-57537]
+| The Query service adds new command line and UI parameters to support node quotas.
+
 | https://issues.couchbase.com/browse/MB-52184[MB-52184]
 | The Query service adds support for sequential scans, which enables querying without an index.
 
@@ -92,9 +95,6 @@ The stats now also include the transient files in progress, state files, and con
 
 | https://issues.couchbase.com/browse/MB-57717[MB-57717]
 | Optimizer statistics for the Query service are now stored in the `&lowbar;system.&lowbar;query` collection for each bucket.
-
-| https://issues.couchbase.com/browse/MB-57931[MB-57931]
-| The `/clusterInit` endpoint in the Nodes and Clusters REST API adds support for Query memory quotas.
 
 | https://issues.couchbase.com/browse/MB-58465[MB-58465]
 | If an uncovered query only references specific fields, the fetch operation retrieves just the necessary fields from the Data service, instead of the entire document.

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -30,6 +30,9 @@ The stats now also include the transient files in progress, state files, and con
 | https://issues.couchbase.com/browse/MB-53472[MB-53472]
 | The cbq shell adds a `-query_context` command line option.
 
+| https://issues.couchbase.com/browse/MB-56743[MB-56743]
+| The Query Admin REST API adds an `/admin/gc` endpoint to run the garbage collector.
+
 | https://issues.couchbase.com/browse/MB-58465[MB-58465]
 | If an uncovered query only references specific fields, the fetch operation retrieves just the necessary fields from the Data service, instead of the entire document.
 

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -30,6 +30,9 @@ The stats now also include the transient files in progress, state files, and con
 | https://issues.couchbase.com/browse/MB-26683[MB-26683]
 | The {sqlpp} language adds a FORMALIZE() function.
 
+| https://issues.couchbase.com/browse/MB-57486[MB-57486]
+| The {sqlpp} language adds a NODE_UUID() function.
+
 | https://issues.couchbase.com/browse/MB-57961[MB-57961]
 | The {sqlpp} language adds multi-byte aware string functions.
 

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -21,6 +21,9 @@ The stats now also include the transient files in progress, state files, and con
 |===
 |Feature | Description
 
+| https://issues.couchbase.com/browse/MB-30383[MB-30383]
+| The {sqlpp} language adds an OFFSET clause to the DELETE statement.
+
 | https://issues.couchbase.com/browse/MB-58465[MB-58465]
 | If an uncovered query only references specific fields, the fetch operation retrieves just the necessary fields from the Data service, instead of the entire document.
 

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -24,6 +24,9 @@ The stats now also include the transient files in progress, state files, and con
 | https://issues.couchbase.com/browse/MB-58465[MB-58465]
 | If an uncovered query only references specific fields, the fetch operation fetches just the necessary fields from the Data service, instead of the entire document.
 
+| https://issues.couchbase.com/browse/MB-57496[MB-57496]
+| The SORT BY and GROUP BY operations overspill to disk if they exceed the Query service memory quota.
+
 |===
 
 [#deprecated-features-and-platforms-760]

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -66,6 +66,9 @@ The stats now also include the transient files in progress, state files, and con
 | https://issues.couchbase.com/browse/MB-52184[MB-52184]
 | The Query service adds support for sequential scans, which enables querying without an index.
 
+| https://issues.couchbase.com/browse/MB-52359[MB-52359]
+| The node-level and request-level N1QL Feature Control parameters now accept hexadecimal strings or decimal integers.
+
 | https://issues.couchbase.com/browse/MB-57717[MB-57717]
 | Optimizer statistics for the Query service are now stored in the `&lowbar;system.&lowbar;query` collection for each bucket.
 

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -27,6 +27,9 @@ The stats now also include the transient files in progress, state files, and con
 | https://issues.couchbase.com/browse/MB-49506[MB-49506]
 | The {sqlpp} language adds a GROUP AS clause to the GROUP BY clause.
 
+| https://issues.couchbase.com/browse/MB-53472[MB-53472]
+| The cbq shell adds a `-query_context` command line option.
+
 | https://issues.couchbase.com/browse/MB-58465[MB-58465]
 | If an uncovered query only references specific fields, the fetch operation retrieves just the necessary fields from the Data service, instead of the entire document.
 

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -30,6 +30,9 @@ The stats now also include the transient files in progress, state files, and con
 | https://issues.couchbase.com/browse/MB-26683[MB-26683]
 | The {sqlpp} language adds a FORMALIZE() function.
 
+| https://issues.couchbase.com/browse/MB-57961[MB-57961]
+| The {sqlpp} language adds multi-byte aware string functions.
+
 | https://issues.couchbase.com/browse/MB-53472[MB-53472]
 | The cbq shell adds a `-query_context` command line option.
 

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -27,8 +27,6 @@ The stats now also include the transient files in progress, state files, and con
 
 This release contains the following fixes.
 
-== Fixed Issues
-
 === XDCR
 [#table-known-issues-76-xdcr, cols="10,40,40"]
 |===

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -97,6 +97,10 @@ This release contains the following fixes.
 | CREATE INDEX statement fails when index key expression matches keyspace.
 | If index key expression matches keyspace, index key expression is no longer converted to SELF.
 
+| https://issues.couchbase.com/browse/MB-60762[MB-60762]
+| ANSI MERGE with DELETE does not always generate an error when the target document matches multiple source documents.
+| ANSI MERGE with DELETE now always generates an error when the target document matches multiple source documents, in compliance with the SQL standard.
+
 |===
 
 === Search Service

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -33,6 +33,9 @@ The stats now also include the transient files in progress, state files, and con
 | https://issues.couchbase.com/browse/MB-57961[MB-57961]
 | The {sqlpp} language adds multi-byte aware string functions.
 
+| https://issues.couchbase.com/browse/MB-22424[MB-22424]
+| The {sqlpp} language adds support for sequences.
+
 | https://issues.couchbase.com/browse/MB-53472[MB-53472]
 | The cbq shell adds a `-query_context` command line option.
 

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -93,6 +93,9 @@ The stats now also include the transient files in progress, state files, and con
 | https://issues.couchbase.com/browse/MB-57717[MB-57717]
 | Optimizer statistics for the Query service are now stored in the `&lowbar;system.&lowbar;query` collection for each bucket.
 
+| https://issues.couchbase.com/browse/MB-57931[MB-57931]
+| The `/clusterInit` endpoint in the Nodes and Clusters REST API adds support for Query memory quotas.
+
 | https://issues.couchbase.com/browse/MB-58465[MB-58465]
 | If an uncovered query only references specific fields, the fetch operation retrieves just the necessary fields from the Data service, instead of the entire document.
 

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -172,10 +172,6 @@ This release contains the following fixes.
 | CREATE INDEX fails when the index key expression matches the keyspace name.
 | If the index key expression matches the keyspace name, the index key expression is no longer converted to SELF.
 
-| https://issues.couchbase.com/browse/MB-60762[MB-60762]
-| ANSI MERGE with DELETE does not always generate an error when the target document matches multiple source documents.
-| ANSI MERGE with DELETE now always generates an error when the target document matches multiple source documents, in compliance with the SQL standard.
-
 | https://issues.couchbase.com/browse/MB-59501[MB-59501]
 | The system catalog allows users to see items without RBAC authentication or authorization.
 | Valid RBAC permissions are required to query the system catalog, and to view items stored in the catalog.

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -45,6 +45,9 @@ The stats now also include the transient files in progress, state files, and con
 | https://issues.couchbase.com/browse/MB-57537[MB-57537]
 | The Query service adds new command line and UI parameters to support node quotas.
 
+| https://issues.couchbase.com/browse/MB-55036[MB-55036]
+| The Query service adds new cluster-level, node-level, and request-level parameters to support reading from replica vBuckets.
+
 | https://issues.couchbase.com/browse/MB-58465[MB-58465]
 | If an uncovered query only references specific fields, the fetch operation retrieves just the necessary fields from the Data service, instead of the entire document.
 

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -71,8 +71,12 @@ This release contains the following fixes.
 |Issue | Description | Resolution
 
 | https://issues.couchbase.com/browse/MB-39484[MB-39484]
-| Remove N1QL support for password-less buckets.
+| Remove {sqlpp} support for password-less buckets.
 | Password-less bucket support removed.
+
+| https://issues.couchbase.com/browse/MB-52228[MB-52228]
+| CREATE INDEX statement failed when index key expression matched keyspace.
+| If index key expression matches keyspace, index key expression is no longer converted to SELF.
 
 |===
 

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -39,6 +39,9 @@ The stats now also include the transient files in progress, state files, and con
 | https://issues.couchbase.com/browse/MB-52634[MB-52634]
 | Named parameters can now be prefixed by `$` or `@` in a query.
 
+| https://issues.couchbase.com/browse/MB-51250[MB-51250]
+| Users can now create a JavaScript function and the corresponding {sqlpp} function in a single statement.
+
 | https://issues.couchbase.com/browse/MB-58465[MB-58465]
 | If an uncovered query only references specific fields, the fetch operation retrieves just the necessary fields from the Data service, instead of the entire document.
 

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -75,6 +75,15 @@ The stats now also include the transient files in progress, state files, and con
 | https://issues.couchbase.com/browse/MB-55036[MB-55036]
 | The Query service adds new cluster-level, node-level, and request-level parameters to support reading from replica vBuckets.
 
+| https://issues.couchbase.com/browse/MB-56068[MB-56068]
+| The Query service adds cluster-level and node-level parameters to limit the number of CPUs.
+
+| https://issues.couchbase.com/browse/MB-57964[MB-57964]
+| The Query service adds cluster-level and node-level parameters to limit the size of explain plans in the completed requests catalog.
+
+| https://issues.couchbase.com/browse/MB-56367[MB-56367]
+| The Query service adds cluster-level and node-level parameters to support node quotas.
+
 | https://issues.couchbase.com/browse/MB-52184[MB-52184]
 | The Query service adds support for sequential scans, which enables querying without an index.
 

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -42,6 +42,9 @@ The stats now also include the transient files in progress, state files, and con
 | https://issues.couchbase.com/browse/MB-54197[MB-54197]
 | The {sqlpp} language adds support for the LATERAL keyword in ANSI joins, ANSI nests, and comma-separated joins.
 
+| https://issues.couchbase.com/browse/MB-56524[MB-56524]
+| The {sqlpp} language adds an EXPLAIN FUNCTION statement.
+
 | https://issues.couchbase.com/browse/MB-38696[MB-38696]
 | The CREATE COLLECTION statement adds support for maxTTL.
 

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -22,7 +22,7 @@ The stats now also include the transient files in progress, state files, and con
 |Feature | Description
 
 | https://issues.couchbase.com/browse/MB-58465[MB-58465]
-| If an uncovered query only references specific fields, the fetch operation fetches just the necessary fields from the Data service, instead of the entire document.
+| If an uncovered query only references specific fields, the fetch operation retrieves just the necessary fields from the Data service, instead of the entire document.
 
 | https://issues.couchbase.com/browse/MB-57496[MB-57496]
 | The SORT BY and GROUP BY operations overspill to disk if they exceed the Query service memory quota.
@@ -94,8 +94,8 @@ This release contains the following fixes.
 | Password-less bucket support removed.
 
 | https://issues.couchbase.com/browse/MB-52228[MB-52228]
-| CREATE INDEX statement fails when index key expression matches keyspace.
-| If index key expression matches keyspace, index key expression is no longer converted to SELF.
+| CREATE INDEX fails when the index key expression matches the keyspace name.
+| If the index key expression matches the keyspace name, the index key expression is no longer converted to SELF.
 
 | https://issues.couchbase.com/browse/MB-60762[MB-60762]
 | ANSI MERGE with DELETE does not always generate an error when the target document matches multiple source documents.

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -63,6 +63,9 @@ The stats now also include the transient files in progress, state files, and con
 | https://issues.couchbase.com/browse/MB-55036[MB-55036]
 | The Query service adds new cluster-level, node-level, and request-level parameters to support reading from replica vBuckets.
 
+| https://issues.couchbase.com/browse/MB-52184[MB-52184]
+| The Query service adds support for sequential scans, which enables querying without an index.
+
 | https://issues.couchbase.com/browse/MB-57717[MB-57717]
 | Optimizer statistics for the Query service are now stored in the `&lowbar;system.&lowbar;query` collection for each bucket.
 

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -155,6 +155,10 @@ This release contains the following fixes.
 | ANSI MERGE with DELETE does not always generate an error when the target document matches multiple source documents.
 | ANSI MERGE with DELETE now always generates an error when the target document matches multiple source documents, in compliance with the SQL standard.
 
+| https://issues.couchbase.com/browse/MB-59501[MB-59501]
+| The system catalog allows users to see items without RBAC authentication or authorization.
+| Valid RBAC permissions are required to query the system catalog, and to view items stored in the catalog.
+
 |===
 
 === Search Service

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -30,6 +30,9 @@ The stats now also include the transient files in progress, state files, and con
 | https://issues.couchbase.com/browse/MB-53384[MB-53384]
 | Correlated subqueries can use primary index or sequential scan.
 
+| https://issues.couchbase.com/browse/MB-29708[MB-29708]
+| INSERT, DELETE, UPDATE, and UPSERT operations can perform mutations as bulk operations.
+
 |===
 
 [#deprecated-features-and-platforms-760]

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -33,6 +33,9 @@ The stats now also include the transient files in progress, state files, and con
 | https://issues.couchbase.com/browse/MB-56743[MB-56743]
 | The Query Admin REST API adds an `/admin/gc` endpoint to run the garbage collector.
 
+| https://issues.couchbase.com/browse/MB-56372[MB-56372]
+| When a query executes a user-defined function, profiling information is now available for any queries within the UDF.
+
 | https://issues.couchbase.com/browse/MB-58465[MB-58465]
 | If an uncovered query only references specific fields, the fetch operation retrieves just the necessary fields from the Data service, instead of the entire document.
 

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -24,6 +24,9 @@ The stats now also include the transient files in progress, state files, and con
 | https://issues.couchbase.com/browse/MB-30383[MB-30383]
 | The {sqlpp} language adds an OFFSET clause to the DELETE statement.
 
+| https://issues.couchbase.com/browse/MB-49506[MB-49506]
+| The {sqlpp} language adds a GROUP AS clause to the GROUP BY clause.
+
 | https://issues.couchbase.com/browse/MB-58465[MB-58465]
 | If an uncovered query only references specific fields, the fetch operation retrieves just the necessary fields from the Data service, instead of the entire document.
 

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -60,6 +60,9 @@ The stats now also include the transient files in progress, state files, and con
 | https://issues.couchbase.com/browse/MB-55036[MB-55036]
 | The Query service adds new cluster-level, node-level, and request-level parameters to support reading from replica vBuckets.
 
+| https://issues.couchbase.com/browse/MB-57717[MB-57717]
+| Optimizer statistics for the Query service are now stored in the `&lowbar;system.&lowbar;query` collection for each bucket.
+
 | https://issues.couchbase.com/browse/MB-58465[MB-58465]
 | If an uncovered query only references specific fields, the fetch operation retrieves just the necessary fields from the Data service, instead of the entire document.
 

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -39,6 +39,9 @@ The stats now also include the transient files in progress, state files, and con
 | https://issues.couchbase.com/browse/MB-22424[MB-22424]
 | The {sqlpp} language adds support for sequences.
 
+| https://issues.couchbase.com/browse/MB-54197[MB-54197]
+| The {sqlpp} language adds support for the LATERAL keyword in ANSI joins, ANSI nests, and comma-separated joins.
+
 | https://issues.couchbase.com/browse/MB-38696[MB-38696]
 | The CREATE COLLECTION statement adds support for maxTTL.
 

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -5,14 +5,24 @@ include::introduction:partial$new-features-76.adoc[]
 
 === Storage Engine
 
-
 [#table-new-features-760-storage-engine, cols="10,40"]
 |===
 |Feature | Description
+
 | https://issues.couchbase.com/browse/MB-52270[MB-52270]
 | Prior to the upgrade,  total disk usage stats only tracked the live completed `sstable` files. +
 The stats now also include the transient files in progress, state files, and configuration files.
 
+|===
+
+=== Query Service
+
+[#table-new-features-760-query-service, cols="10,40"]
+|===
+|Feature | Description
+
+| https://issues.couchbase.com/browse/MB-58465[MB-58465]
+| If an uncovered query only references specific fields, the fetch operation fetches just the necessary fields from the Data service, instead of the entire document.
 
 |===
 
@@ -75,7 +85,7 @@ This release contains the following fixes.
 | Password-less bucket support removed.
 
 | https://issues.couchbase.com/browse/MB-52228[MB-52228]
-| CREATE INDEX statement failed when index key expression matched keyspace.
+| CREATE INDEX statement fails when index key expression matches keyspace.
 | If index key expression matches keyspace, index key expression is no longer converted to SELF.
 
 |===

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -45,6 +45,9 @@ The stats now also include the transient files in progress, state files, and con
 | https://issues.couchbase.com/browse/MB-56524[MB-56524]
 | The {sqlpp} language adds an EXPLAIN FUNCTION statement.
 
+| https://issues.couchbase.com/browse/MB-11512[MB-11512]
+| The WITH clause adds support for recursive CTEs.
+
 | https://issues.couchbase.com/browse/MB-38696[MB-38696]
 | The CREATE COLLECTION statement adds support for maxTTL.
 

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -27,6 +27,9 @@ The stats now also include the transient files in progress, state files, and con
 | https://issues.couchbase.com/browse/MB-49506[MB-49506]
 | The {sqlpp} language adds a GROUP AS clause to the GROUP BY clause.
 
+| https://issues.couchbase.com/browse/MB-26683[MB-26683]
+| The {sqlpp} language adds a FORMALIZE() function.
+
 | https://issues.couchbase.com/browse/MB-53472[MB-53472]
 | The cbq shell adds a `-query_context` command line option.
 

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -42,6 +42,9 @@ The stats now also include the transient files in progress, state files, and con
 | https://issues.couchbase.com/browse/MB-51250[MB-51250]
 | Users can now create a JavaScript function and the corresponding {sqlpp} function in a single statement.
 
+| https://issues.couchbase.com/browse/MB-57537[MB-57537]
+| The Query service adds new command line and UI parameters to support node quotas.
+
 | https://issues.couchbase.com/browse/MB-58465[MB-58465]
 | If an uncovered query only references specific fields, the fetch operation retrieves just the necessary fields from the Data service, instead of the entire document.
 

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -30,6 +30,9 @@ The stats now also include the transient files in progress, state files, and con
 | https://issues.couchbase.com/browse/MB-53472[MB-53472]
 | The cbq shell adds a `-query_context` command line option.
 
+| https://issues.couchbase.com/browse/MB-56912[MB-56912]
+| The cbq shell adds an `-advise` command line option.
+
 | https://issues.couchbase.com/browse/MB-56743[MB-56743]
 | The Query Admin REST API adds an `/admin/gc` endpoint to run the garbage collector.
 

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -36,6 +36,9 @@ The stats now also include the transient files in progress, state files, and con
 | https://issues.couchbase.com/browse/MB-56372[MB-56372]
 | When a query executes a user-defined function, profiling information is now available for any queries within the UDF.
 
+| https://issues.couchbase.com/browse/MB-52634[MB-52634]
+| Named parameters can now be prefixed by `$` or `@` in a query.
+
 | https://issues.couchbase.com/browse/MB-58465[MB-58465]
 | If an uncovered query only references specific fields, the fetch operation retrieves just the necessary fields from the Data service, instead of the entire document.
 


### PR DESCRIPTION
Docs issue: DOC-11917

This PR adds release notes for all enhancements made to the Query service for release 7.6. In particular, note that this PR documents the following under-the-hood improvements and fixes, which are not mentioned elsewhere:

* DOC-10082 CREATE INDEX/UPDATE statements treats as field
* DOC-11662 Query Projection Fields
* DOC-11663 SORT BY / GROUP BY Overspil
* DOC-11664 Correlated Subquery with Primary Index / Sequential Scan
* DOC-11665 Bulk Operations for DML
* DOC-11865 <s>Behavioral change for ANSI MERGE statement with DELETE action</s> (reverted, see comments)

Draft documentation: [Release Notes for Couchbase Server 7.6](https://github.com/couchbase/docs-server/blob/866650f3d6e129f3d8ce1cc5860f36a79a471d91/modules/release-notes/partials/docs-server-7.6-release-note.adoc)