### PR TITLE
DOC-11947 [Trinity Release Note] : Rocky Linux and Alma Linux are missing from supported platform

### DIFF
--- a/modules/introduction/partials/new-features-76.adoc
+++ b/modules/introduction/partials/new-features-76.adoc
@@ -3,7 +3,9 @@
 * Couchbase Server 7.6 adds support for the following platforms:
 +
 --
+** Alma Linux 9
 ** Debian Linux 12 (Bookworm)
+** Rocky Linux 9
 ** macOS 13 "Ventura"
 ** macOS 14 "Sonoma"
 --


### PR DESCRIPTION
Support for additional platforms noted in new-features-76.adoc