### PR TITLE
DOC-11903 quick fix: CentOS 7.x is no longer supported in Couchbase server 7.2

### DIFF
--- a/modules/install/pages/install-platforms.adoc
+++ b/modules/install/pages/install-platforms.adoc
@@ -7,7 +7,7 @@
 
 == Supported Operating Systems
 
-Make sure that your chosen operating system is listed below, before you install Couchbase Server.
+Make sure that your chosen operating system is listed below before you install Couchbase Server.
 
 Note that Couchbase clusters on mixed platforms are not supported.
 Nodes in a Couchbase cluster should all be running on the same OS, and every effort should be made to apply the same OS patches across the entire cluster.
@@ -26,10 +26,6 @@ ARM64 support requires ARMv8 CPUs, such as the Amazon Graviton series.
 
 | Amazon Linux 2023
 | AL2023 (x86-64, ARM64)
-
-| CentOS
-| 7.x (deprecated in Couchbase Server{nbsp}7.2)
-
 
 | Debian
 | 11.x


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-11903