### PR TITLE
DOC-11686: New way to reference named parameters

### DIFF
--- a/modules/settings/examples/param-names.n1ql
+++ b/modules/settings/examples/param-names.n1ql
@@ -1,9 +1,9 @@
 /* tag::arguments[] */
-\SET -$country "France"; -- <1><2>
-\SET -$altitude 500;
+\SET -@country "France"; -- <1>
+\SET -$altitude 500; -- <2>
 /* end::arguments[] */
 
 /* tag::statement[] */
 SELECT COUNT(*) FROM airport
-WHERE country = $country AND geo.alt > $altitude;
+WHERE country = $country AND geo.alt > @altitude;
 /* end::statement[] */

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -168,7 +168,7 @@ a| [%hardbreaks]
 <<tximplicit,tximplicit>>
 <<txdata,txdata>>
 <<use_fts,use_fts>>
-<<identifier,${lt}__identifier__{gt}>>
+<<identifier,{lt}__symbol__{gt}{lt}__identifier__{gt}>>
 |===
 
 .Equivalent Settings for Cluster-Level and Node-Level
@@ -537,19 +537,18 @@ If any statement within the transaction uses a full-text index, by means of the 
 You can add placeholder parameters to a statement, so that you can safely supply variable values when you run the statement.
 A placeholder parameter may be a named parameter or a positional parameter.
 
-* To add a named parameter to a query, enter a dollar sign `$` followed by the parameter name.
+* To add a named parameter to a query, enter a dollar sign `$` or an at sign `@` followed by the parameter name.
 
 * To add a positional parameter to a query, either enter a dollar sign `$` followed by the number of the parameter, or enter a question mark `?`.
 
 To run a query containing placeholder parameters, you must supply values for the parameters.
 
-* The <<identifier,${lt}__identifier__{gt}>> request-level parameter enables you to supply a value for a named parameter.
-The {lt}__identifier__{gt} is the name of the parameter.
+* The <<identifier,{lt}__symbol__{gt}{lt}__identifier__{gt}>> request-level parameter enables you to supply a value for a named parameter.
+The name of this property is a dollar sign `$` or an at sign `@` followed by the parameter name.
 
 * The <<args,args>> request-level parameter enables you to supply a list of values for positional parameters.
 
 You can supply the values for placeholder parameters using any of the methods used to specify <<section_nnj_sjk_k1b,request-level parameters>>.
-In the cbq shell, the REST API, or the Query Workbench, the name of the parameter must begin with a dollar sign `$`.
 
 === Examples
 
@@ -564,6 +563,9 @@ The parameter values are supplied using the cbq shell.
 ----
 include::example$param-names.n1ql[tags=**]
 ----
+
+In this case, the named parameters and the named parameter placeholders use a mixture of `@` and `$` symbol prefixes.
+You can use either of these symbols for named parameters, as preferred.
 ====
 
 .Numbered Positional Parameters

--- a/modules/tools/pages/cbq-shell.adoc
+++ b/modules/tools/pages/cbq-shell.adoc
@@ -1512,16 +1512,16 @@ The cbq shell uses the prefix to differentiate between the different types of pa
 |===
 | Prefix | Parameter Type
 
-| -
+| `-`
 | Query parameter
 
-| -$
+| `-$` or `-@`
 | Named parameters
 
 | No prefix
 | Predefined (built-in) session variable
 
-| $
+| `$`
 | User defined session variable
 |===
 
@@ -1648,13 +1648,13 @@ Default: [.path]__.cbq_history__
 === Handling Named Parameters
 
 Use the \SET command to define named parameters.
-For each named parameter, prefix the variable name with `-$`.
+For each named parameter, prefix the variable name with `-$` or `-@`.
 The following example creates named parameters `r` and `date` with values 9.5 and "1-1-2016" respectively.
 
 [source,console]
 ----
 cbq> \SET -$r 9.5;
-cbq> \SET -$date "1-1-2016";
+cbq> \SET -@date "1-1-2016";
 ----
 
 === Handling Positional Parameters


### PR DESCRIPTION
Docs issue: DOC-11686

Docs preview:

* [Prepared Statements](https://preview.docs-test.couchbase.com/DOC-11686/server/current/guides/prep-statements.html) (how-to guide)
* [Settings and Parameters › Named Parameters and Positional Parameters](https://preview.docs-test.couchbase.com/DOC-11686/server/current/guides/prep-statements.html)
* [cbq › Parameter Manipulation › Setting Variable Values](https://preview.docs-test.couchbase.com/DOC-11686/server/current/guides/prep-statements.html)
* [cbq › Parameter Manipulation › Handling Named Parameters](https://preview.docs-test.couchbase.com/DOC-11686/server/current/guides/prep-statements.html)

Credentials: [Preview docs for internal review](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-review)

Depends on the following upstream PRs:

* https://github.com/couchbaselabs/docs-devex/pull/147
* https://github.com/couchbaselabs/cb-swagger/pull/117