### PR TITLE
DOC-12070 Hard OOM Alert message update

### DIFF
--- a/modules/manage/pages/manage-settings/configure-alerts.adoc
+++ b/modules/manage/pages/manage-settings/configure-alerts.adoc
@@ -147,9 +147,8 @@ The listed alerts are as follows.
 | `overhead`
 
 | Bucket memory on a node is entirely used for metadata
-| All the available RAM on a node is being used to store the metadata for the objects stored.
-This means that there is no memory available for caching values.
-With no memory left for storing metadata, further requests to store data will also fail.
+a| A vBucket on a node has reached its memory quota. 
+Couchbase Server automatically attempts to recover from this issue.
 | `ep_oom_errors`
 
 | Writing data to disk for a specific bucket has failed
@@ -190,20 +189,22 @@ The default warning period is 30 days.
 | `cert_expires_soon`
 
 | Memory usage threshold exceeded
-| System memory use as a percentage of total available memory has exceeded a threshold.
-Note that a warning-level alert is issued when system memory, as a percentage of total available memory, exceeds the _warning_ threshold (90% by default).
-A critical-level alert is issued when system memory exceeds the _critical_ threshold (95% by default).
+a| System memory use as a percentage of total available memory has exceeded a threshold.
+
+NOTE A warning-level alert is issued when system memory, as a percentage of total available memory, exceeds the warning threshold (90% by default).
+A critical-level alert is issued when system memory exceeds the critical threshold (95% by default).
+
 | `memory_threshold`
 
 | History size threshold exceeded
-| The mutation history for a specified bucket is greater than an administrator-specified percentage of the administrator-specified change-history size, for a number of vbuckets.
+| The mutation history for a specified bucket is greater than an administrator-specified percentage of the administrator-specified change-history size, for a number of vBuckets.
 The size of the change history may need to be increased.
 For information, on establishing change-history size, see xref:rest-api:rest-bucket-create.adoc[Creating and Editing Buckets].
 | `history_size_warning`
 
 | Low Indexer Residence Percentage
 | Warns that the Index Service is, on a given node, occupying a percentage of available memory that is below an established threshold, the default for which is `10`.
-| `lowIndexerResidentPerc`
+| `indexer_low_resident_percentage`
 
 a| [#memcached-alert]
 Memcached connection threshold exceeded.


### PR DESCRIPTION
Fairly minor change to accommodate the updated oom message in [MB-60818](https://issues.couchbase.com/browse/MB-60818). 

- Updated the description of `ep_oom_errors` to reflect the updated alert message.
- changed the incorrect method name  `lowIndexerResidentPerc` to `indexer_low_resident_percentage` 
- Reformatted "Memory usage threshold exceeded: to meet style guide.

You can see a preview of these changes here: [Available Alerts](https://preview.docs-test.couchbase.com/oom-alert-7.6.2/server/current/manage/manage-settings/configure-alerts.html#available-alerts)