### PR TITLE
[DOC-12933]: New migration page

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -230,11 +230,15 @@ include::third-party:partial$nav.adoc[]
    **** xref:install:upgrade-docker-cluster-online-full-capacity.adoc[]
   *** xref:install:upgrade-ipv6-cluster.adoc[IPv6 Cluster-Upgrade]
  ** xref:install:upgrade-feature-availability.adoc[Feature Availability During Upgrade]
-* Migration
- ** xref:install:migrating-application-data.adoc[Migrating Data]
+* xref:install:couchbase-migrations.adoc[Data Migration]
+ ** xref:install:migrating-application-data.adoc[]
  ** xref:install:migration.adoc[Enabling Timestamp-based Conflict Resolution for Migrated Data]
- // ** xref:install:migrate-couchdb.adoc[Migrating from Apache CouchDB]
- // ** xref:install:migrate-mysql.adoc[Migrating from Relational Databases]
+ 
+////
+ ** xref:install:migrate-couchdb.adoc[Migrating from Apache CouchDB]
+ ** xref:install:migrate-mysql.adoc[Migrating from Relational Databases]
+////
+
 
 
 
@@ -309,6 +313,7 @@ include::cli:partial$cbcli/nav.adoc[]
   *** xref:cli:cbstats/cbstats-vkey.adoc[vkey]
   *** xref:cli:cbstats/cbstats-warmup.adoc[warmup]
   *** xref:cli:cbstats/cbstats-workload.adoc[workload]
+ ** xref:cli:cbmigrate-tool.adoc[] 
  ** xref:cli:cbsummary.adoc[cbsummary]
  ** xref:cli:cbtools/cbtransfer.adoc[cbtransfer]
  ** xref:cli:cbtools/cbworkloadgen.adoc[cbworkloadgen]

--- a/modules/cli/pages/cbmigrate-tool.adoc
+++ b/modules/cli/pages/cbmigrate-tool.adoc
@@ -1,0 +1,9 @@
+= cbmigrate
+:description: pass:q[Use the `cbmigrate` command-line tool to migrate your data from https://www.mongodb.com[MongoDB], https://aws.amazon.com/dynamodb/[DynamoDB], or https://huggingface.co[Hugging Face] to Couchbase.]
+
+[abstract]
+{description}
+
+[#syntax]
+== Syntax
+

--- a/modules/cli/pages/cbmigrate-tool.adoc
+++ b/modules/cli/pages/cbmigrate-tool.adoc
@@ -1,9 +1,29 @@
 = cbmigrate
-:description: pass:q[Use the `cbmigrate` command-line tool to migrate your data from https://www.mongodb.com[MongoDB], https://aws.amazon.com/dynamodb/[DynamoDB], or https://huggingface.co[Hugging Face] to Couchbase.]
+:description: pass:q[Use the `cbmigrate` command-line tool to migrate your data from other platforms.]
+:page-topic-type: reference
 
 [abstract]
 {description}
 
+== Description
+
+The `cbmigrate` tool will migrate your existing data from the following platforms:
+
+* https://www.mongodb.com[MongoDB]
+* https://aws.amazon.com/dynamodb/[DynamoDB]
+* https://huggingface.co[Hugging Face]
+
+== Installation
+
+You can download `cbmigrate` from its https://github.com/couchbaselabs/cbmigrate/releases[GitHub repository].
+
+Download the latest version for your platform and unpack the file to its own directory.
+
 [#syntax]
 == Syntax
 
+[source,shell]
+----
+cbmigrate [--version] [--help HELP]
+cbmigrate [command]
+----

--- a/modules/install/pages/couchbase-migrations.adoc
+++ b/modules/install/pages/couchbase-migrations.adoc
@@ -1,0 +1,27 @@
+= Migrating your Data to Couchbase
+:description: Couchbase offers a number of options for migrating your data from other platforms to Couchbase Server/Capella.
+
+[abstract]
+{description}
+
+Data migration can take one of two forms:
+
+== Data Migration from earlier versions of Couchbase
+
+With the release of Couchbase Version 7.0, we added support for scopes and collections, which adds more flexible abstraction for your data.
+
+For more information, see xref:learn:data/scopes-and-collections.adoc[]
+
+For more information on migrating from earlier versions of Couchbase, see xref:install:migrating-application-data.adoc[]
+
+== Migrating your data from other platforms
+
+You have the option of migrating your data from other platforms to Couchbase Server or Couchbase Capella
+
+We have a command line tool (`cbmigrate`) for this purpose, which currently supports migration from:
+
+* https://www.mongodb.com[Mongo DB]
+* https://aws.amazon.com/dynamodb/[Dynamo DB]
+* https://huggingface.co[Hugging Face]
+
+For more information, see xref:cli:cbmigrate-tool.adoc[]

--- a/modules/release-notes/partials/docs-server-7.6.0-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6.0-release-note.adoc
@@ -255,6 +255,43 @@ include::partial$index-upgrade-issue.adoc[]
 
 |===
 
+==== Query Service
+
+[#table-known-issues-760-query-service,cols="10,40,40"]
+|===
+|Issue | Description | Workaround
+
+// tag::MB-64966[]
+
+| https://jira.issues.couchbase.com/browse/MB-64966[MB-64966]
+| Scope level user-defined functions (UDFs), sequences, and histogram data are stored in the `bucket/_system/_query` collection. 
+
+``FLUSH``ing the bucket will delete the scoped UDF entries. 
+When the UDFs are executed, it will work until the UDFs are evicted from the cache.
+After that, the execution will always result in an error.
+
+Sequences metadata is also stored in the `bucket/_system/_query` collection. 
+FLUSHing the bucket will delete the entries. When executed, sequences will return errors once evicted from the cache.
+
+``FLUSH``ing the bucket will also delete statistics data stored in the `bucket/_system/_query` collection.
+ By using stale statistics stored in the cache, a non-optimal plan could be generated.
+
+a| For user-defined functions, you can do one of the following:
+
+* Recreate the scoped user-defined functions after the `FLUSH`.
+* Use global UDFs instead of scoped UDFs. (Global UDFs are not stored in the `_query` collection.)
+* Create scoped UDFs on the bucket that does not have FLUSH enabled and then reference them via a fully qualified name (`bucket.scope.UDFname`).
+
+For sequence metadata:
+
+* After the `FLUSH`, recreate the sequence, or
+* Create sequences on the bucket that does not have FLUSH enabled and then reference them via a fully qualified name (`bucket.scope.UDFname`).
+
+For statistical data, rerun `UPDATE STATISTICS` on all the indexes on every scope and collections in the bucket that was flushed.
+
+// end::MB-64966[]
+|===
+
 ==== Search Service
 [#table-known-issues-760-search-service, cols="10,40,40"]
 |===

--- a/modules/release-notes/partials/docs-server-7.6.1-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6.1-release-note.adoc
@@ -48,6 +48,17 @@ include::partial$index-upgrade-issue.adoc[]
 
 |===
 
+==== Query Service
+
+[#table-known-issues-761-query-service,cols="10,40,40"]
+|===
+|Issue | Description | Workaround
+
+include::partial$docs-server-7.6.0-release-note.adoc[tag="MB-64966"]
+
+|===
+
+
 ==== Search Service
 [#table-known-issues-761-search-service, cols="10,40,40"]
 |===

--- a/modules/release-notes/partials/docs-server-7.6.2-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6.2-release-note.adoc
@@ -206,6 +206,8 @@ This release contains the following known issues:
 | Disable memory quota or https://www.couchbase.com/support/working-with-technical-support/[contact support] for alternatives.
 // end::MB-63414[]
 
+include::partial$docs-server-7.6.0-release-note.adoc[tag="MB-64966"]
+
 |===
 
 ==== Index Service

--- a/modules/release-notes/partials/docs-server-7.6.3-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6.3-release-note.adoc
@@ -122,6 +122,8 @@ a| Disable memory quota or https://www.couchbase.com/support/working-with-techni
 
 NOTE: This issue is fixed on Capella.
 
+include::partial$docs-server-7.6.0-release-note.adoc[tag="MB-64966"]
+
 |===
 
 ==== Index Service

--- a/modules/release-notes/partials/docs-server-7.6.4-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6.4-release-note.adoc
@@ -196,7 +196,19 @@ because the server could delete the backup files.
 
 |===
 
+[#known-issues-764]
+=== Known Issues
 
+This release contains the following known issues:
 
+==== Query Service
+
+[#table-known-issues-764-query-service, cols="10,40,40"]
+|===
+|Issue | Description | Workaround
+
+include::partial$docs-server-7.6.0-release-note.adoc[tag="MB-64966"]
+
+|===
 
 

--- a/modules/release-notes/partials/docs-server-7.6.5-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6.5-release-note.adoc
@@ -84,3 +84,20 @@ This inadvertently caused a regression where a subsequent rebalance could get st
 
 |===
 
+
+[#known-issues-765]
+=== Known Issues
+
+This release contains the following known issues:
+
+==== Query Service
+
+[#table-known-issues-765-query-service, cols="10,40,40"]
+|===
+|Issue | Description | Workaround
+
+include::partial$docs-server-7.6.0-release-note.adoc[tag="MB-64966"]
+
+|===
+
+


### PR DESCRIPTION
### Description

This pull request introduces a new documentation page for Couchbase data migration. The new page provides detailed instructions on migrating data from previous Couchbase versions and other platforms using `cbmigrate`. The site navigation has also been updated to include this section under "Data Migration." 

### Checklist

N/A