### PR TITLE
[DOC-12706]: Documentation needed for changes to the Prometheus Discovery API

### DIFF
--- a/modules/rest-api/pages/rest-discovery-api.adoc
+++ b/modules/rest-api/pages/rest-discovery-api.adoc
@@ -36,6 +36,7 @@ By default, the discovery endpoint returns the list of nodes in your database th
 ----
 curl --get -u <username:password> \
     http://<ip-address-or-domain-name>:<port-number>/prometheus_sd_config
+    -d clusterLabels=[none|uuidAndName|uuidOnly]
     -d disposition=[attachment|inline]
     -d network=[default|external]
     -d port=[insecure|secure]
@@ -48,6 +49,11 @@ This is the same role Couchbase Server requires to retrieve metrics.
 
 === Parameters
 
+clusterLabels=[none|uuidAndName|uuidOnly]::
+Controls the inclusion of information labels for the cluster.
+When set to `none`, no labels are included in the response.
+When set to `uuidAndName`, both the UUID and the name of the node are added to the response.
+When set to `uuidOnly`, only the UUID of the node is returned in the response.
 disposition=[attachment|inline]::
 Controls how Couchbase Server returns the list of nodes in the response. 
 When set to the default `inline`, it returns the list inline within the response.
@@ -92,6 +98,34 @@ The next example shows the response that Couchbase Server sends in response to t
     ]
   }
 ]
+----
+
+Adding the `clusterLabels` parameter to the message payload will add additional node information to the response. For example, this command:
+
+[source, shell]
+----
+curl -s --get -u prometheus:password http://node1:8091/prometheus_sd_config \
+-d clusterLabels=uuidAndName | jq
+----
+
+will send back the following response:
+
+[source, json]
+----
+[
+  {
+    "targets": [
+      "node1:18091",
+      "node2:18091",
+      "node3:18091"
+    ],
+    "labels": {
+      "cluster_uuid": "4798c8f9-89bd-d7bf-4bcf-d93fb3e03e46",
+      "cluster_name": "DB1"
+    }
+  }
+]
+
 ----
 
 [[old-api]]


### PR DESCRIPTION

Adding details of the new `clusterLabels` parameter to the Prometheus discovery API page.