### PR TITLE
DOC-12225-7.6-Slow-operations-threshold-logging-documentation-should-be-clearer-that-the-command-needs-to-be-run-on-every-node

### DIFF
--- a/modules/manage/pages/manage-logging/manage-logging.adoc
+++ b/modules/manage/pages/manage-logging/manage-logging.adoc
@@ -456,9 +456,9 @@ The current settings are retrieved by using the `mcctl` cli to execute the `get 
 
 These settings only apply to the nodes _where the changes are made._
 
-The node must also be configured to run the `data service`.
+You must implement the changes on each node to ensure they are applied across the cluster.
 
-To change the threshold across the cluster, then all the configurations must be applied to each node.
+You must also configure the node to run the `data service`.
 ====
 
 .Getting threshold details
@@ -581,4 +581,5 @@ cp opcode-attributes.json opcode-attributes.d
 
 Edit `/opt/couchbase/etc/couchbase/kv/opcode-attributes.d/opcode-attributes.json` with the new settings.
 
-
+NOTE: These settings only apply to the node where the changes are made.
+To change the threshold across the cluster, then all the configurations must be applied to each node.

--- a/modules/manage/pages/manage-logging/manage-logging.adoc
+++ b/modules/manage/pages/manage-logging/manage-logging.adoc
@@ -451,6 +451,16 @@ The command only gets or sets information for the node it's run on.
 === Getting Threshold Details
 The current settings are retrieved by using the `mcctl` cli to execute the `get sla` command:
 
+[IMPORTANT]
+====
+
+These settings only apply to the nodes _where the changes are made._
+
+The node must also be configured to run the `data service`.
+
+To change the threshold across the cluster, then all the configurations must be applied to each node.
+====
+
 .Getting threshold details
 [source, bash]
 ----
@@ -571,5 +581,4 @@ cp opcode-attributes.json opcode-attributes.d
 
 Edit `/opt/couchbase/etc/couchbase/kv/opcode-attributes.d/opcode-attributes.json` with the new settings.
 
-NOTE: These settings only apply to the node where the changes are made.
-To change the threshold across the cluster, then all the configurations must be applied to each node.
+


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-12225