### PR TITLE
Update release month for Couchbase Server 7.2.7 in documentation

### DIFF
--- a/modules/release-notes/partials/docs-server-7.2.7-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.2.7-release-note.adoc
@@ -1,7 +1,7 @@
 [#release-727]
-== Release 7.2.7 (February 2025)
+== Release 7.2.7 (March 2025)
 
-Couchbase Server 7.2.7 was released in February 2025.
+Couchbase Server 7.2.7 was released in March 2025.
 This maintenance release contains the following fixes.
 
 === Fixed Issues


### PR DESCRIPTION
### Description of Changes

- Updated the release month for Couchbase Server version 7.2.7 from February 2025 to March 2025 in the release notes.
- Ensured the documentation reflects the correct timeline for accuracy.

### Checklist

- [ ] I have tested my changes.
- [x] I have updated any related documentation.
- [ ] I have reviewed my changes for adherence to the coding standard/template.