### PR TITLE
DOC-12188 new failover recovery metrics

### DIFF
--- a/modules/introduction/partials/new-features-76_2.adoc
+++ b/modules/introduction/partials/new-features-76_2.adoc
@@ -9,3 +9,21 @@
 ** xref:rest-api:backup-get-task-info.adoc[`/api/v1/cluster/self/repository/{repo-state}/{task-name}/taskHistory`]
 ** xref:rest-api:backup-get-plan-info.adoc[`/api/v1/plan/`]
 
+=== Cluster Manager
+
+* Version 7.6.2 adds Cluster Manager metrics to help you monitor failovers and rebalances:
++
+--
+** `cm_auto_failover_count`: the number of auto-failovers that occurred. 
+** `cm_auto_failover_enabled`: whether auto-failover is enabled.
+** `cm_auto_failover_max_count`: the maximum number of auto-failovers allowed before Cluster Manager disables auto-failover.
+** `cm_failover_total`: The total number of non-graceful failovers that have occurred.
+** `cm_graceful_failover_total`: The total number of graceful failovers that have occurred.
+** `cm_is_balanced`: Whether the Cluster Manager is balanced. Only reported by orchestrator nodes and only reported every 30 seconds.
+** `cm_rebalance_in_progress`: Whether there is a rebalance occurring. Only reported by the orchestrator node.
+** `cm_rebalance_progress`: An estimate of the progress of the current rebalance. Only reported by the orchestrator.
+** `cm_rebalance_total`: The total number of rebalances that have occurred.
+--
++
+For more information, see xref:metrics-reference:ns-server-metrics.adoc[].
+

--- a/modules/metrics-reference/attachments/cm_metrics_metadata.json
+++ b/modules/metrics-reference/attachments/cm_metrics_metadata.json
@@ -47,6 +47,24 @@
     "stability": "internal",
     "type": "counter"
   },
+  "cm_auto_failover_count": {
+    "added": "7.2.6",
+    "help": "Number of auto-failovers",
+    "stability": "committed",
+    "type": "gauge"
+  },
+  "cm_auto_failover_enabled": {
+    "added": "7.2.6",
+    "help": "Indicates if auto-failover is enabled (1 = true, 0 = false)",
+    "stability": "committed",
+    "type": "gauge"
+  },
+  "cm_auto_failover_max_count": {
+    "added": "7.2.6",
+    "help": "Maximum number of auto-failovers before being disabled",
+    "stability": "committed",
+    "type": "gauge"
+  },
   "cm_build_streaming_info_total": {
     "added": "7.0.0",
     "help": "Number of streaming requests processed",
@@ -133,11 +151,33 @@
     "stability": "internal",
     "type": "gauge"
   },
+  "cm_failover_total": {
+    "added": "7.2.6",
+    "help": "Number of non-graceful failover results",
+    "labels": [
+      {
+        "help": "failover result (initiated/completed/failed/stopped)",
+        "name": "event"
+      }
+    ],
+    "type": "counter"
+  },
   "cm_gc_duration_seconds": {
     "added": "7.6.0",
     "help": "Time to perform erlang garbage collection",
     "stability": "committed",
     "type": "histogram"
+  },
+  "cm_graceful_failover_total": {
+    "added": "7.2.6",
+    "help": "Number of graceful failover results",
+    "labels": [
+      {
+        "help": "graceful failover result (initiated/completed/failed/stopped)",
+        "name": "event"
+      }
+    ],
+    "type": "counter"
   },
   "cm_http_requests_seconds": {
     "added": "7.0.0",
@@ -182,6 +222,12 @@
     "help": "Number of times indexing was paused on old master node",
     "stability": "internal",
     "type": "counter"
+  },
+  "cm_is_balanced": {
+    "added": "7.2.6",
+    "help": "Indicates if cluster is balanced (1 = true, 0 = false). Only reported by the orchestrator node and only updated once every 30 seconds",
+    "stability": "committed",
+    "type": "gauge"
   },
   "cm_lease_acquirer_prev_acquire_estimate_in_future_total": {
     "added": "7.6.0",
@@ -452,11 +498,41 @@
     ],
     "type": "counter"
   },
+  "cm_rebalance_in_progress": {
+    "added": "7.2.6",
+    "help": "Indicates if a rebalance is running (1 = true, 0 = false). Only reported by the orchestrator node.",
+    "stability": "committed",
+    "type": "gauge"
+  },
+  "cm_rebalance_progress": {
+    "added": "7.6.2",
+    "help": "Estimate of the rebalance progress (0 - 1) for each stage. Only reported by the orchestrator node.",
+    "labels": [
+      {
+        "help": "Service that the progress is for",
+        "name": "stage"
+      }
+    ],
+    "stability": "volatile",
+    "type": "gauge",
+    "unit": "ratio"
+  },
   "cm_rebalance_stuck": {
     "added": "7.6.0",
     "help": "Boolean indicator of whether the rebalance appears stuck (not making progress)",
     "stability": "internal",
     "type": "gauge"
+  },
+  "cm_rebalance_total": {
+    "added": "7.2.6",
+    "help": "Number of rebalance results",
+    "labels": [
+      {
+        "help": "rebalance result (initiated/completed/failed/stopped)",
+        "name": "event"
+      }
+    ],
+    "type": "counter"
   },
   "cm_request_hibernates_total": {
     "added": "7.0.0",

--- a/modules/metrics-reference/attachments/cm_metrics_metadata.json
+++ b/modules/metrics-reference/attachments/cm_metrics_metadata.json
@@ -48,19 +48,19 @@
     "type": "counter"
   },
   "cm_auto_failover_count": {
-    "added": "7.2.6",
+    "added": "7.6.2",
     "help": "Number of auto-failovers",
     "stability": "committed",
     "type": "gauge"
   },
   "cm_auto_failover_enabled": {
-    "added": "7.2.6",
+    "added": "7.6.2",
     "help": "Indicates if auto-failover is enabled (1 = true, 0 = false)",
     "stability": "committed",
     "type": "gauge"
   },
   "cm_auto_failover_max_count": {
-    "added": "7.2.6",
+    "added": "7.6.2",
     "help": "Maximum number of auto-failovers before being disabled",
     "stability": "committed",
     "type": "gauge"
@@ -152,7 +152,7 @@
     "type": "gauge"
   },
   "cm_failover_total": {
-    "added": "7.2.6",
+    "added": "7.6.2",
     "help": "Number of non-graceful failover results",
     "labels": [
       {
@@ -169,7 +169,7 @@
     "type": "histogram"
   },
   "cm_graceful_failover_total": {
-    "added": "7.2.6",
+    "added": "7.6.2",
     "help": "Number of graceful failover results",
     "labels": [
       {
@@ -224,7 +224,7 @@
     "type": "counter"
   },
   "cm_is_balanced": {
-    "added": "7.2.6",
+    "added": "7.6.2",
     "help": "Indicates if cluster is balanced (1 = true, 0 = false). Only reported by the orchestrator node and only updated once every 30 seconds",
     "stability": "committed",
     "type": "gauge"
@@ -499,7 +499,7 @@
     "type": "counter"
   },
   "cm_rebalance_in_progress": {
-    "added": "7.2.6",
+    "added": "7.6.2",
     "help": "Indicates if a rebalance is running (1 = true, 0 = false). Only reported by the orchestrator node.",
     "stability": "committed",
     "type": "gauge"
@@ -524,7 +524,7 @@
     "type": "gauge"
   },
   "cm_rebalance_total": {
-    "added": "7.2.6",
+    "added": "7.6.2",
     "help": "Number of rebalance results",
     "labels": [
       {


### PR DESCRIPTION
This PR covers the impacts of [MB-61751](https://issues.couchbase.com/browse/MB-61751) which adds new metrics for the Cluster Manager to track failovers and rebalances.

Updates, with links to preview:

* Added section to [What's New](https://preview.docs-test.couchbase.com/cm-metrics/server/current/introduction/whats-new.html#cluster-manager) to cover new feature.
* Updated metrics JSON file from recent build to update the metrics shown in [Cluster Manager Metrics](https://preview.docs-test.couchbase.com/cm-metrics/server/current/metrics-reference/ns-server-metrics.html). Hand-edited this file to change all instances of the 7.2.6 version to 7.6.2. This was done because while these metrics will be backported to 7.2.6, 7.6.2 will be released before 7.2.6. Therefore, we should refere to these as originating in 7.6.2 until w ship 7.2.6. A future update will need to do that.

