### PR TITLE
[DOC-12034] Adding platform limitation for VS to "new features" note

### DIFF
--- a/modules/introduction/partials/new-features-76.adoc
+++ b/modules/introduction/partials/new-features-76.adoc
@@ -163,7 +163,10 @@ A Vector Search database includes:
 ** Third-party framework integration: Langchain (later Llamaindex + others)
 ** Full support for Replicas Partitions and file-based Rebalance
 
-For more information on the vector search, see xref:vector-search:vector-search.adoc[]
+NOTE: Vector Search is currently only supported on Couchbase Server 7.6.0 deployments running on Linux platforms.
+MacOS and Windows platforms are not supported. 
+
+For more information about vector search, see xref:vector-search:vector-search.adoc[]
 
 === Data Service
 


### PR DESCRIPTION
Discovered that there is a limitation on platform support for Vector Search in version 7.6.0 - after a quick consult with the SME, figured it would be a good idea to at least mention this limitation in the "What's New" for Server 7.6.0, until we release 7.6.2 and remove the limitation. 