### PR TITLE
DOC-11980: Changes to "What’s New in Version 7.6" in the Query tab

### DIFF
--- a/modules/introduction/partials/new-features-76.adoc
+++ b/modules/introduction/partials/new-features-76.adoc
@@ -203,6 +203,8 @@ The Query service adds new cluster-level, node-level, and request-level paramete
 
 * The CREATE FUNCTION statement now enables users to create a {sqlpp} user-defined function and the corresponding external JavaScript code in a single operation, without having to create an external library.
 
+* When a query executes a user-defined function, profiling information is now available for any queries within the UDF.
+
 * The SORT BY and GROUP BY operations overspill to disk if they exceed the Query service memory quota.
 
 === Analytics

--- a/modules/introduction/partials/new-features-76.adoc
+++ b/modules/introduction/partials/new-features-76.adoc
@@ -176,6 +176,7 @@ See xref:learn:data/expiration.adoc[] for more information.
 ** FORMALIZE() function.
 ** Multi-bye aware string functions.
 ** Support for sequences.
+** EXPLAIN FUNCTION statement.
 
 * The WITH clause adds support for recursive CTEs.
 

--- a/modules/introduction/partials/new-features-76.adoc
+++ b/modules/introduction/partials/new-features-76.adoc
@@ -197,8 +197,6 @@ See xref:learn:data/expiration.adoc[] for more information.
 
 * The node-level and request-level N1QL Feature Control parameters now accept hexadecimal strings or decimal integers.
 
-* If an uncovered query only references specific fields, the fetch operation retrieves just the necessary fields from the Data service, instead of the entire document.
-
 * The SORT BY and GROUP BY operations overspill to disk if they exceed the Query service memory quota.
 
 === Analytics

--- a/modules/introduction/partials/new-features-76.adoc
+++ b/modules/introduction/partials/new-features-76.adoc
@@ -197,6 +197,9 @@ See xref:learn:data/expiration.adoc[] for more information.
 
 * The node-level and request-level N1QL Feature Control parameters now accept hexadecimal strings or decimal integers.
 
+* Queries can now read from replica vBuckets when active vBuckets are inaccessible.
+The Query service adds new cluster-level, node-level, and request-level parameters to configure this feature.
+
 * The SORT BY and GROUP BY operations overspill to disk if they exceed the Query service memory quota.
 
 === Analytics

--- a/modules/introduction/partials/new-features-76.adoc
+++ b/modules/introduction/partials/new-features-76.adoc
@@ -170,11 +170,11 @@ See xref:learn:data/expiration.adoc[] for more information.
 
 === Query Service
 
-* SQL++ language additions:
+* {sqlpp} language additions:
 ** OFFSET clause added to the DELETE statement.
 ** GROUP AS clause added to the GROUP BY clause.
 ** FORMALIZE() function.
-** Multi-bye aware string functions.
+** Multi-byte aware string functions.
 ** Support for sequences.
 ** EXPLAIN FUNCTION statement.
 
@@ -182,13 +182,13 @@ See xref:learn:data/expiration.adoc[] for more information.
 
 * The CREATE COLLECTION statement adds support for maxTTL.
 
-* The cbq shell adds a `-query_context`  command line option.
+* The cbq shell adds a `-query_context` command line option.
 
 * The cbq shell adds an `-advise` command line option.
 
- * The `/clusterInit` endpoint in the Nodes and Clusters REST API adds support for Query memory quotas.
+* The `/clusterInit` endpoint in the Nodes and Clusters REST API adds support for Query memory quotas.
 
- *  Named and positional parameters can now be prefixed by `$` or `@` in a query.
+* Named and positional parameters can now be prefixed by `$` or `@` in a query.
 
 * `num_replica` configured for each index can now be found through {sqlpp} statement: `system:indexes`
 

--- a/modules/introduction/partials/new-features-76.adoc
+++ b/modules/introduction/partials/new-features-76.adoc
@@ -205,6 +205,8 @@ The Query service adds new cluster-level, node-level, and request-level paramete
 
 * When a query executes a user-defined function, profiling information is now available for any queries within the UDF.
 
+* The Query service collects statistics for the cost-based optimizer automatically when an index is created or built.
+
 * The SORT BY and GROUP BY operations overspill to disk if they exceed the Query service memory quota.
 
 === Analytics

--- a/modules/introduction/partials/new-features-76.adoc
+++ b/modules/introduction/partials/new-features-76.adoc
@@ -200,6 +200,8 @@ See xref:learn:data/expiration.adoc[] for more information.
 * Queries can now read from replica vBuckets when active vBuckets are inaccessible.
 The Query service adds new cluster-level, node-level, and request-level parameters to configure this feature.
 
+* The CREATE FUNCTION statement now enables users to create a {sqlpp} user-defined function and the corresponding external JavaScript code in a single operation, without having to create an external library.
+
 * The SORT BY and GROUP BY operations overspill to disk if they exceed the Query service memory quota.
 
 === Analytics


### PR DESCRIPTION
Docs issue: DOC-11980

This PR updates the Query section in the What's New in Version 7.6 document.

[Draft documentation preview](https://github.com/couchbase/docs-server/blob/e219c0c5d2e5048b21667c685a5e2131de8c15da/modules/introduction/partials/new-features-76.adoc#query-service)
