### PR TITLE
[quickfix/release/7.6] Missed a digit from diagrams.adoc

### DIFF
--- a/modules/install/partials/diagrams.adoc
+++ b/modules/install/partials/diagrams.adoc
@@ -17,7 +17,7 @@ Not built as part of the site
 +-----------------+    |     +-----------------+     |      +-----------------+     |      +-----------------+
 |cFEB             | ---+---> |cBEA             | ----+----> |cBEA             | ----+----> |cBEA             |
 |Cluster  1       | Rolling  |Cluster  1       |    Any     |Cluster  1       |    Any     |Cluster  1       |
-|Version  6.      | Online   |Version  6.6     | Supported  |Version  7.2.3   |  Supported |Version  7.6     |
+|Version  6.6     | Online   |Version  6.6     | Supported  |Version  7.2.3   |  Supported |Version  7.6     |
 |Edition  CE      | Upgrade  |Edition  EE      |  Upgrade   |Edition  EE      |   Upgrade  |Edition  EE      |
 |                 |          |                 |   Type     |                 |    Type    |                 |
 +-----------------+          +-----------------+            +-----------------+            +-----------------+


### PR DESCRIPTION

Fixed missing digit.