### PR TITLE
[DOC-12779] Configuring ftsMemoryQuota

### DIFF
--- a/modules/fts/pages/fts-advanced-settings-ftsMemoryQuota.adoc
+++ b/modules/fts/pages/fts-advanced-settings-ftsMemoryQuota.adoc
@@ -7,7 +7,7 @@ You can configure the `ftsMemoryQuota` from the Couchbase Server Web Console at 
 
 If you're using the Search Service as the only Service on a node, it's recommended to set the `ftsMemoryQuota` to 80% or less of the total available RAM for that node.
 This makes sure to leave enough RAM for your operating system to manage its on-demand filesystem cache.
-The bleve text indexing library uses memory mapping for index files, which uses the operating system cache.
+The search process memory maps your index files to support fast access to indexed content.
 
 == Configure the ftsMemoryQuota
 

--- a/modules/fts/pages/fts-advanced-settings-ftsMemoryQuota.adoc
+++ b/modules/fts/pages/fts-advanced-settings-ftsMemoryQuota.adoc
@@ -1,28 +1,18 @@
 = ftsMemoryQuota
 
-The `ftsMemoryQuota` setting controls the maximum usable memory for the FTS Search service from the total amount of RAM available in the system. 
+The `ftsMemoryQuota` setting controls the maximum usable memory, in MiB, available to the Search Service on each node in your cluster.
+This RAM allocation applies to each node that has the Search Service in 1 of its Service Groups.
 
-Sparing enough RAM memory for the filesystem cache is crucial to override the ftsMemoryQuota.
+You can configure the `ftsMemoryQuota` from the Couchbase Server Web Console at any time.
 
-The FTS Search service recommends a minimum of 512 MB memory-resident ratio for its index. However, users can spare more memory quota for a healthy resident ratio of the index. This lets the system have sufficient memory available to perform indexing, querying, or other lifecycle operations like rebalances, etc.
+If you're using the Search Service as the only Service on a node, it's recommended to set the `ftsMemoryQuota` to 80% or less of the total available RAM for that node.
+This makes sure to leave enough RAM for your operating system to manage its on-demand filesystem cache.
+The bleve text indexing library uses memory mapping for index files, which uses the operating system cache.
 
-Using the manager option, users can control the FTS/Search service's memory quota at run time without a service reboot.
+== Configure the ftsMemoryQuota
 
-== Spare enough memory for filesystem cache
-Another important aspect while configuring the Search memory quota is to leave sufficient leeway RAM for the Operating System to manage the file system cache.
+To configure the `ftsMemoryQuota` setting: 
 
-The Search’s internal text indexing library (bleve) uses memory mapping for the index files, so having enough RAM extra for the operating system helps in keeping the hot regions of index files in the file system cache memory. 
-
-This helps in better search performance.
-The usual guideline is to set the Search memory quota to 60-70% of the available RAM in a Search node.
-
-Configuring enough RAM memory in the system and allocating sufficient Search quota memory is essential for optimal search performance.
-
-=== Example
-
-[source,console]
-----
-curl -XPUT -H "Content-type:application/json" http://username:password@<ip>:8094/api/managerOptions \-d '{
-    "ftsMemoryQuota": "1024"
-}
-----
+. From the Couchbase Server Web Console, go to *Settings*. 
+. Under *Memory Quotas*, in the *Search* field, enter a value, in MiB, for the total amount of RAM you want to allocate to the Search Service for each node in your cluster.
+. Click btn:[Save].

--- a/modules/fts/pages/fts-advanced-settings-ftsMemoryQuota.adoc
+++ b/modules/fts/pages/fts-advanced-settings-ftsMemoryQuota.adoc
@@ -5,8 +5,8 @@ This RAM allocation applies to each node that has the Search Service in 1 of its
 
 You can configure the `ftsMemoryQuota` from the Couchbase Server Web Console at any time.
 
-If you're using the Search Service as the only Service on a node, it's recommended to set the `ftsMemoryQuota` to 80% or less of the total available RAM for that node.
-This makes sure to leave enough RAM for your operating system to manage its on-demand filesystem cache.
+If you're using the Search Service as the only Service on a node, set the `ftsMemoryQuota` to 80% or less of the total available RAM for that node.
+This guideline leaves enough RAM for your operating system to manage its on-demand filesystem cache.
 The search process memory maps your index files to support fast access to indexed content.
 
 == Configure the ftsMemoryQuota


### PR DESCRIPTION
Request came in on this ticket for the unit of measure for setting the ftsMemoryQuota. 

I did some digging while I was in here and found out that some of the information is actually wrong? 

So now this is updating how the ftsMemoryQuota can actually be configured in Server.

Preview site: https://preview.docs-test.couchbase.com/sarah-DOC-12779/server/current/fts/fts-advanced-settings-ftsMemoryQuota.html

Username and password: https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords 