### PR TITLE
DOC-12777: Update Eventing REST API with sync-gateway-aware options

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -508,7 +508,7 @@ include::cli:partial$cbcli/nav.adoc[]
     *** xref:rest-api:rest-fts-query.adoc[Active Queries]
     *** xref:rest-api:rest-fts-partition-file-transfer.adoc[Rebalance Based on File Transfer]
 
-   ** xref:eventing:eventing-api.adoc[Eventing Service API]
+   ** xref:eventing-rest-api:index.adoc[Eventing Service API]
 
    ** xref:analytics:rest-analytics.adoc[Analytics Service API]
      *** xref:analytics:rest-service.adoc[Analytics Service REST API]

--- a/modules/introduction/partials/new_features-76_4.adoc
+++ b/modules/introduction/partials/new_features-76_4.adoc
@@ -37,6 +37,13 @@ For more information about Vector Search similarity metrics, see xref:search:chi
 Use this new object to view detailed query debugging information and resolve query errors in the Web Console or through the REST API.
 For more information about how to run a query with this new object, see xref:search:search-request-params.adoc#validate[the validate property], xref:search:simple-search-rest-api.adoc#example-validate-a-search-query[Run a Simple Search with the REST API and curl/HTTP] or xref:search:simple-search-ui.adoc#example-validate-a-search-query[Run A Simple Search with the Web Console].
 
+[#new-features-764-eventing-service]
+=== Eventing Service
+
+* The Eventing Service now supports Sync Gateway.
+The Eventing REST API provides settings which enable individual Eventing functions to work with Sync Gateway.
+For more information, see xref:eventing-rest-api:index.adoc#adv_settings_update[Update Function Settings].
+
 === Supported Platforms
 
 * Support for Windows 10 is deprecated in Couchbase Server 7.6.4.

--- a/modules/rest-api/pages/rest-intro.adoc
+++ b/modules/rest-api/pages/rest-intro.adoc
@@ -153,7 +153,7 @@ include::partial$rest-search-service-table.adoc[]
 == Eventing Service API
 
 The _Eventing Service_ REST API provides methods for working with _Eventing Functions_.
-The complete API is listed at xref:eventing:eventing-api.adoc[Eventing REST API].
+The complete API is listed at xref:eventing-rest-api:index.adoc[].
 
 == Analytics Service API
 


### PR DESCRIPTION
Docs issue: DOC-12777

Adds Sync Gateway-aware Eventing REST API options to What's New in Couchbase Server 7.6.4. I haven't linked to the originating ticket because it was a CBSE.

Also updates links to the Eventing REST API. This is not strictly necessary because they were caught and handled by page redirects, but it's nice to point to the correct Antora co-ordinates.