### PR TITLE
[DOC-12938]: Flag up incompatibility between Couchbase Server 7.6 and cbbackupmgr versions < 7.6

### DIFF
--- a/modules/introduction/pages/whats-new.adoc
+++ b/modules/introduction/pages/whats-new.adoc
@@ -8,6 +8,14 @@
 
 For information about platform support changes, deprecation notifications, notable improvements, and fixed and known issues, refer to the xref:release-notes:relnotes.adoc[Release Notes].
 
+.note regarding `cbbackupmgr`
+[IMPORTANT]
+====
+If you are performing a backup/restore operation on a Couchbase Server 7.6.x cluster,
+ensure that you use `cbbackupmgr` version 7.6.
+====
+
+
 [#new-features-764]
 == New Features and Enhancements in 7.6.4
 


### PR DESCRIPTION
### Description of the change

This pull request introduces a note to flag the incompatibility between Couchbase Server 7.6 and versions of `cbbackupmgr` earlier than 7.6. The update ensures users are aware of the requirement to use `cbbackupmgr` version 7.6 for proper backup and restore operations.

### Related issues

None specified.

### Checklist

- [ ] Unit tests added or updated
- [ ] Documentation updated
- [ ] All tests passed
- [ ] Related issue linked
- [ ] Code reviews