### PR TITLE
DOC-10703: Add query_context command line argument for cbq

### DIFF
--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -413,6 +413,25 @@ cbq> \set batch on;
 cbq> \set batch off;
 ----
 
+| [[opt-qc]]
+`-qc`
+
+`--query_context`
+| string
+a| Sets the query context parameter.
+For more information, see xref:n1ql:n1ql-intro/queriesandresults.adoc#query-context[Query Context].
+
+Shell command: <<cbq-set,\SET>> `-query_context`
+
+.Default
+`default:`
+
+.Example
+[source,console]
+----
+$ ./cbq -e http://localhost:8091 -qc "travel-sample.inventory"
+----
+
 | [[opt-timeout]]
 `-t`
 

--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -553,9 +553,10 @@ $ ./cbq --version
 
 .Result
 ----
-SHELL VERSION  : 2.0
+GO VERSION : go1.21.6
+SHELL VERSION : 7.6.0-2176
 
-Use {sqlpp} queries select version(); or select min_version(); to display server version.
+Use N1QL queries select version(); or select min_version(); to display server version.
 ----
 
 | [[opt-help]]
@@ -1059,7 +1060,10 @@ cbq> \VERSION;
 
 .Result
 ----
- SHELL VERSION  : 2.0
+GO VERSION : go1.21.6
+SHELL VERSION : 7.6.0-2176
+
+Use N1QL queries select version(); or select min_version(); to display server version.
 ----
 
 | [[cbq-help]]
@@ -2014,21 +2018,26 @@ You can find the version of the client (shell) by using either the command line 
 [source,console]
 ----
 $ ./cbq -v
-SHELL VERSION  : 2.0
+GO VERSION : go1.21.6
+SHELL VERSION : 7.6.0-2176
 
-Use {sqlpp} queries select version(); or select min_version(); to display server version.
+Use N1QL queries select version(); or select min_version(); to display server version.
 
 $ ./cbq --version
-SHELL VERSION  : 2.0
+GO VERSION : go1.21.6
+SHELL VERSION : 7.6.0-2176
 
-Use {sqlpp} queries select version(); or select min_version(); to display server version.
+Use N1QL queries select version(); or select min_version(); to display server version.
 ----
 
 .Example Using the Shell Command
 [source,console]
 ----
 cbq> \VERSION;
-SHELL VERSION : 2.0
+GO VERSION : go1.21.6
+SHELL VERSION : 7.6.0-2176
+
+Use N1QL queries select version(); or select min_version(); to display server version.
 ----
 
 To display the version of the query service, use the {sqlpp} commands `SELECT version();` and `SELECT min_version();`.

--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -328,10 +328,14 @@ a| Runs ADVISE on all queries in the specified file, or that are read from stand
 ./cbq -advise -file queries.txt
 ----
 
-.Result
-[source, json5]
+[source, sqlpp]
 ----
 SELECT ADVISOR(["select * from collection1 where id = 1;","select * from collection2 where name is not missing;"])
+----
+
+.Result
+[source, json]
+----
 {
     "requestID": "15ed5c93-e5f6-4193-83fa-6fdc87847552",
     "signature": {
@@ -363,7 +367,9 @@ SELECT ADVISOR(["select * from collection1 where id = 1;","select * from collect
         }
     }
     ]
+}
 ----
+
 | [[opt-analytics]]
 `-a`
 

--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -438,6 +438,9 @@ $ ./cbq -e http://localhost:8091 -qc "travel-sample.inventory"
 `--timeout`
 | string (duration)
 a| Sets the query timeout parameter.
+For more information, see xref:settings:query-settings.adoc#timeout_req[timeout].
+
+Shell command: <<cbq-set,\SET>> `-timeout`
 
 .Default
 `0ms`
@@ -447,6 +450,8 @@ a| Sets the query timeout parameter.
 ----
 $ ./cbq -e http://localhost:8091 --timeout="1s"
 ----
+
+For further examples, see <<connection-timeout-parameter>>.
 
 | [[opt-user]]
 `-u`

--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -330,7 +330,8 @@ a| Runs ADVISE on all queries in the specified file, or that are read from stand
 
 [source, sqlpp]
 ----
-SELECT ADVISOR(["select * from collection1 where id = 1;","select * from collection2 where name is not missing;"])
+SELECT ADVISOR(["select * from collection1 where id = 1;",
+                "select * from collection2 where name is not missing;"])
 ----
 
 .Result
@@ -424,7 +425,7 @@ For more information, see xref:n1ql:n1ql-intro/queriesandresults.adoc#query-cont
 Shell command: <<cbq-set,\SET>> `-query_context`
 
 .Default
-`default:`
+none
 
 .Example
 [source,console]


### PR DESCRIPTION
DOC-10703

Adds `--query_context` argument for cbq. Also updates output of `--version` argument, and other minor changes.

* Preview documentation: [cbq: The Command Line Shell for SQL++](https://github.com/couchbase/docs-server/blob/db23f64f4f6b4feb83e1a2affb64876536f7f614/modules/tools/pages/cbq-shell.adoc#opt-qc)