### PR TITLE
Release notes 7.2.5

### DIFF
--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -1,5 +1,7 @@
 = Release Notes for Couchbase Server 7.2
 
+include::partial$docs-server-7.2.5-release-note.adoc[]
+
 include::partial$docs-server-7.2.4-release-note.adoc[]
 
 [#release-723]

--- a/modules/release-notes/partials/docs-server-7.2.5-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.2.5-release-note.adoc
@@ -10,8 +10,6 @@ This maintenance release contains new features and fixes.
 [#new-features]
 === New Features and Enhancements
 
-
-
 ==== Index Manager
 
 [#table-new-features-724-cluster-manager, cols="10,40"]
@@ -32,9 +30,30 @@ Enabling this option adds some overhead to the rebalance process.
 
 === Fixed Issues
 
+==== Backup Service
+[#table-fixed-issues-725-backuo-service, cols="10,40,40"]
+|===
+
+| https://issues.couchbase.com/browse/MB-61076[MB-61076]
+| Scheduled merges (for example, merges performed in a task within a plan) did not run.  
+| Merges now run as scheduled.
+
+|===
+
+==== Data Service
+[#table-fixed-issues-725-data-service, cols="10,40,40"]
+|===
+
+| https://issues.couchbase.com/browse/MB-61154[MB-61154]
+| When bucket data exceeded 4 TB and Magma was used as the storage engine, rebalance sometimes hung and failed to run to completion. 
+| This issue has been resolved.
+
+|===
+
+
 ==== Index Service
 
-[#table-known-issues-725-index-service, cols="10,40,40"]
+[#table-fixed-issues-725-index-service, cols="10,40,40"]
 |===
 |Issue | Description | Resolution
 
@@ -45,8 +64,8 @@ These continued reads resulted in wasted CPU resources and potentially blocking 
 | Couchbase Server now stops an index scan from reading data after it has timed out or a client cancels it even if it has not produced a row of data.
 
 | https://issues.couchbase.com/browse/MB-61043[MB-61043]
-| A rebalance followed by a failover could result in partitions not being evenly distributed across all nodes.
-| With this fix, the rebalance detects the partition skew and fixes it.
+| A rebalance followed by a failover could result in partitions not being evenly distributed across all nodes by a later rebalance.
+| The rebalance process now detects the partition skew and fixes it.
 
 | https://issues.couchbase.com/browse/MB-61435[MB-61435]
 | An optimization that skips key-value lookups in some cases when inserting new keys could be incorrectly enabled for all indexes in buckets containing empty indexes.

--- a/modules/release-notes/partials/docs-server-7.2.5-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.2.5-release-note.adoc
@@ -27,29 +27,7 @@ Enabling this option adds some overhead to the rebalance process.
 |===
 
 
-
 === Fixed Issues
-
-==== Backup Service
-[#table-fixed-issues-725-backuo-service, cols="10,40,40"]
-|===
-
-| https://issues.couchbase.com/browse/MB-61076[MB-61076]
-| Scheduled merges (for example, merges performed in a task within a plan) did not run.  
-| Merges now run as scheduled.
-
-|===
-
-==== Data Service
-[#table-fixed-issues-725-data-service, cols="10,40,40"]
-|===
-
-| https://issues.couchbase.com/browse/MB-61154[MB-61154]
-| When bucket data exceeded 4 TB and Magma was used as the storage engine, rebalance sometimes hung and failed to run to completion. 
-| This issue has been resolved.
-
-|===
-
 
 ==== Index Service
 

--- a/modules/release-notes/partials/docs-server-7.2.5-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.2.5-release-note.adoc
@@ -1,0 +1,66 @@
+
+:erlang-7-2-4-note: The Erlang upgrade requires that users have installed Couchbase Server{nbsp}7.1.0 or later, before upgrading to 7.2.4.
+
+[#release-725]
+== Release 7.2.5 (April 2024)
+
+Couchbase Server 7.2.5 was released in April 2024. 
+This maintenance release contains new features and fixes.
+
+[#new-features]
+=== New Features and Enhancements
+
+
+
+==== Index Manager
+
+[#table-new-features-724-cluster-manager, cols="10,40"]
+|===
+|Feature | Description
+
+| https://issues.couchbase.com/browse/MB-61310[MB-61310]
+a| During rebalance, Couchbase Server tracks its progress in moving active index partitions by comparing the sequence number of partitions it has moved to the sequence numbers in a view on the original node.
+It did not use this technique to track the progress of copying replica partitions.
+
+This change adds an argument ot the `api/managerOptions` REST API call named `enableReplicaCatchupOnRebalance`. 
+If you set this argument to `true`, Couchbase Server tracks the progress of replica partitions the same way it tracks active partitions.
+Enabling this option adds some overhead to the rebalance process.
+
+|===
+
+
+
+=== Fixed Issues
+
+==== Index Service
+
+[#table-known-issues-725-index-service, cols="10,40,40"]
+|===
+|Issue | Description | Resolution
+
+| https://issues.couchbase.com/browse/MB-60972[MB-60972]
+| Previously, an index scan would continue reading data until it had returned at least one row of data, even if it had been cancelled or had timed out.
+These continued reads resulted in wasted CPU resources and potentially blocking other scans from starting.
+
+| Couchbase Server now stops an index scan from reading data after it has timed out or a client cancels it even if it has not produced a row of data.
+
+| https://issues.couchbase.com/browse/MB-61043[MB-61043]
+| A rebalance followed by a failover could result in partitions not being evenly distributed across all nodes.
+| With this fix, the rebalance detects the partition skew and fixes it.
+
+| https://issues.couchbase.com/browse/MB-61435[MB-61435]
+| An optimization that skips key-value lookups in some cases when inserting new keys could be incorrectly enabled for all indexes in buckets containing empty indexes.
+This issue could result in duplicate rows being added to indexes.
+| The optimization is not longer incorrectly applied to indexes and duplicate rows are no longer added to indexes.
+
+|===
+
+
+
+
+
+
+
+
+
+

--- a/modules/release-notes/partials/docs-server-7.2.5-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.2.5-release-note.adoc
@@ -10,9 +10,22 @@ This maintenance release contains new features and fixes.
 [#new-features]
 === New Features and Enhancements
 
+==== Analytics
+
+[#table-new-features-725-analytics, cols="10,40"]
+|===
+|Feature | Description
+
+| https://issues.couchbase.com/browse/MB-60813[MB-60813]
+| This release adds the `median` function to the builtin analytics functions. 
+See xref:analytics:8_builtin.adoc[]. 
+
+|===
+
+
 ==== Index Manager
 
-[#table-new-features-724-cluster-manager, cols="10,40"]
+[#table-new-features-725-cluster-manager, cols="10,40"]
 |===
 |Feature | Description
 
@@ -20,9 +33,10 @@ This maintenance release contains new features and fixes.
 a| During rebalance, Couchbase Server tracks its progress in moving active index partitions by comparing the sequence number of partitions it has moved to the sequence numbers in a view on the original node.
 It did not use this technique to track the progress of copying replica partitions.
 
-This change adds an argument ot the `api/managerOptions` REST API call named `enableReplicaCatchupOnRebalance`. 
-If you set this argument to `true`, Couchbase Server tracks the progress of replica partitions the same way it tracks active partitions.
-Enabling this option adds some overhead to the rebalance process.
+This change adds an argument to the `api/managerOptions` REST API call named `enableReplicaCatchupOnRebalance`. 
+If you set this argument to `true`, Couchbase Server tracks the progress of copying replica partitions the same way it tracks active partitions.
+
+NOTE: Enabling this option adds some overhead to the rebalance process.
 
 |===
 


### PR DESCRIPTION
Adds the 7.2.5 release notes. Here is the [preview of the output](https://preview.docs-test.couchbase.com/7.2.5_release_notes/server/current/release-notes/relnotes.html).

This includes all of the issues listed for 7.2.5 on the [JIRA dashboard](https://issues.couchbase.com/secure/Dashboard.jspa?selectPageId=16972).