### PR TITLE
DOC-10648 windows install permissions

### DIFF
--- a/modules/install/pages/install-package-windows.adoc
+++ b/modules/install/pages/install-package-windows.adoc
@@ -15,8 +15,10 @@ If you're upgrading an existing installation of Couchbase Server, refer to xref:
 Couchbase Server works out-of-the-box with most OS configurations.
 However, the procedures on this page assume the following:
 
-* You have _administrator privileges_.
-These are required, for installing Couchbase Server on Windows.
+* You must have administrator privileges to install Couchbase Server on Windows.
+Once installed, Couchbase Server runs as a Windows Service using the Local System user's privileges. 
+A user must have sufficient privileges to start the Couchbase Server Windows Service after installation. 
+See Microsoft's Learn article https://learn.microsoft.com/en-us/troubleshoot/windows-server/windows-security/grant-users-rights-manage-services[How to grant users rights to manage services^]. 
 
 * Your system meets the xref:pre-install.adoc[minimum requirements] and that your operating system version is xref:install-platforms.adoc[supported].
 +

--- a/modules/install/pages/install-package-windows.adoc
+++ b/modules/install/pages/install-package-windows.adoc
@@ -17,7 +17,7 @@ However, the procedures on this page assume the following:
 
 * You must have administrator privileges to install Couchbase Server on Windows.
 Once installed, Couchbase Server runs as a Windows Service using the Local System user account. 
-To start the Windows Service, you must either have administrator privileges or be granted sufficient privileges to start the service. 
+To start or stop the Windows Service, your windows account must either have administrator privileges or be granted sufficient privileges to start the service. 
 For more information, see Microsoft's https://learn.microsoft.com/en-us/troubleshoot/windows-server/windows-security/grant-users-rights-manage-services[How to grant users rights to manage services^]. 
 
 * Your system meets the xref:pre-install.adoc[minimum requirements] and that your operating system version is xref:install-platforms.adoc[supported].

--- a/modules/install/pages/install-package-windows.adoc
+++ b/modules/install/pages/install-package-windows.adoc
@@ -16,9 +16,9 @@ Couchbase Server works out-of-the-box with most OS configurations.
 However, the procedures on this page assume the following:
 
 * You must have administrator privileges to install Couchbase Server on Windows.
-Once installed, Couchbase Server runs as a Windows Service using the Local System user's privileges. 
-A user must have sufficient privileges to start the Couchbase Server Windows Service after installation. 
-See Microsoft's Learn article https://learn.microsoft.com/en-us/troubleshoot/windows-server/windows-security/grant-users-rights-manage-services[How to grant users rights to manage services^]. 
+Once installed, Couchbase Server runs as a Windows Service using the Local System user account. 
+To start the Windows Service, you must either have administrator privileges or be granted sufficient privileges to start the service. 
+For more information, see Microsoft's https://learn.microsoft.com/en-us/troubleshoot/windows-server/windows-security/grant-users-rights-manage-services[How to grant users rights to manage services^]. 
 
 * Your system meets the xref:pre-install.adoc[minimum requirements] and that your operating system version is xref:install-platforms.adoc[supported].
 +


### PR DESCRIPTION
Updated the requirements for installing and running on Windows to state what user the CB windows sevice runs on, and what permissions you need to start and stop it.

See [preview of this change](https://preview.docs-test.couchbase.com/windows-permissions/server/current/install/install-package-windows.html). 