### PR TITLE
[DOC-12589]: Downgrade section is not completely correct

### DIFF
--- a/modules/install/pages/upgrade.adoc
+++ b/modules/install/pages/upgrade.adoc
@@ -27,14 +27,14 @@ Before upgrading, consider the following version compatibility concerns.
 // So long as upgrading from 6.x is supported, this notice will need to stay in some form in each new release.
 === Upgrading to Version 7.x With Earlier Versions of .NET SDK
 
-When upgrading from Couchbase 6.5 or 6.6 to 7.0 or later determine if both of the following are true:
+When upgrading from Couchbase 6.5 or 6.6 to 7.0 or later, determine if both of the following are true:
 
 * You use a version of the .NET SDK prior to 3.2.9.
 * Your cluster is in mixed mode networking where some nodes use IPv4 addressing and others use IPv6. 
 See xref:manage:manage-nodes/manage-address-families.adoc#changing-address-family-to-IPv6[Changing Address Family] for steps to determine if your cluster is running in this mode.
 
 Using a version of the .NET SDK prior to 3.2.9 with mixed mode network addressing can cause issues with write operations. 
-Before upgrading, resolve the mixed mode networking issue.
+Before upgrading, resolve the mixed-mode networking issue.
 
 
 === Upgrading from Pre-7.1 Versions of Couchbase Server
@@ -43,7 +43,7 @@ You cannot upgrade directly from a version of Couchbase Server earlier than 7.1 
 For example, you can directly upgrade from version 6.6 to version 7.2.3.
 You cannot directly upgrade from version 6.6 to version 7.2.4. 
 A compatibility issue with the Erlang version used by these earlier server versions prevents a direct upgrade to later versions of the server. 
-To upgrade from server versions 6.5, 6.6, or 7.0 to version 7.6 or later, first upgrade to version between 7.1 and 7.2.3. 
+To upgrade from server versions 6.5, 6.6, or 7.0 to version 7.6 or later, first upgrade to a version between 7.1 and 7.2.3. 
 Then upgrade to version 7.6 or later.
 
 [#understanding-upgrade]
@@ -60,7 +60,7 @@ A review of the factors that determine the appropriateness of an upgrade-procedu
 [#supported-upgrade-paths]
 == Upgrade Paths
 
-An upgrade _path_ declares that the upgrade of one version of Couchbase Server to another is _supported_.
+An upgrade _path_ declares that the upgrading one version of Couchbase Server to another is _supported_.
 The tables in the following subsections list upgrade paths for Enterprise Edition and for Community Edition, respectively.
 Each instance of the{nbsp}`->`{nbsp}sign declares support for the upgrade of the server-version on the left of the sign to the server-version on the right.
 
@@ -196,7 +196,7 @@ and finally, from *7.2.3* to *7.6.x*.
 
 If you’re currently operating a Couchbase Server cluster on Community Edition, you can upgrade it to Enterprise Edition by way of a xref:upgrade-strategies.adoc#online-upgrade[rolling online upgrade].
 This involves switching out the Community Edition nodes with fresh, net-new Enterprise Edition nodes.
-Both swap rebalance and remove and reblance methods are supported.
+Both swap rebalance and remove and rebalance methods are supported.
 Delta Recovery is not supported since the new nodes must be fresh Enterprise Edition installations without any pre-existing Community Edition data remaining on them.
 
 NOTE: Rolling upgrades from CE to EE are not supported if there are index service nodes running in the cluster.
@@ -217,11 +217,12 @@ include::partial$diagrams.adoc[tag="upgrade-diagram"]
 .Additional Notes about Upgrading from Community to Enterprise
 [sidebar]
 ****
-* Couchbase Server clusters _must_ be run either entirely on Enterprise Edition nodes, or entirely on Community Edition nodes. +
+* Couchbase Server clusters _must_ be run either entirely on Enterprise Edition nodes or entirely on Community Edition nodes. +
 Once you've upgraded one node to Enterprise Edition, you must upgrade all the other nodes before the cluster is considered as being in a steady, supportable state.
 * CE does not support index service rebalancing.
 So, when the cluster is running with one or more CE nodes, then the indexes hosted on nodes being removed may be lost. +
- Users can create equivalent indexes (same index with different name) on different nodes, to avoid loss of index functionality.
+ Users can create equivalent indexes (the same index with a different name) on different nodes
+ to avoid loss of index functionality.
 * If a rolling online upgrade to Enterprise Edition isn't possible in your environment, contact Couchbase for assistance.
 ****
 
@@ -232,8 +233,10 @@ If you're interested in upgrading to Couchbase Server Enterprise Edition, check 
 ====
 
 
-See xref:install:upgrade-procedure-selection.adoc[Upgrade Procedure-Selection], for a list of procedures that can be used when upgrading from Community Edition to Enterprise.
-Note, however, that _Graceful Failover_ for Data Service nodes, with _Delta Recovery_, is _not_ supported for such upgrades: instead, _removal_, _addition_, and _swap rebalance_ should be used; for all nodes.
+See xref:install:upgrade-procedure-selection.adoc[Upgrade Procedure-Selection] for a list of procedures
+that can be used when upgrading from Community Edition to Enterprise.
+Note, however, that _Graceful Failover_ for Data Service nodes, with _Delta Recovery_,
+is _not_ supported for such upgrades: instead, _removal_, _addition_, and _swap rebalance_ should be used; for all nodes.
 
 [#node-naming-and-upgrade]
 == Node-Naming and Upgrade
@@ -246,10 +249,13 @@ For information, see xref:learn:security/certificates.adoc#node-certificate-vali
 == Downgrade
 
 Once an upgrade of a Couchbase-Server cluster has started,
-_downgrade_ to the earlier version of Couchbase Server can be performed,
-as long as one node continues to run the earlier version.
-To downgrade an existing node, you must first remove the existing Linux package installer, then install an earlier version.
-However, once all nodes are running the later version, downgrade can no longer be performed: therefore,
+_downgrading_ to an earlier version of Couchbase Server can be performed by using the _swap/rebalance_ method:
+
+. Remove the target node from the cluster, then perform a rebalance on the cluster.
+. Downgrade the target node (or create a new node using the earlier version of Couchbase).
+. Add the node to the cluster and rebalance.
+
+Bear in mind that once all nodes are running the later version, downgrade can no longer be performed: therefore,
 once all nodes are running the later version,
 should application-support require the earlier version, an entirely new cluster must be created,
 running the earlier version.


### PR DESCRIPTION
### Summary

- Corrected inaccuracies in the `Downgrade` section.
- Fixed typos and grammatical errors.
- Enhanced clarity and resolved inconsistencies in the upgrade process documentation.

----

Preview:

https://preview.docs-test.couchbase.com/docs-server-DOC-12589-Downgrade-section-is-not-completely-correct/server/current/install/upgrade.html

