### PR TITLE
[DOC-12953/release/7.0]: Docs incorrectly state that cbbackupmgr is EE only

### DIFF
--- a/modules/backup-restore/pages/enterprise-backup-restore.adoc
+++ b/modules/backup-restore/pages/enterprise-backup-restore.adoc
@@ -10,7 +10,8 @@ The `cbbackupmgr` tool backs up and restores data, scripts, configurations, and 
 It allows large data sets to be managed with extremely high performance.
 Use of cloud storage is supported.
 
-Only Full Administrators can use `cbbackupmgr`; which is available in Couchbase Server _Enterprise Edition_ only.
+Only Full Administrators can use `cbbackupmgr`; 
+which is available for both Couchbase Server _Enterprise Edition_ and Couchbase Server _Community Edition_.
 Note that `cbbackupmgr` is _not_ backward compatible with backups created by means of `cbbackup`.
 
 === Planning for Disaster Recovery


### PR DESCRIPTION

Updated the documentation to correctly state that `cbbackupmgr` is available in both Enterprise and Community Editions. Improved clarity regarding version compatibility and packaging information.