### PR TITLE
[DOC-10769-7.2]: Remove the obsolete 'Auto-Failover during Rebalance' paragraph. Removed paragraph related to the auto-failover aborting a rebalance.

### DIFF
--- a/modules/learn/pages/clusters-and-availability/automatic-failover.adoc
+++ b/modules/learn/pages/clusters-and-availability/automatic-failover.adoc
@@ -9,14 +9,14 @@
 == Understanding Automatic Failover
 
 _Automatic Failover_ — or _auto-failover_ — can be configured to fail over one or more nodes automatically. No immediate administrator intervention is required.
-Specifically, the Cluster Manager autonomously detects and verifies that the nodes are unresponsive, and then initiates the _hard_ failover process.
+Specifically, the Cluster Manager autonomously detects and verifies that the nodes are unresponsive and then initiates the _hard_ failover process.
 Auto-failover does not fix or identify problems that may have occurred.
 Once appropriate fixes have been applied to the cluster by the administrator, a rebalance is required.
 Auto-failover is always _hard_ failover.
 For information on how services are affected by hard failover, see xref:learn:clusters-and-availability/hard-failover.adoc[Hard Failover].
 
 This page describes auto-failover concepts and policy.
-For information on managing auto-failover, see the information provided for Couchbase Web Console at xref:manage:manage-settings/general-settings.adoc[General] (which provides information on general cluster-settings), for the REST API at xref:rest-api:rest-cluster-autofailover-intro.adoc[Managing Auto-Failover], and for the CLI at xref:cli:cbcli/couchbase-cli-setting-autofailover.adoc[setting-autofailover].
+For information on managing auto-failover, see the information provided for Couchbase Web Console at xref:manage:manage-settings/general-settings.adoc[General], (which provides information on general cluster-settings), for the REST API at xref:rest-api:rest-cluster-autofailover-intro.adoc[Managing Auto-Failover], and for the CLI at xref:cli:cbcli/couchbase-cli-setting-autofailover.adoc[setting-autofailover].
 
 == Failover Events
 
@@ -30,7 +30,7 @@ A server-node within the cluster is unresponsive (due to a network failure, out-
 Concurrent correlated failure of multiple nodes such as physical rack of machines or multiple virtual machines sharing a host.
 
 * _Disk read/write failure_.
-Attempts to read from or write to disk on a particular node have resulted in a significant rate of failure, for longer than a specified time-period.
+Attempts to read from or write to disk on a particular node have resulted in a significant rate of failure for longer than a specified time-period.
 The node is removed by auto-failover, even though the node continues to be contactable.
 
 
@@ -43,11 +43,13 @@ Auto-failover is triggered:
 For example, given a cluster of 18 nodes, _10_ nodes are required for the quorum; and given a cluster of 17 nodes, _9_ nodes are required for the quorum.
 
 * Only up to an administrator-specified maximum number of nodes.
-After this maximum number of auto-failovers has been reached, no further auto-failover occurs, until the count is manually reset by the administrator, or until a rebalance is successfully performed.
+After this maximum number of auto-failovers has been reached,
+no further auto-failover occurs until the count is manually reset by the administrator
+or until a rebalance is successfully performed.
 Note, however, that the count can be manually reset, or a rebalance performed, prior to the maximum number being reached.
 
 * In no circumstances where data-loss might result: for example, when a bucket has no replicas.
-Therefore, even a single event may not trigger a response; and an administrator-specified maximum number of failed nodes may not be reached.
+Therefore, even a single event may not trigger a response, and an administrator-specified maximum number of failed nodes may not be reached.
 
 * Only in accordance with the xref:learn:clusters-and-availability/automatic-failover.adoc#failover-policy[Service-Specific Auto-Failover Policy] for the service or services on the unresponsive node.
 
@@ -60,7 +62,7 @@ Auto-failover is for intra-cluster use only: it does not work with xref:learn:cl
 
 Auto-failover may take significantly longer if the unresponsive node is that on which the _orchestrator_ is running; since _time-outs_ must occur, before available nodes can elect a new orchestrator-node and thereby continue.
 
-See xref:manage:manage-settings/configure-alerts.adoc[Alerts], for
+See xref:manage:manage-settings/configure-alerts.adoc[Alerts] for
 details on configuring email alerts related to failover.
 
 See xref:learn:clusters-and-availability/groups.adoc[Server Group Awareness], for information on server groups.
@@ -70,7 +72,7 @@ See xref:learn:clusters-and-availability/groups.adoc[Server Group Awareness], fo
 
 The auto-failover policy for Couchbase Services is as follows:
 
-* A service must be running on a minimum number of nodes, for auto-failover to be applied to any one of those nodes, should that node become unresponsive.
+* A service must be running on a minimum number of nodes for auto-failover to be applied to any one of those nodes, should that node become unresponsive.
 
 * The required minimum number of nodes is service-specific.
 
@@ -133,7 +135,7 @@ This is illustrated by the following examples:
 +
 If node #4 becomes unresponsive, auto-failover can be triggered, since prior to unavailability, the Search Service was on two nodes (#3 and #4), and the Query Service on three (#3, #4, and #5): both of which figures meet the auto-failover policy requirement (for each of those services, 2).
 +
-However, if instead, node #5 becomes unresponsive, auto-failover is not triggered; since prior to unavailability, the Analytics Service was running only on one node (#5), which is below the auto-failover policy requirement for the Analytics Service (which is 2).
+However, if instead, node #5 becomes unresponsive, auto-failover is not triggered; since prior to unavailability, the Analytics Service was running only on one node (#5), which is below the auto-failover policy requirement for the Analytics Service, (which is 2).
 
 [#data-service-preference]
 * A cluster has the following three nodes:
@@ -187,31 +189,31 @@ WARNING: If an index does not have a replica and is co-located on a Data Service
 
 == Configuring Auto-Failover
 
-Auto-failover is configured by means of parameters that include the following.
+Auto-failover is configured by parameters that include the following:
 
 * _Timeout_.
-The number of seconds that must elapse, after a node or group has become unresponsive, before auto-failover is triggered. This number is configurable: the default is 120 seconds; the minimum permitted is 5; the maximum 3600.
+The number of seconds that must elapse after a node or group has become unresponsive before auto-failover is triggered. This number is configurable: the default is 120 seconds; the minimum permitted is 5; the maximum is 3600.
 Note that a low number reduces the potential time-period during which a consistently unresponsive node remains unresponsive before auto-failover is triggered; but may also result in auto-failover being unnecessarily triggered, in consequence of short, intermittent periods of node unavailability.
 +
-WARNING: Care must be when running an un-replicated Index Service and a Data Service configured for fast failover (i.e. 5 seconds) on the same node.
+WARNING: Care must be when running an un-replicated Index Service and a Data Service configured for fast failover (i.e., 5 seconds) on the same node.
 If the failover is triggered, unnecessarily or otherwise, then the index service will be lost.
 * _Maximum count_.
 The maximum number of nodes that can fail (either concurrently or sequentially in one or more events) and be handled by auto-failover.
-The maximum value can be up to configured number of nodes, the default is 1.
+The maximum value can be up to a configured number of nodes, the default is 1.
 This parameter is available in Enterprise Edition only: in Community Edition, the maximum number of nodes that can fail and be handled by auto-failover is always 1.
 * _Count_.
 The number of nodes that have already failed over.
 The default value is 0.
 The value is incremented by 1 for every node that has an automatic-failover that occurs, up to the defined maximum count: beyond this point, no further automatic failover can be triggered until the count is reset to 0 through administrator-intervention.
-* _Enablement of disk-related automatic failover; with corresponding time-period_.
+* _Enablement of disk-related automatic failover; with a corresponding time-period_.
 Whether automatic failover is enabled to handle continuous read-write failures.
 If it is enabled, a number of seconds can also be specified: this is the length of a constantly recurring time-period against which failure-continuity on a particular node is evaluated.
-The default for this number of seconds is 120; the minimum permitted is 5; the maximum 3600.
-If at least 60% of the most recently elapsed instance of the time-period has consisted of continuous failure, failover is automatically triggered.
+The default for this number of seconds is 120; the minimum permitted is 5; the maximum is 3600.
+If at least 60% of the most recently elapsed time-periods have consisted of continuous failure, failover is automatically triggered.
 The default value for the enablement of disk-related automatic failover is false.
 This parameter is available in Enterprise Edition only.
 
-By default, auto-failover is switched on, to occur after 120 seconds for up to 1 event.
+By default, auto-failover is switched on to occur after 120 seconds for up to 1 event.
 Nevertheless, Couchbase Server triggers auto-failover only within the constraints described above, in xref:learn:clusters-and-availability/automatic-failover.adoc#auto-failover-constraints[Auto-Failover Constraints].
 
 For practical steps towards auto-failover configuration, see the documentation provided for specifying
@@ -224,10 +226,11 @@ xref:cli:cbcli/couchbase-cli-setting-autofailover.adoc[setting-autofailover] wit
 [#auto-failover-during-rebalance]
 == Auto-Failover During Rebalance
 
-Following auto-failover, rebalance is _not_ automatically re-attempted.
-At this point, the cluster is likely to be in an unbalanced state: therefore, rebalance should be performed manually; and the unresponsive node fixed and restored to the cluster, as appropriate.
+If an auto-failover event occurs during a rebalance, the rebalance is stopped; then, auto-failover is triggered.
 
-For information on setting auto-failover in the context of rebalance, see the information on xref:manage:manage-settings/general-settings.adoc[General] settings.
+WARNING: Following an auto-failover, rebalance _is not_ automatically re-attempted.
+
+At this point, the cluster is likely to be in an unbalanced state; therefore, a rebalance should be performed manually, and the unresponsive node fixed and restored to the cluster, as appropriate.
 
 [#auto-failover-and-durability]
 == Auto-Failover and Durability

--- a/modules/learn/pages/clusters-and-availability/automatic-failover.adoc
+++ b/modules/learn/pages/clusters-and-availability/automatic-failover.adoc
@@ -224,14 +224,8 @@ xref:cli:cbcli/couchbase-cli-setting-autofailover.adoc[setting-autofailover] wit
 [#auto-failover-during-rebalance]
 == Auto-Failover During Rebalance
 
-Couchbase Server provides a setting to determine whether, once enabled, auto-failover should specifically be triggered during xref:learn:clusters-and-availability/rebalance.adoc[Rebalance], in the event of a node becoming unresponsive.
-
-If auto-failover _has_ been set to be triggered, following the configured timeout period, the rebalance is stopped; then, auto-failover is duly triggered.
 Following auto-failover, rebalance is _not_ automatically re-attempted.
 At this point, the cluster is likely to be in an unbalanced state: therefore, rebalance should be performed manually; and the unresponsive node fixed and restored to the cluster, as appropriate.
-
-If auto-failover has _not_ been set to be triggered, unless there is manual intervention, no failover occurs.
-This may cause the rebalance to hang for an indeterminate period; before failing, with error messages.
 
 For information on setting auto-failover in the context of rebalance, see the information on xref:manage:manage-settings/general-settings.adoc[General] settings.
 


### PR DESCRIPTION
Removed offending paragraph.

@JackBakes, if you could take a Quick Look at this change and make sure that it is correct, that would be greatly appreciated.