### PR TITLE
DOC-11907 password hash migration

### DIFF
--- a/modules/introduction/partials/new-features-76.adoc
+++ b/modules/introduction/partials/new-features-76.adoc
@@ -128,7 +128,7 @@ This hashing algorithm is more secure than the SHA1 algorithm used to hash passw
 * If you upgrade a database to Couchbase Server 7.6 or later, it continues to use the older SHA1 hashing algorithm for existing user passwords.
 You can enable a new setting that has Couchbase Server migrate user passwords from SHA1 to Argon2id when a user authenticates.
 This setting only works if your the entire cluster  is running Couchbase Server version 7.6 or later.
-See 
+For more information, see xref:learn:security/authentication-overview.adoc#password-hash-migration[Automatic Password Hash Migration]. 
 
 
 === Metrics

--- a/modules/introduction/partials/new-features-76.adoc
+++ b/modules/introduction/partials/new-features-76.adoc
@@ -122,6 +122,15 @@ You can change the alert period via the new `certExpirationDays` alert limit set
 Couchbase Server sends a second alert when certificates expire.
 See xref:learn:security/certificates.adoc#certificate-expiration[Certificate Expiration] for more information. 
 
+* Couchbase Server now defaults to using the (https://en.wikipedia.org/wiki/Argon2)[Argon2id^] algorithm to hash passwords for new users. 
+This hashing algorithm is more secure than the SHA1 algorithm used to hash passwords in earlier server versions.
+
+* If you upgrade a database to Couchbase Server 7.6 or later, it continues to use the older SHA1 hashing algorithm for existing user passwords.
+You can enable a new setting that has Couchbase Server migrate user passwords from SHA1 to Argon2id when a user authenticates.
+This setting only works if your the entire cluster  is running Couchbase Server version 7.6 or later.
+See 
+
+
 === Metrics
 
 * Couchbase Server has a new service discovery endpoint to help you configure the Prometheus event monitoring system.

--- a/modules/introduction/partials/new-features-76.adoc
+++ b/modules/introduction/partials/new-features-76.adoc
@@ -127,7 +127,7 @@ This hashing algorithm is more secure than the SHA1 algorithm used to hash passw
 
 * If you upgrade a database to Couchbase Server 7.6 or later, it continues to use the older SHA1 hashing algorithm for existing user passwords.
 You can enable a new setting that has Couchbase Server migrate user passwords from SHA1 to Argon2id when a user authenticates.
-This setting only works if your the entire cluster  is running Couchbase Server version 7.6 or later.
+This setting works only if the entire cluster  is running Couchbase Server version 7.6 or later.
 For more information, see xref:learn:security/authentication-overview.adoc#password-hash-migration[Automatic Password Hash Migration]. 
 
 

--- a/modules/learn/pages/security/authentication-overview.adoc
+++ b/modules/learn/pages/security/authentication-overview.adoc
@@ -70,6 +70,8 @@ _PBKDF2_ is another powerful password hashing function; and is required to allow
 By default, the PBKDF2 credentials are stored with 5,000 iterations: this can be configured with the `POST settings/security/scramShaIterations` REST API method and URI, with a higher specified number increasing the security of the credentials, with the trade-off of higher resource requirements when authentication is performed.
 Following guidance from NIST, it is recommended to disable SCRAM-SHA1 unless it is absolutely required.
 
+include::learn:partial$argon2-overhead.adoc[]
+
 The various levels of SCRAM SHA can be disabled with `POST /settings/security/scramSha1Enabled`,
 `POST /settings/security/scramSha256Enabled` and
 `POST /settings/security/scramSha512Enabled`.
@@ -85,16 +87,16 @@ You can select which algorithm Couchbase Server uses to hash locally stored pass
 When you change the hash algorithm Couchbase Server uses, it does not update all of the stored passwords using the new algorithm.
 It cannot rehash the existing passwords as it does not have access to the original, unhashed password.
 Instead, existing passwords remain hashed using the previous hashing algorithm.
-Couchbase Server uses the new hashing algorithm for newly created passwords for either new accounts or when an existing account changes its password. 
+Couchbase Server uses the newly-set hashing algorithm for passwords when you create new accounts or when an existing account changes its password. 
 Users can authenticate using passwords hashed with any hashing algorithm Couchbase Server supports.
 
-You can enable Couchbase Server's password hash migration feature to have it automatically rehash user's password when they authenticate.
-Couchbase Server is able hash the user's password with the currently enabled hashing algorithm because it has access to the unhashed password during authentication.
-This rehashing is transparent to users--they do not have to change their passwords to have them hashed with the more secure hashing standard.
+You can enable Couchbase Server's password hash migration feature that automatically rehashes user's password when they authenticate.
+Couchbase Server is able to hash the user's password with the currently enabled hashing algorithm because it has access to the unhashed password during authentication.
+This rehashing is transparent to users--they do not have to change their password to have it hashed with the more new hashing algorithm.
 
 You enable automatic password hash by calling the `/settings/security` endpoint to set the `allowHashMigrationDuringAuth` setting to `true`. 
 ifeval::['{page-component-version}' == '7.6'] 
-This setting only has an effect if the entire database cluster is running Couchbase Server 7.6 or later. 
+This setting has an effect only if the entire database cluster is running Couchbase Server 7.6 or later. 
 endif::[]
 See xref:rest-api:rest-setting-security.adoc[] for more information.
 

--- a/modules/learn/pages/security/authentication-overview.adoc
+++ b/modules/learn/pages/security/authentication-overview.adoc
@@ -77,6 +77,32 @@ For more information on the using the REST API to configure security settings, s
 
 For cases that do not use SCRAM-SHA, such as those that implement TLS network encryption, it is recommended to _disable_ all variations of SCRAM-SHA; as this will prevent the SCRAM-SHA PBKDF2 hashes from being generated, when Argon2ID provides stronger security for those credentials.
 
+
+[#password-hash-migration]
+=== Automatic Password Hash Migration
+
+You can select which algorithm Couchbase Server uses to hash locally stored passwords by setting `passwordHashAlg` using the `/settings/security` REST API. 
+When you change the hash algorithm Couchbase Server uses, it does not update all of the stored passwords using the new algorithm.
+It cannot rehash the existing passwords as it does not have access to the original, unhashed password.
+Instead, existing passwords remain hashed using the previous hashing algorithm.
+Couchbase Server uses the new hashing algorithm for newly created passwords for either new accounts or when an existing account changes its password. 
+Users can authenticate using passwords hashed with any hashing algorithm Couchbase Server supports.
+
+You can enable Couchbase Server's password hash migration feature to have it automatically rehash user's password when they authenticate.
+Couchbase Server is able hash the user's password with the currently enabled hashing algorithm because it has access to the unhashed password during authentication.
+This rehashing is transparent to users--they do not have to change their passwords to have them hashed with the more secure hashing standard.
+
+You enable automatic password hash by calling the `/settings/security` endpoint to set the `allowHashMigrationDuringAuth` setting to `true`. 
+ifeval::['{page-component-version}' == '7.6'] 
+This setting only has an effect if the entire database cluster is running Couchbase Server 7.6 or later. 
+endif::[]
+See xref:rest-api:rest-setting-security.adoc[] for more information.
+
+NOTE: Versions of Couchbase Server prior to 7.6 defaulted to using SHA-1 hashing to store passwords for local accounts.
+This algorithm is obsolete and is no longer considered secure by security experts. 
+After upgrading to 7.6 or later, Couchbase Server defaults to using the Argon2id algorithm to hash newly created passwords for new users and users who change their password.
+Because Argon2id provides better security, you should enable `allowHashMigrationDuringAuth` to allow Couchbase Server to migrate passwords from SHA-1 to Argon2id.
+
 [#authorization]
 == Authorization
 

--- a/modules/learn/pages/security/authentication-overview.adoc
+++ b/modules/learn/pages/security/authentication-overview.adoc
@@ -98,10 +98,12 @@ This setting only has an effect if the entire database cluster is running Couchb
 endif::[]
 See xref:rest-api:rest-setting-security.adoc[] for more information.
 
+ifeval::['{page-component-version}' == '7.6'] 
 NOTE: Versions of Couchbase Server prior to 7.6 defaulted to using SHA-1 hashing to store passwords for local accounts.
 This algorithm is obsolete and is no longer considered secure by security experts. 
 After upgrading to 7.6 or later, Couchbase Server defaults to using the Argon2id algorithm to hash newly created passwords for new users and users who change their password.
 Because Argon2id provides better security, you should enable `allowHashMigrationDuringAuth` to allow Couchbase Server to migrate passwords from SHA-1 to Argon2id.
+endif::[]
 
 [#authorization]
 == Authorization

--- a/modules/learn/partials/argon2-overhead.adoc
+++ b/modules/learn/partials/argon2-overhead.adoc
@@ -1,0 +1,2 @@
+IMPORTANT: By design, the Argon2id hashing algorithm consumes more CPU and memory than the prior default SHA-1 hashing algorithm. 
+If your server handles a high volume of authentications, using the Argon2id hashing algorithm can result in higher CPU and memory use.

--- a/modules/rest-api/pages/rest-setting-security.adoc
+++ b/modules/rest-api/pages/rest-setting-security.adoc
@@ -48,6 +48,7 @@ curl -X POST -u <username>:<password>
   -d pbkdf2HmacSha512Iterations=<integer>
   -d intCredsRotationInterval=<integer>
   -d validateNodeCertSan=<true|false>
+  -d allowHashMigrationDuringAuth=<true|false>
 ----
 
 The syntax for the `GET` and `POST` methods includes the following:
@@ -132,7 +133,8 @@ Note that for Couchbase Server Version 7.6 and later, disablement of all three S
 * `passwordHashAlg`.
 Which hash function to use for Data-Service password hashing.
 The options are `argon2id` (the default), `pbkdf2-hmac-sha512`, and `SHA-1` (which is deprecated).
-Note that if hashes are to be regenerated for existing users, such users should change their passwords (although login using the previous hashes will succeed).
+Changing this setting does not affect existing passwords, only new or changed passwords use the new hashing algorithm. 
+See xref:#migrate-password-hash[`allowHashMigrationDuringAuth`] for a way to migrate passwords to the new hashing algorithm.
 
 * `argon2idTime`, `argon2idMem`.
 Time and memory parameters for `argon2id`.
@@ -166,6 +168,16 @@ A mismatch triggers an error in the following scenarios:
 
 +
 These checks are performed to ensure that each node bears a certificate whose SAN matches the node's hostname, thereby ensuring that other nodes will be able to verify the node's identity when connecting with it.
+
+[#migrate-password-hash]
+* `allowHashMigrationDuringAuth` controls whether Couchbase Server automatically rehashes a locally-stored password if it was hashed using an algorithm other than the one set by `passwordHashAlg`.
+If you set this value to `true`, the user's password is automatically rehashed using the new algorithm after authentication.
+See xref:learn:security/authentication-overview.adoc#password-hash-migration[Automatic Password Hash Migration] for more information.
++
+ifeval::['{page-component-version}' == '7.6'] 
+NOTE: This setting only has an effect if the entire database cluster is running Couchbase Server 7.6 or later. 
+endif::[]
+
 
 For an explanation of the relationships between per service and global settings, see xref:learn:security/on-the-wire-security.adoc[On-the-Wire Security].
 

--- a/modules/rest-api/pages/rest-setting-security.adoc
+++ b/modules/rest-api/pages/rest-setting-security.adoc
@@ -133,8 +133,11 @@ Note that for Couchbase Server Version 7.6 and later, disablement of all three S
 * `passwordHashAlg`.
 Which hash function to use for Data-Service password hashing.
 The options are `argon2id` (the default), `pbkdf2-hmac-sha512`, and `SHA-1` (which is deprecated).
-Changing this setting does not affect existing passwords, only new or changed passwords use the new hashing algorithm. 
+Changing this setting does not affect existing passwords.
+Only new or changed passwords use the new hashing algorithm. 
 See xref:#migrate-password-hash[`allowHashMigrationDuringAuth`] for a way to migrate passwords to the new hashing algorithm.
++
+include::learn:partial$argon2-overhead.adoc[]
 
 * `argon2idTime`, `argon2idMem`.
 Time and memory parameters for `argon2id`.


### PR DESCRIPTION
Covers the new password hash migration featrue in 7.6. 

Changes, with links to preview site:

* Added entry to the What's New page's [Security and Authentication](https://preview.docs-test.couchbase.com/migrate_password_hash/server/current/introduction/whats-new.html#security-and-authentication) section.
* Added [Automatic Password Hash Migration](https://preview.docs-test.couchbase.com/migrate_password_hash/server/current/learn/security/authentication-overview.html#password-hash-migration) section to Understanding Authentication.
* Added new [`allowHashMigrationDuringAuth`](https://preview.docs-test.couchbase.com/migrate_password_hash/server/current/rest-api/rest-setting-security.html#migrate-password-hash) to the /settings/security REST API endpoint. Also added mention of setting to the `passwordHashAlg` description.