### PR TITLE
Update list-cluster-nodes.adoc

### DIFF
--- a/modules/manage/pages/manage-nodes/list-cluster-nodes.adoc
+++ b/modules/manage/pages/manage-nodes/list-cluster-nodes.adoc
@@ -133,18 +133,27 @@ The method returns a large amount of information, which includes many of the det
 The output may be unformatted, and thereby difficult to read until formatting is applied.
 
 The following call passes the result to the https://stedolan.github.io/jq/[jq^] command-line JSON processor for
-formatting, and then uses the standard command-line utility `grep` to reduce the output to available hostnames:
+formatting, and then uses the standard command-line utility `egrep` to reduce the output to available hostnames and otpNode names:
 
 ----
 curl  -u Administrator:password -v -X GET \
-http://10.142.181.101:8091/pools/default | jq '.' | grep hostname
+http://10.142.181.101:8091/pools/default | jq '.' | egrep 'hostname|otpNode'
 ----
 
 The output is as follows:
 
 ----
+"otpNode": "ns_1@10.142.181.101",
 "hostname": "10.142.181.101:8091",
+"otpNode": "ns_1@10.142.181.102",
 "hostname": "10.142.181.102:8091",
+----
+
+As shown in the example REST API command below, the otpNode value can be used with the `/nodes/<otpNode>` URI to retrieve detailed information about the node, including the storage paths for the services:
+
+----
+curl -u Administrator:password -v -X GET \
+http://10.142.181.101:8091/nodes/ns_1@10.142.181.101 | jq '.'
 ----
 
 For more information, see xref:rest-api:rest-cluster-get.adoc[Retrieving Cluster Information].


### PR DESCRIPTION
In the List Nodes with the REST API section, updated REST API command to output both the otpNode and hostname.  This is because you need the otpNode value to be able to get detailed information about the node.  Then, added an example of how to use the `/nodes/<otpNode>` URI to display detailed information about the node.