### PR TITLE
[DOC-11973] Removed line about NRU

### DIFF
--- a/modules/learn/pages/buckets-memory-and-storage/buckets.adoc
+++ b/modules/learn/pages/buckets-memory-and-storage/buckets.adoc
@@ -53,8 +53,6 @@ For a Memcached bucket, this means that data, which is resident in memory (but, 
 Therefore, if removed data is subsequently needed, it cannot be re-acquired from Couchbase Server.
 Ejection removes all of an item's data.
 
-For all bucket-types, items are selected for ejection by means of the _Not Recently Used_ (NRU) algorithm.
-
 All bucket types are fully compatible with the Memcached open source distributed key-value cache.
 
 == Bucket Capabilities


### PR DESCRIPTION
Jira ticket: https://issues.couchbase.com/browse/DOC-11973

Change in this PR:
- Removed line about NRU from https://docs.couchbase.com/server/current/learn/buckets-memory-and-storage/buckets.html (Couchbase doesn't use NRU)

At some point, when we have more bandwidth, we should aim to document that buckets use the MFU algorithm to determine what to eject (more info here https://github.com/couchbase/kv_engine/blob/v7.2.0/docs/HiFi_MFU_eviction_policy.md)

