### PR TITLE
[DOC-12953/release/7.2]: Docs incorrectly state that cbbackupmgr is EE only

### DIFF
--- a/modules/backup-restore/pages/enterprise-backup-restore.adoc
+++ b/modules/backup-restore/pages/enterprise-backup-restore.adoc
@@ -10,11 +10,17 @@ The `cbbackupmgr` tool backs up and restores data, scripts, configurations, and 
 It allows large data sets to be managed with extremely high performance.
 Use of AWS S3 storage is supported.
 
-Only Full Administrators can use `cbbackupmgr`; which is available in Couchbase Server _Enterprise Edition_ only.
-Note that `cbbackupmgr` is _not_ backward compatible with backups created by means of `cbbackup`.
 
-Note that in Couchbase Enterprise Server 7.2 and after, `cbbackupmgr` is available in a tools package that must be downloaded.
+Only Full Administrators can use `cbbackupmgr`;
+which is available for both Couchbase Server _Enterprise Edition_ and Couchbase Server _Community Edition_.
+
+[NOTE]
+====
+`cbbackupmgr` is _not_ backward compatible with backups created by means of `cbbackup`.
+
+In Couchbase Enterprise Server 7.2 and after, `cbbackupmgr` is available in the `Tools` package that must be downloaded.
 See xref:cli:cli-intro.adoc#server-tools-packages[Server Tools Packages].
+====
 
 === Planning for Disaster Recovery
 


### PR DESCRIPTION
### Description of Pull Request

- Updated the documentation to reflect that `cbbackupmgr` is available in both Enterprise and Community Editions.
- Clarified packaging information for Couchbase Enterprise Server 7.2 and later. 

No functional changes are made, only documentation updates.