### PR TITLE
Add release notes for Couchbase Server 7.6.6

### DIFF
--- a/modules/introduction/pages/whats-new.adoc
+++ b/modules/introduction/pages/whats-new.adoc
@@ -15,23 +15,8 @@ If you are performing a backup/restore operation on a Couchbase Server 7.6.x clu
 ensure that you use `cbbackupmgr` version 7.6.
 ====
 
-[#new-features-764]
-== New Features and Enhancements in 7.6.4
 
-The following new features are provided in this release
-
+include::partial$new_features-76_6.adoc[]
 include::partial$new_features-76_4.adoc[]
-
-[#new-features-762]
-== New Features and Enhancements in 7.6.2
-
-The following new features are provided in this release.
-
 include::partial$new-features-76_2.adoc[]
-
-[#new-features]
-== New Features and Enhancements in 7.6.0
-
-The following new features are provided in this release.
-
 include::partial$new-features-76.adoc[]

--- a/modules/introduction/partials/new-features-76.adoc
+++ b/modules/introduction/partials/new-features-76.adoc
@@ -1,3 +1,9 @@
+[#new-features]
+== New Features and Enhancements in 7.6.0
+
+The following new features are provided in this release.
+
+
 === Platform Support
 
 * Couchbase Server 7.6 adds support for the following platforms:

--- a/modules/introduction/partials/new-features-76_2.adoc
+++ b/modules/introduction/partials/new-features-76_2.adoc
@@ -1,3 +1,9 @@
+
+[#new-features-762]
+== New Features and Enhancements in 7.6.2
+
+The following new features are provided in this release.
+
 === Platform Support
 
 * Couchbase Server 7.6.2 adds support for the following platforms:

--- a/modules/introduction/partials/new_features-76_4.adoc
+++ b/modules/introduction/partials/new_features-76_4.adoc
@@ -1,3 +1,10 @@
+
+[#new-features-764]
+== New Features and Enhancements in 7.6.4
+
+The following new features are provided in this release.
+
+
 [#new-features-764-cluster-manager]
 === Cluster Manager
 

--- a/modules/introduction/partials/new_features-76_6.adoc
+++ b/modules/introduction/partials/new_features-76_6.adoc
@@ -1,0 +1,11 @@
+[#new-features-766]
+== New Features and Enhancements in 7.6.6
+
+The following new features are provided in this release.
+
+* The following new platforms are supported.
+** Windows Server 2025
+
+
+
+

--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -3,6 +3,8 @@
 :description: Couchbase Server 7.6.x introduces multiple new features and fixes, as well as some deprecations and removals.
 :page-toclevels: 2
 
+include::partial$docs-server-7.6.6-release-note.adoc[]
+
 include::partial$docs-server-7.6.5-release-note.adoc[]
 
 include::partial$docs-server-7.6.4-release-note.adoc[]

--- a/modules/release-notes/partials/docs-server-7.6.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6.6-release-note.adoc
@@ -1,0 +1,192 @@
+== Release 7.6.6 (May 2025)
+
+Couchbase Server 7.6.6 was released in May 2025.
+This maintenance release contains fixes several for known issues.
+
+For detailed information on new features and enhancements, see xref:introduction:whats-new.adoc[].
+
+[#fixed-issues-766]
+=== Fixed Issues
+
+This release contains the following fixes:
+
+==== Storage Engine
+
+[#table-fixed-issues-766-storage-engine,cols="10,40,40"]
+|===
+|Issue | Description | Resolution
+
+| https://jira.issues.couchbase.com/browse/MB-64353[MB-64353]
+a| Hard failover of ephemeral buckets could lead to the rollback of DCP clients back to 0. 
+There is currently no work-around for this, and currently the only solution is to upgrade to a version with the fix.
+
+7.6.3 is the oldest release with the fix.
+
+*Details:*
+
+
+* Hard failover of an ephemeral bucket.
+
+* Replica promoted to active.
+
+* DCP client reconnects to the new active.
+
+* DCP clients rollback to zero and have to re-stream all the mutations from the new active.
+
+| Issue resolved.
+
+| https://jira.issues.couchbase.com/browse/MB-64742[MB-64742]
+| An issue in the plasma tracking stats flagged a stale recovery point in the recovery log as valid data.
+This made the log cleaning run slowly at a low mutation rate,
+and therefore, unable to trim the recovery point history effectively.
+
+At a higher mutation rate, the mutations alone could push the fragmentation ratio high enough to start the log cleaner,
+and therefore, was able to trim rp history despite the issue with tracking stats.
+ 
+
+| We mark the latest version of the recovery point that exists in both the recovery log and the data log.
+ This effectively means that plasma will keep the recovery point history list to 1 in the recovery log.
+ In addition,
+ the plasma tracking stats are fixed such that it no longer treats the older recovery point as valid data in the recovery log. +
+ This allows the log cleaner to run even at a low mutation rate.
+
+| https://jira.issues.couchbase.com/browse/MB-65738[MB-65738]
+| An optimization to increase the memory residency of active plasma items caused an issue.
+In-memory compression of plasma pages under certain conditions may result in high CPU usage with this optimization. + 
+Prior to Release `7.6.0`, this  issue will not  occur as this optimization was not present.
+
+| Issue resolved.
+
+
+|===
+
+
+==== Data Service
+
+[#table-fixed-issues-766-data-service,cols="10,40,40"]
+|===
+|Issue | Description | Resolution
+
+| https://jira.issues.couchbase.com/browse/MB-63827[MB-63827]
+| DCP connection metrics for connection names that do not conform to the server format are not aggregated by connection type when exposing to Prometheus, potentially producing a large number of time series.
+
+| The metrics are aggregated and exposed with `connection_type="_unknown"`.
+
+
+|===
+
+==== XDCR
+
+[#table-fixed-issues-766-xdcr,cols="10,40,40"]
+|===
+|Issue | Description | Resolution
+
+| https://jira.issues.couchbase.com/browse/MB-62309[MB-62309]
+| Tombstones were not replicated if the binary filter is turned on.
+| Issue resolved.
+
+| https://jira.issues.couchbase.com/browse/MB-64563[MB-64563]
+| If users do not want the replication to be automatically deleted upon either source or bucket deletion and/or recreation, 
+users can set the `skipReplSpecAutoGc` replication setting to `true` upon replication creation. 
+
+In the situation that the replication would have been deleted, 
+it will have been automatically paused instead, 
+and a persistent UI error message logged to be viewed.
+
+Users are expected to manually execute the recovery action by deleting the replication and re-creating a newer one,
+if necessary.
+
+| Issue resolved.
+
+
+|===
+
+==== Query Service
+
+[#table-fixed-issues-766-query-service,cols="10,40,40"]
+|===
+|Issue | Description | Resolution
+
+|https://jira.issues.couchbase.com/browse/MB-65055[MB-65055]
+| In a cluster with multiple query nodes, 
+performing a rolling upgrade to version `7.6.x`
+from an earlier version (such as `7.2`) may cause prepared statements
+containing a WITH clause to malfunction on the upgraded query node.
+
+| Issue resolved.
+
+|===
+
+==== Index Service
+
+[#table-fixed-issues-766-index-service,cols="10,40,40"]
+|===
+|Issue | Description | Resolution
+
+| https://jira.issues.couchbase.com/browse/MB-65012[MB-65012]
+| When shard affinity is enabled, the indexer internally maps all replicas of an index to an alternateID.
+If such an alternateID exists on a node outside the list of nodes, 
+instead of preventing replica creation, 
+the system creates a new replica with the same alternateID on different nodes.
+This leads to rebalance failures on the affected nodes.
+
+| When `ALTER INDEX` is used with the `replica_count` action,
+do not allow the `nodes` clause when shard affinity is enabled
+
+
+|===
+
+==== Search Service
+
+[#table-fixed-issues-766-search-service,cols="10,40,40"]
+|===
+|Issue | Description | Resolution
+
+| https://jira.issues.couchbase.com/browse/MB-63246[MB-63246]
+| A Couchbase cluster upgrade to 7.6.2 caused data ingestion failure for legacy indexes using `gocouchbase`. 
+A `gocbcore`-specific check in https://github.com/couchbase/cbft/blob/f81ec8920f9b022f7d605feee1907eb4c664379a/pindex_bleve.go#L2374[here] is incompatible with the `gocouchbase` feed,
+resulting in ingestion errors.
+
+| Issue Resolved.
+
+|===
+
+[#known-issues-766]
+== Known Issues
+
+=== Query Service
+
+[#table-known-issues-765-query-service,cols="10,40,40"]
+|===
+|Issue | Description | Workaround
+
+| https://jira.issues.couchbase.com/browse/MB-64966[MB-64966]
+a| Scope level user-defined functions, sequences, and histogram data are stored in `bucket/_system/_query` collection. 
+
+Flushing the bucket will delete the scoped UDF entries. 
+When the UDFs are executed, it will work until the UDFs are evicted from the cache.
+After that, it will always result in an error.
+
+Sequences metadata is also stored in `bucket/_system/_query` collection. 
+FLUSHing the bucket will delete the entries. When executed, sequences will return errors once evicted from the cache.
+
+`FLUSH`ing the bucket will also delete statistics data stored in the `bucket/_system/_query collection.
+ By using stale statistics stored in the cache, a non-optimal plan could be generated.
+
+
+a| For user-defined functions, you can do one of the following:
+
+* Recreate the scoped user-defined functions after the `FLUSH`.
+* Use global UDFs instead of scoped UDFs. (Global UDFs are not stored in the `_query` collection.)
+* Create scoped UDFs on the bucket that does not have FLUSH enabled and then reference them via a fully qualified name (`bucket.scope.UDFname`).
+
+For sequence metadata:
+
+* After the `FLUSH`, recreate the sequence, or
+* Create sequences on the bucket that does not have FLUSH enabled and then reference them via a fully qualified name (`bucket.scope.UDFname`).
+
+For statistical data, rerun `UPDATE STATISTICS` on all the indexes on every scope and collections in the bucket that was flushed.
+
+
+|===
+


### PR DESCRIPTION
### Description

This pull request adds release notes for Couchbase Server 7.6.6. Key updates include:

- Added a note about support for Windows Server 2025.
- Enhanced the `What's New` section to separately list updates for each version.
- Included fixes for known issues, details on user-defined functions, sequences, and statistics behavior after a bucket flush.
- Provided workarounds to mitigate identified issues.

### Related Issue

- [DOC-12942]: Create a release note for Couchbase Server 7.6.6

### Checklist

- [ ] Unit tests added or updated (if applicable)
- [x] Documentation updated (if applicable)

[DOC-12942]: https://couchbasecloud.atlassian.net/browse/DOC-12942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ