### PR TITLE
DOC-12048: Doc new indexer setting for default value of "defer build"

### DIFF
--- a/modules/introduction/partials/new-features-76_2.adoc
+++ b/modules/introduction/partials/new-features-76_2.adoc
@@ -41,7 +41,7 @@ For details, see xref:javascript-udfs:javascript-functions-with-couchbase.adoc#r
 [#index_762]
 === Index Service
 
-* From version 7.6.2, index creation operates in deferred build mode by default.
+* From version 7.6.2, you can specify that index creation operates in deferred build mode by default.
 In deferred build mode, creating an index does not trigger the index build phase: you must trigger the index build before you can use the index.
 For details, see xref:n1ql:n1ql-language-reference/createindex.adoc[CREATE INDEX].
 


### PR DESCRIPTION
Jira issue: DOC-12048

Correction to the "What's new" section on this feature.