### PR TITLE
[DOC-12446] Update rest-initialize-cluster.adoc syntax

### DIFF
--- a/modules/rest-api/pages/rest-initialize-cluster.adoc
+++ b/modules/rest-api/pages/rest-initialize-cluster.adoc
@@ -37,11 +37,11 @@ curl -X POST http://<ip-address-or-domain-name>:8091/clusterInit
   -d hostname=<ip-address-or-domain-name>
   -d username=<username>
   -d password=<password>
-  -d data_path=<data-path>
-  -d index_path=<index-path>
-  -d cbas_path=<analytics-path>
-  -d eventing_path=<eventing-path>
-  -d java_home=<jre-path>
+  -d dataPath=<data-path>
+  -d indexPath=<index-path>
+  -d analyticsPath=<analytics-path>
+  -d eventingPath=<eventing-path>
+  -d javaHome=<jre-path>
   -d sendStats=true
   -d clusterName=<cluster-name>
   -d services=<list-of-service-names>
@@ -73,13 +73,13 @@ This parameter must be specified.
 A string that will be the password for the new cluster.
 This parameter must be specified.
 
-* `data_path`, `index_path`, `cbas_path`, `eventing_path`.
+* `dataPath`, `indexPath`, `analyticsPath`, `eventingPath`.
 Paths for the storage of data to be used by the Data, Index, Analytics, and Eventing Services.
 All paths must be writable by user `couchbase`.
 These parameters are optional.
 For the default values, see xref:rest-api:rest-initialize-node.adoc[Initializing a Node].
 
-* `java_home`.
+* `javaHome`.
 Location of the JRE to be used by the Analytics Service.
 The specified path must be writable by user `couchbase`.
 This parameter is optional.
@@ -91,7 +91,7 @@ See the xref:cli:cbcli/couchbase-cli-cluster-init.adoc#:~:text=software%20update
 It's always set to `true` for Couchbase Server Community Edition.
 In Couchbase Server Enterprise Edition, you can set the value to the default `true` or `false`.
 
-* `cluster_name`.
+* `clusterName`.
 A name for the cluster.
 This name is for convenience of identification, and will not be used for network access.
 This parameter is optional.


### PR DESCRIPTION
The syntax had incorrect field names, so corrected.  Note that the example on the same page had the correct field names.