### PR TITLE
[DOC-10769/7.6]: Remove the obsolete 'Auto-Failover during Rebalance' paragraph. Removed paragraph related to the auto-failover aborting a rebalance.

### DIFF
--- a/modules/learn/pages/clusters-and-availability/automatic-failover.adoc
+++ b/modules/learn/pages/clusters-and-availability/automatic-failover.adoc
@@ -224,16 +224,11 @@ xref:cli:cbcli/couchbase-cli-setting-autofailover.adoc[setting-autofailover] wit
 [#auto-failover-during-rebalance]
 == Auto-Failover During Rebalance
 
-Couchbase Server provides a setting to determine whether, once enabled, auto-failover should specifically be triggered during xref:learn:clusters-and-availability/rebalance.adoc[Rebalance], in the event of a node becoming unresponsive.
+If an auto-failover event occurs during a rebalance, the rebalance is stopped; then, auto-failover is triggered.
 
-If auto-failover _has_ been set to be triggered, following the configured timeout period, the rebalance is stopped; then, auto-failover is duly triggered.
-Following auto-failover, rebalance is _not_ automatically re-attempted.
-At this point, the cluster is likely to be in an unbalanced state: therefore, rebalance should be performed manually; and the unresponsive node fixed and restored to the cluster, as appropriate.
+WARNING: Following an auto-failover, rebalance _is not_ automatically re-attempted.
 
-If auto-failover has _not_ been set to be triggered, unless there is manual intervention, no failover occurs.
-This may cause the rebalance to hang for an indeterminate period; before failing, with error messages.
-
-For information on setting auto-failover in the context of rebalance, see the information on xref:manage:manage-settings/general-settings.adoc[General] settings.
+At this point, the cluster is likely to be in an unbalanced state; therefore, a rebalance should be performed manually, and the unresponsive node fixed and restored to the cluster, as appropriate.
 
 [#auto-failover-and-durability]
 == Auto-Failover and Durability


### PR DESCRIPTION
Removed offending paragraph.
Added warning to the effect that the rebalance is not restarted automatically.