### PR TITLE
Add indications that two backup-related features were adding in 7.6.2

### DIFF
--- a/modules/learn/pages/security/roles.adoc
+++ b/modules/learn/pages/security/roles.adoc
@@ -229,7 +229,12 @@ The role supports access to Couchbase Web Console, but does not support the read
 
 The *Read-Only Admin* role (an Administrative role) supports the reading of Couchbase Server statistics. 
 This information includes registered usernames with roles and authentication domains, but excludes passwords.
+ifeval::['{page-component-version}' == '7.6']
+Since Couchbase Server version 7.6.2, users with this role can also read Backup Service data to monitor backup plans and tasks.
+endif::[]
+ifeval::['{page-component-version}' != '7.6']
 Users with this role can also read Backup Service data to monitor backup plans and tasks.
+endif::[]
 The role allows access to Couchbase Server Web Console.
 
 This role is also available in Couchbase Server Community Edition.
@@ -270,7 +275,7 @@ This role is also available in Couchbase Server Community Edition.
 ^| image:introduction/no.png[]
 ^| image:introduction/no.png[]
 
-^| Backup Service (tasks and plans)
+^| Backup Service (tasks and plans) [.status]#Couchbase Server 7.6.2#
 ^| image:introduction/yes.png[]
 ^| image:introduction/no.png[]
 ^| image:introduction/no.png[]

--- a/modules/learn/pages/services-and-indexes/services/backup-service.adoc
+++ b/modules/learn/pages/services-and-indexes/services/backup-service.adoc
@@ -197,12 +197,12 @@ When you use 0 to indicate today,  the range starts from the time the scheduled 
 Therefore, if today is March 15, the time range is from March 11 to March 8, with both the start and end days included entirely.
 
 [#threads]
-== Thread Usage
+== Thread Usage [.status]#Couchbase Server 7.6.2#
 
 By default, the Backup Service chooses the number of threads it uses based on the number of CPU cores in the node. 
 The Backup Service creates one client connection per thread to connect in parallel to nodes when retrieving their data.
 The more threads the service uses, the faster it retrieves data.
-The formula for the number of threads it uses is stem:[\max(1, cpu\_cores \times 0.75)]   (stem:[\tfrac{3}{4}] the number of CPU cores in the system or 1, whichever is larger).
+The formula for the number of threads it uses is stem:[\max(1, cpu\_cores \times 0.75)]   (stem:[\frac{3}{4}] the number of CPU cores in the system or 1, whichever is larger).
 
 In some cases, you may find that the default number of threads the Backup Service is using is too high. 
 Depending on resources, a large number of threads can cause performance issues or out-of-memory errors.

--- a/modules/rest-api/pages/backup-node-threads.adoc
+++ b/modules/rest-api/pages/backup-node-threads.adoc
@@ -1,6 +1,7 @@
 = Manage Backup Service Threads
 :description: You can change the number of threads a Backup Service node uses when backing up data.
 :stem: latexmath
+:page-status: Couchbase Server 7.6.2
 
 [abstract]
 {description}


### PR DESCRIPTION
Added some 7.6.2 disclaimers for backup-related features that already merged into 7.6.2.