### PR TITLE
[DOC-12729/release/7.6]: Feedback on Disabling Transparent Huge Pages (THP) | Couchbase Docs

### DIFF
--- a/modules/install/pages/thp-disable.adoc
+++ b/modules/install/pages/thp-disable.adoc
@@ -3,18 +3,26 @@
 :tabs:
 
 [abstract]
+--
 {description}
-THP must be disabled in order for Couchbase Server to function correctly on Linux.
+
+THP must be disabled in order for Couchbase Server to function correctly on Linux, as having THP enabled can worsen performance and possibly lead to an OOM kill. 
+--
 
 In Linux operating systems, _huge pages_ is a feature that provides a way for the CPU and OS to create pre-allocated contiguous memory space, and which is designed to improve application performance.
-_Transparent huge pages (THP)_ is a Linux OS feature that automates the creation of contiguous memory space, and conceals much of the complexity of using actual huge pages on systems with large amounts of memory.
+_Transparent huge pages (THP)_ is a Linux OS feature that automates the creation of contiguous memory space and conceals much of the complexity of using actual huge pages on systems with large amounts of memory.
 
 THP is enabled by default in most Linux operating systems, and functions very well for most applications and processes.
 However, THP is detrimental to Couchbase's performance (as it is for nearly all databases that tend to have sparse rather than contiguous memory access patterns).
 
-You must disable THP on Linux systems to ensure the optimal performance of Couchbase Server.
+Since we tend to have more random, sparse data access, we allocate pages that can remain mostly empty.
+This leads to memory fragmentation as portions of memory are not used but still accounted for in the RSS.
+As a result, the data stored which we keep track of may be smaller while RSS can be significantly higher,
+leading to possible OOM kill.
 
-NOTE: If you are using Rocky Linux, then <<using-thp-service, use the instructions to install the THP disabler as a system service.>>
+Therefore, you must disable THP on Linux systems to ensure the optimal performance of Couchbase Server.
+
+NOTE: If you are using Rocky Linux, then <<using-thp-service,use the instructions to install the THP disabler as a system service.>>
 
 
 
@@ -86,7 +94,7 @@ sudo chmod 755 /etc/init.d/disable-thp
 
 . Configure the OS to run the script on boot.
 +
-[{tabs}] 
+[tabs] 
 ==== 
 Red Hat, CentOS, & Amazon Linux::
 +
@@ -130,7 +138,7 @@ When they are in use on a system, they can be used to enable and disable THP.
 
 To disable THP in `tuned` and `ktune`, you need to edit or create a new _profile_ that sets THP to `never`.
 
-[{tabs}] 
+[tabs] 
 ==== 
 Red Hat/CentOS 7:: 
 +


### PR DESCRIPTION

Clarified the reasoning behind disabling THP for Couchbase server.
Added extra details concerning the RSS and OOM kill.