### PR TITLE
MB-61925 Backporting Hyun-Ju's fixes to 7.2.

### DIFF
--- a/modules/rest-api/pages/rest-initialize-cluster.adoc
+++ b/modules/rest-api/pages/rest-initialize-cluster.adoc
@@ -37,11 +37,11 @@ curl -X POST http://<ip-address-or-domain-name>:8091/clusterInit
   -d hostname=<ip-address-or-domain-name>
   -d username=<username>
   -d password=<password>
-  -d data_path=<data-path>
-  -d index_path=<index-path>
-  -d cbas_path=<analytics-path>
-  -d eventing_path=<eventing-path>
-  -d java_home=<jre-path>
+  -d dataPath=<data-path>
+  -d indexPath=<index-path>
+  -d analyticsPath=<analytics-path>
+  -d eventingPath=<eventing-path>
+  -d javaHome=<jre-path>
   -d sendStats=true
   -d clusterName=<cluster-name>
   -d services=<list-of-service-names>
@@ -72,13 +72,13 @@ This parameter must be specified.
 A string that will be the password for the new cluster.
 This parameter must be specified.
 
-* `data_path`, `index_path`, `cbas_path`, `eventing_path`.
+* `dataPath`, `indexPath`, `analyticsPath`, `eventingPath`.
 Paths for the storage of data to be used by the Data, Index, Analytics, and Eventing Services.
 All paths must be writable by user `couchbase`.
 These parameters are optional.
 For the default values, see xref:rest-api:rest-initialize-node.adoc[Initializing a Node].
 
-* `java_home`.
+* `javaHome`.
 Location of the JRE to be used by the Analytics Service.
 The specified path must be writable by user `couchbase`.
 This parameter is optional.
@@ -89,7 +89,7 @@ Whether the cluster should send statistics to Couchbase, for analysis.
 This parameter is optional.
 The value can be `true` (the default) or `false`.
 
-* `cluster_name`.
+* `clusterName`.
 A name for the cluster.
 This name is for convenience of identification, and will not be used for network access.
 This parameter is optional.

--- a/modules/rest-api/pages/rest-initialize-node.adoc
+++ b/modules/rest-api/pages/rest-initialize-node.adoc
@@ -40,7 +40,7 @@ Per platform, the default data-folder locations for all services are:
 ----
 curl -X POST http://<node-ip-address-or-domain-name>:8091/nodes/self/controller/settings
   -u <username>:<password>
-  -d data_path=<data-path>
+  -d path=<data-path>
   -d index_path=<index-path>
   -d cbas_path=<analytics-path>
   -d eventing_path=<eventing-path>
@@ -64,7 +64,7 @@ The following example establishes the paths for the Data, Index, Analytics, and 
 ----
 curl -X POST \
   http://10.142.181.103:8091/nodes/self/controller/settings \
-  -d 'data_path=%2Fopt%2Fcouchbase%2Fvar%2Flib%2Fcouchbase%2Fdata&' \
+  -d 'path=%2Fopt%2Fcouchbase%2Fvar%2Flib%2Fcouchbase%2Fdata&' \
   -d 'index_path=%2Fopt%2Fcouchbase%2Fvar%2Flib%2Fcouchbase%2Fidata&' \
   -d 'cbas_path=%2Fopt%2Fcouchbase%2Fvar%2Flib%2Fcouchbase%2Fadata&' \
   -d 'eventing_path=%2Fopt%2Fcouchbase%2Fvar%2Flib%2Fcouchbase%2Fedata&'


### PR DESCRIPTION
Backporting Hyun-Ju's fixes for DOC-12446 to 7.2 to satisfy [MB-61925](https://jira.issues.couchbase.com/browse/MB-61925).

Update rest-initialize-cluster.adoc syntax (#3701)

The syntax had incorrect field names, so corrected.  Note that the example on the same page had the correct field names.

(cherry picked from commit 6073c1735c54e3bd5485e6b46618b1160176c990)

[MB-61925]: https://couchbasecloud.atlassian.net/browse/MB-61925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ