### PR TITLE
DOC-11917: Query Release Notes for Server 7.6

### DIFF
--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -45,20 +45,11 @@ The stats now also include the transient files in progress, state files, and con
 | https://issues.couchbase.com/browse/MB-26683[MB-26683]
 | The {sqlpp} language adds a FORMALIZE() function.
 
-| https://issues.couchbase.com/browse/MB-57486[MB-57486]
-| The {sqlpp} language adds a NODE_UUID() function.
-
 | https://issues.couchbase.com/browse/MB-57961[MB-57961]
 | The {sqlpp} language adds multi-byte aware string functions.
 
 | https://issues.couchbase.com/browse/MB-22424[MB-22424]
 | The {sqlpp} language adds support for sequences.
-
-| https://issues.couchbase.com/browse/MB-54197[MB-54197]
-| The {sqlpp} language adds a LATERAL keyword to ANSI joins, ANSI nests, and comma-separated joins.
-
-| https://issues.couchbase.com/browse/MB-56524[MB-56524]
-| The {sqlpp} language adds an EXPLAIN FUNCTION statement.
 
 | https://issues.couchbase.com/browse/MB-11512[MB-11512]
 | The WITH clause adds support for recursive CTEs.
@@ -72,26 +63,11 @@ The stats now also include the transient files in progress, state files, and con
 | https://issues.couchbase.com/browse/MB-56912[MB-56912]
 | The cbq shell adds an `-advise` command line option.
 
-| https://issues.couchbase.com/browse/MB-56743[MB-56743]
-| The Query Admin REST API adds an `/admin/gc` endpoint to run the garbage collector.
-
 | https://issues.couchbase.com/browse/MB-57931[MB-57931]
 | The `/clusterInit` endpoint in the Nodes and Clusters REST API adds support for Query memory quotas.
 
-| https://issues.couchbase.com/browse/MB-56372[MB-56372]
-| When a query executes a user-defined function, profiling information is now available for any queries within the UDF.
-
 | https://issues.couchbase.com/browse/MB-52634[MB-52634]
 | Named parameters can now be prefixed by `$` or `@` in a query.
-
-| https://issues.couchbase.com/browse/MB-51250[MB-51250]
-| Users can now create a JavaScript function and the corresponding {sqlpp} function in a single statement.
-
-| https://issues.couchbase.com/browse/MB-55036[MB-55036]
-| The Query service adds new cluster-level, node-level, and request-level parameters to support reading from replica vBuckets.
-
-| https://issues.couchbase.com/browse/MB-56068[MB-56068]
-| The Query service adds cluster-level and node-level parameters to limit the number of CPUs.
 
 | https://issues.couchbase.com/browse/MB-57500[MB-57500]
 | `num_replica` configured for each index can now be found through {sqlpp} statement: `system:indexes`
@@ -99,32 +75,17 @@ The stats now also include the transient files in progress, state files, and con
 | https://issues.couchbase.com/browse/MB-57964[MB-57964]
 | The Query service adds cluster-level and node-level parameters to limit the size of explain plans in the completed requests catalog.
 
-| https://issues.couchbase.com/browse/MB-56367[MB-56367]
-| The Query service adds cluster-level and node-level parameters to support node quotas.
-
-| https://issues.couchbase.com/browse/MB-57537[MB-57537]
-| The Query service adds new command line and UI parameters to support node quotas.
-
 | https://issues.couchbase.com/browse/MB-52184[MB-52184]
 | The Query service adds support for sequential scans, which enables querying without an index.
 
 | https://issues.couchbase.com/browse/MB-52359[MB-52359]
 | The node-level and request-level N1QL Feature Control parameters now accept hexadecimal strings or decimal integers.
 
-| https://issues.couchbase.com/browse/MB-57717[MB-57717]
-| Optimizer statistics for the Query service are now stored in the `&lowbar;system.&lowbar;query` collection for each bucket.
-
 | https://issues.couchbase.com/browse/MB-58465[MB-58465]
 | If an uncovered query only references specific fields, the fetch operation retrieves just the necessary fields from the Data service, instead of the entire document.
 
 | https://issues.couchbase.com/browse/MB-57496[MB-57496]
 | The SORT BY and GROUP BY operations overspill to disk if they exceed the Query service memory quota.
-
-| https://issues.couchbase.com/browse/MB-53384[MB-53384]
-| Correlated subqueries can use primary index or sequential scan.
-
-| https://issues.couchbase.com/browse/MB-29708[MB-29708]
-| INSERT, DELETE, UPDATE, and UPSERT operations can perform mutations as bulk operations.
 
 |===
 

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -190,6 +190,9 @@ a| Stats now use the number of logical processors online on the system. This cor
 | Observed a memory leak with multiple executions of the same UDF function.
 | Fix the condition whereby UDF functions are being re-loaded into cache from storage every time the function is executed.
 
+| https://issues.couchbase.com/browse/MB-59501[MB-59501]
+| The system catalog allows users to see items without RBAC authentication or authorization.
+| Valid RBAC permissions are required to query the system catalog, and to view items stored in the catalog.
 |===
 
 

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -190,11 +190,6 @@ a| Stats now use the number of logical processors online on the system. This cor
 | Observed a memory leak with multiple executions of the same UDF function.
 | Fix the condition whereby UDF functions are being re-loaded into cache from storage every time the function is executed.
 
-| https://issues.couchbase.com/browse/MB-60942[MB-60942]
-| ANSI MERGE errors on multiple DELETE operations.
-| Fixed the behavior where a target document (to be deleted) matches  multiple source documents.
-  Instead of silently ignoring the second deletion, the system will now trigger an error if the target document matches multiple source documents.
-
 |===
 
 


### PR DESCRIPTION
Removed all Query fixes which were based on private tickets. I haven't looked at any tickets for other components.

I also removed the fixed issue MB-60942, based on comments on that issue yesterday.

Finally I restored the fixed issue MB-59501, as it's not a private ticket, and looking at the comments on the ticket it seems that the previous behavior was incorrect. Happy to remove this last one if you like.