### PR TITLE
Fix references to non-existent 7.2.3 CE edition

### DIFF
--- a/modules/install/pages/upgrade.adoc
+++ b/modules/install/pages/upgrade.adoc
@@ -104,10 +104,10 @@ TIP: As far as is possible, you should aim to keep your cluster up to date with 
 | Starting Version | Path to Current Version
 
 | 5.x
-| 5.x  -> 6.6 -> 7.2.3 -> 7.6.x{blank}xref:erlang-7-2-4-footnote2[^+[1]+^]
+| 5.x  -> 6.6 -> 7.2.2 -> 7.6.x{blank}xref:erlang-7-2-4-footnote2[^+[1]+^]
 
 | 6.x
-| 6.0 -> 6.6 -> 7.2.3 -> 7.6.x{blank}xref:erlang-7-2-4-footnote2[^+[1]+^]
+| 6.0 -> 6.6 -> 7.2.2 -> 7.6.x{blank}xref:erlang-7-2-4-footnote2[^+[1]+^]
 
 | 7.x
 | 7.0 -> 7.1 -> 7.6.x{blank}xref:erlang-7-2-4-footnote2[^+[1]+^]


### PR DESCRIPTION
There was no 7.2.3 version of CE, so we need to say 7.2.2. 