### PR TITLE
[DOC-12254]: Duplicate table heading in cbstats dcp -- Couchbase Docs

### DIFF
--- a/modules/cli/pages/cbstats/cbstats-dcp.adoc
+++ b/modules/cli/pages/cbstats/cbstats-dcp.adoc
@@ -7,7 +7,7 @@
 
 == Syntax
 
-Request syuntax:
+Request syntax:
 
 ....
 cbstats HOST:11210 dcp
@@ -42,10 +42,10 @@ For example, if your client is named `slave1`, the identifier for the DCP statis
 | True if the DCP stream is reserved
 
 | `supports_ack`
-| True if the connection use flow control
+| True if the connection uses flow control
 
 | `total_acked_bytes`
-| The amount of bytes that the consumer has acknowledged
+| The number of bytes that the consumer has acknowledged
 
 | `type`
 | The connection type (producer, consumer, or notifier)
@@ -58,10 +58,10 @@ Consumer connection per-stream statistics::
 | Name | Description
 
 | `buffer_bytes`
-| The amount of unprocessed bytes
+| The number of unprocessed bytes
 
 | `buffer_items`
-| The amount of unprocessed items
+| The number of unprocessed items
 
 | `end_seqno`
 | The sequence number where this stream should end
@@ -91,14 +91,14 @@ Consumer connection per-stream statistics::
 | The vBucket UUID used to create this stream
 |===
 
-Producer and notifier connection statistics::
+Producer and notifier connection statistics (stream-level statistics)::
 +
 [cols="20,67"]
 |===
 | Name | Description
 
 | `backfilled`
-| The amount of items sent from disk
+| The number of items sent from disk
 
 | `cur_snapshot_end`
 | The end sequence number of the current snapshot being received
@@ -122,7 +122,7 @@ Producer and notifier connection statistics::
 | The last sequence number sent by this stream
 
 | `memory`
-| The amount of items sent from memory
+| The number of items sent from memory
 
 | `opaque`
 | The unique stream identifier
@@ -143,13 +143,13 @@ Producer and notifier connection statistics::
 | The vBucket UUID used in the stream request
 |===
 
-Producer and notifier connection statistics::
+Producer and notifier connection statistics (producer-level statistics)::
 +
 |===
 | Name | Description
 
 | `bytes_sent`
-| The amount of unacknowledged bytes sent to the consumer.
+| The number of unacknowledged bytes sent to the consumer.
 
 | `connected`
 | True if this client is connected.
@@ -161,16 +161,16 @@ Producer and notifier connection statistics::
 | True if the connection uses flow control.
 
 | `items_remaining`
-| The amount of items remaining to be sent.
+| The number of items remaining to be sent.
 
 | `items_sent`
-| The amount of items already sent to the consumer.
+| The number of items already sent to the consumer.
 
 | `last_sent_time`
 | The last time items have been sent.
 
 | `noop_enabled`
-| Indicates whether this connection sends noop's .
+| Indicates whether this connection sends noops.
 
 | `noop_wait`
 | Indicates whether this connection is waiting for a noop response from the consumer.
@@ -194,7 +194,7 @@ Producer and notifier connection statistics::
 | The connection type (producer, consumer, or notifier).
 
 | `unacked_bytes`
-| The amount of bytes the consumer has not acknowledged.
+| The number of bytes the consumer has not acknowledged.
 |===
 
 == Options


### PR DESCRIPTION
### Description

This pull request addresses the following:
- Corrected grammatical issues such as replacing "amount" with "number".
- Fixed the duplicate table heading issue in cbstats-dcp documentation.

