### PR TITLE
DOC-12165 Add .NET SDK compatibility notes to What's New and release notes

### DIFF
--- a/modules/introduction/partials/dot-net-sdk-compat.adoc
+++ b/modules/introduction/partials/dot-net-sdk-compat.adoc
@@ -1,0 +1,6 @@
+Use version 3.5.1 or later of the .NET SDK with Couchbase Server 7.6. 
+Earlier versions of this SDK have some compatibility issues.
+
+WARNING: v3.4.10 is incompatible with Server 7.6 and later--do not use. 
+This version of the SDK is deprecated. 
+For details, see https://issues.couchbase.com/browse/NCBC-3724[NCBC-3724].

--- a/modules/introduction/partials/dot-net-sdk-compat.adoc
+++ b/modules/introduction/partials/dot-net-sdk-compat.adoc
@@ -1,6 +1,3 @@
 Use version 3.5.1 or later of the .NET SDK with Couchbase Server 7.6. 
 Earlier versions of this SDK have some compatibility issues.
 
-WARNING: v3.4.10 is incompatible with Server 7.6 and later--do not use. 
-This version of the SDK is deprecated. 
-For details, see https://issues.couchbase.com/browse/NCBC-3724[NCBC-3724].

--- a/modules/introduction/partials/new-features-76.adoc
+++ b/modules/introduction/partials/new-features-76.adoc
@@ -295,3 +295,10 @@ See xref:install:upgrade.adoc[] for more information.
 
 * You can no longer set the `sendStats` to `false` in Couchbase Server Community Edition clusters.
 You can still set `sendStats` to `false` on Couchbase Server Enterprise Edition clusters.
+
+=== .NET SDK Compatibility
+
+include::partial$dot-net-sdk-compat.adoc[]
+
+
+

--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -1,6 +1,7 @@
 = Release Notes for Couchbase Server 7.6
 :page-aliases: analytics:releasenote
 :description: Couchbase Server 7.6.0 introduces multiple new features and fixes, as well as some deprecations and removals.
+:page-toclevels: 2
 
 include::partial$docs-server-7.6.1-release-note.adoc[]
 

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -199,11 +199,7 @@ This release contains the following known issues:
 |Issue | Description | Workaround
 
 | https://issues.couchbase.com/browse/NCBC-3724[NCBC-3724]
-a| Versions of the .NET SDK earlier than 3.5.1 have compatibility issues with Couchbase Server 7.6.
-
-WARNING: v3.4.10 is incompatible with Server 7.6 and later--do not use. 
-This version of the SDK is deprecated. 
-
+| Versions of the .NET SDK earlier than 3.5.1 have compatibility issues with Couchbase Server 7.6.
 | Use version 3.5.1 or later of the .NET SDK with Couchbase Server 7.6.
 
 |===

--- a/modules/release-notes/partials/docs-server-7.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6-release-note.adoc
@@ -193,6 +193,21 @@ The user will now be able to run queries via {sqlpp} without having to run the k
 
 This release contains the following known issues:
 
+==== .NET SDK Compatibility
+[#table-known-issues-760-dotnet-sdk, cols="10,40,40"]
+|===
+|Issue | Description | Workaround
+
+| https://issues.couchbase.com/browse/NCBC-3724[NCBC-3724]
+a| Versions of the .NET SDK earlier than 3.5.1 have compatibility issues with Couchbase Server 7.6.
+
+WARNING: v3.4.10 is incompatible with Server 7.6 and later--do not use. 
+This version of the SDK is deprecated. 
+
+| Use version 3.5.1 or later of the .NET SDK with Couchbase Server 7.6.
+
+|===
+
 ==== User Interface
 [#table-known-issues-760-user-interface, cols="10,40,40"]
 |===


### PR DESCRIPTION
This PR adds statements about .NET SDK compatibility to the 7.6 docs (links lead to preview site):

- Added [.NET SDK Compatibility](https://preview.docs-test.couchbase.com/dotnet-sdk-compatibility-note/server/current/introduction/whats-new.html#net-sdk-compatibility) entry to the What's New page. 
- Added [.NET SDK Compatibility](https://preview.docs-test.couchbase.com/dotnet-sdk-compatibility-note/server/current/release-notes/relnotes.html#net-sdk-compatibility) section to the 7.6.0 Known Issues section of release notes.