### PR TITLE
Fix cbbs task fail system event reference

### DIFF
--- a/modules/system-event-reference/pages/system-event-reference.adoc
+++ b/modules/system-event-reference/pages/system-event-reference.adoc
@@ -346,7 +346,7 @@ The following system events are returned for the Backup Service.
 
 | 6149 | A scheduled or one-off task has completed | Info | Cluster, repository, run type, and name.
 
-| 6150 | Cluster, repository, run type, and name. failed | Error |luster, repository, run type, name, and error message.
+| 6150 | A scheduled or one-off task has failed | Error | Cluster, repository, run type, name, and error message.
 
 | 6151 | Restore started | Info | NA
 


### PR DESCRIPTION
This change fixes the mangled wording & description for the `task failed` cbbs system event.