### PR TITLE
DOC11936 release note for 7.2.4 doesn’t mention open ssl upgrade

### DIFF
--- a/modules/release-notes/partials/docs-server-7.2.4-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.2.4-release-note.adoc
@@ -12,6 +12,12 @@ This maintenance release contains new features and fixes.
 
 * Prometheus now records information related to disk usage over time:
 * REST interface added to set the retention period of audit files
+* In response to
+ https://nvd.nist.gov/vuln/detail/CVE-2023-5363[CVE-2023-5363^] and
+  https://nvd.nist.gov/vuln/detail/CVE-2023-5678[CVE-2023-5678^],
+  OpenSSL upgraded to version{nbsp}3.1.4.
++
+NOTE: If you are experiencing handshake errors in  your client applications, then you may need to upgrade the Couchbase client library to support the latest cipher protocol.
 * Erlang upgraded to version{nbsp}25.
 +
 NOTE: {erlang-7-2-4-note}

--- a/modules/release-notes/partials/docs-server-7.2.4-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.2.4-release-note.adoc
@@ -17,7 +17,12 @@ This maintenance release contains new features and fixes.
   https://nvd.nist.gov/vuln/detail/CVE-2023-5678[CVE-2023-5678^],
   OpenSSL upgraded to version{nbsp}3.1.4.
 +
-NOTE: If you are experiencing handshake errors in  your client applications, then you may need to upgrade the Couchbase client library to support the latest cipher protocol.
+NOTE: This update changes the available ciphers for TLS connections.
+If you have not updated your client applications to use recent TLS libraries,
+you may experience an inability to connect and TLS handshake failures.
+Before upgrading, we recommend testing compatibility in a separate environment –
+especially if you are unsure that your platform TLS (OpenSSL,
+Java Secure Socket Extensions, .NET Security Provider, etc.) has compatible ciphers.
 * Erlang upgraded to version{nbsp}25.
 +
 NOTE: {erlang-7-2-4-note}


### PR DESCRIPTION
Changed the text of the OpenSSL warning