### PR TITLE
DOC-11044: Document new /admin/gc endpoint

### DIFF
--- a/modules/rest-api/partials/rest-query-service-table.adoc
+++ b/modules/rest-api/partials/rest-query-service-table.adoc
@@ -120,6 +120,14 @@
 | `/admin/ping`
 | xref:n1ql:n1ql-rest-api/admin.adoc#_get_ping[Ping]
 
+| `GET`
+| `/admin/gc`
+| xref:n1ql:n1ql-rest-api/admin.adoc#_get_gc[Run Garbage Collector]
+
+| `POST`
+| `/admin/gc`
+| xref:n1ql:n1ql-rest-api/admin.adoc#_post_gc[Run Garbage Collector and Release Memory]
+
 |===
 // end::query-admin[]
 


### PR DESCRIPTION
Docs issue: DOC-11044

Updates the table of contents partial for the REST API reference.

This PR depends on the following upstream PR, which must be merged before this one:

* https://github.com/couchbaselabs/cb-swagger/pull/111