### PR TITLE
DOC-12448 ubuntu 24.04 support

### DIFF
--- a/modules/install/pages/install-platforms.adoc
+++ b/modules/install/pages/install-platforms.adoc
@@ -73,7 +73,8 @@ a|* 14 "Sonoma"
 * 12 "Monterey" (x86-64 and Apple Silicon ARM64) (deprecated in Couchbase Server 7.6)
 
 | Windows Desktop
-a|* 10 (requires Anniversary Update)
+a|* 11
+* 10 (requires Anniversary Update)
 |===
 
 == Supported Virtualization and Container Platforms

--- a/modules/install/pages/install-platforms.adoc
+++ b/modules/install/pages/install-platforms.adoc
@@ -5,12 +5,14 @@
 [abstract]
 {description}
 
+[#oses]
 == Supported Operating Systems
 
-Make sure that your chosen operating system is listed below, before you install Couchbase Server.
+Choose an operating system from the following list to deploy Couchbase Server.
 
 NOTE: Couchbase clusters on mixed platforms are not supported.
-Nodes in a Couchbase cluster should all be running on the same OS, and every effort should be made to apply the same OS patches across the entire cluster.
+Nodes in a Couchbase cluster should all be running on the same OS.
+Be sure to apply the same OS updates to all nodes the cluster.
 
 ARM64 support requires ARMv8 CPUs, such as the Amazon Graviton series.
 
@@ -20,48 +22,43 @@ ARM64 support requires ARMv8 CPUs, such as the Amazon Graviton series.
 | Operating System | Supported Versions (64-bit)
 
 | Alma Linux
-| 9.x
+a|* 9.x
 | Amazon Linux 2
-| LTS (x86-64, ARM64) (deprecated in Couchbase Server 7.6)
+a|* LTS (x86-64, ARM64) (deprecated in Couchbase Server 7.6)
 
 | Amazon Linux 2023
-| AL2023 (x86-64, ARM64)
+a|* AL2023 (x86-64, ARM64)
 
 | Debian
-| 12.x
+a| * 12.x
+* 11.x
 
-11.x
-
-
-| Oracle Linux{empty}footnote:[Only the Red Hat Compatible Kernel (RHCK) is supported. The Unbreakable Enterprise Kernel (UEK) is not supported.]
-| 8.x
-
-9.x
+| Oracle Linux{empty}footnote:[Only the Red Hat Compatible Kernel (RHCK) is supported.
+The Unbreakable Enterprise Kernel (UEK) is not supported.]
+a|* 9.x
+* 8.x
 
 | Red Hat Enterprise Linux (RHEL)
-| 8.x
-
-9.x
+a|* 9.x
+* 8.x
 
 | Rocky Linux
-| 9.x
+a|* 9.x
 
 | SUSE Linux Enterprise Server (SLES)
-a| 12.x
-
-15.x
+a|* 15.x 
+* 12.x
 
 NOTE: Versions earlier than SP2 are no longer supported in Couchbase Server 7.2 and later.
 
 | Ubuntu
-| 20.04 LTS (x86, ARM64) (deprecated in Couchbase Server 7.6)
-
-22.x LTS (x86, ARM64)
+a|* 24.04 LTS (x86, ARM64)
+* 22.x LTS (x86, ARM64)
+* 20.04 LTS (x86, ARM64) (deprecated in Couchbase Server 7.6)
 
 | Windows Server
-| 2022
-
-2019 (deprecated in Couchbase Server 7.6)
+a|* 2022
+* 2019 (deprecated in Couchbase Server 7.6)
 
 |===
 
@@ -71,14 +68,12 @@ NOTE: Versions earlier than SP2 are no longer supported in Couchbase Server 7.2 
 | Operating System | Supported Versions (64-bit)
 
 | macOS
-| 14 "Sonoma"
+a|* 14 "Sonoma"
+* 13 "Ventura"
+* 12 "Monterey" (x86-64 and Apple Silicon ARM64) (deprecated in Couchbase Server 7.6)
 
-13 "Ventura"
-
-12 "Monterey" (x86-64 and Apple Silicon ARM64) (deprecated in Couchbase Server 7.6)
- 
 | Windows Desktop
-| 10 (requires Anniversary Update)
+a|* 10 (requires Anniversary Update)
 |===
 
 == Supported Virtualization and Container Platforms
@@ -89,7 +84,8 @@ NOTE: Versions earlier than SP2 are no longer supported in Couchbase Server 7.2 
 | Platform | Notes
 
 | Docker
-| Couchbase Server is compatible with Docker.
+| Couchbase Server is compatible with Docker when hosted on one of operating systems listed in <<Supported Operating Systems>>.
+
 
 Official Docker images are available on https://hub.docker.com/_/couchbase[Docker Hub].
 Follow the best practices to run xref:best-practices-vm.adoc[Couchbase Server on a virtualized environment].

--- a/modules/install/pages/install-platforms.adoc
+++ b/modules/install/pages/install-platforms.adoc
@@ -91,7 +91,7 @@ Official Docker images are available on https://hub.docker.com/_/couchbase[Docke
 Follow the best practices to run xref:best-practices-vm.adoc[Couchbase Server on a virtualized environment].
 
 | Kernel-based Virtual Machine (KVM)
-| Couchbase Server is compatible with KVM.
+| Couchbase Server is compatible with KVM on operating systems listed in <<Supported Operating Systems>>.
 
 Follow the best practices to run xref:best-practices-vm.adoc[Couchbase Server on a virtualized environment].
 
@@ -103,6 +103,7 @@ Follow the best practices to run xref:best-practices-vm.adoc[Couchbase Server on
 
 | VMware
 | Couchbase Server is compatible with VMware.
+Your virtual machines must use one of the operating systems listed in <<Supported Operating Systems>>.
 
 Follow the best practices to run xref:best-practices-vm.adoc[Couchbase Server on a virtualized environment].
 |===

--- a/modules/install/pages/install-platforms.adoc
+++ b/modules/install/pages/install-platforms.adoc
@@ -8,7 +8,7 @@
 [#oses]
 == Supported Operating Systems
 
-Choose an operating system from the following list to deploy Couchbase Server.
+Choose an operating system from the following list for your Couchbase Server deployment.
 
 NOTE: Couchbase clusters on mixed platforms are not supported.
 Nodes in a Couchbase cluster should all be running on the same OS.
@@ -87,7 +87,7 @@ a|* 10 (requires Anniversary Update)
 | Couchbase Server is compatible with Docker when hosted on one of operating systems listed in <<Supported Operating Systems>>.
 
 
-Official Docker images are available on https://hub.docker.com/_/couchbase[Docker Hub].
+You can find official Docker images at https://hub.docker.com/_/couchbase[Docker Hub].
 Follow the best practices to run xref:best-practices-vm.adoc[Couchbase Server on a virtualized environment].
 
 | Kernel-based Virtual Machine (KVM)

--- a/modules/install/pages/install-platforms.adoc
+++ b/modules/install/pages/install-platforms.adoc
@@ -1,5 +1,5 @@
 = Supported Platforms
-:description: Couchbase Server is supported on several popular operating systems and virtual environments.
+:description: Couchbase Server supports several popular operating systems and virtual environments. The Couchbase Server Web Console supports most recent major browsers.
 :page-aliases: install:install-browsers
 
 [abstract]
@@ -49,7 +49,7 @@ a|* 9.x
 a|* 15.x 
 * 12.x
 
-NOTE: Versions earlier than SP2 are no longer supported in Couchbase Server 7.2 and later.
+NOTE: Versions earlier than 12 SP2 are no longer supported in Couchbase Server 7.2 and later.
 
 | Ubuntu
 a|* 24.04 LTS (x86, ARM64)
@@ -79,32 +79,33 @@ a|* 11
 
 == Supported Virtualization and Container Platforms
 
+When running Couchbase Server in virtualized or containerized environments, base the container or VM on one of the operating systems listed under  <<Supported Operating Systems>>.
+Couchbase Server has no operating system requirements for the system hosting the VM or container.
+
 .Supported VM and Container Platforms
 [cols="100,135",options="header"]
 |===
 | Platform | Notes
 
 | Docker
-| Couchbase Server is compatible with Docker when hosted on one of operating systems listed in <<Supported Operating Systems>>.
-
+| Couchbase Server is compatible with Docker.
 
 You can find official Docker images at https://hub.docker.com/_/couchbase[Docker Hub].
 Follow the best practices to run xref:best-practices-vm.adoc[Couchbase Server on a virtualized environment].
 
 | Kernel-based Virtual Machine (KVM)
-| Couchbase Server is compatible with KVM on operating systems listed in <<Supported Operating Systems>>.
+| Couchbase Server is compatible with KVM.
 
 Follow the best practices to run xref:best-practices-vm.adoc[Couchbase Server on a virtualized environment].
 
 | Kubernetes
-| First-party integration with Kubernetes is made available with the xref:operator::overview.adoc[Couchbase Autonomous Operator].
+| xref:operator::overview.adoc[Couchbase Autonomous Operator] provides Kubernetes integration.
 
 | Red Hat OpenShift
-| First-party integration with Red Hat OpenShift is made available with the xref:operator::overview.adoc[Couchbase Autonomous Operator].
+| xref:operator::overview.adoc[Couchbase Autonomous Operator] provides Red Hat OpenShift integration.
 
 | VMware
 | Couchbase Server is compatible with VMware.
-Your virtual machines must use one of the operating systems listed in <<Supported Operating Systems>>.
 
 Follow the best practices to run xref:best-practices-vm.adoc[Couchbase Server on a virtualized environment].
 |===


### PR DESCRIPTION
* Added Ubuntu 24.04 to satisfy DOC-12448
* Added general guidelines about virtualized and containerized environments using supported OSes mainly for [DOC-10639](https://jira.issues.couchbase.com/browse/DOC-10639).
* Reordered some the version numbers in the list of supported OSes so they consistently go from high to low (some went from low to high).
* Added bullets to supported OS list to help readability.
* Misc. rewording/depassivefying.
* Added Windows 11 as a supported platform, as apparently it's been [supported since 7.1](https://jira.issues.couchbase.com/browse/MB-52138). Windows 10 deprecation is a separate issue.

Preview: https://preview.docs-test.couchbase.com/DOC-12448_ubuntu_24.04_support/server/current/install/install-platforms.html



[DOC-10639]: https://couchbasecloud.atlassian.net/browse/DOC-10639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ