### PR TITLE
DOC-7394: Remove N1QL auditing and backfill pages

### DIFF
--- a/modules/manage/pages/manage-settings/general-settings.adoc
+++ b/modules/manage/pages/manage-settings/general-settings.adoc
@@ -192,12 +192,25 @@ The top section of the panel appears as follows:
 
 image::manage-settings/query-settings-top.png["The top half of the Query Settings panel",548,align=center]
 
-Specify either *Unrestricted* or *Restricted*, to determine which URLs are permitted to be accessed by the `curl` function.
-If *Unrestricted* (the default) is specified, all URLs can be accessed.
-If *Restricted* is specified, the UI expands, to display configurable fields into which the URLs allowed and disallowed can be entered.
+Under *CURL() Function Access*, specify either *Unrestricted* or *Restricted*, to determine which URLs can be accessed by the `curl` function.
 
-The *Query Temp Disk Path* field allows specification of the path to which temporary files are written, based on query activities.
-The maximum size of the target can be specified, in megabytes.
+* If *Unrestricted* (the default) is specified, all URLs can be accessed.
+
+* If *Restricted* is specified, the UI expands, to display configurable fields into which you can enter the allowed and disallowed URLs.
+
+(((backfill)))
+When a query has an extremely large corresponding index scan, the indexer buffers the results into a temporary directory.
+Since this method may cause high I/O and works differently on Windows, Couchbase Server enables you to configure backfill settings.
+
+* The *Query Temp Disk Path* field enables you to specify the path to which the indexer writes temporary backfill files, to store any transient data during query processing.
+The specified path must already exist.
+Only absolute paths are allowed.
+The default path is `var/lib/couchbase/tmp` within the Couchbase Server installation directory.
+
+* The *Quota* field enables you to specify the maximum size of temporary backfill files, in megabytes.
+Setting the size to `0` disables backfill.
+Setting the size to `-1` means the size is unlimited.
+The maximum size is limited only by the available disk space.
 
 Additional Query settings are provided in the lower section of the panel:
 

--- a/modules/manage/pages/manage-settings/general-settings.adoc
+++ b/modules/manage/pages/manage-settings/general-settings.adoc
@@ -189,16 +189,16 @@ However, for best performance it is recommended to benchmark with different sett
 [#query-settings]
 === Query Settings
 
-Left-clicking on the *Advanced Query Settings* tab displays interactive fields whereby the Query Service can be configured.
+Left-clicking on *Advanced Query Settings* displays interactive fields with which you can configure the Query Service.
 The top section of the panel appears as follows:
 
 image::manage-settings/query-settings-top.png["The top half of the Query Settings panel",548,align=center]
 
-Under *CURL() Function Access*, specify either *Unrestricted* or *Restricted*, to determine which URLs can be accessed by the `curl` function.
+Under *CURL() Function Access*, specify either *Unrestricted* or *Restricted*, to determine which URLs the CURL() function can access.
 
-* If *Unrestricted* (the default) is specified, all URLs can be accessed.
+* If you specify *Unrestricted* (the default), the CURL() function can access all URLs.
 
-* If *Restricted* is specified, the UI expands, to display configurable fields into which you can enter the allowed and disallowed URLs.
+* If you specify *Restricted*, the UI expands, to display configurable fields into which you can enter the allowed and disallowed URLs.
 
 (((backfill)))
 When a query has an extremely large corresponding index scan, the indexer buffers the results into a temporary directory.

--- a/modules/manage/pages/manage-settings/general-settings.adoc
+++ b/modules/manage/pages/manage-settings/general-settings.adoc
@@ -218,6 +218,8 @@ Additional Query settings are provided in the lower section of the panel:
 
 image::manage-settings/query-settings-bottom.png["The bottom half of the Query Settings panel",548,align=center]
 
+// NOTE: The N1QL Feature Controller still contains the word N1QL in the UI
+
 * *Pipeline Batch*: The number of items that can be batched for fetches from the Data Service.
 
 * *Pipeline Cap*: The maximum number of items that can be buffered in a fetch.
@@ -235,8 +237,6 @@ image::manage-settings/query-settings-bottom.png["The bottom half of the Query S
 * *Log Level*: The log level used in the logger.
 
 * *Max Parallelism*: The maximum number of index partitions for parallel aggregation-computing.
-
-// NOTE: This option is still called the N1QL Feature Controller
 
 * *N1QL Feature Controller*: Enables or disables features in the Query engine.
 +

--- a/modules/manage/pages/manage-settings/general-settings.adoc
+++ b/modules/manage/pages/manage-settings/general-settings.adoc
@@ -1,8 +1,10 @@
 = General
 :description: pass:q[_General_ settings allow configuration of _cluster name_, _memory quotas_, _storage modes_, and _node availability_ for the cluster; and of _advanced settings_ for the Index and Query Services.]
-:page-aliases: settings:cluster-settings,settings:change-failover-settings,manage:manage-settings/cluster-settings,manage:manage-settings/change-failover-settings,manage:manage-settings/update-notification
+:page-aliases: settings:cluster-settings, settings:change-failover-settings, manage:manage-settings/cluster-settings, manage:manage-settings/change-failover-settings, manage:manage-settings/update-notification, n1ql:n1ql-language-reference/backfill
+:keywords: backfill
 :imagesdir: ../../assets/images
 :page-toclevels: 3
+
 [abstract]
 {description}
 

--- a/modules/manage/pages/manage-settings/general-settings.adoc
+++ b/modules/manage/pages/manage-settings/general-settings.adoc
@@ -847,6 +847,7 @@ For more information on getting and setting the rebalance retry status, see xref
 
 To inspect the current maximum number of concurrent vBucket moves permitted for every node, use the `GET /settings/rebalance` HTTP method and URI, with the `rebalanceMovesPerNode` parameter, as follows:
 
+[source,shell]
 ----
 curl -v -X GET http://10.143.201.101:8091/settings/rebalance \
 -u Administrator:password
@@ -854,6 +855,7 @@ curl -v -X GET http://10.143.201.101:8091/settings/rebalance \
 
 This returns an object, confirming the current setting as being `4` (which is the default value):
 
+[source,json]
 ----
 {"rebalanceMovesPerNode":4}
 ----
@@ -861,6 +863,7 @@ This returns an object, confirming the current setting as being `4` (which is th
 To _set_ a new value for the parameter use the `POST` method with the same URI, and with the `rebalanceMovesPerNode` parameter.
 Note that the minimum value is `1`, and the maximum `64`.
 
+[source,shell]
 ----
 curl -v -X POST http://10.143.201.101:8091/settings/rebalance \
 -u Administrator:password \
@@ -869,6 +872,7 @@ curl -v -X POST http://10.143.201.101:8091/settings/rebalance \
 
 If successful, the call returns an object confirming the new setting:
 
+[source,json]
 ----
 {"rebalanceMovesPerNode":10}
 ----

--- a/modules/manage/pages/manage-settings/general-settings.adoc
+++ b/modules/manage/pages/manage-settings/general-settings.adoc
@@ -786,7 +786,7 @@ include::rest-api:example$query-settings-post-access.sh[tag=request]
 ----
 
 A JSON document is specified as the payload for the method.
-The document's values indicate that `https://company1.com` is allowed, and `https://company2.com` is disallowed.
+The document's values indicate that `+https://company1.com+` is allowed, and `+https://company2.com+` is disallowed.
 
 If successful, the call returns a JSON document that confirms the modified settings:
 

--- a/modules/manage/pages/manage-settings/general-settings.adoc
+++ b/modules/manage/pages/manage-settings/general-settings.adoc
@@ -1,6 +1,6 @@
 = General
 :description: pass:q[_General_ settings allow configuration of _cluster name_, _memory quotas_, _storage modes_, and _node availability_ for the cluster; and of _advanced settings_ for the Index and Query Services.]
-:page-aliases: settings:cluster-settings, settings:change-failover-settings, manage:manage-settings/cluster-settings, manage:manage-settings/change-failover-settings, manage:manage-settings/update-notification, n1ql:n1ql-language-reference/backfill
+:page-aliases: settings:cluster-settings, settings:change-failover-settings, manage:manage-settings/cluster-settings, manage:manage-settings/change-failover-settings, manage:manage-settings/update-notification, n1ql:n1ql-language-reference/backfill, settings:backfill
 :keywords: backfill
 :imagesdir: ../../assets/images
 :page-toclevels: 3

--- a/modules/manage/pages/manage-settings/general-settings.adoc
+++ b/modules/manage/pages/manage-settings/general-settings.adoc
@@ -202,7 +202,7 @@ Under *CURL() Function Access*, specify either *Unrestricted* or *Restricted*, t
 
 (((backfill)))
 When a query has an extremely large corresponding index scan, the indexer buffers the results into a temporary directory.
-Since this method may cause high I/O and works differently on Windows, Couchbase Server enables you to configure backfill settings.
+Since this method may cause high I/O and works differently on Windows, you can configure backfill settings for the {sqlpp} engine and its embedded GSI client.
 
 * The *Query Temp Disk Path* field enables you to specify the path to which the indexer writes temporary backfill files, to store any transient data during query processing.
 The specified path must already exist.
@@ -760,14 +760,14 @@ Also see the REST API reference page, xref:rest-api:rest-reader-writer-thread-co
 [#query-settings-via-rest]
 === Query Settings via REST
 
-To set the directory for temporary query data, and establish its size-limit, use the `/settings/querySettings` method.
+To set the directory for temporary backfill data, and establish its size-limit, use the `/settings/querySettings` method.
 
 [source,shell]
 ----
 include::rest-api:example$query-settings-post-settings.sh[tag=request]
 ----
 
-This specifies that the directory for temporary query data should be `/tmp`; and that the maximum size should be 2048 megabytes.
+This specifies that the directory for temporary backfill data should be `/tmp`; and that the maximum size should be 2048 megabytes.
 
 If successful, this call returns a JSON document featuring all the current query-related settings, including access-control:
 


### PR DESCRIPTION
Docs issue: DOC-7394

This PR fills out some of the details of the Query backfill settings, and redirects the redundant SQL++ Backfill page to the General settings page. Also makes some minor formatting adjustments.

You can preview the change here in GitHub: [General › Configure General Settings with the UI › Query Settings](https://github.com/couchbase/docs-server/blob/7b28ef372e4489d77e6ab2cb877e0039286ce1e0/modules/manage/pages/manage-settings/general-settings.adoc#query-settings)

This PR must be merged at the same time as the following related change:

* https://github.com/couchbaselabs/docs-devex/pull/183