### PR TITLE
DOC-10441 - Typo on first paragraph

### DIFF
--- a/modules/learn/pages/buckets-memory-and-storage/vbuckets.adoc
+++ b/modules/learn/pages/buckets-memory-and-storage/vbuckets.adoc
@@ -12,7 +12,7 @@ Couchbase Server allows users and applications to save data, in binary or JSON f
 Each bucket therefore contains _keys_ and associated _values_.
 See xref:buckets-memory-and-storage/buckets.adoc[Buckets], for detailed information.
 
-Within the memory and storage management system of Couchbase Server, both Couchbase and Ephermal buckets are implemented as _vBuckets_, 1024 of which are created for every bucket (except on MacOS, where the number is 64).
+Within the memory and storage management system of Couchbase Server, both Couchbase and Ephemeral buckets are implemented as _vBuckets_, 1024 of which are created for every bucket (except on MacOS, where the number is 64).
 vBuckets are distributed evenly across the memory and storage facilities of the cluster; and the bucket's items are distributed evenly across its vBuckets.
 This evenness of distribution ensures that all instances of the xref:services-and-indexes/services/data-service.adoc[Data Service] take an approximately equal share of the workload, in terms of numbers of documents to maintain, and operations to handle.
 


### PR DESCRIPTION
Typo on first paragraph from Ephermal to Ephemeral.