### PR TITLE
DOC-12699: Update views-intro.adoc

### DIFF
--- a/modules/learn/pages/views/views-intro.adoc
+++ b/modules/learn/pages/views/views-intro.adoc
@@ -5,7 +5,7 @@
 [abstract]
 {description}
 
-NOTE: Views are deprecated in Couchbase Server 7.0+. Views support in Couchbase Server will be removed in a future release only when the core functionality of the View engine is covered by other services. Views will not run on the newer xref:learn:buckets-memory-and-storage/storage-engines.adoc[Magma storage engine].
+NOTE: Views are deprecated in Couchbase Server 7.0+. Views support in Couchbase Server will be removed in a future release. Instead of views, use indexes and queries using the xref:learn:services-and-indexes/services/index-service.adoc[Index Service] (GSI) and the xref:learn:services-and-indexes/services/query-service.adoc[Query Service] (SQL++). Views will not run on the newer xref:learn:buckets-memory-and-storage/storage-engines.adoc[Magma storage engine].
 
 A view creates an index on the data according to the defined format and structure.
 The view consists of specific fields and information extracted from the objects in Couchbase.

--- a/modules/learn/pages/views/views-intro.adoc
+++ b/modules/learn/pages/views/views-intro.adoc
@@ -5,7 +5,10 @@
 [abstract]
 {description}
 
-NOTE: Views are deprecated in Couchbase Server 7.0+. Views support in Couchbase Server will be removed in a future release. Instead of views, use indexes and queries using the xref:learn:services-and-indexes/services/index-service.adoc[Index Service] (GSI) and the xref:learn:services-and-indexes/services/query-service.adoc[Query Service] (SQL++). Views will not run on the newer xref:learn:buckets-memory-and-storage/storage-engines.adoc[Magma storage engine].
+NOTE: Views are deprecated in Couchbase Server 7.0+.
+Views support in Couchbase Server will be removed in a future release.
+Instead of views, use indexes and queries using the xref:learn:services-and-indexes/services/index-service.adoc[Index Service] (GSI) and the xref:learn:services-and-indexes/services/query-service.adoc[Query Service] ({sqlpp}).
+Views will not run on the newer xref:learn:buckets-memory-and-storage/storage-engines.adoc[Magma storage engine].
 
 A view creates an index on the data according to the defined format and structure.
 The view consists of specific fields and information extracted from the objects in Couchbase.


### PR DESCRIPTION
Update views deprecation notice to include that customers should use "Instead of views, use indexes and queries using the Index Service (GSI) and the Query Service (SQL++)".