### PR TITLE
[DOC-12885]: System resource requirements page does not list exception for higher Backup Service requirements

### DIFF
--- a/modules/install/pages/pre-install.adoc
+++ b/modules/install/pages/pre-install.adoc
@@ -39,7 +39,7 @@ Network file systems such as CIFS and NFS are not supported.
 =====
 If the node is used for administering backups, then be aware that the resource requirements will be higher.
 
-The minimum hardware requirement for running `cbbackupmgr` is four CPU cores and 8GiB RAM. 
+The minimum hardware requirement is four CPU cores and 8GiB RAM. 
 
 The recommended hardware is sixteen CPU cores, 16GiB RAM, and SSD disks.
 

--- a/modules/install/pages/pre-install.adoc
+++ b/modules/install/pages/pre-install.adoc
@@ -37,26 +37,15 @@ Network file systems such as CIFS and NFS are not supported.
 [IMPORTANT]
 .Backup Nodes
 =====
-If the node is used for administering backups, then be aware that the resource requirements will be higher:
+If the node is used for administering backups, then be aware that the resource requirements will be higher.
+
+The minimum hardware requirement for running `cbbackupmgr` is four CPU cores and 8GiB RAM. 
+
+The recommended hardware is sixteen CPU cores, 16GiB RAM, and SSD disks.
+
 =====
 
-| *CPU*
-| 2 GHz quad-core x86_64 CPU supporting SSE4.2
-| 3 GHz sixteen-core x86_64 CPU supporting SSE4.2 and above
 
-| *RAM*
-| 8 GiB (physical)
-| 16 GB (physical) and above
-
-| *Storage (disk space)*
-a|
-8 GiB (block-based; HDD, SSD, EBS, iSCSI)
-
-Network file systems such as CIFS and NFS are not supported.
-a|
-16 GiB and above (SSD)
-
-Network file systems such as CIFS and NFS are not supported.
 |===
 --
 

--- a/modules/install/pages/pre-install.adoc
+++ b/modules/install/pages/pre-install.adoc
@@ -14,22 +14,47 @@ x86 Processors::
 | | Minimum Specifications* | Recommended Specifications**
 
 | *CPU*
-| 2 GHz dual core x86_64 CPU supporting SSE4.2
-| 3 GHz quad core x86_64 CPU supporting SSE4.2 and above
+| 2 GHz dual-core x86_64 CPU supporting SSE4.2
+| 3 GHz quad-core x86_64 CPU supporting SSE4.2 and above
 
 3 GHz six core x86_64 CPU supporting SSE4.2 when using Cross Datacenter Replication (XDCR) and Views
 
 | *RAM*
-| 4 GB (physical)
+| 4 GiB (physical)
+| 16 GiB (physical) and above
+
+| *Storage (disk space)*
+a|
+8 GiB (block-based; HDD, SSD, EBS, iSCSI)
+
+Network file systems such as CIFS and NFS are not supported.
+a|
+16 GiB and above (SSD)
+
+Network file systems such as CIFS and NFS are not supported.
+
+3+a| 
+[IMPORTANT]
+.Backup Nodes
+=====
+If the node is used for administering backups, then be aware that the resource requirements will be higher:
+=====
+
+| *CPU*
+| 2 GHz quad-core x86_64 CPU supporting SSE4.2
+| 3 GHz sixteen-core x86_64 CPU supporting SSE4.2 and above
+
+| *RAM*
+| 8 GiB (physical)
 | 16 GB (physical) and above
 
 | *Storage (disk space)*
 a|
-8 GB (block-based; HDD, SSD, EBS, iSCSI)
+8 GiB (block-based; HDD, SSD, EBS, iSCSI)
 
 Network file systems such as CIFS and NFS are not supported.
 a|
-16 GB and above (block-based; HDD, SSD, EBS, iSCSI)
+16 GiB and above (SSD)
 
 Network file systems such as CIFS and NFS are not supported.
 |===
@@ -47,16 +72,41 @@ ARM Processors::
 | 2.5 Ghz quad core 64bit ARM v8 CPU
 
 | *RAM*
-| 4 GB (physical)
-| 16 GB (physical) and above
+| 4 GiB (physical)
+| 16 GiB (physical) and above
 
 | *Storage (disk space)*
 a|
-8 GB (block-based; HDD, SSD, EBS, iSCSI)
+8 GiB (block-based; HDD, SSD, EBS, iSCSI)
 
 Network file systems such as CIFS and NFS are not supported.
 a|
-16 GB and above (block-based; HDD, SSD, EBS, iSCSI)
+16 GiB and above (SSD)
+
+Network file systems such as CIFS and NFS are not supported.
+
+3+a| 
+[IMPORTANT]
+.Backup Nodes
+=====
+If the node is used for administering backups, then be aware that the resource requirements will be higher:
+=====
+
+| *CPU*
+| 2 GHz quad-core x86_64 CPU supporting SSE4.2
+| 3 GHz sixteen-core x86_64 CPU supporting SSE4.2 and above
+
+| *RAM*
+| 8 GiB (physical)
+| 16 GiB (physical) and above
+
+| *Storage (disk space)*
+a|
+8 GiB (block-based; HDD, SSD, EBS, iSCSI)
+
+Network file systems such as CIFS and NFS are not supported.
+a|
+16 GiB and above (SSD)
 
 Network file systems such as CIFS and NFS are not supported.
 |===


### PR DESCRIPTION
### Description of Changes

- Updated the hardware requirements documentation to include higher resource specifications for nodes administering the Backup Service.
- Made CPU description formatting more consistent by adjusting hyphenation.
- Added a dedicated section for backup node requirements with updated CPU and RAM recommendations.

----

Preview can be viewed here:

https://preview.docs-test.couchbase.com/docs-server-DOC-12885-System-resource-requirements-page-does-not-list-exception-for-higher-Backup-Service-requirements/server/current/install/pre-install.html

