### PR TITLE
DOC-10181: Query Monitor is only available in Enterprise Edition

### DIFF
--- a/modules/tools/pages/query-monitoring.adoc
+++ b/modules/tools/pages/query-monitoring.adoc
@@ -1,10 +1,12 @@
 = Query Monitoring
+:imagesdir: ../assets/images
+:page-edition: Enterprise Edition
 :description: Couchbase Server provides a UI to monitor the current state of Query Service.
 
 [abstract]
 {description}
 
-NOTE: Starting version 6.5, Query Monitoring is available in both Enterprise and Community Editions.
+NOTE: Query Monitoring is only available in Enterprise Edition.
 
 From the [.ui]*Couchbase Web Console* > [.ui]*Query* > [.ui]*Query Monitor*, you can view the different types queries that are Active (currently running), Completed (recently run), and Prepared (aggregate statistics for prepared queries).
 Statistics information for the query service is displayed at the bottom of the page.


### PR DESCRIPTION
Docs issue: DOC-10181

Backported from #3545 