### PR TITLE
DOC-12340: Tweak the upgrade warning

### DIFF
--- a/modules/install/pages/upgrade.adoc
+++ b/modules/install/pages/upgrade.adoc
@@ -8,7 +8,7 @@
 [abstract]
 {description}
 
-.Upgrading from Versions 7.1 or 7.2 to Version 7.6.0 or 7.6.1
+.Upgrading from Versions 7.1 or 7.2 to Versions 7.6.0 or 7.6.1
 [WARNING]
 ====
 

--- a/modules/install/pages/upgrade.adoc
+++ b/modules/install/pages/upgrade.adoc
@@ -8,11 +8,11 @@
 [abstract]
 {description}
 
-.Upgrading from Version 7.1 or 7.2 to Version 7.6.x
+.Upgrading from Versions 7.1 or 7.2 to Version 7.6.0 or 7.6.1
 [WARNING]
 ====
 
-If there are index service nodes running in your cluster, you must use the swap rebalance method when upgrading from Couchbase 7.1 or 7.2 to Couchbase 7.6.x.
+If there are index service nodes running in your cluster, you must use the swap rebalance method when upgrading from Couchbase Server 7.1 or 7.2 to Server 7.6.0 or 7.6.1.
 
 See xref:install:upgrade-procedure-selection.adoc#swap-rebalance[Swap Rebalance] for more information about the swap rebalance method.
 ====


### PR DESCRIPTION
So that it explicitly references 7.6.0 and 7.6.1