### PR TITLE
[DOC-12706]: Documentation needed for changes to the Prometheus Discovery API

### DIFF
--- a/modules/rest-api/pages/rest-discovery-api.adoc
+++ b/modules/rest-api/pages/rest-discovery-api.adoc
@@ -4,14 +4,14 @@
 [abstract]
 {description}
 
-You can use Prometheus or similar tools to collect statistics and alerts from your Couchbase Database. 
-In order for these tools to collect metrics, they must have a list of nodes in your Couchbase Server database. 
+You can use Prometheus or similar tools to collect statistics and alerts from your Couchbase Database.
+In order for these tools to collect metrics, they must have a list of nodes in your Couchbase Server database.
 The discovery API provides this list to these tools.
 
 See xref:manage:monitor/set-up-prometheus-for-monitoring.adoc[Configure Prometheus to Collect Couchbase Metrics] for detailed information about using this API with Prometheus.
 
-NOTE: This endpoint is a replacement for the earlier `/prometheus_sd-config.yaml` endpoint. 
-That endpoint is now deprecated. 
+NOTE: This endpoint is a replacement for the earlier `/prometheus_sd-config.yaml` endpoint.
+That endpoint is now deprecated.
 See <<old-api,Replicate the Earlier Discovery API>> to learn how to call the new discovery API to get he same output as the old API.
 
 == HTTP Method and URI
@@ -25,7 +25,7 @@ GET /prometheus_sd_config
 
 By default, the discovery endpoint returns the list of nodes in your database that:
 
-* is in JSON format. 
+* is in JSON format.
 * uses the primary address of the node
 * uses the secure port number
 
@@ -36,6 +36,7 @@ By default, the discovery endpoint returns the list of nodes in your database th
 ----
 curl --get -u <username:password> \
     http://<ip-address-or-domain-name>:<port-number>/prometheus_sd_config
+    -d clusterLabels=[none|uuidAndName|uuidOnly]
     -d disposition=[attachment|inline]
     -d network=[default|external]
     -d port=[insecure|secure]
@@ -43,34 +44,39 @@ curl --get -u <username:password> \
 ----
 
 
-The username you use to call endpoint must have the xref:learn:security/roles.adoc#external-stats-reader[External Stats Reader] role. 
-This is the same role Couchbase Server requires to retrieve metrics. 
+The username you use to call endpoint must have the xref:learn:security/roles.adoc#external-stats-reader[External Stats Reader] role.
+This is the same role Couchbase Server requires to retrieve metrics.
 
 === Parameters
 
+clusterLabels=[none|uuidAndName|uuidOnly]::
+Controls the inclusion of information labels for the cluster.
+When set to `none`, no labels are included in the response.
+When set to `uuidAndName`, both the UUID and the name of the node are added to the response.
+When set to `uuidOnly`, only the UUID of the node is returned in the response.
 disposition=[attachment|inline]::
-Controls how Couchbase Server returns the list of nodes in the response. 
+Controls how Couchbase Server returns the list of nodes in the response.
 When set to the default `inline`, it returns the list inline within the response.
 When set to `attachment`, it returns the list as an attachment to the response.
 
 network=[default|external]::
-Controls which network address Couchbase Server uses in the list. 
+Controls which network address Couchbase Server uses in the list.
 When set to the default value of `default`, it uses the nodes's default address.
-When set to `external`, it uses the node's xref:learn:clusters-and-availability/connectivity.adoc#alternate-addresses[alternate address]. 
+When set to `external`, it uses the node's xref:learn:clusters-and-availability/connectivity.adoc#alternate-addresses[alternate address].
 
 port=[insecure|secure]::
-Controls which port Couchbase Server uses in the list of nodes. 
+Controls which port Couchbase Server uses in the list of nodes.
 When set to the default `secure`, it uses the node's secure port in the list.
 When set to `insecure`, it uses the node's unencrypted port.
 
 type=[json|yaml]::
-Controls the data format Couchbase Server uses for the node list. 
+Controls the data format Couchbase Server uses for the node list.
 When set to the default `json`, it returns the list of nodes in JSON format.
-When set to `yaml`, it returns the list of nodes in YAML format. 
+When set to `yaml`, it returns the list of nodes in YAML format.
 
 == Examples
 
-The following example demonstrates calling the `prometheus_sd_config` endpoint on a node with the hostname `node1` using default values. 
+The following example demonstrates calling the `prometheus_sd_config` endpoint on a node with the hostname `node1` using default values.
 It pipes the response through the `jq` command to make it readable.
 
 [source, shell]
@@ -79,7 +85,7 @@ curl -s --get -u prometheus:password http://node1:8091/prometheus_sd_config \
      | jq
 ----
 
-The next example shows the response that Couchbase Server sends in response to the previous command. 
+The next example shows the response that Couchbase Server sends in response to the previous command.
 
 [source, json]
 ----
@@ -94,10 +100,38 @@ The next example shows the response that Couchbase Server sends in response to t
 ]
 ----
 
+Adding the `clusterLabels` parameter to the message payload will add additional node information to the response. For example, this command:
+
+[source, shell]
+----
+curl -s --get -u prometheus:password http://node1:8091/prometheus_sd_config \
+-d clusterLabels=uuidAndName | jq
+----
+
+will send back the following response:
+
+[source, json]
+----
+[
+  {
+    "targets": [
+      "node1:18091",
+      "node2:18091",
+      "node3:18091"
+    ],
+    "labels": {
+      "cluster_uuid": "4798c8f9-89bd-d7bf-4bcf-d93fb3e03e46",
+      "cluster_name": "DB1"
+    }
+  }
+]
+
+----
+
 [[old-api]]
 == Replicate the Earlier Discovery API
 
-The earlier `/prometheus_sd_config.yaml` discovery API endpoint returned a list of nodes in your Couchbase Server in a different format than the default output of the `/prometheus_sd_config`. 
+The earlier `/prometheus_sd_config.yaml` discovery API endpoint returned a list of nodes in your Couchbase Server in a different format than the default output of the `/prometheus_sd_config`.
 If you have already configured Prometheus using the old endpoint, you can have the new endpoint return the same output by using the following parameters:
 
 [source, shell]
@@ -105,7 +139,7 @@ If you have already configured Prometheus using the old endpoint, you can have t
 curl -s --get -u prometheus:password http://node1:8091/prometheus_sd_config \
      -d type=yaml \
      -d disposition=attachment \
-     -d port=insecure 
+     -d port=insecure
 ----
 
 The equivalent encoded URI that you can add to your Prometheus configuration is:


### PR DESCRIPTION

Added information on the new `clusterLabels` parameter to the Prometheus discovery API page.