### PR TITLE
DOC-11990 Removing CentOS 7.x and Redhat 7.x from supported

### DIFF
--- a/modules/install/pages/install-platforms.adoc
+++ b/modules/install/pages/install-platforms.adoc
@@ -27,10 +27,6 @@ ARM64 support requires ARMv8 CPUs, such as the Amazon Graviton series.
 | Amazon Linux 2023
 | AL2023 (x86-64, ARM64)
 
-| CentOS
-| 7.x (deprecated in Couchbase Server{nbsp}7.2)
-
-
 | Debian
 | 12.x
 
@@ -43,9 +39,7 @@ ARM64 support requires ARMv8 CPUs, such as the Amazon Graviton series.
 9.x
 
 | Red Hat Enterprise Linux (RHEL)
-| 7.x (deprecated in Couchbase Server{nbsp}7.2)
-
-8.x
+| 8.x
 
 9.x
 

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -17,8 +17,10 @@ deprecated in Couchbase Server{nbsp}7.6:
 
 * We are removing these platforms from support (they are already deprecated):
 
+** CentOS 7.x
 ** Debian Linux 10 (Buster)
 ** MacOS 11 (BigSur)
+** Red Hat Enterprise Linux (RHEL) 7.x
 
 * Removed support for TLS `1.0` and `1.1`. Both the standards bodies and Couchbase have already deprecated these versions due to their lack of security. (https://issues.couchbase.com/browse/MB-58045[MB-58045])
 


### PR DESCRIPTION
Removed from supported platforms. Updated list of removed platforms in the release notes.