### PR TITLE
Revert "DOC-11936 Release note for 7.2.4 does not mention OpenSSL upgrade"

### DIFF
--- a/modules/release-notes/partials/docs-server-7.2.4-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.2.4-release-note.adoc
@@ -12,12 +12,6 @@ This maintenance release contains new features and fixes.
 
 * Prometheus now records information related to disk usage over time:
 * REST interface added to set the retention period of audit files
-* In response to
- https://nvd.nist.gov/vuln/detail/CVE-2023-5363[CVE-2023-5363^] and
-  https://nvd.nist.gov/vuln/detail/CVE-2023-5678[CVE-2023-5678^],
-  OpenSSL upgraded to version{nbsp}3.1.4.
-+
-NOTE: If you are experiencing handshake errors in  your client applications, then you may need to upgrade the Couchbase client library to support the latest cipher protocol.
 * Erlang upgraded to version{nbsp}25.
 +
 NOTE: {erlang-7-2-4-note}


### PR DESCRIPTION
Reverts couchbase/docs-server#3487