### PR TITLE
[DOC-12916]: Add release notes for Couchbase Server 7.2.7

### DIFF
--- a/modules/introduction/pages/whats-new.adoc
+++ b/modules/introduction/pages/whats-new.adoc
@@ -12,6 +12,7 @@ For information about platform support changes, deprecation notifications, notab
 
 The following new features are provided in this release.
 
+include::partial$new-features-7.2.7.adoc[]
 include::partial$new-features-7.2.6.adoc[]
 include::partial$new-features-72.adoc[]
 

--- a/modules/introduction/partials/new-features-7.2.7.adoc
+++ b/modules/introduction/partials/new-features-7.2.7.adoc
@@ -1,0 +1,9 @@
+[#new-features-727]
+=== What's new in 7.2.7
+
+* The following new platforms are supported.
+** Windows Server 2025
+
+
+
+

--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -1,5 +1,7 @@
 = Release Notes for Couchbase Server 7.2
 
+include::partial$docs-server-7.2.7-release-note.adoc[]
+
 include::partial$docs-server-7.2.6-release-note.adoc[]
 
 include::partial$docs-server-7.2.5-release-note.adoc[]

--- a/modules/release-notes/partials/docs-server-7.2.0-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.2.0-release-note.adoc
@@ -1,7 +1,6 @@
 [#release-720]
 == Release 7.2
 
-[#new-features-720]
 === New Features and Enhancements
 
 include::introduction:partial$new-features-72.adoc[]

--- a/modules/release-notes/partials/docs-server-7.2.7-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.2.7-release-note.adoc
@@ -6,9 +6,8 @@ This maintenance release contains the following fixes.
 
 === Fixed Issues
 
-==== Data Service
-
-[#table-fixed-issues-727-data-service, cols="10,40,40"]
+==== Storage Engine
+[#table-fixed-issues-727-storage-engine, cols="10,40,40"]
 |===
 |Issue | Description | Resolution
 
@@ -28,6 +27,21 @@ a|A bug in the plasma tracking statistics incorrectly marked stale recovery poin
 
 | The system now marks only the latest recovery point that exists in both the recovery log and data log. This change effectively limits the recovery point history list to a single entry in the recovery log. The plasma tracking statistics have been fixed to correctly identify older recovery points as stale data in the recovery log. These improvements allow the log cleaner to run efficiently even at low mutation rates.
 
+
+
+|===
+
+==== Data Service
+
+[#table-fixed-issues-727-data-service, cols="10,40,40"]
+|===
+|Issue | Description | Resolution
+
+
+| https://jira.issues.couchbase.com/browse/MB-63827[MB-63827]
+| DCP connection metrics with connection names that do not conform to the server format are not exposed to Prometheus.
+
+| The metrics are aggregated and exposed with `connection_type="_unknown"`.
 
 |===
 

--- a/modules/release-notes/partials/docs-server-7.2.7-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.2.7-release-note.adoc
@@ -1,0 +1,47 @@
+[#release-727]
+== Release 7.2.7 (February 2025)
+
+Couchbase Server 7.2.7 was released in February 2025.
+This maintenance release contains the following fixes.
+
+=== Fixed Issues
+
+==== Data Service
+
+[#table-fixed-issues-727-data-service, cols="10,40,40"]
+|===
+|Issue | Description | Resolution
+
+| https://jira.issues.couchbase.com/browse/MB-63261[MB-63261]
+| An issue occurred caused by a race condition in the index recovery code path, which may result in item count mismatch and wrong query results. 
+Prior to Release `7.6.0`, this issue may occur during an Indexer restart. 
+However, as part of the file-based rebalance process introduced in `7.6.0`, a recovery of the index is performed after the index is moved, which increases the likelihood that this race condition might be reached.
+
+| The race condition has been addressed and the issue is resolved.
+
+
+| https://jira.issues.couchbase.com/browse/MB-64742[MB-64742]
+a|A bug in the plasma tracking statistics incorrectly marked stale recovery points in the recovery log as valid data. This caused two problems:
+
+* At low mutation rates, the log cleaning process ran slowly and couldn't effectively trim recovery point history.
+* At higher mutation rates, the system worked around this issue because mutations would increase the fragmentation ratio enough to trigger the log cleaner, which could then trim recovery point history despite the tracking statistics bug.
+
+| The system now marks only the latest recovery point that exists in both the recovery log and data log. This change effectively limits the recovery point history list to a single entry in the recovery log. The plasma tracking statistics have been fixed to correctly identify older recovery points as stale data in the recovery log. These improvements allow the log cleaner to run efficiently even at low mutation rates.
+
+
+|===
+
+==== XDCR
+
+[#table-fixed-issues-727-xdcr, cols="10,40,40"]
+|===
+|Issue | Description | Resolution
+
+| https://jira.issues.couchbase.com/browse/MB-64565[MB-64565]
+| If users did not want the replication to be automatically deleted upon either source or bucket deletion and/or recreation, they could set the `skipReplSpecAutoGc` replication setting to `true` upon replication creation. 
+
+In the situation that the replication would have been deleted, it would have been automatically paused instead, and a persistent UI error message logged for viewing. Users are expected to manually execute the recovery action by deleting the replication and re-creating a newer one, if necessary.
+
+| In the situation that the replication has been deleted, it will be automatically paused instead, and a persistent UI error message logged for viewing. Users are then expected to manually execute the recovery action by deleting the replication and re-creating a newer one, if necessary.
+
+|===


### PR DESCRIPTION

Adding release note for Couchbase Server 7.2.7

----

You can view the preview here:

https://preview.docs-test.couchbase.com/docs-server-DOC-12916-Create-Release-Note-for-7.2.7/server/current/release-notes/relnotes.html