### PR TITLE
DOC-12465 non avx2 processor deprecation 7.6

### DIFF
--- a/modules/release-notes/partials/docs-server-7.6.3-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6.3-release-note.adoc
@@ -8,7 +8,7 @@ For detailed information on new features and enhancements, please see xref:intro
 === Deprecated Platforms
 
 The use of x86 processors that do not support Advanced Vector Extensions 2 (AVX2) is deprecated in version 7.6.3. 
-Future versions of the Vector Search feature will rely on these instructions to improve performance.
+Future versions of Vector Search will rely on these instructions to improve performance.
 These instructions are available in most Intel processors produced since 2013 and AMD processors produced since 2015. 
 
 [#fixed-issues-763]

--- a/modules/release-notes/partials/docs-server-7.6.3-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6.3-release-note.adoc
@@ -4,7 +4,7 @@ Couchbase Server 7.6.3 was released in September 2024. This maintenance release 
 
 For detailed information on new features and enhancements, please see xref:introduction:whats-new.adoc[].
 
-[#deprecated-7.6.3]
+[#deprecated-7-6-3]
 === Deprecated Platforms
 
 The use of x86 processors that do not support Advanced Vector Extensions 2 (AVX2) is deprecated in version 7.6.3. 

--- a/modules/release-notes/partials/docs-server-7.6.3-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6.3-release-note.adoc
@@ -4,6 +4,13 @@ Couchbase Server 7.6.3 was released in September 2024. This maintenance release 
 
 For detailed information on new features and enhancements, please see xref:introduction:whats-new.adoc[].
 
+[#deprecated-7.6.3]
+=== Deprecated Platforms
+
+The use of x86 processors that do not support Advanced Vector Extensions 2 (AVX2) is deprecated in version 7.6.3. 
+Future versions of the Vector Search feature will rely on these instructions to improve performance.
+These instructions are available in most Intel processors produced since 2013 and AMD processors produced since 2015. 
+
 [#fixed-issues-763]
 === Fixed Issues
 


### PR DESCRIPTION
Added deprecation notice to the 7.6.3 release notes stating that use of processors without AVX2 support is deprecated. 

[Preview](https://preview.docs-test.couchbase.com/7.6.3-deprecation-non-avx2/server/current/release-notes/relnotes.html#deprecated-7-6-3)