### PR TITLE
[DOC-12943]: Add MB-64966 to known issues in 7.6.x

### DIFF
--- a/modules/release-notes/partials/docs-server-7.6.0-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6.0-release-note.adoc
@@ -255,6 +255,43 @@ include::partial$index-upgrade-issue.adoc[]
 
 |===
 
+==== Query Service
+
+[#table-known-issues-760-query-service,cols="10,40,40"]
+|===
+|Issue | Description | Workaround
+
+// tag::MB-64966[]
+
+| https://jira.issues.couchbase.com/browse/MB-64966[MB-64966]
+| Scope level user-defined functions (UDFs), sequences, and histogram data are stored in the `bucket/_system/_query` collection. 
+
+``FLUSH``ing the bucket will delete the scoped UDF entries. 
+When the UDFs are executed, it will work until the UDFs are evicted from the cache.
+After that, the execution will always result in an error.
+
+Sequences metadata is also stored in the `bucket/_system/_query` collection. 
+FLUSHing the bucket will delete the entries. When executed, sequences will return errors once evicted from the cache.
+
+``FLUSH``ing the bucket will also delete statistics data stored in the `bucket/_system/_query` collection.
+ By using stale statistics stored in the cache, a non-optimal plan could be generated.
+
+a| For user-defined functions, you can do one of the following:
+
+* Recreate the scoped user-defined functions after the `FLUSH`.
+* Use global UDFs instead of scoped UDFs. (Global UDFs are not stored in the `_query` collection.)
+* Create scoped UDFs on the bucket that does not have FLUSH enabled and then reference them via a fully qualified name (`bucket.scope.UDFname`).
+
+For sequence metadata:
+
+* After the `FLUSH`, recreate the sequence, or
+* Create sequences on the bucket that does not have FLUSH enabled and then reference them via a fully qualified name (`bucket.scope.UDFname`).
+
+For statistical data, rerun `UPDATE STATISTICS` on all the indexes on every scope and collections in the bucket that was flushed.
+
+// end::MB-64966[]
+|===
+
 ==== Search Service
 [#table-known-issues-760-search-service, cols="10,40,40"]
 |===

--- a/modules/release-notes/partials/docs-server-7.6.1-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6.1-release-note.adoc
@@ -48,6 +48,17 @@ include::partial$index-upgrade-issue.adoc[]
 
 |===
 
+==== Query Service
+
+[#table-known-issues-761-query-service,cols="10,40,40"]
+|===
+|Issue | Description | Workaround
+
+include::partial$docs-server-7.6.0-release-note.adoc[tag="MB-64966"]
+
+|===
+
+
 ==== Search Service
 [#table-known-issues-761-search-service, cols="10,40,40"]
 |===

--- a/modules/release-notes/partials/docs-server-7.6.2-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6.2-release-note.adoc
@@ -206,6 +206,8 @@ This release contains the following known issues:
 | Disable memory quota or https://www.couchbase.com/support/working-with-technical-support/[contact support] for alternatives.
 // end::MB-63414[]
 
+include::partial$docs-server-7.6.0-release-note.adoc[tag="MB-64966"]
+
 |===
 
 ==== Index Service

--- a/modules/release-notes/partials/docs-server-7.6.3-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6.3-release-note.adoc
@@ -122,6 +122,8 @@ a| Disable memory quota or https://www.couchbase.com/support/working-with-techni
 
 NOTE: This issue is fixed on Capella.
 
+include::partial$docs-server-7.6.0-release-note.adoc[tag="MB-64966"]
+
 |===
 
 ==== Index Service

--- a/modules/release-notes/partials/docs-server-7.6.4-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6.4-release-note.adoc
@@ -196,7 +196,19 @@ because the server could delete the backup files.
 
 |===
 
+[#known-issues-764]
+=== Known Issues
 
+This release contains the following known issues:
 
+==== Query Service
+
+[#table-known-issues-764-query-service, cols="10,40,40"]
+|===
+|Issue | Description | Workaround
+
+include::partial$docs-server-7.6.0-release-note.adoc[tag="MB-64966"]
+
+|===
 
 

--- a/modules/release-notes/partials/docs-server-7.6.5-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6.5-release-note.adoc
@@ -84,3 +84,20 @@ This inadvertently caused a regression where a subsequent rebalance could get st
 
 |===
 
+
+[#known-issues-765]
+=== Known Issues
+
+This release contains the following known issues:
+
+==== Query Service
+
+[#table-known-issues-765-query-service, cols="10,40,40"]
+|===
+|Issue | Description | Workaround
+
+include::partial$docs-server-7.6.0-release-note.adoc[tag="MB-64966"]
+
+|===
+
+


### PR DESCRIPTION
### Description

----
This pull request adds the known issue MB-64966 to the query service release notes for versions 7.6.0 to 7.6.5. The issue concerns the loss of scoped UDFs, sequences, and statistics data when a bucket is flushed. Documented workarounds and alternate strategies are included to mitigate the problem. 

### Type of change

- [x] Documentation update
- [ ] New feature
- [ ] Bug fix
----

### Preview

https://preview.docs-test.couchbase.com/docs-server-DOC-12943-Add-MB-64966-to-known-issues-in-7.6.x/server/current/release-notes/relnotes.html
