### PR TITLE
[DOC-12515/release/7.2]: Improve the diagram on the Upgrade page. Changed color scheme. Changed the diagram shapes to allow for drop shadows.

### DIFF
--- a/modules/install/partials/diagrams.adoc
+++ b/modules/install/partials/diagrams.adoc
@@ -6,20 +6,20 @@ Not built as part of the site
 
 // tag::upgrade-diagram[]
 .Example Upgrade Path from Community to Enterprise
-[ditaa]
+[ditaa, round-corners=true]
 ....
               /-----------------\           /-----------------\            /-----------------\
               |     Step 1:     |           |     Step 2:     |            |     Step 3:     |
-              : Upgrade Edition |           : Upgrade Version |            : Upgrade Version |
+              | Upgrade Edition |           | Upgrade Version |            | Upgrade Version |
               \--------+--------/           \--------+--------/            \--------+--------/
                        |                             |                              |
                        |                             |                              |
-+-----------------+    :     +-----------------+     :      +-----------------+     :      +-----------------+
-|cBLU             | ---+---> |cC02             | ----+----> |cC02             | ----+----> |cC02             |
++-----------------+    |     +-----------------+     |      +-----------------+     |      +-----------------+
+|cFEB             | ---+---> |cBEA             | ----+----> |cBEA             | ----+----> |cBEA             |
 |Cluster 1        | Rolling  |Cluster 1        |    Any     |Cluster 1        |    Any     |Cluster 1        |
 |Version: 6.6     | Online   |Version: 6.6     | Supported  |Version: 7.2.3   |  Supported |Version: 7.2.4   |
 |Edition: CE      | Upgrade  |Edition: EE      |  Upgrade   |Edition: EE      |   Upgrade  |Edition: EE      |
-|              {s}|          |              {s}|   Type     |              {s}|    Type    |             {s} |
+|                 |          |                 |   Type     |                 |    Type    |                 |
 +-----------------+          +-----------------+            +-----------------+            +-----------------+
 ....
 // end::upgrade-diagram[]


### PR DESCRIPTION
Minor improvements to the upgrade diagram.

https://jira.issues.couchbase.com/browse/DOC-12515

The diagram now looks like this:

<img width="989" alt="image" src="https://github.com/user-attachments/assets/6cfe867a-7616-4121-9a68-15f64d978570">
