### PR TITLE
DOC-12443: Reorganize GSI documents

### DIFF
--- a/modules/fts/pages/fts-analyzers-search-functions.adoc
+++ b/modules/fts/pages/fts-analyzers-search-functions.adoc
@@ -4,7 +4,7 @@ xref:n1ql:n1ql-language-reference/searchfun.adoc[Search functions] allow users t
 
 In the context of {sqlpp} queries, a full text search index can be described as one of the following :
 
-* xref:n1ql:n1ql-language-reference/covering-indexes.adoc[Covering index]
+* xref:indexes:covering-indexes.adoc[Covering index]
 
 * Non-covering index
 

--- a/modules/install/pages/migrate-mysql.adoc
+++ b/modules/install/pages/migrate-mysql.adoc
@@ -83,7 +83,7 @@ However, the old-school RDBMS data modeling techniques still play a meaningful r
 
 Like MySQL, Couchbase Server offers a rich set of features and functionality far beyond those offered in simple key-value stores.
 
-With Couchbase Server, you also get an expressive SQL-like query language and query engine called xref:n1ql:n1ql-language-reference/index.adoc[{sqlpp}], which is combined with a new powerful indexing mechanism -- xref:learn:services-and-indexes/indexes/global-secondary-indexes.adoc[Global Secondary Indexes].
+With Couchbase Server, you also get an expressive SQL-like query language and query engine called xref:n1ql:n1ql-language-reference/index.adoc[{sqlpp}], which is combined with a new powerful indexing mechanism -- xref:indexes:indexing-overview.adoc[Global Secondary Indexes].
 
 .Feature differences between MySQL and Couchbase Server
 [cols="1,3"]

--- a/modules/introduction/pages/intro.adoc
+++ b/modules/introduction/pages/intro.adoc
@@ -97,11 +97,11 @@ image::n1ql-ansi-join-example.png[,450]
 [.column]
 .Index Service
 * xref:learn:services-and-indexes/services/index-service.adoc[Index Service]
-* xref:learn:services-and-indexes/indexes/global-secondary-indexes.adoc[Global Secondary Indexes]
-* xref:learn:services-and-indexes/indexes/index-replication.adoc[Availability and Performance]
-* xref:learn:services-and-indexes/indexes/index-scans.adoc[Index Scans]
-* xref:learn:services-and-indexes/indexes/index_pushdowns.adoc[Index Pushdowns]
-* xref:learn:services-and-indexes/indexes/storage-modes.adoc[Index Storage Settings]
+* xref:indexes:indexing-overview.adoc[Global Secondary Indexes]
+* xref:indexes:index-replication.adoc[Availability and Performance]
+* xref:indexes:index-scans.adoc[Index Scans]
+* xref:indexes:index_pushdowns.adoc[Index Pushdowns]
+* xref:indexes:storage-modes.adoc[Index Storage Settings]
 
 [.column]
 .Query Service

--- a/modules/introduction/partials/new-features-76.adoc
+++ b/modules/introduction/partials/new-features-76.adoc
@@ -235,7 +235,7 @@ See xref:n1ql:n1ql-intro/sysinfo.adoc#querying-indexes[Query Indexes].
 See xref:n1ql:n1ql-manage/query-settings.adoc#queryPreparedLimit[queryPreparedLimit] and xref:n1ql:n1ql-manage/query-settings.adoc#prepared-limit[prepared-limit].
 
 * The Query Service adds support for sequential scans, controlled by RBAC, which enables querying without an index.
-See xref:learn:services-and-indexes/indexes/query-without-index.adoc[].
+See xref:indexes:query-without-index.adoc[].
 
 * The node-level N1QL Feature Control parameter now accepts hexadecimal strings or decimal integers.
 See xref:n1ql:n1ql-manage/query-settings.adoc#n1ql-feat-ctrl[n1ql-feat-ctrl].

--- a/modules/learn/pages/clusters-and-availability/groups.adoc
+++ b/modules/learn/pages/clusters-and-availability/groups.adoc
@@ -134,7 +134,7 @@ Note, however, that if Group 2 were now to go offline, the data originally activ
 
 Indexes and index replicas can only be located on nodes that run the Index Service.
 
-As described in xref:learn:services-and-indexes/indexes/index-replication.adoc#index-replication[Index Replication], the Index Service allows index replicas to be defined in either of two ways:
+As described in xref:indexes:index-replication.adoc#index-replication[Index Replication], the Index Service allows index replicas to be defined in either of two ways:
 
 * By establishing the number of replicas required, for a given index, without the actual node-locations of the replicas being specified.
 This is itself accomplished in either of the following ways:
@@ -146,7 +146,7 @@ This is itself accomplished in either of the following ways:
 * By establishing the number of replicas required, for a given index, with the actual node-locations for the index itself and each of its replicas being specified.
 This is accomplished by providing, as the argument to the `WITH` clause, an array of nodes.
 
-Examples of these different forms of replica-definition are provided in xref:learn:services-and-indexes/indexes/index-replication.adoc#index-replication[Index Replication].
+Examples of these different forms of replica-definition are provided in xref:indexes:index-replication.adoc#index-replication[Index Replication].
 
 If the node-locations for index and replicas _are_ specified, by means of the `WITH` clause and node-array, this user-defined topology is duly followed in the locating of index and replicas across the cluster, and any server groups that may have been defined.
 In this case, it is the administrator's responsibility to ensure that optimal index-availability has been achieved, so as to handle possible instances of node or group failure.
@@ -158,7 +158,7 @@ Such distributions are exemplified as follows.
 === Optimal Distribution
 
 When the number of index replicas created for a given index is at least one less than the total number of groups for the cluster, and each group contains sufficient nodes running the Index Server, automatic distribution ensures that each index and index replica resides on its own group.
-(Indexes and index replicas always exist each on their own Index Server node, with index-creation failing if there is an insufficiency of such nodes to accommodate the specified number of index replicas &#8212; see xref:learn:services-and-indexes/indexes/index-replication.adoc#index-replication[Index Replication].)
+(Indexes and index replicas always exist each on their own Index Server node, with index-creation failing if there is an insufficiency of such nodes to accommodate the specified number of index replicas &#8212; see xref:indexes:index-replication.adoc#index-replication[Index Replication].)
 
 For example:
 

--- a/modules/learn/pages/clusters-and-availability/groups.adoc
+++ b/modules/learn/pages/clusters-and-availability/groups.adoc
@@ -158,7 +158,7 @@ Such distributions are exemplified as follows.
 === Optimal Distribution
 
 When the number of index replicas created for a given index is at least one less than the total number of groups for the cluster, and each group contains sufficient nodes running the Index Server, automatic distribution ensures that each index and index replica resides on its own group.
-(Indexes and index replicas always exist each on their own Index Server node, with index-creation failing if there is an insufficiency of such nodes to accommodate the specified number of index replicas &#8212; see xref:indexes:index-replication.adoc#index-replication[Index Replication].)
+(Indexes and index replicas always exist each on their own Index Server node, with index-creation failing if there is an insufficiency of such nodes to accommodate the specified number of index replicas -- see xref:indexes:index-replication.adoc#index-replication[Index Replication].)
 
 For example:
 
@@ -198,7 +198,7 @@ When multiple groups are to be added to a cluster simultaneously, the additions 
 [#group-failover-and-service-availability]
 == Group Failover and Service Availability
 
-When groups are defined to correspond to racks or availability zones, all services required for data access &#8212; such as the Index Service and the Search Service &#8212; should be deployed so as to ensure their own continued availability, during the outage of a rack or zone.
+When groups are defined to correspond to racks or availability zones, all services required for data access -- such as the Index Service and the Search Service -- should be deployed so as to ensure their own continued availability, during the outage of a rack or zone.
 
 For example, given a cluster:
 

--- a/modules/learn/pages/clusters-and-availability/rebalance.adoc
+++ b/modules/learn/pages/clusters-and-availability/rebalance.adoc
@@ -148,10 +148,10 @@ The rebalance process takes into account the nodes' CPU, RAM, and disk bandwidth
 [#index-rebalance-methods]
 ==== Index Rebalance Methods
 
-By default, Couchbase Server rebuilds the indexes in their new locations during a rebalance.  
-If your cluster uses xref:learn:services-and-indexes/indexes/storage-modes.adoc#standard-index-storage[Standard Index Storage], you can choose to enable file-based rebalance which moves index files between nodes instead of rebuilding them. 
+By default, Couchbase Server rebuilds the indexes in their new locations during a rebalance.
+If your cluster uses xref:indexes:storage-modes.adoc#standard-index-storage[Standard Index Storage], you can choose to enable file-based rebalance which moves index files between nodes instead of rebuilding them. 
 Copying the index files is faster than having the target node rebuild the index from scratch.
-You cannot use file-based rebalance if you have enabled xref:learn:services-and-indexes/indexes/storage-modes.adoc#memory-optimized-index-storage[Memory Optimized Index Storage] because this option does not store index metadata in files.
+You cannot use file-based rebalance if you have enabled xref:indexes:storage-modes.adoc#memory-optimized-index-storage[Memory Optimized Index Storage] because this option does not store index metadata in files.
 
 Couchbase Capella defaults to file-based index rebalance.
 

--- a/modules/learn/pages/clusters-and-availability/recovery.adoc
+++ b/modules/learn/pages/clusters-and-availability/recovery.adoc
@@ -28,13 +28,13 @@ _Full_ recovery involves removing all pre-existing data from, and assigning new 
 
 * A new set of vBuckets and documents is assigned to the node.
 
-* When the node’s vBuckets are all up to date, and the rebalance process concludes, the node recommences the serving of data.
+* When the node's vBuckets are all up to date, and the rebalance process concludes, the node recommences the serving of data.
 If GSI Indexes reside on the node, they become active, and are updated by the Index Service as appropriate.
 
 [#delta-recovery]
 == Delta Recovery
 
-_Delta_ recovery maintains and resynchronizes a node’s pre-existing data.
+_Delta_ recovery maintains and resynchronizes a node's pre-existing data.
 Therefore, when this option is applied:
 
 * No existing vBucket or document is removed from the node.
@@ -46,7 +46,7 @@ Then, vBuckets are duly updated from that point; based on the data-changes that 
 
 * If GSI Indexes reside on the node, they are left unmodified during the rebalance process.
 
-* When the node’s vBuckets are all up to date, and the rebalance process concludes, the node recommences the serving of data.
+* When the node's vBuckets are all up to date, and the rebalance process concludes, the node recommences the serving of data.
 If GSI Indexes reside on the node, they become active, and are updated by the Index Service as appropriate (this includes updates that correspond to whatever mutations were made by the Data Service while the node was in a failed over state).
 
 [#delta-recovery-requirements]
@@ -81,11 +81,11 @@ This indicates that one or more of the following conditions exist:
 [#recovery-performance]
 == Recovery Performance
 
-In many cases, Delta recovery is faster than Full recovery; since a significant quantity of usable data already resides on the node, and therefore does not require network-transfer: only updates made since the node’s last-recorded mutation need to be accessed from other nodes in the cluster.
+In many cases, Delta recovery is faster than Full recovery; since a significant quantity of usable data already resides on the node, and therefore does not require network-transfer: only updates made since the node's last-recorded mutation need to be accessed from other nodes in the cluster.
 
-However, in cases where the node’s memory-footprint is extremely large, and data exceeds bucket memory-quotas, the memory-management overhead potentially entailed by Delta recovery might imply Full recovery’s taking less time overall.
+However, in cases where the node's memory-footprint is extremely large, and data exceeds bucket memory-quotas, the memory-management overhead potentially entailed by Delta recovery might imply Full recovery's taking less time overall.
 
-Note that in Couchbase Server 6.5 and later, a xref:indexes:index-scans.adoc[scan] can be requested from each index, as soon as the index has warmed up &#8212; the recovery does not need to be fully complete.
+Note that in Couchbase Server 6.5 and later, a xref:indexes:index-scans.adoc[scan] can be requested from each index, as soon as the index has warmed up -- the recovery does not need to be fully complete.
 This can reduce the downtime during recovery.
 
 Only scans where consistency is `not_bounded`, or scans for which a consistent snapshot is available, are allowed during recovery.

--- a/modules/learn/pages/clusters-and-availability/recovery.adoc
+++ b/modules/learn/pages/clusters-and-availability/recovery.adoc
@@ -85,7 +85,7 @@ In many cases, Delta recovery is faster than Full recovery; since a significant 
 
 However, in cases where the node’s memory-footprint is extremely large, and data exceeds bucket memory-quotas, the memory-management overhead potentially entailed by Delta recovery might imply Full recovery’s taking less time overall.
 
-Note that in Couchbase Server 6.5 and later, a xref:learn:services-and-indexes/indexes/index-scans.adoc[scan] can be requested from each index, as soon as the index has warmed up &#8212; the recovery does not need to be fully complete.
+Note that in Couchbase Server 6.5 and later, a xref:indexes:index-scans.adoc[scan] can be requested from each index, as soon as the index has warmed up &#8212; the recovery does not need to be fully complete.
 This can reduce the downtime during recovery.
 
 Only scans where consistency is `not_bounded`, or scans for which a consistent snapshot is available, are allowed during recovery.

--- a/modules/learn/pages/services-and-indexes/indexes/indexes.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/indexes.adoc
@@ -29,10 +29,14 @@ A Secondary Index is frequently referred to as a _Global Secondary Index_, or _G
 This is the kind of index used most frequently in Couchbase Server, for queries performed with {sqlpp}.
 For information on Global Secondary Indexes, see xref:indexes:indexing-overview.adoc[].
 
-Full Text:: Provided by the xref:services-and-indexes/services/search-service.adoc[Search Service], this is a specially purposed index, which contains targets derived from the textual contents of documents within one or more specified keyspaces.
+Search:: Provided by the xref:services-and-indexes/services/search-service.adoc[Search Service], this is a specially purposed index, which contains targets derived from the textual contents of documents within one or more specified keyspaces.
 Text-matches of different degrees of exactitude can be searched for.
 Both input and target text-values can be purged of irrelevant characters (such as punctuation marks or html tags).
-For information on how to create Full Text Indexes, see xref:fts:fts-creating-indexes.adoc[Creating Indexes].
+For information on how to create Search indexes, see xref:fts:fts-creating-indexes.adoc[Creating Indexes].
+
+Vector Search:: Provided by the xref:services-and-indexes/services/search-service.adoc[Search Service], this is a type of Search index which supports vector embeddings.
+Use Vector Search indexes to run searches with the Search service using vector comparisons.
+To create Vector Search indexes, see xref:vector-search:create-vector-search-index-ui.adoc[] or xref:vector-search:create-vector-search-index-rest-api[].
 
 Analytics:: Provided by the xref:services-and-indexes/services/analytics-service.adoc[Analytics Service], this is a materialized access path for the shadow data in an Analytics collection.
 Analytics indexes can be used to speed up Analytics selection queries and join queries.

--- a/modules/learn/pages/services-and-indexes/indexes/indexes.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/indexes.adoc
@@ -31,12 +31,13 @@ For information on Global Secondary Indexes, see xref:indexes:indexing-overview.
 
 Search:: Provided by the xref:services-and-indexes/services/search-service.adoc[Search Service], this is a specially purposed index, which contains targets derived from the textual contents of documents within one or more specified keyspaces.
 Text-matches of different degrees of exactitude can be searched for.
-Both input and target text-values can be purged of irrelevant characters (such as punctuation marks or html tags).
+Both input and target text-values can be purged of irrelevant characters (such as punctuation marks or HTML tags).
 For information on how to create Search indexes, see xref:fts:fts-creating-indexes.adoc[Creating Indexes].
 
 Vector Search:: Provided by the xref:services-and-indexes/services/search-service.adoc[Search Service], this is a type of Search index which supports vector embeddings.
 Use Vector Search indexes to run searches with the Search service using vector comparisons.
-To create Vector Search indexes, see xref:vector-search:create-vector-search-index-ui.adoc[] or xref:vector-search:create-vector-search-index-rest-api[].
+You can use Vector Search indexes for Retrieval Augmented Generation (RAG) with an existing Large Language Model (LLM).
+To create Vector Search indexes, see xref:vector-search:create-vector-search-index-ui.adoc[] or xref:vector-search:create-vector-search-index-rest-api.adoc[].
 
 Analytics:: Provided by the xref:services-and-indexes/services/analytics-service.adoc[Analytics Service], this is a materialized access path for the shadow data in an Analytics collection.
 Analytics indexes can be used to speed up Analytics selection queries and join queries.

--- a/modules/learn/pages/services-and-indexes/indexes/indexes.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/indexes.adoc
@@ -31,7 +31,7 @@ For information on Global Secondary Indexes, see xref:indexes:indexing-overview.
 
 Search:: Provided by the xref:services-and-indexes/services/search-service.adoc[Search Service], this is a specially purposed index, which contains targets derived from the textual contents of documents within one or more specified keyspaces.
 Search indexes support text matching, geospatial, date-time, numeric range searches, and more.
-Both input and target text-values can be purged of irrelevant characters (such as punctuation marks or HTML tags).
+For text matching, you can add filters to remove undesirable characters from input and target text values, such as punctuation marks or HTML tags.
 For information on how to create Search indexes, see xref:search:create-search-indexes.adoc[].
 
 Vector Search:: Provided by the xref:services-and-indexes/services/search-service.adoc[Search Service], this is a type of Search index which supports vector embeddings.

--- a/modules/learn/pages/services-and-indexes/indexes/indexes.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/indexes.adoc
@@ -32,7 +32,7 @@ For information on Global Secondary Indexes, see xref:indexes:indexing-overview.
 Search:: Provided by the xref:services-and-indexes/services/search-service.adoc[Search Service], this is a specially purposed index, which contains targets derived from the textual contents of documents within one or more specified keyspaces.
 Text-matches of different degrees of exactitude can be searched for.
 Both input and target text-values can be purged of irrelevant characters (such as punctuation marks or HTML tags).
-For information on how to create Search indexes, see xref:fts:fts-creating-indexes.adoc[Creating Indexes].
+For information on how to create Search indexes, see xref:search:create-search-indexes.adoc[].
 
 Vector Search:: Provided by the xref:services-and-indexes/services/search-service.adoc[Search Service], this is a type of Search index which supports vector embeddings.
 Use Vector Search indexes to run searches with the Search service using vector comparisons.

--- a/modules/learn/pages/services-and-indexes/indexes/indexes.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/indexes.adoc
@@ -20,14 +20,14 @@ The following forms of index are available:
 Primary:: Provided by the xref:services-and-indexes/services/index-service.adoc[Index Service], this is based on the unique key of every item in a specified collection.
 Every primary index is maintained asynchronously.
 A primary index is intended to be used for simple queries, which have no filters or predicates.
-For information on primary indexes, see xref:services-and-indexes/indexes/global-secondary-indexes.adoc[Using Indexes].
+For information on primary indexes, see xref:indexes:indexing-overview.adoc[].
 
 Secondary:: Provided by the xref:services-and-indexes/services/index-service.adoc[Index Service], this is based on an attribute _within_ a document.
 The value associated with the attribute can be of any type: scalar, object, or array.
 +
 A Secondary Index is frequently referred to as a _Global Secondary Index_, or _GSI_.
 This is the kind of index used most frequently in Couchbase Server, for queries performed with {sqlpp}.
-For information on Global Secondary Indexes, see xref:services-and-indexes/indexes/global-secondary-indexes.adoc[Using Indexes].
+For information on Global Secondary Indexes, see xref:indexes:indexing-overview.adoc[].
 
 Full Text:: Provided by the xref:services-and-indexes/services/search-service.adoc[Search Service], this is a specially purposed index, which contains targets derived from the textual contents of documents within one or more specified keyspaces.
 Text-matches of different degrees of exactitude can be searched for.

--- a/modules/learn/pages/services-and-indexes/indexes/indexes.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/indexes.adoc
@@ -1,0 +1,43 @@
+= Indexes
+:description: Couchbase Server indexes enhance the performance of query and search operations.
+:page-aliases: understanding-couchbase:services-and-indexes/indexes/indexes,concepts:indexing
+
+[abstract]
+{description}
+
+_Indexes_ are used by certain services, such as _Query_, _Analytics_, and _Search_, as targets for search-routines.
+Each index makes a predefined subset of data available for the search.
+
+The _Query_ service relies on indexes provided by the _Index_ service.
+The _Search_ and _Analytics_ services both provide their own indexes, internally.
+
+Indexes, when well-designed, provide significant enhancements to the performance of search-operations.
+
+== Indexes
+
+The following forms of index are available:
+
+Primary:: Provided by the xref:services-and-indexes/services/index-service.adoc[Index Service], this is based on the unique key of every item in a specified collection.
+Every primary index is maintained asynchronously.
+A primary index is intended to be used for simple queries, which have no filters or predicates.
+For information on primary indexes, see xref:services-and-indexes/indexes/global-secondary-indexes.adoc[Using Indexes].
+
+Secondary:: Provided by the xref:services-and-indexes/services/index-service.adoc[Index Service], this is based on an attribute _within_ a document.
+The value associated with the attribute can be of any type: scalar, object, or array.
++
+A Secondary Index is frequently referred to as a _Global Secondary Index_, or _GSI_.
+This is the kind of index used most frequently in Couchbase Server, for queries performed with {sqlpp}.
+For information on Global Secondary Indexes, see xref:services-and-indexes/indexes/global-secondary-indexes.adoc[Using Indexes].
+
+Full Text:: Provided by the xref:services-and-indexes/services/search-service.adoc[Search Service], this is a specially purposed index, which contains targets derived from the textual contents of documents within one or more specified keyspaces.
+Text-matches of different degrees of exactitude can be searched for.
+Both input and target text-values can be purged of irrelevant characters (such as punctuation marks or html tags).
+For information on how to create Full Text Indexes, see xref:fts:fts-creating-indexes.adoc[Creating Indexes].
+
+Analytics:: Provided by the xref:services-and-indexes/services/analytics-service.adoc[Analytics Service], this is a materialized access path for the shadow data in an Analytics collection.
+Analytics indexes can be used to speed up Analytics selection queries and join queries.
+If changes in operational data result in corresponding modifications to shadow data, Analytics indexes are updated automatically.
+See the section on xref:analytics:7_using_index.adoc[Using Indexes] in Couchbase Analytics.
+
+View:: Supports xref:learn:views/views-intro.adoc[Couchbase Views], with fields and information extracted from documents.
+Views are deprecated in Couchbase Server 7.0, and will be removed in a future release.

--- a/modules/learn/pages/services-and-indexes/indexes/indexes.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/indexes.adoc
@@ -29,7 +29,7 @@ A Secondary Index is frequently referred to as a _Global Secondary Index_, or _G
 This is the kind of index used most frequently in Couchbase Server, for queries performed with {sqlpp}.
 For information on Global Secondary Indexes, see xref:indexes:indexing-overview.adoc[].
 
-Search:: Provided by the xref:services-and-indexes/services/search-service.adoc[Search Service], this is a specially purposed index, which contains targets derived from the textual contents of documents within one or more specified keyspaces.
+Search:: Provided by the xref:services-and-indexes/services/search-service.adoc[Search Service], this is a specially purposed index, which contains targets derived from the contents of documents within one or more specified keyspaces.
 Search indexes support text matching, geospatial, date-time, numeric range searches, and more.
 For text matching, you can add filters to remove undesirable characters from input and target text values, such as punctuation marks or HTML tags.
 For information on how to create Search indexes, see xref:search:create-search-indexes.adoc[].

--- a/modules/learn/pages/services-and-indexes/indexes/indexes.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/indexes.adoc
@@ -30,7 +30,7 @@ This is the kind of index used most frequently in Couchbase Server, for queries 
 For information on Global Secondary Indexes, see xref:indexes:indexing-overview.adoc[].
 
 Search:: Provided by the xref:services-and-indexes/services/search-service.adoc[Search Service], this is a specially purposed index, which contains targets derived from the textual contents of documents within one or more specified keyspaces.
-Text-matches of different degrees of exactitude can be searched for.
+Search indexes support text matching, geospatial, date-time, numeric range searches, and more.
 Both input and target text-values can be purged of irrelevant characters (such as punctuation marks or HTML tags).
 For information on how to create Search indexes, see xref:search:create-search-indexes.adoc[].
 

--- a/modules/learn/pages/services-and-indexes/services/index-service.adoc
+++ b/modules/learn/pages/services-and-indexes/services/index-service.adoc
@@ -56,7 +56,7 @@ A snapshot of the index is maintained on disk, to permit rapid recovery if node-
 A _skiplist_ (rather than a conventional _B-tree_) structure is used; optimizing memory consumption.
 Lock-free index-processing enhances concurrency.
 
-For more information, see xref:services-and-indexes/indexes/storage-modes.adoc[Index Storage Settings].
+For more information, see xref:indexes:storage-modes.adoc[].
 
 [#using-global-secondary-indexes]
 == Primary and Global Secondary Indexes
@@ -67,4 +67,4 @@ A primary index is intended to be used for simple queries, which have no filters
 _Secondary_ Indexes, often referred to as _Global Secondary Indexes_ or _GSIs_, constitute the principal means of indexing documents to be accessed by the _Query Service_.
 Secondary Indexes can be created on specified fields; placed on specific cluster-nodes; and replicated.
 
-For information on using the Indexing Service, see xref:services-and-indexes/indexes/global-secondary-indexes.adoc[Using Indexes].
+For information on using the Indexing Service, see xref:indexes:indexing-overview.adoc[].

--- a/modules/learn/pages/views/view-indexes-for-n1ql.adoc
+++ b/modules/learn/pages/views/view-indexes-for-n1ql.adoc
@@ -8,4 +8,4 @@ New view indexes cannot be created, and existing view indexes are not accessible
 
 == Related Links
 
-xref:learn:services-and-indexes/indexes/global-secondary-indexes.adoc[Global Secondary Indexes]
+xref:indexes:indexing-overview.adoc[]

--- a/modules/manage/pages/manage-indexes/manage-indexes.adoc
+++ b/modules/manage/pages/manage-indexes/manage-indexes.adoc
@@ -4,10 +4,10 @@
 :escape-hatch: cloud:clusters:index-service/manage-indexes.adoc
 
 // Cross references
-:storage-modes: xref:learn:services-and-indexes/indexes/storage-modes.adoc
-:index-partitioning: xref:learn:services-and-indexes/indexes/index-replication.adoc#index-partitioning
-:index-replication: xref:learn:services-and-indexes/indexes/index-replication.adoc#index-replication
-:index-scans: xref:learn:services-and-indexes/indexes/index-scans.adoc
+:storage-modes: xref:indexes:storage-modes.adoc
+:index-partitioning: xref:indexes:index-replication.adoc#index-partitioning
+:index-replication: xref:indexes:index-replication.adoc#index-replication
+:index-scans: xref:indexes:index-scans.adoc
 :index-storage-settings-via-cli: xref:manage:manage-settings/general-settings.adoc#index-storage-settings-via-cli
 :index-settings-via-rest: xref:manage:manage-settings/general-settings.adoc#index-settings-via-rest
 :monitor-indexes: xref:manage:monitor/monitoring-indexes.adoc
@@ -76,12 +76,12 @@ There may also be one or more indicators after the index name, giving further in
 image::manage-indexes/index-indicators.png["Index indicators: partitioned, replica 1, stale"]
 
 ** `partitioned` indicates that the index is _partitioned_.
-An overview of partitioning is provided in xref:learn:services-and-indexes/indexes/index-replication.adoc#index-partitioning[Index Partitioning].
+An overview of partitioning is provided in xref:indexes:index-replication.adoc#index-partitioning[Index Partitioning].
 Examples of creating partitioned indexes are provided in
 xref:n1ql:n1ql-language-reference/index-partitioning.adoc#partition-keys[Partition Keys].
 
 ** `replica __n__` indicates that this is an _index replica_, where `__n__` is the replica ID.
-An overview of index replication, and examples of creating index replicas, are provided in xref:learn:services-and-indexes/indexes/index-replication.adoc#index-replication[Index Replication].
+An overview of index replication, and examples of creating index replicas, are provided in xref:indexes:index-replication.adoc#index-replication[Index Replication].
 
 ** `stale` indicates that the node on which the index or partition is stored is not available.
 

--- a/modules/manage/pages/manage-nodes/create-cluster.adoc
+++ b/modules/manage/pages/manage-nodes/create-cluster.adoc
@@ -161,7 +161,7 @@ An OS-specific default is provided.
 The read-only *Free* field shows the current amount of free space for this location.
 
 * *Index Storage Setting*: If the Index Service has been selected, either *Standard Global Secondary* Indexes or *Memory-Optimized* Global Secondary Indexes can be chosen here, by means of radio buttons.
-See xref:learn:services-and-indexes/indexes/global-secondary-indexes.adoc[Global Secondary Indexes], for details.
+See xref:indexes:indexing-overview.adoc[] for details.
 
 * *Indexes Disk Path*: Enter the location on the current node where indexes will be stored.
 An OS-specific default is provided.

--- a/modules/manage/pages/manage-settings/configure-compact-settings.adoc
+++ b/modules/manage/pages/manage-settings/configure-compact-settings.adoc
@@ -17,7 +17,7 @@ Auto-compaction settings affect _on-disk_ data, and therefore do not apply to Ep
 Full and Cluster administrators can configure compaction settings with xref:manage:manage-settings/configure-compact-settings.adoc#configure-auto-compaction-with-the-ui[Couchbase Web Console], the Couchbase xref:manage:manage-settings/configure-compact-settings.adoc#configure-auto-compaction-with-the-cli[CLI], or the xref:manage:manage-settings/configure-compact-settings.adoc#configure-auto-compaction-with-the-rest-api[REST] API.
 
 Note that in Couchbase Server Enterprise Edition, auto-compaction does not apply to memory-optimized index storage, and there are no settings necessary for configuring the auto-compaction of Global Secondary Indexes using standard index storage.
-See xref:learn:services-and-indexes/indexes/storage-modes.adoc#standard-index-storage[Standard Index Storage], for information.
+See xref:indexes:storage-modes.adoc#standard-index-storage[Standard Index Storage] for information.
 
 [#configure-auto-compaction-with-the-ui]
 == Configure Auto-Compaction with the UI
@@ -160,7 +160,7 @@ Optionally, check the [.ui]*Abort compaction if run time exceeds the set time in
 
 Note that whenever you change the compaction settings for the index, the system starts the global secondary index process on all the nodes.
 
-See xref:learn:services-and-indexes/indexes/storage-modes.adoc#standard-index-storage[Standard Index Storage] for information on append-only and circular write modes.
+See xref:indexes:storage-modes.adoc#standard-index-storage[Standard Index Storage] for information on append-only and circular write modes.
 
 [#tombstone-purge-interval]
 === Metadata Purge Interval

--- a/modules/manage/pages/manage-settings/general-settings.adoc
+++ b/modules/manage/pages/manage-settings/general-settings.adoc
@@ -275,7 +275,7 @@ This panel provides radio buttons that set the storage mode for indexes and some
 
 image::manage-settings/index-storage-mode.png["The Index Storage Mode panel",480,align=center]
 
-The index storage mode options are xref:learn:services-and-indexes/indexes/storage-modes.adoc#memory-optimized-index-storage[Memory Optimized Index Storage], and xref:learn:services-and-indexes/indexes/storage-modes.adoc#standard-index-storage[Standard Index Storage].
+The index storage mode options are xref:indexes:storage-modes.adoc#memory-optimized-index-storage[Memory Optimized Index Storage], and xref:indexes:storage-modes.adoc#standard-index-storage[Standard Index Storage].
 
 The settings under *Advanced Settings* for indexes are:
 
@@ -286,7 +286,7 @@ The default value of 0 has the Index Service use one thread per core on the node
 
 * *Num Replica*:
 Sets the default number of index replicas the Index Service creates for new indexes. Defaults to 0 (no replicas).
-See xref:learn:services-and-indexes/indexes/index-replication.adoc#index-replication[Index Replication].
+See xref:indexes:index-replication.adoc#index-replication[Index Replication].
 
 * *Indexer Rebalance Settings*: 
  When cleared, *Optimize Index Placement On Rebalance*  has Couchbase Server only redistribute indexes during a rebalance when the nodes containing them are leaving the cluster.
@@ -301,7 +301,7 @@ The default is `Info`.
 * *Bloom Filter*:
 The default cleared setting for *Enable Bloom Filter* turns off Bloom filters for memory management.
 When selected, *Enable Bloom Filter* enables Bloom filters. 
-See xref:learn:services-and-indexes/indexes/storage-modes.adoc#per-page-bloom-filters[Per Page Bloom Filters].
+See xref:indexes:storage-modes.adoc#per-page-bloom-filters[Per Page Bloom Filters].
 +
 // tag::bloom-filter-default[]
 [.edition]#7.2.1{plus}#

--- a/modules/manage/pages/manage-ui/manage-ui.adoc
+++ b/modules/manage/pages/manage-ui/manage-ui.adoc
@@ -503,7 +503,7 @@ image:manage-ui/indexesScreenFullyPrepared.png[,700,align=left]
 [#indexes-define-and-manage]
 === Indexes: Define and Manage
 
-For a detailed explanation of indexes, see xref:learn:services-and-indexes/indexes/global-secondary-indexes.adoc[Global Secondary Indexes].
+For a detailed explanation of indexes, see xref:indexes:indexing-overview.adoc[].
 Information on how to manage indexes is given in xref:manage:manage-indexes/manage-indexes.adoc[Manage Indexes].
 
 [#console-search]

--- a/modules/rest-api/pages/post-settings-indexes.adoc
+++ b/modules/rest-api/pages/post-settings-indexes.adoc
@@ -3,7 +3,7 @@
 :page-topic-type: reference
 
 // Cross-references
-:index-replication: xref:learn:services-and-indexes/indexes/index-replication.adoc#index-replication
+:index-replication: xref:indexes:index-replication.adoc#index-replication
 :rebalancing-the-index-service: xref:learn:clusters-and-availability/rebalance.adoc#rebalancing-the-index-service
 
 [abstract]
@@ -94,7 +94,7 @@ For further details, refer to {rebalancing-the-index-service}[Rebalancing the In
 | `enablePageBloomFilter`
 | Whether Bloom filters are enabled for memory management.
 The default is that they are _disabled_.
-See xref:learn:services-and-indexes/indexes/storage-modes.adoc#per-page-bloom-filters[Per Page Bloom Filters].
+See xref:indexes:storage-modes.adoc#per-page-bloom-filters[Per Page Bloom Filters].
 | boolean
 
 | `storageMode`

--- a/modules/rest-api/pages/rest-autocompact-global.adoc
+++ b/modules/rest-api/pages/rest-autocompact-global.adoc
@@ -15,7 +15,7 @@ Auto-compaction settings for the cluster can be established and retrieved by the
 
 Auto-compaction settings for _GSI Indexes_ are provided; however, these are for use with Couchbase Server Community Edition only.
 These settings are not needed for the indexes used by Enterprise Edition: if these settings are established, they are ignored by nodes running Enterprise Edition.
-For more information, see xref:learn:services-and-indexes/indexes/storage-modes.adoc[Storage Settings].
+For more information, see xref:indexes:storage-modes.adoc[].
 
 == HTTP methods and URIs
 

--- a/modules/rest-api/pages/rest-bucket-create.adoc
+++ b/modules/rest-api/pages/rest-bucket-create.adoc
@@ -851,7 +851,7 @@ Note that if `autoCompactionDefined` is specified as `true`:
 If it is not defined, an error-notification such as the following is returned: `{"parallelDBAndViewCompaction":"parallelDBAndViewCompaction is missing"}`.
 
 Auto-compaction settings are unnecessary for _memory-optimized_ indexes.
-For information on index storage, see xref:learn:services-and-indexes/indexes/storage-modes.adoc[Storage Settings].
+For information on index storage, see xref:indexes:storage-modes.adoc[].
 
 For further information on auto-compaction settings, see xref:manage:manage-settings/configure-compact-settings.adoc[Auto-Compaction].
 
@@ -1114,7 +1114,7 @@ A conceptual description of buckets is provided in xref:learn:buckets-memory-and
 Options for managing buckets with Couchbase Web Console are provided in xref:manage:manage-buckets/bucket-management-overview.adoc[Manage Buckets].
 For information on the Couchbase CLI command `bucket-create`, see the reference page for xref:cli:cbcli/couchbase-cli-bucket-create.adoc[bucket-create].
 
-Information on memory-management options for Couchbase Server is provided in For information on index storage, see xref:learn:services-and-indexes/indexes/storage-modes.adoc[Storage Settings].
+Information on memory-management options for Couchbase Server is provided in For information on index storage, see xref:indexes:storage-modes.adoc[].
 Information on auto-compaction settings is provided in xref:manage:manage-settings/configure-compact-settings.adoc[Auto-Compaction].
 
 For an overview of change history, see xref:learn:data/change-history.adoc[Change History].

--- a/modules/rest-api/pages/rest-initialize-cluster.adoc
+++ b/modules/rest-api/pages/rest-initialize-cluster.adoc
@@ -137,7 +137,7 @@ For information, see xref:learn:clusters-and-availability/node-to-node-encryptio
 
 * `indexerStorageMode`.
 This can be `plasma` (the default) or `magma`.
-For information, see xref:learn:services-and-indexes/indexes/storage-modes.adoc[Storage Settings].
+For information, see xref:indexes:storage-modes.adoc[].
 This parameter is optional.
 
 * `port`.
@@ -194,4 +194,4 @@ An overview of nodes is provided in xref:learn:clusters-and-availability/nodes.a
 Information on storage and memory-management is provided in xref:learn:buckets-memory-and-storage/memory-and-storage.adoc[Memory and Storage].
 Node-to-node Encryption is described in xref:learn:clusters-and-availability/node-to-node-encryption.adoc[Node-to-Node Encryption].
 Address families are described in xref:manage:manage-nodes/manage-address-families.adoc[Manage Address Families].
-Index storage modes are explained in xref:learn:services-and-indexes/indexes/storage-modes.adoc[Storage Settings].
+Index storage modes are explained in xref:indexes:storage-modes.adoc[].

--- a/modules/tools/pages/query-workbench.adoc
+++ b/modules/tools/pages/query-workbench.adoc
@@ -16,7 +16,7 @@
 :select: xref:n1ql:n1ql-language-reference/selectintro.adoc
 :merge: xref:n1ql:n1ql-language-reference/merge.adoc
 :advise: xref:n1ql:n1ql-language-reference/advise.adoc
-:covering-indexes: xref:n1ql:n1ql-language-reference/covering-indexes.adoc
+:covering-indexes: xref:indexes:covering-indexes.adoc
 :recommendation-rules: xref:n1ql:n1ql-language-reference/advise.adoc#recommendation-rules
 :scan_consistency: xref:n1ql:n1ql-manage/query-settings.adoc#scan_consistency
 :max_parallelism: xref:n1ql:n1ql-manage/query-settings.adoc#max_parallelism_req


### PR DESCRIPTION
Jira issue: DOC-12443

This PR does three things:

1. Moves the indexes concept doc from docs-devex back to docs-server. This is not a new document; it's been languishing in docs-devex since the original migration. It's not used in Capella. I argue it belongs here, in the `learn` module.
2. Updates links to the index docs in docs-devex, which have been moved out of `learn` into their own module. The `learn` module is now completely self-contained within docs-server.
3. Adds vector search to the indexes concept doc.

Steps 1 and 3 (at least) should be backported to Server 7.6.

Docs preview: [Indexes](https://preview.docs-test.couchbase.com/DOC-12443/server/7.7/learn/services-and-indexes/indexes/indexes.html)
Credentials: [Preview docs for internal review](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-review)

This PR must be merged at the same time as the following:

* https://github.com/couchbaselabs/docs-devex/pull/261