### PR TITLE
DOC-12190: Add REST API to get active/completed requests

### DIFF
--- a/modules/rest-api/partials/rest-analytics-service-table.adoc
+++ b/modules/rest-api/partials/rest-analytics-service-table.adoc
@@ -139,14 +139,14 @@
 
 | `GET`
 | `/analytics/library`
-| xref:analytics:rest-library.adoc#read-all-libraries[Read All Libraries]
+| xref:analytics:rest-library.adoc#_get_collection[Read All Libraries]
 
 | `POST`
 | `/analytics/library/{scope}/{library}`
-| xref:analytics:rest-library.adoc#create-or-update-a-library[Create or Update a Library]
+| xref:analytics:rest-library.adoc#_post_library[Create or Update a Library]
 
 | `DELETE`
 | `/analytics/library/{scope}/{library}`
-| xref:analytics:rest-links.adoc#delete-a-library[Delete a Library]
+| xref:analytics:rest-links.adoc#_delete_library[Delete a Library]
 
 |===

--- a/modules/rest-api/partials/rest-analytics-service-table.adoc
+++ b/modules/rest-api/partials/rest-analytics-service-table.adoc
@@ -28,9 +28,17 @@
 |===
 | HTTP Method | URI | Documented at
 
+| `GET`
+| `/analytics/admin/active_requests`
+| xref:analytics:rest-admin.adoc#_return_active_requests[Active Requests]
+
 | `DELETE`
 | `/analytics/admin/active_requests`
 | xref:analytics:rest-admin.adoc#_cancel_request[Request Cancellation]
+
+| `GET`
+| `/analytics/admin/completed_requests`
+| xref:analytics:rest-admin.adoc#_completed_requests[Completed Requests]
 
 | `GET`
 | `/analytics/cluster`

--- a/modules/rest-api/partials/rest-analytics-service-table.adoc
+++ b/modules/rest-api/partials/rest-analytics-service-table.adoc
@@ -6,19 +6,19 @@
 
 | `POST`
 | `/analytics/service`
-| xref:analytics:rest-service.adoc#query-service[Query Service]
+| xref:analytics:rest-service.adoc#_post_service[Query Service]
 
 | `GET`
 | `/analytics/service`
-| xref:analytics:rest-service.adoc#read-only-query-service[Read-Only Query Service]
+| xref:analytics:rest-service.adoc#_get_service[Read-Only Query Service]
 
 | `POST`
 | `/query/service`
-| xref:analytics:rest-service.adoc#query-service-alternative[Query Service (Alternative)]
+| xref:analytics:rest-service.adoc#_post_query[Query Service (Alternative)]
 
 | `GET`
 | `/query/service`
-| xref:analytics:rest-service.adoc#read-only-query-service-alternative[Read-Only Query Service (Alternative)]
+| xref:analytics:rest-service.adoc#_get_query[Read-Only Query Service (Alternative)]
 
 |===
 
@@ -30,28 +30,23 @@
 
 | `DELETE`
 | `/analytics/admin/active_requests`
-| xref:analytics:rest-admin.adoc#request-cancellation[Request Cancellation]
+| xref:analytics:rest-admin.adoc#_cancel_request[Request Cancellation]
 
 | `GET`
 | `/analytics/cluster`
-| xref:analytics:rest-admin.adoc#cluster-status[Cluster Status]
+| xref:analytics:rest-admin.adoc#_cluster_status[Cluster Status]
 
 | `POST`
 | `/analytics/cluster/restart`
-| xref:analytics:rest-admin.adoc#cluster-restart[Cluster Restart]
+| xref:analytics:rest-admin.adoc#_restart_cluster[Cluster Restart]
 
 | `POST`
 | `/analytics/node/restart`
-| xref:analytics:rest-admin.adoc#node-restart[Node Restart]
+| xref:analytics:rest-admin.adoc#_restart_node[Node Restart]
 
 | `GET`
 | `/analytics/status/ingestion`
-| xref:analytics:rest-admin.adoc##ingestion-status[Ingestion Status]
-
-// deprecated methods
-// | `GET`
-// | `/analytics/node/agg/stats/remaining`
-// | xref:analytics:rest-admin.adoc#pending-mutations[Pending Mutations]
+| xref:analytics:rest-admin.adoc#_ingestion_status[Ingestion Status]
 
 |===
 
@@ -63,19 +58,19 @@
 
 | `GET`
 | `/analytics/config/service`
-| xref:analytics:rest-config.adoc#view-service-level-parameters[View Service-Level Parameters]
+| xref:analytics:rest-config.adoc#_get_service[View Service-Level Parameters]
 
 | `PUT`
 | `/analytics/config/service`
-| xref:analytics:rest-config.adoc#modify-service-level-parameters[Modify Service-Level Parameters]
+| xref:analytics:rest-config.adoc#_put_service[Modify Service-Level Parameters]
 
 | `GET`
 | `/analytics/config/node`
-| xref:analytics:rest-config.adoc#view-node-specific-parameters[View Node-Specific Parameters]
+| xref:analytics:rest-config.adoc#_get_node[View Node-Specific Parameters]
 
 | `PUT`
 | `/analytics/config/node`
-| xref:analytics:rest-config.adoc#modify-node-specific-parameters[Modify Node-Specific Parameters]
+| xref:analytics:rest-config.adoc#_put_node[Modify Node-Specific Parameters]
 
 |===
 
@@ -87,11 +82,11 @@
 
 | `GET`
 | `/settings/analytics`
-| xref:analytics:rest-settings.adoc#view-analytics-settings[View Analytics Settings]
+| xref:analytics:rest-settings.adoc#_get_settings[View Analytics Settings]
 
-| `PUT`
+| `POST`
 | `/settings/analytics`
-| xref:analytics:rest-settings.adoc#modify-analytics-settings[Modify Analytics Settings]
+| xref:analytics:rest-settings.adoc#_post_settings[Modify Analytics Settings]
 
 |===
 
@@ -103,44 +98,27 @@
 
 | `POST`
 | `/analytics/link/{scope}/{name}`
-| xref:analytics:rest-links.adoc#create-link[Create Link]
+| xref:analytics:rest-links.adoc#_post_link[Create Link]
 
 | `GET`
 | `/analytics/link/{scope}/{name}`
-| xref:analytics:rest-links.adoc#query-link[Query Link]
+| xref:analytics:rest-links.adoc#_get_link[Query Link]
 
 | `PUT`
 | `/analytics/link/{scope}/{name}`
-| xref:analytics:rest-links.adoc#edit-link[Edit Link]
+| xref:analytics:rest-links.adoc#_put_link[Edit Link]
 
 | `DELETE`
 | `/analytics/link/{scope}/{name}`
-| xref:analytics:rest-links.adoc#delete-link[Delete Link]
+| xref:analytics:rest-links.adoc#_delete_link[Delete Link]
 
 | `GET`
 | `/analytics/link`
-| xref:analytics:rest-links.adoc#query-all-links[Query All Links]
+| xref:analytics:rest-links.adoc#_get_all[Query All Links]
 
 | `GET`
 | `/analytics/link/{scope}`
-| xref:analytics:rest-links.adoc#query-scope-links[Query Scope Links]
-
-// deprecated methods
-// | `POST`
-// | `/analytics/link`
-// | xref:analytics:rest-links.adoc#create-link-alternative[Create Link (Alternative)]
-
-// | `GET`
-// | `/analytics/link`
-// | xref:analytics:rest-links.adoc#query-link-alternative[Query Link (Alternative)]
-
-// | `PUT`
-// | `/analytics/link/`
-// | xref:analytics:rest-links.adoc#edit-link-alternative[Edit Link (Alternative)]
-
-// | `DELETE`
-// | `/analytics/link`
-// | xref:analytics:rest-links.adoc#delete-link-alternative[Delete Link (Alternative)]
+| xref:analytics:rest-links.adoc#_get_scope[Query Scope Links]
 
 |===
 


### PR DESCRIPTION
Jira issue: DOC-12190

This PR updates the partial for the Analytics REST APIs, which is included in the overall REST API reference landing page, to include the new Active Requests and Completed Requests operations.

It also corrects the links for all of the other Analytics REST APIs, which had bit-rotted when we migrated the Analytics documentation from Markdown to AsciiDoc. Commented-out links to deprecated Analytics REST APIs are removed.

Related PR:

* https://github.com/couchbaselabs/cb-swagger/pull/129