### PR TITLE
DOC-9384 add xdcr links

### DIFF
--- a/modules/rest-api/pages/rest-xdcr-create-ref.adoc
+++ b/modules/rest-api/pages/rest-xdcr-create-ref.adoc
@@ -9,7 +9,7 @@
 
 == Description
 
-Use the `/pools/default/remoteClusters` REST API endpoint to create a XDCR reference to a target cluster.
+Use the `/pools/default/remoteClusters` REST API endpoint to create an XDCR reference to a target cluster.
 You must create a reference to a target cluster on the source cluster before you can create a replication. 
 The target cluster is usually a different cluster from the source cluster.
 However, you can create a replication where the source and target are the same cluster.
@@ -68,7 +68,7 @@ curl -v -u <source-cluster-username>:<source-cluster-password>
 | A local name for the reference. 
 The name does not need to correspond to any network-visible name for the target cluster.
 When editing an existing reference by supplying its name in the REST API URI, you must still supply the `name` parameter. 
-Set it the name of the existing reference to keep its name the same.
+Set it to the name of the existing reference to keep its name the same.
 If you set the `name` parameter to a different value, Couchbase Server renames the reference.  
 | String
 
@@ -120,7 +120,7 @@ You must supply this parameter if you set `secureType` to `full`.
 
 | `clientCertificate` and `clientKey`
 | The client certificate and key that Couchbase Server uses to authenticate with the target cluster.
-Only set these parameters if you set `secureType` to `full` and you have chosen to use a certificate instead of a username and password for authentication.
+Set these parameters only if you set `secureType` to `full` and you have chosen to use a certificate instead of a username and password for authentication.
 | URL-encoded string
 
 |===

--- a/modules/rest-api/pages/rest-xdcr-create-ref.adoc
+++ b/modules/rest-api/pages/rest-xdcr-create-ref.adoc
@@ -47,7 +47,7 @@ POST /pools/default/remoteClusters/{REFERENCE_NAME}
 [source, console]
 ----
 curl -v -u <source-cluster-username>:<source-cluster-password>
-  http://<source-cluster-ip-address-or-domain-name>:8091/pools/default/remoteClusters/[<target-cluster-local-name>]
+  http://<source-cluster-ip-address-or-host-name>:8091/pools/default/remoteClusters/[<target-cluster-local-name>]
   -d name=<target-cluster-local-name>
   -d hostname=<target-cluster-ip-address-or-domain-name>[:<port-number>]
   [-d network_type='external']
@@ -66,7 +66,7 @@ curl -v -u <source-cluster-username>:<source-cluster-password>
 |Name | Description | Schema
 | `name`
 | A local name for the reference. 
-The name does not need to correspond to any network-visible name established for the target cluster.
+The name does not need to correspond to any network-visible name for the target cluster.
 When editing an existing reference by supplying its name in the REST API URI, you must still supply the `name` parameter. 
 Set it the name of the existing reference to keep its name the same.
 If you set the `name` parameter to a different value, Couchbase Server renames the reference.  
@@ -80,12 +80,14 @@ For information about using DNS SRV in this context, see xref:xdcr-reference:xdc
 
 | `network_type`
 | Whether the network address specified in `hostname` is internal or external.
-| Must be `external` if the network is external.
+| String. 
+Must be `external` if the network is external.
 Do not supply this parameter if the network is internal.
 
 | `demandEncryption`
 | Whether to use encryption for the reference's connection to the target cluster.
-a| Integer, one of:
+a| Integer.
+Valid values:
 
 * `0`: The default value. 
 Couchbase Server does not use encryption for the connection to the target cluster.
@@ -95,7 +97,7 @@ Use the `secureType` parameter to set whether the connection is partially or ful
 | `secureType` 
 | Optional parameter that sets whether the connection to the target cluster is encrypted, and if so, whether it partially or fully encrypts communication. 
 If you do not supply this parameter and you set `demandEncryption` parameter to `1`, the `secureType` defaults to `full`.
-a| One of:
+a| String. Valid settings are:
 
 * `none`: (default value) Couchbase Server does not use encryption for the connection to the target cluster. 
 Couchbase Server sends all traffic unencrypted, including the password.
@@ -243,7 +245,7 @@ http://localhost:8091/pools/default/remoteClusters \
 ----
 
 The `username` and `password` in the example are for an account on the remote cluster.
-The reference is half-encrypted (only the password is sent encrypted) because the `demandEncryption` flag is `1` and the `encryptionType` flag is `half`.
+The reference is half-encrypted (only the password is encrypted) because the `demandEncryption` flag is `1` and the `encryptionType` flag is `half`.
 The `--data-urlencode` flag specifies the local path to the root certificate for the target cluster.
 
 If the source Couchbase Server connects to the target cluster, it returns the following message:

--- a/modules/rest-api/pages/rest-xdcr-create-ref.adoc
+++ b/modules/rest-api/pages/rest-xdcr-create-ref.adoc
@@ -119,7 +119,7 @@ You must supply this parameter if you set `secureType` to `full`.
 | URL-encoded string
 
 | `clientCertificate` and `clientKey`
-| The local absolute path to the client certificate and key file that Couchbase Server uses to authenticate with the target cluster.
+| The client certificate and key that Couchbase Server uses to authenticate with the target cluster.
 Only set these parameters if you set `secureType` to `full` and you have chosen to use a certificate instead of a username and password for authentication.
 | URL-encoded string
 
@@ -201,7 +201,7 @@ http://localhost:8091/pools/default/remoteClusters \
 This example sets a `username` and `password` for an account on the target cluster.
 It does not set the `demandEncryption`.
 However, because it sets the `encryptionType` parameter to `full`, the reference uses full encryption.
-The `--data-urlencode` flag specifies the local path to the root certificate for the target cluster.
+Using `curl`'s `--data-urlencode` flag encodes the contents of the root certificate for the target cluster returned by the `cat` command.
 
 Formatted, the output from a successful execution is:
 
@@ -246,7 +246,7 @@ http://localhost:8091/pools/default/remoteClusters \
 
 The `username` and `password` in the example are for an account on the remote cluster.
 The reference is half-encrypted (only the password is encrypted) because the `demandEncryption` flag is `1` and the `encryptionType` flag is `half`.
-The `--data-urlencode` flag specifies the local path to the root certificate for the target cluster.
+Using `curl`'s `--data-urlencode` flag encodes the contents of the root certificate for the target cluster returned by the `cat` command.
 
 If the source Couchbase Server connects to the target cluster, it returns the following message:
 
@@ -295,6 +295,7 @@ curl -X POST -u Administrator:password http://localhost:8091/pools/default/remot
 Because the example sets the `demandEncryption` flag to `1` and does not supply a `secureType` parameter, the connection to the target cluster is fully encrypted.
 The `network_type=external` parameter indicates that Couchbase Server should connect to the target's external network if it has been configured.
 If the target cluster does not have an external network defined, the source cluster attempts to connect to the target cluster's internal network.
+The example supplies three URL-encoded values: the root certificate of the target cluster and a certificate and key for the client connection.
 
 If successful, the command returns the following:
 
@@ -324,8 +325,8 @@ If successful, the command returns the following:
 }
 ----
 
-The `secureType` field specifies `full`which is the default value if you set `demandEncryption` to `1` and do not supply a `secureType` parameter in the REST API call.
-The output includes Both the target cluster's root certificate and the source cluster's client certificate.
+The `secureType` field specifies `full` which is the default value if you set `demandEncryption` to `1` and do not supply a `secureType` parameter in the REST API call.
+The output includes both the target cluster's root certificate and the source cluster's client certificate.
 
 == See Also
 

--- a/modules/rest-api/pages/rest-xdcr-create-ref.adoc
+++ b/modules/rest-api/pages/rest-xdcr-create-ref.adoc
@@ -1,128 +1,190 @@
-= Creating a Reference
+= Creating or Editing a Reference
 
-:description: pass:q[The REST API can be used to create an XDCR reference to a destination cluster.]
+:description: pass:q[You can use the REST API to create or edit an XDCR reference to a target cluster.]
 :page-topic-type: reference 
+:page-toclevels: 4
 
 [abstract]
 {description}
 
 == Description
 
-On the cluster that is intended to be a _source_ for XDCR, a _reference_ to an intended _target_ cluster must first be defined.
-The target cluster is typically a different cluster from the source cluster; but may be the same cluster.
+Use the `/pools/default/remoteClusters` REST API endpoint to create a XDCR reference to a target cluster.
+You must create a reference to a target cluster on the source cluster before you can create a replication. 
+The target cluster is usually a different cluster from the source cluster.
+However, you can create a replication where the source and target are the same cluster.
 
-A source cluster's references can be defined by means of the REST API.
+You can edit an existing reference using the REST API by adding its name ot the URI.
 
-The Full Admin, Cluster Admin, or XDCR Admin role is required.
+== HTTP Method and URI
 
-== HTTP method and URI
 
+.Create a new reference
+[source, uri]
 ----
 POST /pools/default/remoteClusters
-
-POST /pools/default/remoteClusters/<target-cluster-local-name>
 ----
+
+.Edit an existing reference
+[source, uri]
+----
+POST /pools/default/remoteClusters/{REFERENCE_NAME}
+----
+
+.Path Parameters
+[cols="2,3,2", caption=]
+|===
+|Name | Description | Schema
+
+| `REFERENCE_NAME`
+| The name of an existing reference. 
+| String
+|===
+
 
 == Curl Syntax
 
+[source, console]
 ----
 curl -v -u <source-cluster-username>:<source-cluster-password>
-  http://<source-cluster-ip-address-or-domain-name>]:8091/pools/default/remoteClusters/[<target-cluster-local-name>]
+  http://<source-cluster-ip-address-or-domain-name>:8091/pools/default/remoteClusters/[<target-cluster-local-name>]
   -d name=<target-cluster-local-name>
-  -d hostname=<target-cluster-ip-address-or-domain-name][:<port-number>]
+  -d hostname=<target-cluster-ip-address-or-domain-name>[:<port-number>]
   [-d network_type='external']
-  [-d username=<target-cluster-username>]
-  [-d password=<target-cluster-password>]
   [-d demandEncryption=[ 0 | 1 ] ]
   [-d secureType=[ 'none' | 'half' | 'full'] ]
-    [--data-urlencode "certificate=$(cat <local-pathname-to-target-root-certificate>)"]
-    [--data-urlencode "clientCertificate=$(cat /Users/username/clientcert/travel-sample.pem)"]
-    [--data-urlencode "clientKey=$(cat /Users/username/clientcert/travel-sample.key)"]
+  [-d username=<target-cluster-username>]
+  [-d password=<target-cluster-password>]
+    [--data-urlencode "certificate=$(cat <local-path-to-target-root-certificate>)"]
+    [--data-urlencode "clientCertificate=$(cat <local-path-to-client-pem>)"]
+    [--data-urlencode "clientKey=$(cat <local-path-to-client-key>)"]
 ----
 
-The value of the `name` parameter (`target-cluster-local-name`) is for local reference only, and so need not correspond to any network-visible name established for the target cluster.
-If an existing reference is being edited, the existing value of `name` should be specified as a path-parameter that terminates the endpoint: in such cases, the `name` flag itself must still be included in the the payload, specifying either the existing or a new value.
+.POST Parameters
+[cols="2,3,3", caption=]
+|===
+|Name | Description | Schema
+| `name`
+| A local name for the reference. 
+The name does not need to correspond to any network-visible name established for the target cluster.
+When editing an existing reference by supplying its name in the REST API URI, you must still supply the `name` parameter. 
+Set it the name of the existing reference to keep its name the same.
+If you set the `name` parameter to a different value, Couchbase Server renames the reference.  
+| String
 
-The value of the `hostname` parameter (`target-cluster-ip-address-or-domain-name`) determines the target cluster to which the connection will be made.
-This value can specify either the _internal_ or (if one has been configured) the _external_ address of the target cluster.
-For information on using DNS SRV in this context, see xref:xdcr-reference:xdcr-security-and-networking.adoc[XDCR Security and Networking].
+|`hostname` 
+| The hostname or IP address of the reference's target cluster.
+This value can specify either the internal address or external address (if one has been configured) of the target cluster.
+For information about using DNS SRV in this context, see xref:xdcr-reference:xdcr-security-and-networking.adoc[XDCR Security and Networking].
+| String
 
-The value of the optional `network_type` parameter must be `external`.
-If this is specified, and an external network has been configured for the target cluster, use of the target cluster's external address is attempted.
-If no external network has been configured, and the hostname refers to a valid internal address for the cluster, the internal address is used.
+| `network_type`
+| Whether the network address specified in `hostname` is internal or external.
+| Must be `external` if the network is external.
+Do not supply this parameter if the network is internal.
 
-The values specified for the optional `username` and `password` parameters must be the username and password for the _target_ cluster, respectively.
-These values must be established if `none` or `half` is the value of the `secureType` parameter.
-These values must also be established if `full` is the value of the `secureType` parameter, and authentication with client certificates is not being attempted.
-However, if `full` is the value of `secureType`, and authentication with client certificates _is_ being attempted, these values must _not_ be established.
+| `demandEncryption`
+| Whether to use encryption for the reference's connection to the target cluster.
+a| Integer, one of:
 
-The optional `secureType` parameter can be `none` (which is the default), `half`, or `full`; and thus specifies the type of security to be used for the connection.
-If the optional `demandEncryption` parameter is specified with a value of `1`, a secure connection is enforced: in such a case, if `secureType` is specified as `half` or `full`, the security of the connection is established according to the value of `secureType`; whereas if `secureType` is _not_ specified, the security of the connection is established as `full`.
-The default value of `demandEncryption` is `0`.
+* `0`: The default value. 
+Couchbase Server does not use encryption for the connection to the target cluster.
+* `1`: Encrypt the connection to the target cluster.
+Use the `secureType` parameter to set whether the connection is partially or fully encrypted.
 
-If `secureType` is `full`, the local pathname of the target cluster's root certificate must be specified, as the value of the `--data-urlencode` flag.
-Note that this additionally requires _either_ that values be established for the `username` and `password` parameters; _or_ that no values be established for the `username` and `password` parameters, and instead, local pathnames to a client certificate and corresponding client private key be established.
-Each certificate or key must be specified as the value of a separate `data-urlencode` flag.
+| `secureType` 
+| Optional parameter that sets whether the connection to the target cluster is encrypted, and if so, whether it partially or fully encrypts communication. 
+If you do not supply this parameter and you set `demandEncryption` parameter to `1`, the `secureType` defaults to `full`.
+a| One of:
 
-If `secureType` is `half`, and the target cluster is running a pre-5.5 version of Couchbase Server, the local pathname of the target cluster's root certificate must be specified, as the value of the `--data-urlencode` flag.
-However, if the target cluster is running 5.5 or later, the pathname need not be specified.
+* `none`: (default value) Couchbase Server does not use encryption for the connection to the target cluster. 
+Couchbase Server sends all traffic unencrypted, including the password.
+* `half`: Couchbase Server uses encryption only when sending the password to the target cluster during authentication. 
+The data it sends to the target is not encrypted.
+When using this value, you must provide a username and password.
+* `full`: Couchbase Server uses encryption to secure all communication with the target cluster.
+When you choose this value, you must supply a path to a local copy of the target cluster's root certificate in the `certificate` parameter (except for Capella--see <<#capella_cert_note,the note after this table>>). You must also either supply a username and password or paths to a client certificate and key. 
 
-Note that Capella CAs are automatically trusted by XDCR when the REST API is used to enable fully secure replications from Couchbase Enterprise Server to Capella: in such cases, the option `--data-urlencode "certificate=$(cat <local-pathname-to-target-root-certificate>)"`, provided for specifying the CA, does not need to be used.
-See xref:manage:manage-xdcr/secure-xdcr-replication.adoc#capella-trusted-cas[Capella Trusted CAs].
+| `username` and `password`
+| The username and password to use when authenticating with the target cluster.
+You must supply these parameters if you did not supply the `secureType` parameter or set it to `none` or `half`. 
+However, if `secureType` is `full` you can choose to either use a username and password or to supply a client certificate and key.
+| String
+
+| `certificate` 
+| The local path to a copy of the root CA of the target cluster. 
+You must supply this parameter if you set `secureType` to `full`. 
+| URL-encoded string
+
+| `clientCertificate` and `clientKey`
+| The local absolute path to the client certificate and key file that Couchbase Server uses to authenticate with the target cluster.
+Only set these parameters if you set `secureType` to `full` and you have chosen to use a certificate instead of a username and password for authentication.
+| URL-encoded string
+
+|===
+
+[#capella_cert_note]
+NOTE: XDCR automatically trusts Capella root certificates when you use the REST API to enable fully secure replications from Couchbase Enterprise Server to Capella.
+In this case, you do not need to supply the `certificate` parameter to the command.
+See xref:manage:manage-xdcr/secure-xdcr-replication.adoc#capella-trusted-cas[Capella Trusted CAs] for more information.
 
 == Responses
 
-Successful execution returns `200 OK`, establishes the reference, and returns an object whose key-value pairs provide details of the reference.
-The keys are as follows:
-
-* `certificate`.
-The root certificate for the target cluster, if one was used, in the creation of a `half` secure or `full` secure connection.
-
-* `clientCertificate`.
-The client certificate for the source cluster, if one was used, in the creation of a `full` secure connection.
-
-* `deleted`.
-Whether the reference has been deleted.
-The value can be one of the booleans `true` and `false`.
-
-* `hostname`.
-A string that contains the IP address (or domain name) and port number of the target cluster.
-
-* `name`.
-A string that is the locally defined reference to the target cluster.
-
-* `secureType`.
-A string that specifies the level of security required for connection.
-This can be `none`, `half`, or `full`.
-
-* `uri`.
-A string that is the URI of the locally named target cluster.
+200 OK::
+Successful execution.
+Couchbase Server creates the reference, and returns the details of the reference in a JSON message.
+The keys in the JSON message are:
++
+* `certificate`: the root certificate for the target cluster, if one was used, in the creation of a `half` secure or `full` secure connection.
+* `clientCertificate`: the client certificate for the source cluster, if one was used, in the creation of a `full` secure connection.
+* `deleted`: whether the reference has been deleted.
+The value can be `true` or `false`.
+* `hostname`: the IP address or domain name and port number of the target cluster.
+* `name`: the locally defined reference to the target cluster.
+* `secureType`: the level of security required for connection.
+This value can be `none`, `half`, or `full`.
+* `uri`: the URI of the locally named target cluster.
 For example, `"/pools/default/remoteClusters/FirstTarget"`.
-
-* `username`.
-A string that is the name of the current user.
-
-* `uuid`.
-A string that is the universally unique identifier for the reference.
+* `username`: the username used for authentication with the target cluster.
+This value is an empty string when not using a username for authentication.
+* `uuid`: the universally unique identifier for the reference.
 For example, `"5ccf771844cd32375df8c4de70e9d44e"`.
-
-* `validateURI.`
-A string that is the URI for internal validation of the reference.
+* `validateURI` the URI for internal validation of the reference.
 For example, `"/pools/default/remoteClusters/SecondTarget?just_validate=1"`.
 
-Failure to authenticate returns `401 Unauthorized`.
-An incorrectly specified URI returns `404 Object Not Found`.
-If `secureType` is `full`, and credentials _and_ client certificates are specified, connection fails with `400 Bad Request`, and an error message such as `{"_":"username and client certificate cannot both be given when secure type is full"}`.
+400 Bad Request::
+Occurs when `secureType` is `full` and you supply both client certificates and a username and password. 
+In this case, Couchbase Server also returns the following message:
++
+[source, json]
+----
+{"_":"username and client certificate cannot both be given when secure type is full"}
+----
++
+Supply either client certificates or a username and password for authentication with the target cluster, not both.
+
+401 Unauthorized::
+Authentication failure, such as incorrect username and password.
+
+404 Object Not Found::
+The URI used in the REST API call was not correct.
+Couchbase Server respond with this error code if you attempt to edit a non-existent reference by adding its name to the REST API URI.
+
+== Required Permissions
+
+You must have Full Admin, Cluster Admin, or XDCR Admin role to call this API.
 
 == Examples
 
-The following examples demonstrate how a reference can be established.
-All examples are piped to https://stedolan.github.io/jq/[jq^], and certificate output is truncated, in order to enhance the readability of output.
+The following examples demonstrate how to create a reference.
+All examples are piped through https://stedolan.github.io/jq/[jq^], and certificate output is truncated, to make the output more readable.
 
-== Create a Fully Secure Reference, Using Credentials
+=== Create a Fully Secure Reference, Using Credentials
 
-To create a fully secure reference from `localhost` to `10.144.220.102` by means of the target cluster's administrative credentials and root certificate, enter the following.
+This example creates a fully secure reference from `localhost` to `10.144.220.102`.
+It uses a username and password plus the target cluster's root certificate to authenticate.
 
+[source, console]
 ----
 curl -X POST -u Administrator:password \
 http://localhost:8091/pools/default/remoteClusters \
@@ -134,12 +196,13 @@ http://localhost:8091/pools/default/remoteClusters \
 --data-urlencode "certificate=$(cat ./ca.pem)" | jq '.'
 ----
 
-The `username` and `password` specified are those of the target cluster.
+The `username` and `password` specified are for an account on the target cluster.
 Note that the `demandEncryption` flag is not specified; however, the `encryptionType` flag is set to `full`.
 The `--data-urlencode` flag specifies the local path to the root certificate for the target cluster.
 
-Formatted, the output from a successful execution is as follows:
+Formatted, the output from a successful execution is:
 
+[source, json]
 ----
 {
   "certificate": "-----BEGIN CERTIFICATE-----\nMIIDJzCC
@@ -160,11 +223,12 @@ Formatted, the output from a successful execution is as follows:
 }
 ----
 
-== Create a Half-Secure Reference, Using Credentials
+=== Create a Half-Secure Reference, Using Credentials
 
 To create a half-secure reference from `localhost` to `10.142.180.102` by means of the remote cluster's administrative credentials and its root certificate, enter the following.
 (Note that `10.144.220.102` is assumed to be running a pre-5.5 version of Couchbase Server.)
 
+[source, console]
 ----
 curl -X POST -u Administrator:password \
 http://localhost:8091/pools/default/remoteClusters \
@@ -180,8 +244,9 @@ The `username` and `password` specified are those of the remote cluster.
 Note that the `demandEncryption` flag is set to `1`, while, the `encryptionType` flag specifies `half`.
 The `--data-urlencode` flag specifies the local path to the root certificate for the (pre-5.5) target cluster.
 
-If connection is successful, the following is returned:
+If Couchbase Server successfully connects, it returns the following message:
 
+[source, json]
 ----
 {
   "certificate": "-----BEGIN CERTIFICATE-----\nMIIDJzCCAg+gAwIBAgIUSaVkKhAwNl8aTxDkfyoeUiStp1cw/
@@ -203,10 +268,15 @@ If connection is successful, the following is returned:
 
 ----
 
-== Create a Fully Secure Reference, Using Certificates
+=== Create a Fully Secure Reference, Using Certificates
 
-To create a fully secure reference from `localhost` to `target.en.cl`, specifying that connection should occur with an external network, demanding full encryption, and authenticating by means of the remote cluster's root certificate, a client certificate, and a client private key, enter the following:
+This example create a fully secure reference from `localhost` to `target.en.cl` by doing the following:
 
+* Specifies that connection is over an external network
+* Enables full encryption
+* Authenticates using the remote cluster's root certificate, a client certificate, and a client private key.
+
+[source, console]
 ----
 curl -X POST -u Administrator:password http://localhost:8091/pools/default/remoteClusters \
 -d name=TargetCluster \
@@ -218,11 +288,13 @@ curl -X POST -u Administrator:password http://localhost:8091/pools/default/remot
 --data-urlencode "clientKey=$(cat ./travel-sample.key)"
 ----
 
-Note that the `demandEncryption` flag is set to `1`, and a fully encrypted connection is thus enforced.
-The `network_type=external` parameter is specified, indicating that the target's external network should be connected to, if it has been configured; otherwise, connection to an internal network is attempted.
+Because the example sets the `demandEncryption` flag to `1` and does not supply a `secureType` parameter, the connection to the target cluster is fully encrypted.
+The `network_type=external` parameter indicates that Couchbase Server should connect to the target's external network if it has been configured.
+If the target cluster does not have an external network defined, the source cluster attempts to connect to the target cluster's internal network.
 
 If successful, the command returns the following:
 
+[source, json]
 ----
 {
   "certificate": "-----BEGIN CERTIFICATE-----\nMIIDJzCCAg+gAwIBAgIUSaVkKh
@@ -248,10 +320,15 @@ If successful, the command returns the following:
 }
 ----
 
-The `secureType` field specifies `full`: therefore, the reference and its associated replications have now been fully secured.
-Both the target cluster's root certificate and the source cluster's client certificate are included in the output.
+The `secureType` field specifies `full`which is the default value if you set `demandEncryption` to `1` and do not supply a `secureType` parameter in the REST API call.
+The output includes Both the target cluster's root certificate and the source cluster's client certificate.
+
+
 
 == See Also
 
-For information on using the REST API to create secure connections, see xref:manage:manage-xdcr/secure-xdcr-replication.adoc[Secure a Replication].
-Additional information is provided in xref:learn:security/certificates.adoc[Certificates] and xref:xdcr-reference:xdcr-security-and-networking.adoc[XDCR Security and Networking].
+* See xref:manage:manage-xdcr/enable-full-secure-replication.adoc[] for an overview of securing replications.
+* See xref:manage:manage-xdcr/secure-xdcr-replication.adoc[] 
+for information about using the REST API to create secure connections.
+* See  xref:learn:security/certificates.adoc[] for an overview of using certificates with Couchbase Server. 
+* See xref:xdcr-reference:xdcr-security-and-networking.adoc[] for some requirements when configuring XDCR.

--- a/modules/rest-api/pages/rest-xdcr-create-ref.adoc
+++ b/modules/rest-api/pages/rest-xdcr-create-ref.adoc
@@ -14,7 +14,7 @@ You must create a reference to a target cluster on the source cluster before you
 The target cluster is usually a different cluster from the source cluster.
 However, you can create a replication where the source and target are the same cluster.
 
-You can edit an existing reference using the REST API by adding its name ot the URI.
+You can edit an existing reference using the REST API by adding its name to the URI.
 
 == HTTP Method and URI
 
@@ -42,7 +42,7 @@ POST /pools/default/remoteClusters/{REFERENCE_NAME}
 |===
 
 
-== Curl Syntax
+== curl Syntax
 
 [source, console]
 ----
@@ -196,8 +196,9 @@ http://localhost:8091/pools/default/remoteClusters \
 --data-urlencode "certificate=$(cat ./ca.pem)" | jq '.'
 ----
 
-The `username` and `password` specified are for an account on the target cluster.
-Note that the `demandEncryption` flag is not specified; however, the `encryptionType` flag is set to `full`.
+This example sets a `username` and `password` for an account on the target cluster.
+It does not set the `demandEncryption`.
+However, because it sets the `encryptionType` parameter to `full`, the reference uses full encryption.
 The `--data-urlencode` flag specifies the local path to the root certificate for the target cluster.
 
 Formatted, the output from a successful execution is:
@@ -225,8 +226,9 @@ Formatted, the output from a successful execution is:
 
 === Create a Half-Secure Reference, Using Credentials
 
-To create a half-secure reference from `localhost` to `10.142.180.102` by means of the remote cluster's administrative credentials and its root certificate, enter the following.
-(Note that `10.144.220.102` is assumed to be running a pre-5.5 version of Couchbase Server.)
+The following example creates a half-secure reference from `localhost` to `10.142.180.102`.
+It uses a  username and password to authenticate with the target cluster. 
+
 
 [source, console]
 ----
@@ -240,11 +242,11 @@ http://localhost:8091/pools/default/remoteClusters \
 --data-urlencode "certificate=$(cat ./ca.pem)" | jq '.'
 ----
 
-The `username` and `password` specified are those of the remote cluster.
-Note that the `demandEncryption` flag is set to `1`, while, the `encryptionType` flag specifies `half`.
-The `--data-urlencode` flag specifies the local path to the root certificate for the (pre-5.5) target cluster.
+The `username` and `password` in the example are for an account on the remote cluster.
+The reference is half-encrypted (only the password is sent encrypted) because the `demandEncryption` flag is `1` and the `encryptionType` flag is `half`.
+The `--data-urlencode` flag specifies the local path to the root certificate for the target cluster.
 
-If Couchbase Server successfully connects, it returns the following message:
+If the source Couchbase Server connects to the target cluster, it returns the following message:
 
 [source, json]
 ----
@@ -270,7 +272,7 @@ If Couchbase Server successfully connects, it returns the following message:
 
 === Create a Fully Secure Reference, Using Certificates
 
-This example create a fully secure reference from `localhost` to `target.en.cl` by doing the following:
+This example create a fully secure reference from `localhost` to `target.example.com` by doing the following:
 
 * Specifies that connection is over an external network
 * Enables full encryption
@@ -280,7 +282,7 @@ This example create a fully secure reference from `localhost` to `target.en.cl` 
 ----
 curl -X POST -u Administrator:password http://localhost:8091/pools/default/remoteClusters \
 -d name=TargetCluster \
--d hostname=target.en.cl \
+-d hostname=target.example.com \
 -d network_type=external \
 -d demandEncryption=1 \
 --data-urlencode "certificate=$(cat ./ca.pem)" \
@@ -310,7 +312,7 @@ If successful, the command returns the following:
   "deleted": false,
   "demandEncryption": true,
   "encryptionType": "full",
-  "hostname": "target.en.cl",
+  "hostname": "target.example.com",
   "name": "TargetCluster",
   "secureType": "full",
   "uri": "/pools/default/remoteClusters/TargetCluster",
@@ -322,8 +324,6 @@ If successful, the command returns the following:
 
 The `secureType` field specifies `full`which is the default value if you set `demandEncryption` to `1` and do not supply a `secureType` parameter in the REST API call.
 The output includes Both the target cluster's root certificate and the source cluster's client certificate.
-
-
 
 == See Also
 

--- a/modules/rest-api/pages/rest-xdcr-intro.adoc
+++ b/modules/rest-api/pages/rest-xdcr-intro.adoc
@@ -8,7 +8,8 @@
 == APIs in this Section
 
 Cross Datacenter Replication (XDCR) configuration replicates data between a source bucket and a target bucket.
-For a detailed introduction and overview, see xref:learn:clusters-and-availability/xdcr-overview.adoc[Cross Data Center Replication (XDCR)].
+For a detailed introduction and overview, see xref:learn:clusters-and-availability/xdcr-overview.adoc[].
+To learn how to secure an XDCR connection, see xref:manage:manage-xdcr/enable-full-secure-replication.adoc[].
 
 For a list of the methods and URIs covered by the pages in this section, see the table below.
 


### PR DESCRIPTION
This covers  a request to add some links to the the XDCR docs. I took the opportunity to edit/reformat the Create Reference doc to bring it in line with our standards.

Preview is [available here](https://preview.docs-test.couchbase.com/DOC9384-add-xdcr-links/server/current/rest-api/rest-xdcr-create-ref.html).