### PR TITLE
DOC-11919 - Deprecated the cli utilities: cbbackup and cbrestore

### DIFF
--- a/modules/introduction/partials/new-features-76.adoc
+++ b/modules/introduction/partials/new-features-76.adoc
@@ -43,6 +43,10 @@ When restoring a backup, `cbbackupmgr` defaults to not overwriting existing user
 You can change this default behavior using the new `--overwrite-users` command-line argument. 
 See  xref:backup-restore:cbbackupmgr-config.adoc[cbbackupmgr config] and xref:backup-restore:cbbackupmgr-restore.adoc[cbbackupmgr restore] for more about user backup.
 
+* `cbbackupmgr` now encrypts the backup data before sending it to archive storage.
+
+* The `cbbackup` and `cbrestore` utilities have been removed from Couchbase Server{nbsp}7.6. The same functionality is provided in `cbbackupmgr`.
+
 * The Role-Based Access Control (RBAC) REST API has a new `backup` endpoint that lets you backup and restore user and user groups. See xref:rest-api:rbac.adoc#backup-and-restore-users-and-groups[Backup and Restore Users and Groups]. 
 
 * You can choose to have the rebalance process move an index's files between nodes instead of rebuilding them from scratch. 

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -92,6 +92,7 @@ The stats now also include the transient files in progress, state files, and con
 [#deprecated-features-and-platforms-760]
 == Deprecated and Removed Features and Platforms
 
+* The `cbbackup` and `cbrestore` utilities have been removed from Couchbase Server{nbsp}7.6. The same functionality is provided in `cbbackupmgr`.
 
 * Removed support for TLS 1.0 and 1.1.
 Both the standards bodies and Couchbase have already deprecated these versions due to their lack of security. (https://issues.couchbase.com/browse/MB-58045[MB-58045])


### PR DESCRIPTION
Noted that cbbackupmgr now encrypts data before sending off to the archive.