### PR TITLE
[DOC-11995] Added "more information" links to Eventing What's New

### DIFF
--- a/modules/introduction/partials/new-features-76.adoc
+++ b/modules/introduction/partials/new-features-76.adoc
@@ -216,7 +216,7 @@ For more information, see xref:server:eventing:eventing-advanced-keyspace-access
 
 * The built-in `ANALYTICS()` function allows the Eventing Service to integrate directly with {sqlpp} Analytics.
 This integration simplifies Eventing code logic and lets Eventing benefit from the high availability and load balancing of {sqlpp} Analytics.
-For more information, see xref:server:eventing:eventing-language-constructs.adoc#analytics_call[`ANALYTICS()`].
+For more information, see xref:server:eventing:eventing-language-constructs.adoc#analytics_call[`ANALYTICS()` Function Call].
 
 * The advanced TOUCH operation allows you to modify the expiration time of a document without having to access that document first.
 For more information, see xref:server:eventing:eventing-advanced-keyspace-accessors.adoc#advanced-touch-op[Advanced TOUCH Operation].

--- a/modules/introduction/partials/new-features-76.adoc
+++ b/modules/introduction/partials/new-features-76.adoc
@@ -209,6 +209,22 @@ The Query service adds new cluster-level, node-level, and request-level paramete
 
 * The SORT BY and GROUP BY operations overspill to disk if they exceed the Query service memory quota.
 
+=== Eventing Service
+
+* The optional parameter `{ "self_recursion": true }` can be used with the INSERT, UPSERT, and REPLACE advanced operations to prevent the suppression of recursive source bucket mutations.
+For more information, see xref:server:eventing:eventing-advanced-keyspace-accessors.adoc#optional-params-recursion[Optional `{ "self_recursion": true }` Parameter].
+
+* The built-in `ANALYTICS()` function allows the Eventing Service to integrate directly with {sqlpp} Analytics.
+This integration simplifies Eventing code logic and lets Eventing benefit from the high availability and load balancing of {sqlpp} Analytics.
+For more information, see xref:server:eventing:eventing-language-constructs.adoc#analytics_call[`ANALYTICS()`].
+
+* The advanced TOUCH operation allows you to modify the expiration time of a document without having to access that document first.
+For more information, see xref:server:eventing:eventing-advanced-keyspace-accessors.adoc#advanced-touch-op[Advanced TOUCH Operation].
+
+* The Sub-Document MUTATEIN operation allows you to modify only parts of a document instead of the entire document.
+This Sub-Document operation is faster and more efficient than a full-document operation like REPLACE or UPSERT.
+For more information, see xref:server:eventing:eventing-advanced-keyspace-accessors.adoc#advanced-subdoc-array-op[Sub-Document MUTATEIN Operation].
+
 === Analytics
 
 [#power-bi-connector-1-0-release]
@@ -222,18 +238,6 @@ Binaries::
 https://packages.couchbase.com/releases/couchbase-powerbi-connector/1.0/couchbase-powerbi-connector-1.0.mez[powerbi-connector-1.0.mez]
 Binaries SHAs::
 https://packages.couchbase.com/releases/couchbase-powerbi-connector/1.0/couchbase-powerbi-connector-1.0.mez.sha256[powerbi-connector-1.0.mez.sha256]
-
-=== Eventing Service
-
-* The optional parameter `{ "self_recursion": true }` can be used with the INSERT, UPSERT, and REPLACE advanced operations to prevent the suppression of recursive source bucket mutations.
-
-* The built-in `ANALYTICS()` function allows the Eventing Service to integrate directly with {sqlpp} Analytics.
-This integration simplifies Eventing code logic and lets Eventing benefit from the high availability and load balancing of {sqlpp} Analytics.
-
-* The advanced TOUCH operation allows you to modify the expiration time of a document without having to access that document first.
-
-* The Sub-Document MUTATEIN operation allows you to modify only parts of a document instead of the entire document.
-This Sub-Document operation is faster and more efficient than a full-document operation like REPLACE or UPSERT.
 
 === Install & Upgrade
 


### PR DESCRIPTION
Change in this PR:
- Added "more info" links to Eventing bullet points
- Moved Eventing section to be after Query and before Analytics