### PR TITLE
DOC-11729-Feedback-on-Release-Notes-for-Couchbase-Server-7.2-Couchbase-Docs

### DIFF
--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -6,3 +6,7 @@
 include::partial$docs-server-7.6.1-release-note.adoc[]
 
 include::partial$docs-server-7.6-release-note.adoc[]
+
+== Documentation for Older Versions
+
+Documentation for older versions of Couchbase software can be found in the https://docs-archive.couchbase.com/home/index.html[Documentation Archive^]


### PR DESCRIPTION
Adding link to documentation archive link to the release notes page.