### PR TITLE
DOC-12189 cbq in tools package

### DIFF
--- a/modules/cli/pages/cli-intro.adoc
+++ b/modules/cli/pages/cli-intro.adoc
@@ -1,6 +1,6 @@
 = CLI Reference
 :description: The command-line interface (CLI) tools lets you manage and monitor your Couchbase Server installation including clusters, servers, vBuckets, and XDCR.
-
+:tools-ver: 7.6.2
 [abstract]
 {description}
 
@@ -49,20 +49,20 @@ This package lets you install these tools on systems where you have not installe
 
 Download the command line tools package for your platform from the following links:
 
-* Linux: https://packages.couchbase.com/releases/7.6.0/couchbase-server-tools_7.6.0-linux_x86_64.tar.gz[]
-* Linux aarch64: https://packages.couchbase.com/releases/7.6.0/couchbase-server-tools_7.6.0-linux_aarch64.tar.gz[]
-* macOS: https://packages.couchbase.com/releases/7.6.0/couchbase-server-tools_7.6.0-macos_x86_64.zip[]
-* macOS arm64: https://packages.couchbase.com/releases/7.6.0/couchbase-server-tools_7.6.0-macos_arm64.zip[]
-* Windows: https://packages.couchbase.com/releases/7.6.0/couchbase-server-tools_7.6.0-windows_amd64.zip[]
+* Linux: https://packages.couchbase.com/releases/{tools-ver}/couchbase-server-tools_{tools-ver}-linux_x86_64.tar.gz[]
+* Linux aarch64: https://packages.couchbase.com/releases/{tools-ver}/couchbase-server-tools_{tools-ver}-linux_aarch64.tar.gz[]
+* macOS: https://packages.couchbase.com/releases/{tools-ver}/couchbase-server-tools_{tools-ver}-macos_x86_64.zip[]
+* macOS arm64: https://packages.couchbase.com/releases/{tools-ver}/couchbase-server-tools_{tools-ver}-macos_arm64.zip[]
+* Windows: https://packages.couchbase.com/releases/{tools-ver}/couchbase-server-tools_{tools-ver}-windows_amd64.zip[]
 
 Unzip or untar the packages, and the binaries are ready to run.
 For example:
 
-[source,console]
+[source,console,subs="attributes+"]
 ----
-wget https://packages.couchbase.com/releases/7.6.0/couchbase-server-tools_7.6.0-linux_x86_64.tar.gz
+wget https://packages.couchbase.com/releases/{tools-ver}/couchbase-server-tools_{tools-ver}-linux_x86_64.tar.gz
 
-tar -xf couchbase-server-tools_7.6.0-linux_x86_64.tar.gz
+tar -xf couchbase-server-tools_{tools-ver}-linux_x86_64.tar.gz
 ----
 
 Each package also contains a `README` file and a copy of the software license.
@@ -75,7 +75,7 @@ If you do not have these libraries installed, download them from https://docs.mi
 
 The versions of the utilities installed by the tools package are the same as the corresponding Couchbase Server installation package.
 
-The 7.6.0 `cbimport`, `cbexport`, `cbbackupmgr`, and `cbq` utilities are compatible with the following Couchbase Server versions:
+The {tools-ver} `cbimport`, `cbexport`, `cbbackupmgr`, and `cbq` utilities are compatible with the following Couchbase Server versions:
 
 * 7.6.0
 * 7.2.x

--- a/modules/cli/pages/cli-intro.adoc
+++ b/modules/cli/pages/cli-intro.adoc
@@ -1,48 +1,59 @@
 = CLI Reference
-:description: Couchbase Server command-line interface (CLI) tools are provided to manage and monitor clusters, servers, vBuckets, XDCR, and so on.
+:description: The command-line interface (CLI) toolslet lets you manage and monitor your Couchbase Server installation including clusters, servers, vBuckets, and XDCR.
 
 [abstract]
 {description}
 
-By default, the CLI tools are installed into the following locations on each platform:
+The Couchbase Server installation process installs the command-line tools.
+The location of these tools depends on your platform:
 
 [cols="50,313"]
 |===
 | Operating System | Directory Locations
 
 | Linux
-| [.path]_/opt/couchbase/bin_, [.path]_/opt/couchbase/bin/install_, and [.path]_/opt/couchbase/bin/tools_
+a| 
+* [.path]`/opt/couchbase/bin`
+* [.path]`/opt/couchbase/bin/install`
+* [.path]`/opt/couchbase/bin/tools`
 
 | Windows
-| [.path]_C:\Program Files\couchbase\server\bin_, [.path]_C:\Program Files\couchbase\server\bin\install_, and [.path]_C:\Program Files\couchbase\server\bin\tools_.
+a|
+* [.path]`C:\Program Files\couchbase\server\bin`
+* [.path]`C:\Program Files\couchbase\server\bin\install`
+* [.path]`C:\Program Files\couchbase\server\bin\tools`.
 
 | Mac OS X
-| [.path]_/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin_
-
-[.path]_/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/tools_
-
-[.path]_/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/install_
+a| 
+* [.path]`/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin`
+* [.path]`/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/tools`
+* [.path]`/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/install`
 |===
 
 == Managing diagnostics
 
 The command-line interface provides commands to start, stop, and report status for log collection.
-You can collect diagnostics through the command-line interface by using either the xref:cli:cbcli/couchbase-cli.adoc[couchbase-cli] tool or the xref:cbcollect-info-tool.adoc[[.cmd]`cbcollect_info`] cbcollect_info tool.
+You can collect diagnostics through the command-line interface by using the xref:cli:cbcli/couchbase-cli.adoc[`couchbase-cli`] or the xref:cbcollect-info-tool.adoc[`cbcollect_info`] tool.
 
 [#server-tools-packages]
 == Server Tools Packages
 
-For convenience, the following EE Server utilities are also available in a tools package that you can download --
-xref:tools:cbimport.adoc[cbimport], xref:tools:cbexport.adoc[cbexport], and xref:backup-restore:cbbackupmgr.adoc[cbbackupmgr].
-This allows developers, testers, and others to use the tools from machines on which Couchbase Server is not installed.
+For convenience, Couchbase provides a  tools package  that contains the following utilities:
 
-Download the command line tools package for your platform through the following links:
+* xref:tools:cbimport.adoc[`cbimport`]
+* xref:tools:cbexport.adoc[`cbexport`]
+* xref:cli:cbq-tool.adoc[`cbq`]
+* xref:backup-restore:cbbackupmgr.adoc[`cbbackupmgr`]
 
-* Linux: https://packages.couchbase.com/releases/7.6.0/couchbase-server-tools_7.6.0-linux_x86_64.tar.gz[https://packages.couchbase.com/releases/7.6.0/couchbase-server-tools_7.6.0-linux_x86_64.tar.gz]
-* Linux aarch64: https://packages.couchbase.com/releases/7.6.0/couchbase-server-tools_7.6.0-linux_aarch64.tar.gz[https://packages.couchbase.com/releases/7.6.0/couchbase-server-tools_7.6.0-linux_aarch64.tar.gz]
-* macOS: https://packages.couchbase.com/releases/7.6.0/couchbase-server-tools_7.6.0-macos_x86_64.zip[https://packages.couchbase.com/releases/7.6.0/couchbase-server-tools_7.6.0-macos_x86_64.zip]
-* macOS arm64: https://packages.couchbase.com/releases/7.6.0/couchbase-server-tools_7.6.0-macos_arm64.zip[https://packages.couchbase.com/releases/7.6.0/couchbase-server-tools_7.6.0-macos_arm64.zip]
-* Windows: https://packages.couchbase.com/releases/7.6.0/couchbase-server-tools_7.6.0-windows_amd64.zip[https://packages.couchbase.com/releases/7.6.0/couchbase-server-tools_7.6.0-windows_amd64.zip]
+This package lets you install these tools on systems where you have not installed Couchbase Server.
+
+Download the command line tools package for your platform from the following links:
+
+* Linux: https://packages.couchbase.com/releases/7.6.0/couchbase-server-tools_7.6.0-linux_x86_64.tar.gz[]
+* Linux aarch64: https://packages.couchbase.com/releases/7.6.0/couchbase-server-tools_7.6.0-linux_aarch64.tar.gz[]
+* macOS: https://packages.couchbase.com/releases/7.6.0/couchbase-server-tools_7.6.0-macos_x86_64.zip[]
+* macOS arm64: https://packages.couchbase.com/releases/7.6.0/couchbase-server-tools_7.6.0-macos_arm64.zip[]
+* Windows: https://packages.couchbase.com/releases/7.6.0/couchbase-server-tools_7.6.0-windows_amd64.zip[]
 
 Unzip or untar the packages, and the binaries are ready to run.
 For example:
@@ -54,17 +65,17 @@ wget https://packages.couchbase.com/releases/7.6.0/couchbase-server-tools_7.6.0-
 tar -xf couchbase-server-tools_7.6.0-linux_x86_64.tar.gz
 ----
 
-Each package also contains a `README` file, and a copy of the software license.
+Each package also contains a `README` file and a copy of the software license.
 
-Note that on Windows, a recent Microsoft Visual C++ Redistributable must already have been installed.
-Download the latest Visual C++ Redistributable from https://docs.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170[Microsoft Visual C++ Redistributable latest supported downloads].
+NOTE: On Windows, you must have a recent version of the Microsoft Visual {cpp} Redistributable runtime libraries installed.
+If you do not have these libraries installed, download them from https://docs.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170[Microsoft Visual {cpp} Redistributable latest supported downloads].
 
 [#version-compatibility]
 == Version Compatibility
 
-The versions of the utilities are the same as the Couchbase Server versions that the utilities are from.
+The versions of the utilities installed by the tools package are the same as the corresponding Couchbase Server installation package.
 
-The 7.6.0 `cbimport`, `cbexport`, and `cbbackupmgr` utilities can be run against the following Couchbase Server versions:
+The 7.6.0 `cbimport`, `cbexport`, `cbbackupmgr`, and `cbq` utilities are compatible with the following Couchbase Server versions:
 
 * 7.6.0
 * 7.2.x

--- a/modules/cli/pages/cli-intro.adoc
+++ b/modules/cli/pages/cli-intro.adoc
@@ -1,12 +1,12 @@
 = CLI Reference
-:description: The command-line interface (CLI) tools lets you manage and monitor your Couchbase Server installation including clusters, servers, vBuckets, and XDCR.
+:description: The command-line interface (CLI) tools let you manage and monitor your Couchbase Server installation including clusters, servers, vBuckets, and XDCR.
 :tools-ver: 7.6.2
 
 [abstract]
 {description}
 
 The Couchbase Server installation process installs the command-line tools.
-The location of these tools depends on your platform:
+After installation, the location of these tools depends on your platform:
 
 [cols="50,313"]
 |===
@@ -22,7 +22,7 @@ a|
 a|
 * [.path]`C:\Program Files\couchbase\server\bin`
 * [.path]`C:\Program Files\couchbase\server\bin\install`
-* [.path]`C:\Program Files\couchbase\server\bin\tools`.
+* [.path]`C:\Program Files\couchbase\server\bin\tools`
 
 | Mac OS X
 a| 
@@ -31,7 +31,7 @@ a|
 * [.path]`/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/install`
 |===
 
-== Managing diagnostics
+== Managing Diagnostics
 
 The command-line interface provides commands to start, stop, and report status for log collection.
 You can collect diagnostics through the command-line interface by using the xref:cli:cbcli/couchbase-cli.adoc[`couchbase-cli`] or the xref:cbcollect-info-tool.adoc[`cbcollect_info`] tool.
@@ -78,7 +78,7 @@ The versions of the utilities installed by the tools package are the same as the
 
 The {tools-ver} `cbimport`, `cbexport`, `cbbackupmgr`, and `cbq` utilities are compatible with the following Couchbase Server versions:
 
-* 7.6.0
+* 7.6.0, 7.6.1
 * 7.2.x
 * 7.1.x
 * 7.0.x

--- a/modules/cli/pages/cli-intro.adoc
+++ b/modules/cli/pages/cli-intro.adoc
@@ -1,5 +1,5 @@
 = CLI Reference
-:description: The command-line interface (CLI) toolslet lets you manage and monitor your Couchbase Server installation including clusters, servers, vBuckets, and XDCR.
+:description: The command-line interface (CLI) tools lets you manage and monitor your Couchbase Server installation including clusters, servers, vBuckets, and XDCR.
 
 [abstract]
 {description}

--- a/modules/cli/pages/cli-intro.adoc
+++ b/modules/cli/pages/cli-intro.adoc
@@ -1,6 +1,7 @@
 = CLI Reference
 :description: The command-line interface (CLI) tools lets you manage and monitor your Couchbase Server installation including clusters, servers, vBuckets, and XDCR.
 :tools-ver: 7.6.2
+
 [abstract]
 {description}
 


### PR DESCRIPTION
This PR handles updating the CB Server docs for the addition of the cbq tool into the downloadable packages. I've also edited the page to meet our current documentation standards, and make later updating easier.

[Here's a preview of the changes](https://preview.docs-test.couchbase.com/cbq-in-tools-package/server/current/cli/cli-intro.html).