### PR TITLE
[CBSE-17766]: Amadeus: Docs: Swap Rebalance: Explicitly mention to not use Graceful Failover

### DIFF
--- a/modules/install/pages/upgrade-procedure-selection.adoc
+++ b/modules/install/pages/upgrade-procedure-selection.adoc
@@ -62,6 +62,14 @@ _Swap Rebalance_ is automatically performed by Couchbase Server when all the fol
 Since the introduced nodes are recognized by Couchbase Server to have equivalent capacities and configurations to those that have been taken out, rebalance is performed as a _swap rebalance_; which largely confines its activity to the incoming and outgoing nodes.
 Thus, for example, if one Data Service node is removed and another added, the swap rebalance ensures that the vBucket layout of the outgoing node is created identically on the incoming node; with the layouts of other Data Service nodes not requiring modification.
 
+[NOTE]
+====
+.Node Removal and Swap Rebalancing
+
+If you are removing a data node, then there is no need to perform a xref:manage:manage-nodes/failover-graceful.adoc[failover operation].
+
+Remove the node using the xref:manage:manage-nodes/remove-node-and-rebalance.adoc#remove-a-node-with-the-ui[UI], the xref:manage:manage-nodes/remove-node-and-rebalance.adoc#remove-a-node-with-the-rest-api[REST API], or the xref:manage:manage-nodes/remove-node-and-rebalance.adoc#remove-a-node-with-the-cli[CLI], and then trigger a rebalance.
+====
 By contrast, if two Data Service nodes are taken out, and one Data Service node and one Search Service node are introduced, since the incoming and outgoing nodes differ in configuration, when rebalance is triggered by the administrator, Couchbase Server performs a _full_ rebalance; involving more nodes than those in transit; and indeed, potentially involving the entire cluster.
 
 Note that the effect of rebalance on different Couchbase Services is described in xref:learn:clusters-and-availability/rebalance.adoc[Rebalance]: familiarity with this information is required before proceeding.

--- a/modules/install/pages/upgrade-procedure-selection.adoc
+++ b/modules/install/pages/upgrade-procedure-selection.adoc
@@ -63,9 +63,8 @@ Since the introduced nodes are recognized by Couchbase Server to have equivalent
 Thus, for example, if one Data Service node is removed and another added, the swap rebalance ensures that the vBucket layout of the outgoing node is created identically on the incoming node; with the layouts of other Data Service nodes not requiring modification.
 
 [NOTE]
-====
 .Node Removal and Swap Rebalancing
-
+====
 If you are removing a data node, then there is no need to perform a xref:manage:manage-nodes/failover-graceful.adoc[failover operation].
 
 Remove the node using the xref:manage:manage-nodes/remove-node-and-rebalance.adoc#remove-a-node-with-the-ui[UI], the xref:manage:manage-nodes/remove-node-and-rebalance.adoc#remove-a-node-with-the-rest-api[REST API], or the xref:manage:manage-nodes/remove-node-and-rebalance.adoc#remove-a-node-with-the-cli[CLI], and then trigger a rebalance.


### PR DESCRIPTION

Added a note instructing user to simply remove the node, then trigger a rebalance.