### PR TITLE
DOC-12886: correcting bucket memory quotas info

### DIFF
--- a/modules/learn/pages/buckets-memory-and-storage/memory.adoc
+++ b/modules/learn/pages/buckets-memory-and-storage/memory.adoc
@@ -71,10 +71,10 @@ This quota is allocated for the bucket on a per node basis and must be less than
 Set the memory quota based on the expected size of your dataset. 
 The memory quota for a bucket must support the minimum memory resident ratio of its xref:learn:buckets-memory-and-storage/storage-engines.adoc[storage engine]: 
 
-* *Couchstore*: The memory quota is recommended to be at least 10-20% of your expected dataset size. 
-* *Magma*: The memory quota is recommended to be at least 2% of your expected dataset size. 
+* *Couchstore*: The memory quota is recommended to be at least 10% of your expected dataset size. 
+* *Magma*: The memory quota is recommended to be at least 1% of your expected dataset size. 
 
-For example, if you expect to have about 2TBs of data per node in your cluster and want to use the *Magma* engine, you could set the memory quota for a bucket to 40GB. 
+For example, if you expect to have about 2TBs of data per node in your cluster and want to use the *Magma* engine, you could set the memory quota for a bucket to 20GB. 
 
 NOTE: These values are recommendations only. 
 The specific memory quota requirements for your bucket are dependent on access patterns, data density, and other factors.


### PR DESCRIPTION
Doc-12886 -- correcting bucket memory quotas info -- the corrected info is consistent with the information here --https://docs.couchbase.com/server/current/learn/buckets-memory-and-storage/storage-engines.html#couchstore-and-magma-at-a-glance