### PR TITLE
[DOC-12953/release/7.1]: Docs incorrectly state that cbbackupmgr is EE only

### DIFF
--- a/modules/backup-restore/pages/enterprise-backup-restore.adoc
+++ b/modules/backup-restore/pages/enterprise-backup-restore.adoc
@@ -10,8 +10,9 @@ The `cbbackupmgr` tool backs up and restores data, scripts, configurations, and 
 It allows large data sets to be managed with extremely high performance.
 Use of AWS S3 storage is supported.
 
-Only Full Administrators can use `cbbackupmgr`; which is available in Couchbase Server _Enterprise Edition_ only.
-Note that `cbbackupmgr` is _not_ backward compatible with backups created by means of `cbbackup`.
+Only Full Administrators can use `cbbackupmgr`; which is available for both Couchbase Server _Enterprise Edition_ and Couchbase Server _Community Edition_.
+
+NOTE:  `cbbackupmgr` is _not_ backward compatible with backups created by means of `cbbackup`.
 
 === Planning for Disaster Recovery
 


### PR DESCRIPTION
### Description of the Change

This pull request addresses inaccuracies in the documentation for `cbbackupmgr`, which previously stated that it is available only in the Enterprise Edition. The corrected documentation now reflects that `cbbackupmgr` is available in both the Enterprise and Community Editions. Additional revisions were made to improve clarity regarding version compatibility and packaging details.