### PR TITLE
[DOC-12938]: Flag cbbackupmgr incompatibility with Couchbase Server 7.6

### DIFF
--- a/modules/introduction/pages/whats-new.adoc
+++ b/modules/introduction/pages/whats-new.adoc
@@ -8,6 +8,13 @@
 
 For information about platform support changes, deprecation notifications, notable improvements, and fixed and known issues, refer to the xref:release-notes:relnotes.adoc[Release Notes].
 
+.note regarding `cbbackupmgr`
+[IMPORTANT]
+====
+If you are performing a backup/restore operation on a Couchbase Server 7.6.x cluster,
+ensure that you use `cbbackupmgr` version 7.6.
+====
+
 [#new-features-764]
 == New Features and Enhancements in 7.6.4
 


### PR DESCRIPTION
### Description

This update adds a note to highlight that backups and restores on Couchbase Server 7.6.x clusters must be performed using cbbackupmgr version 7.6 to ensure compatibility and avoid operational issues.

----

Preview here:

https://preview.docs-test.couchbase.com/docs-server-DOC-12938-Flag-up-incompatibility-between-Couchbase-Server-7.6-and-cbbackupmgr-versions-7.6/server/current/introduction/whats-new.html

If you need a password to access the preview site:
https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords
