### PR TITLE
[DOC-10842/release/7.0]: Wrong file extension

### DIFF
--- a/modules/manage/pages/monitor/set-up-prometheus-for-monitoring.adoc
+++ b/modules/manage/pages/monitor/set-up-prometheus-for-monitoring.adoc
@@ -28,7 +28,7 @@ This will generate a configuration file containing the target addresses of the n
 
 NOTE: The name and contents of the file will depend on the configuration of the cluster:
 
-.couchbase_sd_config_my-cluster.yml
+.couchbase_sd_config_my-cluster.yaml
 [source, yaml]
 ----
 - targets:
@@ -41,7 +41,7 @@ Create a new directory on your system and copy the file to the new directory:
 [source, console]
 ----
 mkdir ~/prometheus
-cp couchbase_sd_config_my-cluster.yml ~/prometheus
+cp couchbase_sd_config_my-cluster.yaml ~/prometheus
 ----
 
 == Create the Prometheus configuration file
@@ -75,7 +75,7 @@ The directory should contain the following files.
 📂 ~ (home directory)
 + 📂 prometheus
     📄 prometheus.yml
-    📄 couchbase_sd_config_my-cluster.yml
+    📄 couchbase_sd_config_my-cluster.yaml
 
 ----
 


### PR DESCRIPTION

Changed the extension on the generated file from `yml` to `yaml`.