### PR TITLE
DOC-11998: What’s New in 7.6 — Query section does not have links

### DIFF
--- a/modules/introduction/partials/new-features-76.adoc
+++ b/modules/introduction/partials/new-features-76.adoc
@@ -37,9 +37,9 @@ Assignment can be made by means of either the CLI or the REST API.
 This feature allows the cluster's most mission-critical data to be rebalanced most quickly.
 See xref:rest-api:rest-bucket-create.adoc[Creating and Editing Buckets].
 
-* You can now have Couchbase Server prune rotated audit logs after a period of time. 
-You set how long  Couchbase Server should keep audit logs by using the new `pruneAge` parameter for the `/settings/audit` endpoint. 
-The default value of 0 means that Couchbase Server does not prune audit logs. 
+* You can now have Couchbase Server prune rotated audit logs after a period of time.
+You set how long  Couchbase Server should keep audit logs by using the new `pruneAge` parameter for the `/settings/audit` endpoint.
+The default value of 0 means that Couchbase Server does not prune audit logs.
 See xref:rest-api:rest-auditing.adoc[Configure Auditing].
 
 * You can add one or more arbiter nodes to a cluster.
@@ -47,15 +47,15 @@ include::learn:partial$arbiter-node-benefits.adoc[]
 
 === Backup and Restore
 
-* The Role-Based Access Control (RBAC) REST API has a new `backup` endpoint that lets you backup and restore user and user groups. See xref:rest-api:rbac.adoc#backup-and-restore-users-and-groups[Backup and Restore Users and Groups]. 
+* The Role-Based Access Control (RBAC) REST API has a new `backup` endpoint that lets you backup and restore user and user groups. See xref:rest-api:rbac.adoc#backup-and-restore-users-and-groups[Backup and Restore Users and Groups].
 
-* The `cbbackupmgr` command has a new `--enable-users` flag that backs up user groups and users including roles and permissions. 
-When you supply the new argument, `cbbackupmgr` saves user passwords in the backup in a hashed format. 
-When restoring a backup, `cbbackupmgr` defaults to not overwriting existing users in the database with identically named users in the backup. 
-You can change this default behavior using the new `--overwrite-users` command-line argument. 
+* The `cbbackupmgr` command has a new `--enable-users` flag that backs up user groups and users including roles and permissions.
+When you supply the new argument, `cbbackupmgr` saves user passwords in the backup in a hashed format.
+When restoring a backup, `cbbackupmgr` defaults to not overwriting existing users in the database with identically named users in the backup.
+You can change this default behavior using the new `--overwrite-users` command-line argument.
 See xref:backup-restore:cbbackupmgr-config.adoc[cbbackupmgr config] and xref:backup-restore:cbbackupmgr-restore.adoc[cbbackupmgr restore] for more about user backup.
 
-* The `cbbackupmgr` encrypted backups feature is now GA for both cbbackupmgr CLI and the Backup Service. See xref:backup-restore:cbbackupmgr-encryption.adoc[Backup Encryption]
+* The `cbbackupmgr` encrypted backups feature is now GA for both cbbackupmgr CLI and the Backup Service. See xref:backup-restore:cbbackupmgr-encryption.adoc[Backup Encryption].
 
 === Cross Data Center Replication (XDCR)
 
@@ -67,8 +67,8 @@ See xref:learn:clusters-and-availability/xdcr-overview.adoc#xdcr-filter-binary[F
 
 === Performance
 
-* You can now migrate buckets from one storage backend to another. 
-This feature supports migrating buckets from Couchstore to Magma and from Magma to Couchstore. 
+* You can now migrate buckets from one storage backend to another.
+This feature supports migrating buckets from Couchstore to Magma and from Magma to Couchstore.
 You can migrate buckets while the database continues running.
 To complete the migration you must trigger a swap rebalance or a graceful failover followed by a full recovery on each node that contains the bucket.
 See xref:manage:manage-buckets/migrate-bucket.adoc[].
@@ -81,31 +81,31 @@ See xref:rest-api:rest-setting-security.adoc[Configure On-the-Wire Security].
 * Credentials for Couchbase-Server internal users can now be rotated at any time, by means of the REST API.
 See xref:rest-api:rest-rotate-internal-credentials.adoc[Rotate Internal Credentials].
 
-* LDAP authentication now supports using regular expressions to map users to LDAP users and groups. 
-You can supply multiple regular expressions that Couchbase attempts to match against the user name supplied during an authentication attempt. 
-This feature gives you greater flexibility when authenticating users. 
-For example, you can use a regular expression to map the domain name in an email address to an LDAP organization. 
+* LDAP authentication now supports using regular expressions to map users to LDAP users and groups.
+You can supply multiple regular expressions that Couchbase attempts to match against the user name supplied during an authentication attempt.
+This feature gives you greater flexibility when authenticating users.
+For example, you can use a regular expression to map the domain name in an email address to an LDAP organization.
 See xref:manage:manage-security/configure-ldap.adoc#ldap-advanced-mapping[Advanced Query] under xref:manage:manage-security/configure-ldap.adoc#enable-ldap-user-authentication[User Authentication Enablement].
 
-* The Couchbase Server Web Console now supports using Structured Authentication Markup Language (SAML) for authentication. 
-When you enable SAML authentication, a btn:[Sign In Using SSO] button appears on the Web Console login screen. 
-This button lets users who have already authenticated with the SAML identity provider (Okta, for example) to skip having to enter credentials.  
+* The Couchbase Server Web Console now supports using Structured Authentication Markup Language (SAML) for authentication.
+When you enable SAML authentication, a btn:[Sign In Using SSO] button appears on the Web Console login screen.
+This button lets users who have already authenticated with the SAML identity provider (Okta, for example) to skip having to enter credentials.
 See xref:learn:security/authentication-domains.adoc#saml-authentication[SAML Authentication] for more information.
 
 * Couchbase Server's LDAP support now has a setting that turns on and off TLS middlebox compatibility.
 This setting controls low-level network communication options when Couchbase Server securely connects to an LDAP server through intermediate systems such as proxies and firewalls.
 See xref:manage:manage-security/configure-ldap.adoc#advanced-settings[Advanced Settings] on the xref:manage:manage-security/configure-ldap.adoc[] page for more information about this setting.
 
-* Couchbase Server now supports using Public-Key Cryptography Standard (PKCS) #12 format certificates for node certificates. 
-This format lets you bundle the node's private key, public key, and certificate chain into a single file.  
+* Couchbase Server now supports using Public-Key Cryptography Standard (PKCS) #12 format certificates for node certificates.
+This format lets you bundle the node's private key, public key, and certificate chain into a single file.
 See xref:learn:security/certificates.adoc#pkcs12[PKCS #12 Certificates for Nodes] for more information.
 
 * Couchbase Server now supports the X.509 Elliptic Curve Key cipher suites.
-Elliptic Curve Key ciphers are less resource-intensive than other cipher suites. 
+Elliptic Curve Key ciphers are less resource-intensive than other cipher suites.
 They're useful when communicating with resource-constrained devices such as IoT hardware.
 See xref:learn:security/certificates.adoc#private-key-formats[Private Keys] for more information.
 
-* Couchbase Server no longer supports TLS versions 1.0 and 1.1. 
+* Couchbase Server no longer supports TLS versions 1.0 and 1.1.
 When upgrading to version 7.6 or later, the upgrade process automatically sets  `minTLSVersion` to `tlsv1.2` if it's set to `tlsv1` or `tlsv1.1`.
 Before you upgrade, be sure all the clients you use support TLS 1.2 or greater.
 See xref:learn:security/on-the-wire-security.adoc[] for more information.
@@ -116,16 +116,16 @@ See xref:learn:security/on-the-wire-security.adoc[] for more information.
 ** TLS_RSA_WITH_AES_256_CBC_SHA
 ** TLS_RSA_WITH_AES_128_CBC_SHAa
 
-* You can now enable alerts for certificate expiration. 
-When enabled, Couchbase Server alerts you when server, node, or XDCR certificates are within 30 days of expiration. 
+* You can now enable alerts for certificate expiration.
+When enabled, Couchbase Server alerts you when server, node, or XDCR certificates are within 30 days of expiration.
 You can change the alert period via the new `certExpirationDays` alert limit setting.
 Couchbase Server sends a second alert when certificates expire.
-See xref:learn:security/certificates.adoc#certificate-expiration[Certificate Expiration] for more information. 
+See xref:learn:security/certificates.adoc#certificate-expiration[Certificate Expiration] for more information.
 
 === Metrics
 
 * Couchbase Server has a new service discovery endpoint to help you configure the Prometheus event monitoring system.
-The old endpoint, named `/prometheus_sd_config.yaml` is now deprecated. 
+The old endpoint, named `/prometheus_sd_config.yaml` is now deprecated.
 The new endpoint is able to produce the same output as the old endpoint and has additional features.
 See xref:manage:monitor/set-up-prometheus-for-monitoring.adoc[Configure Prometheus to Collect Couchbase Metrics].
 
@@ -133,9 +133,9 @@ See xref:manage:monitor/set-up-prometheus-for-monitoring.adoc[Configure Promethe
 
 === Index Service
 
-* You can choose to have the rebalance process move an index's files between nodes instead of rebuilding them from scratch. 
-This setting improves rebalance performance as moving the files is faster than rebuilding them. 
-See xref:learn:clusters-and-availability/rebalance.adoc#index-rebalance-methods[Index Rebalance Methods]
+* You can choose to have the rebalance process move an index's files between nodes instead of rebuilding them from scratch.
+This setting improves rebalance performance as moving the files is faster than rebuilding them.
+See xref:learn:clusters-and-availability/rebalance.adoc#index-rebalance-methods[Index Rebalance Methods].
 
 === Search Service
 
@@ -160,9 +160,9 @@ For more information on the vector search, see xref:vector-search:vector-search.
 
 * Two changes in Couchbase Server 7.6 affect the `maxTTL` setting for collections:
 
-** In earlier versions, you could only set a collection's `maxTTL` setting when creating the collection. 
+** In earlier versions, you could only set a collection's `maxTTL` setting when creating the collection.
 You can now change the `maxTTL` setting on a collection after creation.
-** You can now set a collection's `maxTTL` to -1 to prevent a bucket's non-zero `maxTTL` setting from causing documents in the collection to expire automatically. 
+** You can now set a collection's `maxTTL` to -1 to prevent a bucket's non-zero `maxTTL` setting from causing documents in the collection to expire automatically.
 This new setting is useful if you want most of the documents in a bucket to automatically expire, but want to prevent the documents in one or more collections from expiring by default.
 
 +
@@ -247,5 +247,5 @@ See xref:install:upgrade.adoc[] for more information.
 
 === Couchbase Server Community Edition
 
-* You can no longer set the `sendStats` to `false` in Couchbase Server Community Edition clusters.  
+* You can no longer set the `sendStats` to `false` in Couchbase Server Community Edition clusters.
 You can still set `sendStats` to `false` on Couchbase Server Enterprise Edition clusters.

--- a/modules/introduction/partials/new-features-76.adoc
+++ b/modules/introduction/partials/new-features-76.adoc
@@ -171,41 +171,67 @@ See xref:learn:data/expiration.adoc[] for more information.
 === Query Service
 
 * {sqlpp} language additions:
+
 ** OFFSET clause added to the DELETE statement.
+See xref:n1ql:n1ql-language-reference/delete.adoc[].
+
 ** GROUP AS clause added to the GROUP BY clause.
+See xref:n1ql:n1ql-language-reference/groupby.adoc[].
+
 ** FORMALIZE() function.
+See xref:n1ql:n1ql-language-reference/metafun.adoc#formalize[FORMALIZE()].
+
 ** Multi-byte aware string functions.
+See xref:n1ql:n1ql-language-reference/stringfun.adoc[].
+
 ** Support for sequences.
+See xref:n1ql:n1ql-language-reference/sequenceops.adoc[].
+
 ** EXPLAIN FUNCTION statement.
+See xref:n1ql:n1ql-language-reference/explainfunction.adoc[].
+
+* cbq shell additions.
+See xref:tools:cbq-shell.adoc[cbq]:
+
+** The `-query_context` command line option.
+** The `-advise` command line option.
 
 * The WITH clause adds support for recursive CTEs.
+See xref:n1ql:n1ql-language-reference/with-recursive.adoc[].
 
 * The CREATE COLLECTION statement adds support for maxTTL.
-
-* The cbq shell adds a `-query_context` command line option.
-
-* The cbq shell adds an `-advise` command line option.
+See xref:n1ql:n1ql-language-reference/createcollection.adoc[].
 
 * The `/clusterInit` endpoint in the Nodes and Clusters REST API adds support for Query memory quotas.
+See xref:rest-api:rest-initialize-cluster.adoc[].
 
 * Named and positional parameters can now be prefixed by `$` or `@` in a query.
+See xref:settings:query-settings.adoc#section_srh_tlm_n1b[Named Parameters and Positional Parameters].
 
-* `num_replica` configured for each index can now be found through {sqlpp} statement: `system:indexes`
+* The `system:indexes` catalog now enables you to find the number of replicas configured for each index.
+See xref:n1ql:n1ql-intro/sysinfo.adoc#querying-indexes[Query Indexes].
 
-* The Query Service adds cluster-level and node-level parameters to limit the size of explain plans in the completed requests catalog.
+* The Query Service adds cluster-level and node-level parameters to limit the size of explain plans in the cache.
+See xref:settings:query-settings.adoc#queryPreparedLimit[queryPreparedLimit] and xref:settings:query-settings.adoc#prepared-limit[prepared-limit].
 
 * The Query Service adds support for sequential scans, which enables querying without an index.
+See xref:learn:services-and-indexes/indexes/query-without-index.adoc[].
 
-* The node-level and request-level N1QL Feature Control parameters now accept hexadecimal strings or decimal integers.
+* The node-level N1QL Feature Control parameter now accepts hexadecimal strings or decimal integers.
+See xref:settings:query-settings.adoc#n1ql-feat-ctrl[n1ql-feat-ctrl].
 
 * Queries can now read from replica vBuckets when active vBuckets are inaccessible.
 The Query service adds new cluster-level, node-level, and request-level parameters to configure this feature.
+See xref:manage:manage-settings/general-settings.adoc#query-settings[Query Settings].
 
 * The CREATE FUNCTION statement now enables users to create a {sqlpp} user-defined function and the corresponding external JavaScript code in a single operation, without having to create an external library.
+See xref:n1ql:n1ql-language-reference/createfunction.adoc#sql-managed-user-defined-functions[{sqlpp} Managed User-Defined Functions].
 
 * When a query executes a user-defined function, profiling information is now available for any queries within the UDF.
+See xref:manage:monitor/monitoring-n1ql-query.adoc[].
 
 * The Query service collects statistics for the cost-based optimizer automatically when an index is created or built.
+See xref:n1ql:n1ql-language-reference/cost-based-optimizer.adoc[].
 
 * The SORT BY and GROUP BY operations overspill to disk if they exceed the Query service memory quota.
 

--- a/modules/introduction/partials/new-features-76.adoc
+++ b/modules/introduction/partials/new-features-76.adoc
@@ -214,7 +214,7 @@ See xref:n1ql:n1ql-intro/sysinfo.adoc#querying-indexes[Query Indexes].
 * The Query Service adds cluster-level and node-level parameters to limit the size of explain plans in the cache.
 See xref:settings:query-settings.adoc#queryPreparedLimit[queryPreparedLimit] and xref:settings:query-settings.adoc#prepared-limit[prepared-limit].
 
-* The Query Service adds support for sequential scans, which enables querying without an index.
+* The Query Service adds support for sequential scans, controlled by RBAC, which enables querying without an index.
 See xref:learn:services-and-indexes/indexes/query-without-index.adoc[].
 
 * The node-level N1QL Feature Control parameter now accepts hexadecimal strings or decimal integers.


### PR DESCRIPTION
Docs issue: DOC-11998

* Added links to the [new features in the Query section](https://preview.docs-test.couchbase.com/DOC-11998/server/current/introduction/whats-new.html#query-service).
* Also fixes DOC-11999: Revise Query section for Sequential Scans.

Password: [Preview docs for internal review](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-review)