### PR TITLE
DOC-11628 & DOC-11677 storage migration updates

### DIFF
--- a/modules/manage/examples/migrate-bucket-storage-backend.sh
+++ b/modules/manage/examples/migrate-bucket-storage-backend.sh
@@ -23,9 +23,9 @@ curl -s GET -u Administrator:password \
 # end::get-backend[]
 
 # tag::get-node-overrides[]
-curl GET -u Administrator:password \
+curl -s GET -u Administrator:password \
     http://localhost:8091/pools/default/buckets/travel-sample \
-    jq '.nodes[] | .hostname,.storageBackend'  
+    | jq '.nodes[] | .hostname,.storageBackend'  
 # end::get-node-overrides[]
 
 
@@ -50,3 +50,12 @@ curl -X POST -u Administrator:password  \
     http://localhost:8091/controller/rebalance \
     -d 'knownNodes=ns_1@node1.,ns_1@node2.,ns_1@node3.'
 # end::rebalance-cluster[]
+
+
+# tag::change-backend-couchstore[]
+curl -X POST -u Administrator:password \
+  http://localhost:8091/pools/default/buckets/travel-sample \
+  -d 'storageBackend=couchstore'
+# end::change-backend-couchstore[]
+
+

--- a/modules/manage/pages/manage-buckets/migrate-bucket.adoc
+++ b/modules/manage/pages/manage-buckets/migrate-bucket.adoc
@@ -5,11 +5,11 @@
 
 == Storage Backend Migration Overview
 
-You can migrate a bucket's storage backend if you find the bucket's current backend is not appropriate. 
-You can migrate from Couchstore to Magma, or from Magma to Couchstore. 
+You can migrate a bucket's storage backend if you find the bucket's current performance is not meeting your needs. 
 For example, you can migrate a bucket from Couchstore to Magma if the bucket's working set grows beyond its memory quota. 
 
-You start a bucket's migration by calling the REST API to edit the bucket's `storageBackend` parameter. 
+You can migrate from Couchstore to Magma, or from Magma to Couchstore. 
+You start a bucket's migration by calling the REST API to edit the bucket's `storageBackend` setting. 
 This call changes the bucket's global storage backend parameter. 
 However, it does not trigger an immediate conversion of the vBuckets to the new backend. 
 Instead, Couchbase adds override settings to each node to indicate its vBuckets still use the old storage backend. 
@@ -103,28 +103,31 @@ If the bucket has a low write workload, Couchbase Server may be able to compact 
 
 Magma's default fragmentation threshold is 50%.
 Couchbase Server treats this threshold differently than the Couchstore threshold.
-It does not try to compact the bucket until it has 0% fragmentation.
-Instead, Couchbase Server tries to compact a Magma bucket to maintain its fragmentation at 50%.
-This maintenance of 50% fragmentation may result in greater disk use for a Magma-backed bucket verses the Couchstore-backed bucket.
+It does not perform a full compaction with the goal of reducing the bucket's fragmentation to 0%.
+Instead, Couchbase Server compacts a Magma bucket to maintain its fragmentation at the threshold value.
+This maintenance of the default 50% fragmentation can result in greater disk use for a Magma-backed bucket verses the Couchstore-backed bucket.
 
-If you find that a bucket migrated to Magma has high disk use, you have two options:
+If a bucket you migrated to Magma has higher sustained disk use that interferes with the node's performance, you have two options:
 
 * Reduce the fragmentation threshold of the Magma bucket. 
-FOr example, you could choose to reduce the fragmentation threshold to 30%.
-You should only consider changing the threshold if the bucket's workload is not write intensive.
+For example, you could choose to reduce the fragmentation threshold to 30%.
+You should only consider changing the threshold if the bucket's workload is not write-intensive.
+For write-intensive workloads, the best practice for Magma buckets is to leave the fragmentation setting at 50%.
+See xref:manage:manage-settings/configure-compact-settings.adoc[] to learn how to change the bucket's database fragmentation setting.
 
 * Roll back the migration. 
-You can revert a bucket from Magma back to Couchstore after (or even during) a migration.
+You can revert a bucket from Magma back to Couchstore during or after a migration.
 See the next section for more information.
 
 == Rolling Back a Migration
 
-As you migrate each node's vBuckets to a new storage backend, you may decided that the migration is not meeting your needs.
+As you migrate each node's vBuckets to a new storage backend, you may decide that the migration is not meeting your needs.
 For example, you may see increased disk usage when moving from Couchstore to Magma as explained in xref:#disk_usage[Disk Use Under Couchstore Verses Magma].
-You can roll back the migration by changing the bucket's backend setting to its original value.
-Then have any migrated nodes rewrite their vBuckets back to the old backend.
-You can perform a roll back on an ongoing migration. 
-Just force the nodes you have already migrated to rewrite their vBuckets.
+You can roll back the migration by:
+
+. Changing the bucket's backend setting to its original value.
+. Force any migrated nodes to rewrite their vBuckets back to the old backend.
+
 You do not have to perform any steps for nodes you did not migrate.
 
 For example, to roll back the migration shown in xref:#perform_migration[Perform a Migration], you would follow these steps:

--- a/modules/manage/pages/manage-buckets/migrate-bucket.adoc
+++ b/modules/manage/pages/manage-buckets/migrate-bucket.adoc
@@ -1,9 +1,9 @@
 = Migrate a Bucket's Storage Backend
 :description: Full and Cluster Administrators can migrate a bucket's storage backend by calling the REST API and then performing full restores on the nodes containing the bucket.
 
-== Storage Backend Migration Overview
-
 [.edition]#{enterprise}#
+
+== Storage Backend Migration Overview
 
 You can migrate a bucket's storage backend if you find the bucket's current backend is not appropriate. 
 You can migrate from Couchstore to Magma, or from Magma to Couchstore. 
@@ -26,6 +26,10 @@ Before migrating a bucket, verify that the bucket's parameters meet the requirem
 For example, a Magma bucket must have a memory quota of at least 1{nbsp}GB. 
 The REST API call to change the bucket's storage backend returns an error if the bucket does not meet the new storage backend's requirements. 
 See xref:learn:buckets-memory-and-storage/storage-engines.adoc[] for a list of storage backend requirements.
+
+If you're planning to migrate from Couchstore to Magma, also consider the current disk usage on the nodes containing the bucket. 
+Magma's default fragmentation settings can result in higher disk use. 
+See xref:#disk_usage[Disk Use Under Couchstore Verses Magma] for more information.
 
 [#perform_migration]
 == Perform a Migration
@@ -90,36 +94,42 @@ It has migrated to the new storage backend.
 . Repeat the previous two steps for the remaining nodes in the cluster.
 
 [#disk_usage]
-== Disk Usage Under Couchstore Verses Magma
+== Disk Use Under Couchstore Verses Magma
 
 If you migrate a bucket's storage from Couchstore to Magma, you may see increased disk usage. 
 Couchstore's default threshold for fragmentation is 30%.
 When a Couchstore bucket reaches this threshold, Couchbase Server attempts to fully compact the bucket. 
 If the bucket has a low write workload, Couchbase Server may be able to compact the bucket to 0% fragmentation.
+
 Magma's default fragmentation threshold is 50%.
 Couchbase Server treats this threshold differently than the Couchstore threshold.
-Instead of attempting to compact the bucket until it has 0% fragmentation, Couchbase Server tries to compact a Magma bucket to maintain its fragmentation at 50%.
-This maintenance of 50% fragmentation may result in greater disk use for a Magma-backed bucket vs. the Couchstore-backed bucket.
+It does not try to compact the bucket until it has 0% fragmentation.
+Instead, Couchbase Server tries to compact a Magma bucket to maintain its fragmentation at 50%.
+This maintenance of 50% fragmentation may result in greater disk use for a Magma-backed bucket verses the Couchstore-backed bucket.
 
-If you find the migrated bucket's disk use is too high, you have two options:
+If you find that a bucket migrated to Magma has high disk use, you have two options:
 
-* Reduce the fragmentation threshold of the Magma bucket to 30%.
+* Reduce the fragmentation threshold of the Magma bucket. 
+FOr example, you could choose to reduce the fragmentation threshold to 30%.
 You should only consider changing the threshold if the bucket's workload is not write intensive.
 
 * Roll back the migration. 
-You can migrate a bucket from Magma back to Couchstore after conversion.
-You can even roll back an in-process migration if you notice high disk usage on nodes that you have already migrated.
-See the next section for details.
+You can revert a bucket from Magma back to Couchstore after (or even during) a migration.
+See the next section for more information.
 
 == Rolling Back a Migration
 
 As you migrate each node's vBuckets to a new storage backend, you may decided that the migration is not meeting your needs.
-For example, you may see increased disk usage when moving from Couchstore to Magma as explained in xref:#disk_usage[Disk Usage Under Couchstore Verses Magma].
-In this case, you can roll back the migration:
+For example, you may see increased disk usage when moving from Couchstore to Magma as explained in xref:#disk_usage[Disk Use Under Couchstore Verses Magma].
+You can roll back the migration by changing the bucket's backend setting to its original value.
+Then have any migrated nodes rewrite their vBuckets back to the old backend.
+You can perform a roll back on an ongoing migration. 
+Just force the nodes you have already migrated to rewrite their vBuckets.
+You do not have to perform any steps for nodes you did not migrate.
 
-. Call the REST API to change the bucket's backed back to its previous value. 
-For example, suppose you followed the steps in xref:#perform_migration[Perform a Migration] to migrate the Travel Sample bucket to Magma.
-Then you would use this command to roll it back:
+For example, to roll back the migration shown in xref:#perform_migration[Perform a Migration], you would follow these steps:
+
+. Call the REST API to change the bucket's backend back to Couchstore: 
 +
 [source,console]
 ----
@@ -133,7 +143,7 @@ include::manage:example$migrate-bucket-storage-backend.sh[tag=change-backend-cou
 include::manage:example$migrate-bucket-storage-backend.sh[tag=get-node-overrides]
 ----
 +
-If you followed the earlier example of migrating the Travel Sample bucket to Magma, the output would look like this:
+For the migration shown in xref:#perform_migration[Perform a Migration], the output looks like this:
 +
 [source,json]
 ----
@@ -145,11 +155,11 @@ null
 null
 ----
 +
-In this case, the node named node3 was migrated to Magma and must be rolled back.
+In this case, you must roll back node3 because you migrated it to Magma.
 
 . For each node that you have already migrated, perform another xref:install:upgrade-procedure-selection.adoc#swap-rebalance[swap rebalance] or a xref:learn:clusters-and-availability/graceful-failover.adoc[graceful failover] followed by a xref:learn:clusters-and-availability/recovery.adoc#full-recovery[full recovery] and xref:learn:clusters-and-availability/rebalance.adoc[rebalance] to roll the vBuckets on the node back to the previous backend. 
 +
-For example, to roll back node3 shown in the prior step, follow these steps:
+To roll back node3, follow these steps:
 +
 .. Perform a graceful failover of node3: 
 +

--- a/modules/manage/pages/manage-buckets/migrate-bucket.adoc
+++ b/modules/manage/pages/manage-buckets/migrate-bucket.adoc
@@ -5,26 +5,40 @@
 
 [.edition]#{enterprise}#
 
-You can migrate a bucket's storage backend if you find the bucket's current backend is not appropriate. You can migrate from Couchstore to Magma, or from Magma to Couchstore. For example, you can migrate a bucket from Couchstore to Magma if the bucket's working set grows beyond its memory quota. 
+You can migrate a bucket's storage backend if you find the bucket's current backend is not appropriate. 
+You can migrate from Couchstore to Magma, or from Magma to Couchstore. 
+For example, you can migrate a bucket from Couchstore to Magma if the bucket's working set grows beyond its memory quota. 
 
-You start a bucket's migration by calling the REST API to edit the bucket's `storageBackend` parameter. This call changes the bucket's global storage backend parameter. However, it doesn't trigger an immediate conversion of the vBuckets to the new backend. Instead, Couchbase adds override settings to each node to indicate its vBuckets still use the old storage backend. To complete the migration, you must force the vBuckets to be rewritten. The two ways to trigger this rewrite is by performing a swap rebalance or a graceful failover followed by a full recovery. As Couchbase writes the vBuckets during these processes, it removes the storage override and saves the vBuckets using the new storage backend.
+You start a bucket's migration by calling the REST API to edit the bucket's `storageBackend` parameter. 
+This call changes the bucket's global storage backend parameter. 
+However, it does not trigger an immediate conversion of the vBuckets to the new backend. 
+Instead, Couchbase adds override settings to each node to indicate its vBuckets still use the old storage backend. 
+To complete the migration, you must force the vBuckets to be rewritten. 
+The two ways to trigger this rewrite are to perform a swap rebalance or a graceful failover followed by a full recovery. 
+As Couchbase writes the vBuckets during these processes, it removes the storage override and saves the vBuckets using the new storage backend.
 
-NOTE: While you're migrating a bucket between storage backends, you can only change the bucket's `ramQuota` and `storageBackend` parameters. Couchbase Server prevents you from making changes to the bucket's other parameters.
+NOTE: While you're migrating a bucket between storage backends, you can only change the bucket's `ramQuota` and `storageBackend` parameters. 
+Couchbase Server prevents you from making changes to the bucket's other parameters.
 
 == Prerequisites
 
-Before migrating a bucket, verify that the bucket's parameters meet the requirements for the new storage backend. For example, a Magma bucket must have a memory quota of at least 1{nbsp}GB. The REST API call to change the bucket's storage backend returns an error if the bucket doesn't meet the new storage backend's requirements. See xref:learn:buckets-memory-and-storage/storage-engines.adoc[] for a list of storage backend requirements.
+Before migrating a bucket, verify that the bucket's parameters meet the requirements for the new storage backend. 
+For example, a Magma bucket must have a memory quota of at least 1{nbsp}GB. 
+The REST API call to change the bucket's storage backend returns an error if the bucket does not meet the new storage backend's requirements. 
+See xref:learn:buckets-memory-and-storage/storage-engines.adoc[] for a list of storage backend requirements.
 
-
+[#perform_migration]
 == Perform a Migration
 
-. Call the REST API to change the bucket's `storageBackend` parameter. For example, the following command changes the storage backend of the travel-sample bucket to Magma.
+. Call the REST API to change the bucket's `storageBackend` parameter. 
+For example, the following command changes the storage backend of the travel-sample bucket to Magma.
 +
 [source,console]
 ----
 include::manage:example$migrate-bucket-storage-backend.sh[tag=change-backend]
 ----
-. Verify that the nodes containing the bucket now have storage backend override settings for their vBuckets. The following example calls the REST API to get the bucket configuration and filters the result through the `jq` command to list the node names and their storage backend formats.
+. Verify that the nodes containing the bucket now have storage backend override settings for their vBuckets. 
+The following example calls the REST API to get the bucket configuration and filters the result through the `jq` command to list the node names and their storage backend formats.
 +
 [source,console]
 ----
@@ -36,9 +50,13 @@ The output of the previous command lists each node and the backend storage forma
 ----
 include::example$storage_backend_overrides.log[]
 ----
-. For every node that contains the bucket, perform either a xref:install:upgrade-procedure-selection.adoc#swap-rebalance[swap rebalance] or a xref:learn:clusters-and-availability/graceful-failover.adoc[graceful failover] followed by a xref:learn:clusters-and-availability/recovery.adoc#full-recovery[full recovery] and xref:learn:clusters-and-availability/rebalance.adoc[rebalance] to rewrite the vBuckets on the node. Both of these methods have their own limitations. Swap rebalance requires that you add an additional node to the cluster. The graceful failover and full recovery method temporarily removes a node from your cluster which can cause disruptions. 
+. For every node that contains the bucket, perform either a xref:install:upgrade-procedure-selection.adoc#swap-rebalance[swap rebalance] or a xref:learn:clusters-and-availability/graceful-failover.adoc[graceful failover] followed by a xref:learn:clusters-and-availability/recovery.adoc#full-recovery[full recovery] and xref:learn:clusters-and-availability/rebalance.adoc[rebalance] to rewrite the vBuckets on the node. 
+Both of these methods have their own limitations. 
+Swap rebalance requires that you add an additional node to the cluster. 
+The graceful failover and full recovery method temporarily removes a node from your cluster which can cause disruptions. 
 +
-You can take these steps via the UI, the command-line tool, or REST API calls. The following example demonstrates using the REST API to perform a graceful failover and full recovery on a node named node3.
+You can take these steps via the UI, the command-line tool, or REST API calls. 
+The following example demonstrates using the REST API to perform a graceful failover and full recovery on a node named node3.
 +
 .. Perform a graceful failover of node3: 
 +
@@ -46,7 +64,8 @@ You can take these steps via the UI, the command-line tool, or REST API calls. T
 ----
 include::manage:example$migrate-bucket-storage-backend.sh[tag=failover-node]
 ----
-.. Wait until the failover is complete. Then perform a full recovery on the node:
+.. Wait until the failover is complete. 
+Then perform a full recovery on the node:
 +
 [source,console]
 ----
@@ -58,12 +77,98 @@ include::manage:example$migrate-bucket-storage-backend.sh[tag=recover-node]
 ----
 include::manage:example$migrate-bucket-storage-backend.sh[tag=rebalance-cluster]
 ----
-. After triggering each node to rewrite its vBuckets, verify the node is now using the new storage backend. Re-run the command from step 2 to list the nodes and any storage backend overrides:
+. After triggering each node to rewrite its vBuckets, verify the node is now using the new storage backend. 
+Re-run the command from step 2 to list the nodes and any storage backend overrides:
 +
 [source,console]
 ----
 include::manage:example$storage-backend-override-node3.sh[]
 ----
 +
-The `null` under node3 indicates that it does not have a storage backend override. It has migrated to the new storage backend.
+The `null` under node3 indicates that it does not have a storage backend override. 
+It has migrated to the new storage backend.
 . Repeat the previous two steps for the remaining nodes in the cluster.
+
+[#disk_usage]
+== Disk Usage Under Couchstore Verses Magma
+
+If you migrate a bucket's storage from Couchstore to Magma, you may see increased disk usage. 
+Couchstore's default threshold for fragmentation is 30%.
+When a Couchstore bucket reaches this threshold, Couchbase Server attempts to fully compact the bucket. 
+If the bucket has a low write workload, Couchbase Server may be able to compact the bucket to 0% fragmentation.
+Magma's default fragmentation threshold is 50%.
+Couchbase Server treats this threshold differently than the Couchstore threshold.
+Instead of attempting to compact the bucket until it has 0% fragmentation, Couchbase Server tries to compact a Magma bucket to maintain its fragmentation at 50%.
+This maintenance of 50% fragmentation may result in greater disk use for a Magma-backed bucket vs. the Couchstore-backed bucket.
+
+If you find the migrated bucket's disk use is too high, you have two options:
+
+* Reduce the fragmentation threshold of the Magma bucket to 30%.
+You should only consider changing the threshold if the bucket's workload is not write intensive.
+
+* Roll back the migration. 
+You can migrate a bucket from Magma back to Couchstore after conversion.
+You can even roll back an in-process migration if you notice high disk usage on nodes that you have already migrated.
+See the next section for details.
+
+== Rolling Back a Migration
+
+As you migrate each node's vBuckets to a new storage backend, you may decided that the migration is not meeting your needs.
+For example, you may see increased disk usage when moving from Couchstore to Magma as explained in xref:#disk_usage[Disk Usage Under Couchstore Verses Magma].
+In this case, you can roll back the migration:
+
+. Call the REST API to change the bucket's backed back to its previous value. 
+For example, suppose you followed the steps in xref:#perform_migration[Perform a Migration] to migrate the Travel Sample bucket to Magma.
+Then you would use this command to roll it back:
++
+[source,console]
+----
+include::manage:example$migrate-bucket-storage-backend.sh[tag=change-backend-couchstore]
+----
+
+. Determine which nodes you have already migrated by calling the REST API to get the bucket's metadata:
++
+[source,console]
+----
+include::manage:example$migrate-bucket-storage-backend.sh[tag=get-node-overrides]
+----
++
+If you followed the earlier example of migrating the Travel Sample bucket to Magma, the output would look like this:
++
+[source,json]
+----
+"node3.:8091"
+"magma"
+"node2.:8091"
+null
+"node1.:8091"
+null
+----
++
+In this case, the node named node3 was migrated to Magma and must be rolled back.
+
+. For each node that you have already migrated, perform another xref:install:upgrade-procedure-selection.adoc#swap-rebalance[swap rebalance] or a xref:learn:clusters-and-availability/graceful-failover.adoc[graceful failover] followed by a xref:learn:clusters-and-availability/recovery.adoc#full-recovery[full recovery] and xref:learn:clusters-and-availability/rebalance.adoc[rebalance] to roll the vBuckets on the node back to the previous backend. 
++
+For example, to roll back node3 shown in the prior step, follow these steps:
++
+.. Perform a graceful failover of node3: 
++
+[source,console]
+----
+include::manage:example$migrate-bucket-storage-backend.sh[tag=failover-node]
+----
+.. Wait until the failover is complete. 
+Then perform a full recovery on the node:
++
+[source,console]
+----
+include::manage:example$migrate-bucket-storage-backend.sh[tag=recover-node]
+----
+.. When recovery is complete, perform a rebalance:
++
+[source,console]
+----
+include::manage:example$migrate-bucket-storage-backend.sh[tag=rebalance-cluster]
+----
+
+. Repeat the previous step until all nodes that you'd migrated have rolled back to their original storage backend. 


### PR DESCRIPTION
All changes are in [Migrate a Bucket’s Storage Backend](https://preview.docs-test.couchbase.com/migration_updates_7.6/server/current/manage/manage-buckets/migrate-bucket.html) (link leads to preview of changes).

Summary of changes made for these tickets:

- [DOC-11628](https://issues.couchbase.com/browse/DOC-11628) [storage migration] Include a note to mention storageBackend migration can be rolled back mid migration. Added [Rolling Back a Migration](https://preview.docs-test.couchbase.com/migration_updates_7.6/server/current/manage/manage-buckets/migrate-bucket.html#rolling-back-a-migration) section.
- [DOC-11677](https://issues.couchbase.com/browse/DOC-11677) Update to Couchstore-to-Magma document. Added [Disk Use Under Couchstore Verses Magma](https://preview.docs-test.couchbase.com/migration_updates_7.6/server/current/manage/manage-buckets/migrate-bucket.html#disk_usage)



