### PR TITLE
DOC-12343: Change to refer to the Erlang upgrade in 7.2.4

### DIFF
--- a/modules/install/pages/upgrade.adoc
+++ b/modules/install/pages/upgrade.adoc
@@ -1,7 +1,7 @@
 = Upgrade
 :description: To upgrade a Couchbase-Server cluster means to upgrade the version of Couchbase Server that is running on every node.
 
-:erlang-upgrade-note: The upgrade to Erlang support in Couchbase server 7.2.6 requires that you first upgrade Couchbase to version 7.1.0 or later before upgrading to version 7.6.x
+:erlang-upgrade-note: The upgrade to Erlang support in Couchbase server 7.2.4 requires that you first upgrade Couchbase to version 7.1.0 or later before upgrading to version 7.6.x
 
 :xrefstyle: short
 


### PR DESCRIPTION
As 7.2.4 was in fact the release that had an upgrade to Erlang requiring that clusters first be on 7.1 before upgrading to 7.2 or later.