### PR TITLE
DOC-11945: New way to reference positional parameters

### DIFF
--- a/modules/settings/examples/param-names.n1ql
+++ b/modules/settings/examples/param-names.n1ql
@@ -1,6 +1,6 @@
 /* tag::arguments[] */
-\SET -@country "France"; -- <1>
-\SET -$altitude 500; -- <2>
+\SET -@country "France";
+\SET -$altitude 500;
 /* end::arguments[] */
 
 /* tag::statement[] */

--- a/modules/settings/examples/param-numbers.n1ql
+++ b/modules/settings/examples/param-numbers.n1ql
@@ -4,5 +4,5 @@
 
 /* tag::statement[] */
 SELECT COUNT(*) FROM airport
-WHERE country = $1 AND geo.alt > $2;
+WHERE country = $1 AND geo.alt > @2;
 /* end::statement[] */

--- a/modules/settings/examples/param-numbers.n1ql
+++ b/modules/settings/examples/param-numbers.n1ql
@@ -1,5 +1,5 @@
 /* tag::arguments[] */
-\SET -args ["France", 500]; -- <1><2><3>
+\SET -args ["France", 500];
 /* end::arguments[] */
 
 /* tag::statement[] */

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -559,7 +559,7 @@ include::ROOT:partial$query-context.adoc[tag=section]
 The following query uses named parameter placeholders.
 The parameter values are supplied using the cbq shell.
 
-[source.no-callouts,sqlpp]
+[source,sqlpp]
 ----
 include::example$param-names.n1ql[tags=**]
 ----
@@ -573,7 +573,7 @@ You can use either of these symbols as preferred.
 The following query uses numbered positional parameter placeholders.
 The parameter values are supplied using the cbq shell.
 
-[source.no-callouts,sqlpp]
+[source,sqlpp]
 ----
 include::example$param-numbers.n1ql[tag=**]
 ----

--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -539,7 +539,7 @@ A placeholder parameter may be a named parameter or a positional parameter.
 
 * To add a named parameter to a query, enter a dollar sign `$` or an at sign `@` followed by the parameter name.
 
-* To add a positional parameter to a query, either enter a dollar sign `$` followed by the number of the parameter, or enter a question mark `?`.
+* To add a positional parameter to a query, enter a dollar sign `$` or an at sign `@` followed by the number of the parameter, or enter a question mark `?`.
 
 To run a query containing placeholder parameters, you must supply values for the parameters.
 
@@ -564,8 +564,8 @@ The parameter values are supplied using the cbq shell.
 include::example$param-names.n1ql[tags=**]
 ----
 
-In this case, the named parameters and the named parameter placeholders use a mixture of `@` and `$` symbol prefixes.
-You can use either of these symbols for named parameters, as preferred.
+The named parameters and named parameter placeholders in this example use a mixture of `@` and `$` symbol prefixes.
+You can use either of these symbols as preferred.
 ====
 
 .Numbered Positional Parameters
@@ -578,7 +578,10 @@ The parameter values are supplied using the cbq shell.
 include::example$param-numbers.n1ql[tag=**]
 ----
 
-In this case, the first positional parameter value is used for the placeholder numbered `$1`, the second positional parameter value is used for the placeholder numbered `$2`, and so on.
+In this case, the first positional parameter value is used for the placeholder numbered `$1`, the second positional parameter value is used for the placeholder numbered `@2`, and so on.
+
+The numbered positional parameter placeholders in this example use a mixture of `@` and `$` symbol prefixes.
+You can use either of these symbols as preferred.
 ====
 
 .Unnumbered Positional Parameters


### PR DESCRIPTION
Docs issue: DOC-11945

Docs preview:

* [Prepared Statements](https://preview.docs-test.couchbase.com/DOC-11945/server/current/guides/prep-statements.html) (how-to guide)
* [Settings and Parameters › Named Parameters and Positional Parameters](https://preview.docs-test.couchbase.com/DOC-11945/server/current/settings/query-settings.html#section_srh_tlm_n1b)

Credentials: [Preview docs for internal review](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-review)

Depends on the following upstream PR:

* https://github.com/couchbaselabs/docs-devex/pull/148