### PR TITLE
Update rest-cluster-email-notifications.adoc

### DIFF
--- a/modules/rest-api/pages/rest-cluster-email-notifications.adoc
+++ b/modules/rest-api/pages/rest-cluster-email-notifications.adoc
@@ -132,7 +132,6 @@ The default value contains all alerts: these are listed in xref:manage:manage-se
 
 * `enabled`.
 Enables or disables alerts: the value can be `true` or `false` (the default).
-This parameter is optional.
 If alerts are enabled, any alert that appears in the list that is passed as the value of `alerts` or `pop_up_alerts` (see immediately below) will have an email and/or pop-up display generated as appropriate.
 
 * `historyWarningThreshold`.


### PR DESCRIPTION
I don't see this parameter is optional. If not included with a POST request, a 400 Bad Request is returned. Also all the examples include a value for the enabled parameter.