### PR TITLE
Updating release note for 7.2.5

### DIFF
--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -12,4 +12,6 @@ include::partial$docs-server-7.2.1-release-note.adoc[]
 
 include::partial$docs-server-7.2.0-release-note.adoc[]
 
+== Documentation for Older Versions
 
+Documentation for older versions of Couchbase software can be found in the https://docs-archive.couchbase.com/home/index.html[Documentation Archive^].

--- a/modules/release-notes/partials/docs-server-7.2.5-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.2.5-release-note.adoc
@@ -10,6 +10,22 @@ This maintenance release contains new features and fixes.
 [#new-features-725]
 === New Features and Enhancements
 
+==== XDCR
+
+[#table-new-features-725-xdcr, cols="10,40"]
+|===
+|Feature | Description
+
+| https://issues.couchbase.com/browse/MB-60892[MB-60892]
+| `XDCR` will no longer roll back to 0 due to purge sequence number moving ahead of a replication's checkpoint.
+
+
+
+| https://issues.couchbase.com/browse/MB-61303[MB-61303]
+| Once faulty remote cluster credentials are fixed, XDCR will now be able to  restart replications that depend on the repaired references more quickly.
+
+|===
+
 ==== Analytics
 
 [#table-new-features-725-analytics, cols="10,40"]
@@ -84,8 +100,40 @@ a| The calculation now uses the number of logical processors online on the syste
 
 |===
 
+==== XDCR
 
+[#table-fixed-issues-725-xdcr, cols="10,40,40"]
+|===
+|Issue | Description | Resolution
 
+| https://issues.couchbase.com/browse/MB-60616[MB-60616]
+| When `goxdcr` process is killed in a paused replication state, `changes_left` had a negative value.
+| Issue resolved.
+
+| https://issues.couchbase.com/browse/MB-60859[MB-60859]
+| During target cluster rebalance, XDCR will error out with invalid packets because of VBucket movements.
+| Issue resolved. VBucket movements will no longer cause packet errors.
+
+| https://issues.couchbase.com/browse/MB-60930[MB-60930]
+| `MergeNewTasks` of backfillSpec can append a null task in the task list
+| XDCR backfill pipeline will not contain null tasks, avoiding unnecessary trigger of backfill pipeline.
+
+| https://issues.couchbase.com/browse/MB-61414[MB-61414]
+| JSON documents are considered invalid when there are whitespace characters at the end of the document during filtering.
+| JSON documents with terminating whitespaces are now processed correctly and can be replicated with advanced filtering.
+
+|===
+
+==== Query Service
+
+[#table-fixed-issues-725-query-service, cols="10,40,40"]
+|===
+
+| https://issues.couchbase.com/browse/MB-60294[MB-60294]
+| `COUNT(*)` on `system:indexes` can return incorrect results
+| Issue resolved.
+
+|===
 
 
 


### PR DESCRIPTION
Adding late additions to the 7.2.5 release note.
Adding link to the documentation archive.

NOTE: This not the complete list of outstanding entries, but I've just added the ones that have release note information attached to the Jira requests.