### PR TITLE
[DOC-12446] Update rest-initialize-node.adoc to fix wrong field/key name in synta…

### DIFF
--- a/modules/rest-api/pages/rest-initialize-node.adoc
+++ b/modules/rest-api/pages/rest-initialize-node.adoc
@@ -40,7 +40,7 @@ Per platform, the default data-folder locations for all services are:
 ----
 curl -X POST http://<node-ip-address-or-domain-name>:8091/nodes/self/controller/settings
   -u <username>:<password>
-  -d data_path=<data-path>
+  -d path=<data-path>
   -d index_path=<index-path>
   -d cbas_path=<analytics-path>
   -d eventing_path=<eventing-path>
@@ -64,7 +64,7 @@ The following example establishes the paths for the Data, Index, Analytics, and 
 ----
 curl -X POST \
   http://10.142.181.103:8091/nodes/self/controller/settings \
-  -d 'data_path=%2Fopt%2Fcouchbase%2Fvar%2Flib%2Fcouchbase%2Fdata&' \
+  -d 'path=%2Fopt%2Fcouchbase%2Fvar%2Flib%2Fcouchbase%2Fdata&' \
   -d 'index_path=%2Fopt%2Fcouchbase%2Fvar%2Flib%2Fcouchbase%2Fidata&' \
   -d 'cbas_path=%2Fopt%2Fcouchbase%2Fvar%2Flib%2Fcouchbase%2Fadata&' \
   -d 'eventing_path=%2Fopt%2Fcouchbase%2Fvar%2Flib%2Fcouchbase%2Fedata&'


### PR DESCRIPTION
…x and example

For the REST API shown, both the syntax and the example showed the wrong field/key name for the data service path -- it is just  "path" in this specific REST API `/nodes/self/controller/settings` .   The other names are correct -- "index_path", "eventing_path", and "cbas_path".  Note that in the `/clusterInit` REST API, the field/key names are different.