### PR TITLE
Added planner fix. Fixed punctuation for the archive link.

### DIFF
--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -11,4 +11,4 @@ include::partial$docs-server-7.6.0-release-note.adoc[]
 
 == Documentation for Older Versions
 
-Documentation for older versions of Couchbase software can be found in the https://docs-archive.couchbase.com/home/index.html[Documentation Archive^]
+Documentation for older versions of Couchbase software can be found in the https://docs-archive.couchbase.com/home/index.html[Documentation Archive^].

--- a/modules/release-notes/partials/docs-server-7.6.2-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6.2-release-note.adoc
@@ -117,6 +117,10 @@ sure the memcached
 |===
 |Issue | Description | Resolution
 
+| https://issues.couchbase.com/browse/MB-61014[MB-61014]
+| The planner may not pick a covering index if the index is defined with a complex `WHERE` clause (e.g. `AND` or `OR` clauses involving `!=`, `NOT` or `IN` predicates).
+| Fixed.
+
 | https://issues.couchbase.com/browse/MB-61171[MB-61171]
 | In rare circumstances with high-load Query, requests can fail to complete, blocking rebalance attempts. +
 Such requests don't affect other regular processing beyond occupying a servicer, but a rebalance can't complete until they do.


### PR DESCRIPTION
[DOC-12207: Adding last entries for Couchbase Server 7.6.2 release note.