### PR TITLE
DOC-12511 morpheus role changes

### DIFF
--- a/modules/introduction/partials/new-features-80.adoc
+++ b/modules/introduction/partials/new-features-80.adoc
@@ -139,6 +139,65 @@ to create all replicas and partitions in the same iteration,
 rather than doing it asynchronously in the background.
 This leads to better utilization of DCP streams.
 
+
+[#section-new-features-800-roles]
+=== Roles
+
+To support new features, Couchbase Server 8.0 has added, removed, or changed some roles:
+
+https://jira.issues.couchbase.com/browse/MB-64960[MB-64960]::
+The new Application Telemetry Writer (`application_telemetry_writer`) role supports the new application telemetry feature.
+Users with this role can call the telemetry endpoint to report telemetry to Couchbase Server.
+
+https://jira.issues.couchbase.com/browse/MB-63584[MB-63584]::
+The new Query Manage System Catalog (`query_manage_system_catalog`) role lets the user manage the system catalogs created by the new query workload report feature.
+
+
+https://jira.issues.couchbase.com/browse/MB-59606[MB-59606]::
+Couchbase Server 8.0 adds, removes, and changes some roles to split user management privileges from other security administration privileges.
+These changes are necessary to allow users to backup and restore users without requiring them to have the Full Admin role. 
+
++
+The following two roles have been removed:
+
++
+--
+* Local User Security Admin (`security_admin_local`)
+* External User Security Admin (`security_admin_external`)
+--
++
+Couchbase Server adds the following three roles to replace the removed roles:
+
++
+--
+* Security Admin (`security_admin`) has all of the non-user-related security privileges as the old Local User Security Admin and External User Security Admin roles had.
+* Local User Admin (`user_admin_local`) lets a user manage users and groups defined in the local authentication domain.  
+It does not have the other security privileges that the old Local User Security Admin role.
+* External User Admin (`user_admin_external`) lets a user manage users defined in the external authentication domain. 
+It does not have the other security privileges that the old External User Security Admin had.
+--
++
+In addition, the Backup Full Admin (`backup_admin`) role now lets a user backup and restore users. 
+In prior versions of Couchbase Server, users required the Full Admin role to be able to backup and restore users.
+
++
+Couchbase Server 8.0 upgrade process reassigns roles to users who have the now-deleted roles:
+
++
+* Users with the deleted Local User Security Admin role get the new Local User Admin and Security Admin roles.
+* Users with the deleted External User Security Admin role get the new External User Admin and  Security Admin roles.
+
++
+These role changes ensure that the users with the Local User Security Admin or External User Security Admin roles still have the same privileges they did before the upgrade.
+
++
+The Backup Service in  Couchbase Sever 8.0 or later also performs these changes when restoring a backup from a pre-8.0 Couchbase Server version. 
+
++
+NOTE: If the user restoring a backup does not have a role that allows them to restore specific roles to a user in the backup, the backup server skips restoring that user. 
+
+See xref:learn:security/roles.adoc[] for more information.
+
 [#section-new-feature-800--tools]
 === Tools
 

--- a/modules/introduction/partials/new-features-80.adoc
+++ b/modules/introduction/partials/new-features-80.adoc
@@ -149,6 +149,9 @@ https://jira.issues.couchbase.com/browse/MB-64960[MB-64960]::
 The new Application Telemetry Writer (`application_telemetry_writer`) role supports the new application telemetry feature.
 Users with this role can call the telemetry endpoint to report telemetry to Couchbase Server.
 
+https://jira.issues.couchbase.com/browse/MB-65045[MB-65045]::
+The new Query List Index (`query_list_index`) lets the user list indexes without being able to alter them. 
+
 https://jira.issues.couchbase.com/browse/MB-63584[MB-63584]::
 The new Query Manage System Catalog (`query_manage_system_catalog`) role lets the user manage the system catalogs created by the new query workload report feature.
 

--- a/modules/learn/assets/source/compare_roles_doc_to_json.py
+++ b/modules/learn/assets/source/compare_roles_doc_to_json.py
@@ -1,0 +1,64 @@
+# This program compares the list of roles output by the Couchbase Server
+# /settings/rbac/roles endpoint (by calling the server runnning on localhost) 
+# to the content of the roles.adoc file. 
+
+#  It reports any deltas between the two.
+
+
+import re
+import requests
+
+
+def load_roles_from_rbac():
+    """Fetch roles from Couchbase RBAC REST API."""
+    url = "http://localhost:8091/settings/rbac/roles"
+    auth = ("Administrator", "password")  # Update with actual credentials
+    
+    response = requests.get(url, auth=auth)
+    response.raise_for_status()
+    
+    roles = response.json()
+    return {role['role'] for role in roles}
+
+def extract_roles_from_asciidoc(asciidoc_file):
+    """Extract roles from roles.adoc based on the given pattern."""
+    pattern = re.compile(r'\|\s*Role:.*?\(`(.*?)`\)')
+    extracted_roles = set()
+    
+    with open(asciidoc_file, 'r', encoding='utf-8') as f:
+        for line in f:
+            match = pattern.search(line)
+            if match:
+                extracted_roles.add(match.group(1))
+    
+    return extracted_roles
+
+def generate_report(json_roles, asciidoc_roles):
+    """Generate a report showing discrepancies between the two lists."""
+    missing_in_asciidoc = json_roles - asciidoc_roles
+    missing_in_json = asciidoc_roles - json_roles
+    
+    report = """
+Roles in RBAC but NOT in roles.adoc:
+------------------------------------------------
+{}
+
+Roles in roles.adoc but NOT in RBAC:
+------------------------------------------------
+{}
+""".format("\n".join(sorted(missing_in_asciidoc)), "\n".join(sorted(missing_in_json)))
+    
+    return report
+
+def main():
+    asciidoc_file = "../../pages/security/roles.adoc"
+    
+    rbac_roles = load_roles_from_rbac()
+    asciidoc_roles = extract_roles_from_asciidoc(asciidoc_file)
+    
+    report = generate_report(rbac_roles, asciidoc_roles)
+    
+    print(report)
+    
+if __name__ == "__main__":
+    main()

--- a/modules/learn/pages/security/authentication-domains.adoc
+++ b/modules/learn/pages/security/authentication-domains.adoc
@@ -10,6 +10,7 @@
 Couchbase Server authenticates each user by means of one of two _authentication domains_.
 The domains are:
 
+[#local_domain]
 * _Local_: Contains users defined locally.
 This includes:
 
@@ -25,6 +26,7 @@ Generated Users are created to ensure that legacy applications can continue to a
 +
 Note that from release 7.6, Couchbase Server no longer supports {sqlpp) operations on buckets without password specification.
 
+[#external_domain]
 * _External_: Contains either or both of the following:
 
 ** Users that are explicitly registered on Couchbase Server as _external_; as supported either by _LDAP_, _Security Assertion Markup Language (SAML)_, or _PAM_.

--- a/modules/learn/pages/security/roles.adoc
+++ b/modules/learn/pages/security/roles.adoc
@@ -11,52 +11,26 @@ Administrators assign roles to users to enable them to perform the tasks they ne
 [#roles-and-privileges]
 == Roles and Privileges
 
-Each role grants one or more privileges to interact with a resource.
-A Privilege is an action that a user can take with a resource.
-They include:
-
-* Execute
-* Flush
-* List
-* Manage
-* Read 
-* Write
-
-Roles provide a set of privileges for interacting with a resource. 
-For example, the Data Writer role grants a user the ability to write data.
-This ability can be limited to specific collections, scopes, or buckets.
-This role does not grant the user the ability to read data.
+Roles provide a set of privileges for interacting with a resource.
+These privileges are often specific. 
+For example, the Data Writer role lets a user write data using key-value operations.
+This role does not let the user read data.
 The Data Reader role grants that ability.
 
-An administrator can grant a user a set of roles to precisely tailor their privileges so they can perform their tasks in the database.
+Some roles let the you limit the privileges a role grants to specific collections, scopes, or buckets.
+For example, when granting a user the Data Writer role, you can limit the user so they can only write to a specific collection. 
+You can also enable the user to write data to multiple collections, multiple scopes, or even to all buckets.
+For detailed information about scopes and collections, see xref:learn:data/scopes-and-collections.adoc[].
 
-Roles fall into the following categories:
-
-* Administrative roles have cluster-wide privileges.
-Some of these roles are for administrators who manage cluster-configurations, read statistics, or enforce security.
-Others are for users and user-defined applications that must access cluster-wide resources.
-
-* Bucket: roles have privileges for bucket administration, collection management, and application access.
-Roles in this category grant privileges to one, multiple, or all buckets in the cluster.
-
-* Data, Views, and XDCR roles have privileges associated with the Data Service.
-These privileges include reading, writing, monitoring, backing-up, and restoring data. 
-They also allow the administration of Views and Cross Datacenter Replication (XDCR) connections.
-
-* Other Services roles are for the administration of services other than the Data Service.
-These roles have the following subcategories: Query & Index, Search, Analytics, and Backup.
-(Eventing administration is covered within the Administrative category.)
-
-* Mobile roles are associated with the administration of Sync Gateway.
-
-A user (including administrators and applications) authenticates when they attempt to access a resource.
-Couchbase Server checks the roles associated with the user's credentials.
-If the associated roles grant the user the right to access the resource, Couchbase Server allows the access.
+You can grant a user a set of roles to precisely tailor their privileges so they can perform their tasks in the database.
+Some roles, such as Query List Index, are so limited that they are only useful 
+For example, you can grant a user the ability to read all data in a specific bucket va the Data Reader role.
+Additionally, you can grant the user the Data Writer role, but limit them to writing data into a specific collection within the bucket.
 
 [#roles-in-relation-to-buckets]
 === Roles in Relation to Buckets
 
-All data within a collection, which in urn is within a scope which is stored within a bucket. 
+All data within a collection, which in turn is within a scope which is stored within a bucket. 
 Administrators granting bucket-related roles can restrict the user's privileges to access to data in any of the following ways:
 
 * By Bucket: Permissions apply to all data in the specified bucket: all scopes and collections are thus covered by the permissions.
@@ -65,7 +39,7 @@ Administrators granting bucket-related roles can restrict the user's privileges 
 
 * By Bucket, Scope, and Collection: Permissions apply only to the data within the specified collection (or collections), within the specified scope (or scopes), within the specified bucket.
 
-For detailed information about scopes and collections, see xref:learn:data/scopes-and-collections.adoc[].
+
 
 [#commonly-used-roles]
 === Commonly Used Roles
@@ -88,32 +62,27 @@ For example, only the Full Admin role lets a user access the entire **Security**
 Users with either the Local User Admin or the External User Admin roles can only see the **Users & Groups** tab on this screen.
 
 Applications::
-Application users are can read or write data.
-They cannot log into Couchbase Server Web Console or modify cluster settings.
+Users you create to be used by applications when interacting with Couchbase Server often need to read or write data.
+Most of the roles you grant applications do not allow them to log into Couchbase Server Web Console or modify cluster settings.
 For example, the Data Reader and Data Writer roles lets the user read and write one or more collections, within one or more scopes, within one or more buckets.
-Other application roles are Application Access, Data Writer, Data Backup & Restore, and Data Monitor.
-See <<#>> for details on each.
+Other roles appropriate for applications are Application Access, Data Writer, Data Backup & Restore, and Data Monitor.
+
 
 Developers::
-Can be given a selection of roles, allowing the right degree of data and console access.
-For example, the *Read-Only Admin* role allows the reading of cluster-statistics, while the *Data Read* and *Data Write* roles allow access to data on one or more buckets.
-
-The following list contains all roles supported by Couchbase Server Enterprise Edition.
-In each table-body, where a privilege is associated with a resource, this is indicated with a check-mark.
-
-Note that some roles grant access to Couchbase Web Console; while others do not.
-The set of features displayed within the console varies, according to role.
-
-also that any authentication failure will be logged in the log file for the resource on which access was attempted.
-See xref:manage:manage-logging/manage-logging.adoc[Manage Logging], for detailed information on using log files.
+User accounts for developers require more privileges to access data and manage resources than applications.
+However, they should not have the unrestricted privileges that most Administrator roles grant.
+These roles do let users log into the Couchbase Server Web Console, so they can perform tasks in a GUI environment.
+You can tailor the roles you grant to developers so they have just enough privileges to perform their tasks.
+For example, the Analytics Admin and Manage Global External Functions roles were designed for interactive users.
+They let the user maintain some parts of your database.
+However, they lack the ability to change cluster settings or universally read data like most administrator roles.
 
 == Role Overviews
 
 The following sections describe the roles Defined by Couchbase Server. 
-Each description lists the resources the roles allow users to access, and any limitations on their access.
-
-NOTE: Most roles have a table listing resources and a summary of what the role permits and does not allow user to do with the resource.
-If a resource does not appear in this table, the role does not grant the user any access to it. 
+The list is broken into the same categories that appear within the COuchbase Server Web Console's *Edit User* dialog.
+Each description has a table listing the resources the roles allow users to access, and any limitations on their access.
+If a resource does not appear in this table, the role does not grant the user any privileges to it. 
 
 
 [#admin-roles]
@@ -124,18 +93,19 @@ The following roles grant users the ability to administer some aspects of Couchb
 [#full-admin]
 === Full Admin
 
-The Full Admin role  grants full access to all Couchbase Server features and resources, including security.
-The role grants access to Couchbase Server Web Console.
+The Full Admin role (`admin`) grants full privileges to all Couchbase Server features and resources, including security.
+The role grants lets the user log into to the Couchbase Server Web Console.
 
 This role is also available in Couchbase Server Community Edition.
 
 [#read-only-admin]
 === Read-Only Admin
 
-The Read-Only Admin role grants the user the ability to read Couchbase Server settings and statistics. 
+The Read-Only Admin role lets the user read Couchbase Server settings and statistics. 
 This information includes registered usernames with roles and authentication domains, but excludes passwords.
 Users with this role can also read Backup Service data to monitor backup plans and tasks.
-The role allows access to Couchbase Server Web Console.
+
+The role lets the user log into the Couchbase Server Web Console.
 
 This role is also available in Couchbase Server Community Edition.
 
@@ -207,8 +177,9 @@ h| Restrictions
 === Cluster Admin
 
 The Cluster Admin role lets the user manage of all cluster features except security.
-The role grants access to Couchbase Server Web Console.
 Cluster Admins can create, edit, and drop buckets but cannot read or write data.
+
+This role lets users log into the Couchbase Server Web Console.
 
 [#table_cluster_admin_role,cols="1,2,2,hrows=3"]
 |===
@@ -274,12 +245,13 @@ h| Restrictions
 [#local-user-security-admin]
 === Local User Admin
 
-The Local User Admin role grants a user the ability to manage users defined in the xref:learn:security/authentication-domains.adoc#local-domain[local authentication domain].
+The Local User Admin role lets a user manage users defined in the xref:learn:security/authentication-domains.adoc#local-domain[local authentication domain].
 It also grants the ability to read all cluster statistics such as the settings, logs, and buckets.
 It does not grant the ability to read data.
 The role allows users to edit local users, but they cannot grant these users the Full Admin, Read-Only Admin,  Local User Admin, or External User Admin roles.
 They also cannot edit the accounts for any user with those roles (including their own account).
-The role grants access to Couchbase Server Web Console.
+
+This role lets users log into the Couchbase Server Web Console.
 
 [#table_security_admin_local_role,cols="1,2,2,hrows=3"]
 |===
@@ -343,15 +315,164 @@ Cannot access non-user and group security resources.
 
 |===
 
+
+[#eventing-full-admin]
+=== Eventing Full Admin
+
+The Eventing Full Admin role lets a user create and manage eventing functions as well as other administration tasks.
+
+The role lets the user log into the Couchbase Server Web Console.
+
+[#table_eventing_admin_role,cols="1,2,2,hrows=3"]
+|===
+3+^|  Role: Eventing Full Admin (`eventing_admin`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Servers* 
+| View configuration and statistics
+| Cannot add, failover, remove, modify services, rebalance
+
+| *Buckets*
+| List buckets, scopes, and collections. 
+Can create, compact, and drop buckets, scopes, and collections.
+Can read and write data in buckets.
+| None
+
+| *Backup*
+| List repositories and plans
+| Cannot add or edit repositories or plans 
+
+| *XDCR* 
+| List outgoing replications 
+| Cannot list incoming replications or remote clusters.
+Cannot add or edit replications.
+
+| *Security*
+| None
+| All
+
+| *Settings*
+| View all settings and load sample buckets
+| Cannot edit settings
+
+| *Logs*
+| View logs
+| Cannot collect information
+
+| *Indexes*
+| All
+| None
+
+| *Query*
+| All
+| None
+
+| *Search*
+| All
+| None
+
+| *Analytics*
+| All   
+| None
+
+| *Eventing*
+| All
+| None
+
+| *Views*
+| All  
+| None
+
+|===
+
+
+[#backup-full-admin]
+=== Backup Full Admin
+
+The Backup Full Admin role lets the user administer backup-related tasks as well as other aspects of Couchbase Server.
+
+This role lets the user log into Couchbase Server Web Console.
+
+[#table_backup_admin_role,cols="1,2,2,hrows=3"]
+|===
+3+^|  Role: Backup Full Admin (`backup_admin`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Servers* 
+| All
+| None
+
+| *Buckets*
+| All, including add and drop buckets and edit, add, and drop documents
+| None
+
+| *Backup*
+| All
+| None
+
+| *XDCR* 
+| All
+| None
+
+| *Security*
+| None
+| All
+
+| *Settings*
+| All
+| None
+
+| *Logs*
+| View logs
+| Cannot collect information
+
+| *Query*
+| All
+| None
+
+| *Indexes*
+| All
+| None
+
+
+| *Search*
+| All
+| None
+
+| *Analytics*
+| All   
+| None
+
+| *Eventing*
+| All
+| None
+
+| *Views*
+| All  
+| None
+
+|===
+
+
 [#external-user-security-admin]
 === External User Admin
 
-The External User Admin role gives users the ability to manage external users.
-It also allows the user to manage groups and read all cluster statistics.
-Users with this role cannot grant external users or groups Full Admin, Read-Only Admin, Local or External User Admin, or Security Admin roles.
+The External User Admin role lets users manage users defined in the xref:learn:security/authentication-domains.adoc#external_domain[external authentication domain].
+It also lets the user manage groups and read all cluster statistics.
+Users with this role cannot grant external users or groups Full Admin, Read-Only Admin, Security Admin, or Local or External User Admin roles.
 They also cannot edit users with those roles. 
 
-This role grants Couchbase Server Web Console access.
+This role lets the user log into the Couchbase Server Web Console.
 
 [#table_security_admin_external_role,cols="1,2,2,hrows=3"]
 |===
@@ -377,7 +498,7 @@ h| Restrictions
 
 | *XDCR* 
 | View list of outgoing replications
-| View incoming replications, remote clusters, add or edit connections.
+| View incoming replications, remote clusters, add or edit connections
 
 | *Security* 
 | Add, delete, edit external users.
@@ -423,7 +544,7 @@ Cannot access security resources besides users and groups.
 
 The Security Admin role grants the user the ability manage all security settings except for users and groups.
 
-The role grants Couchbase Server Web Console access.
+This role lets the user log into the Couchbase Server Web Console.
 
 [#table_security_admin_role,cols="1,2,2,hrows=3]
 |===
@@ -490,10 +611,10 @@ h| Restrictions
 === External Stats Reader
 
 The External Stats Reader role only access to just the `/metrics` and `/prometheus_sd_config` REST API endpoints,
-Assign this role to a user to allow Prometheus to collect mestrics from all Couchbase Server services.
+Assign this role to a user to allow Prometheus to collect metrics from all Couchbase Server services.
 See xref:manage:monitor/set-up-prometheus-for-monitoring.adoc[] for more information.
 
-The role does not grant Couchbase Server Web Console access.
+This role does not let the user log into the Couchbase Server Web Console.
 
 [#table_external_stats_role,cols="1,2,2,hrows=3]
 |===
@@ -517,9 +638,9 @@ h| Restrictions
 === Application Telemetry Writer
 
 This role lets the user report application telemetry through SDK calls.
-A user requires this role to send telemetry information to Couchbase Server via SDK calls.
+Assign this role to application users that need to report telemetry information to Couchbase Server.
 
-This role does not grant the user Couchbase Server Web Console access.
+This role does not let the user log into Couchbase Server Web Console.
 
 [#table_application_telemetry_writer,cols="1,2,2,hrows=3]
 |===
@@ -537,697 +658,6 @@ h| Restrictions
 | None
 
 |===
-
-
-[#query-roles]
-== Query & Index Roles
-
-[#query-curl-access]
-=== Query CURL Access
-
-The Query CURL Access role lets the user call the {sqlpp} curl function in their queries.
-
-CAUTION: The Query CURL Access role allows users to run GET and POST requests to any system on the network Couchbase Server uses for client connections.
-If your cluster is not configured to use a private network for internal communication, they also have access to the entire cluster.  
-They can interact with any system on this network.
-
-
-This role only grants the user the ability to read data returned by the {sqlpp} curl function.
-Usually, you assign additional roles to the user to allow them to read and write data.
-
-For more information about the {sqlpp} curl function, see xref:n1ql:n1ql-language-reference/curl.adoc[].
-
-This role lets the user log into Couchbase Server Web Console. 
-
-[#table_query_external_access_role,cols="1,2,2,hrows=3]
-|===
-
-3+^| Role: Query Curl Access (`query_external_access`)
-
-.2+^h| Resource
-2+^h| Privileges
-
-h| Permissions
-h| Restrictions
-
-| *Servers* 
-| List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
-
-| *Buckets*
-| List buckets
-| Cannot list scopes or collections.
-Cannot create, drop, or edit buckets.
-Cannot read data other than the results of the {sqlpp} curl function call.
-Cannot write data.
-
-| *Query*
-| Can execute {sqlpp} curl function calls
-| Cannot execute any other queries.
-Cannot use the Query Workbench in Couchbase Server Web Console.
-
-|===
-
-
-[#query-system-catalog]
-=== Query System Catalog
-
-The Query System Catalog role lets the user query the system catalog using {sqlpp}.
-This access include querying `system:indexes`, `system:prepareds`, and tables listing current and past queries.
-Assign this role to developers who need to query these tables when troubleshooting and debugging queries.
-
-The role grants Couchbase Server Web Console access.
-
-[#table_query_system_catalog_role,cols="1,2,2,hrows=3]
-|===
-
-3+^|  Role: Query System Catalog (`query_system_catalog`)
-
-.2+^h| Resource
-2+^h| Privileges
-
-h| Permissions
-h| Restrictions
-
-| *Servers* 
-| List servers.
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
-
-| *Buckets*
-| List buckets and view bucket settings.
-| Cannot list scopes or collections, create, drop, edit settings, read or write data.
-
-| *Query*
-| Can query system tables.
-| Cannot perform any other query actions.
-Cannot use the query workbench in Couchbase Server Web Console.
-
-|===
-
-[#manage-global-functions]
-=== Manage Global Functions
-
-The Manage Global Functions role lets the user create and drop global user-defined {sqlpp} functions. 
-See xref:n1ql:n1ql-language-reference/createfunction.adoc[].
-
-This role grants Couchbase Server Web Console access.
-
-[#table_manage_global_functions_role,cols="1,2,2,hrows=3]
-|===
-
-3+^|  Role: Manage Global Functions (`query_manage_global_functions`)
-
-.2+^h| Resource
-2+^h| Privileges
-
-h| Permissions
-h| Restrictions
-
-| *Servers* 
-| List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
-
-| *Buckets*
-| List buckets
-| Cannot list scopes or collections, create, drop, edit settings, read or write data.
-
-| *Query*
-| Can execute `CREATE FUNCTION` and `DROP FUNCTION` statements.
-| Cannot perform any other queries, including calling the global functions.
-Cannot use the Query Workbench in Couchbase Server Web Console.
-
-| *Settings*
-| View cluster settings
-| Cannot view any other settings or change settings.
-
-|===
-
-
-[#execute-global-functions]
-=== Execute Global Functions
-
-The Execute Global Functions role lets the user call global {sqlpp} functions.
-
-This role lets the user log into Couchbase Server Web Console. 
-
-[#table_query_execute_global_functions_role,cols="1,2,2,hrows=3]
-|===
-
-3+^|   Role: Execute Global Functions (`query_execute_global_functions`)
-
-.2+^h| Resource
-2+^h| Privileges
-
-h| Permissions
-h| Restrictions
-
-| *Servers* 
-| List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
-
-| *Buckets*
-| List buckets
-| Cannot list scopes or collections, create, drop, edit settings, read or write data.
-
-| *Query*
-| Can execute global user-defined functions.
-| Cannot perform any other queries.
-Cannot use the Query Workbench in Couchbase Server Web Console.
-
-| *Settings*
-| View cluster settings
-| Cannot view any other settings or change settings.
-
-|===
-
-
-[#manage-scope-functions]
-=== Manage Scope Functions (Query and Index)
-
-The Manage Scope Functions role lets the user create an drop user-defined {sqlpp} functions for one or more scopes.
-See xref:n1ql:n1ql-language-reference/createfunction.adoc[].
-
-This role lets the user log into Couchbase Server Web Console. 
-
-
-[#table_manage_scope_functions_role,cols="1,2,2,hrows=3]
-|===
-
-3+^| Role: Manage Scope Functions (`query_manage_functions`)
-
-.2+^h| Resource
-2+^h| Privileges
-
-h| Permissions
-h| Restrictions
-
-| *Servers* 
-| List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
-
-| *Buckets*
-| List buckets
-| Cannot list scopes or collections, create, drop, edit settings, read or write data.
-
-| *Query*
-| Can execute `CREATE FUNCTION` and `DROP FUNCTION` statements to create user-defined functions in specific scopes.
-| Cannot perform any other queries, including calling the functions.
-Cannot use the Query Workbench in Couchbase Server Web Console.
-
-| *Settings*
-| View cluster settings
-| Cannot view any other settings or change settings.
-
-|===
-
-[#query-select]
-=== Query Select
-
-The Query Select role lets the user execute `SELECT` statements on the data in one or more collections.
-The administrator sets which collections the user can access when granting this role.
-See xref:guides:query.adoc[].
-
-This role lets the user log into Couchbase Server Web Console. 
-
-
-[#table_query_select_role,cols="1,2,2,hrows=3]
-|===
-
-3+^| Role: Query Select (`query_select`)
-
-.2+^h| Resource
-2+^h| Privileges
-
-h| Permissions
-h| Restrictions
-
-| *Servers* 
-| List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
-
-| *Buckets*
-| Can list buckets.
-Can read data from specific collections.
-| Cannot list scopes or collections, create, drop, edit settings, read or write data.
-
-| *Query*
-| Can execute `SELECT` statements on data in one or more collections.
-Can read data from one or more collections.
-| Cannot perform any other queries.
-Cannot use the Query Workbench in Couchbase Server Web Console.
-
-| *Settings*
-| View cluster settings
-| Cannot view any other settings or change any settings.
-
-|===
-
-
-[#query-update]
-=== Query Update
-
-The Query Update role grants the user the ability to execute `UPDATE` statements to mutate existing documents in specific collections.  
-See xref:n1ql:n1ql-language-reference:update.adoc[] for more information.
-The administrator granting this role selects which collections contain documents the user can mutate.
-
-This role lets the user log into Couchbase Server Web Console. 
-
-
-[#table_query_update_role,cols="1,2,2,hrows=3]
-|===
-3+^| Role: Query Update (`query_update`)
-
-.2+^h| Resource
-2+^h| Privileges
-
-h| Permissions
-h| Restrictions
-
-| *Servers* 
-| List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
-
-| *Buckets*
-| List buckets and view bucket settings.
-| Cannot list scopes or collections, create, drop, edit settings.
-
-| *Query*
-| Can execute `UPDATE` statements on documents in one or more collections.
-| Cannot perform any other queries.
-Cannot create new documents.
-Cannot use the Query Workbench in Couchbase Server Web Console.
-
-| *Settings*
-| View cluster settings
-| Cannot view any other settings or change settings.
-
-|===
-
-[#query-insert]
-=== Query Insert
-
-The Query Insert role grants the user the ability to execute the {sqlpp} `INSERT` statement to add new documents to one or more collections.
-See xref:n1ql:n1ql-language-reference:insert.adoc[] for more information.
-The administrator granting this role selects which collections the user can add documents to.
-
-This role lets the user log into Couchbase Server Web Console.
-
-
-[#table_query_insert_role,cols="1,2,2,hrows=3]
-|===
-
-3+^|  Role: Query Insert (`query_insert`)
-
-.2+^h| Resource
-2+^h| Privileges
-
-h| Permissions
-h| Restrictions
-
-| *Servers* 
-| List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
-
-| *Buckets*
-| List buckets and view bucket settings.
-| Cannot list scopes or collections, create, drop, edit settings.
-
-| *Query*
-| Can execute `INSERT` statements to create documents in one or more collections.
-| Cannot perform any other queries.
-Cannot mutate existing documents.
-Cannot use the Query Workbench in Couchbase Server Web Console.
-
-| *Settings*
-| View cluster settings
-| Cannot view any other settings or change settings.
-
-|===
-
-[#query-delete]
-=== Query Delete
-
-The Query Delete role grants the user the ability to execute the {sqlpp} `DELETE` to delete documents from one or more scopes.
-See xref:n1ql:n1ql-language-reference:delete.adoc[] for more information.
-The administrator granting this role selects which collections the user can delete documents from.
-
-This role lets the user log into Couchbase Server Web Console. 
-
-
-[#table_query_delete_role,cols="1,2,2,hrows=3]
-|===
-3+^|  Role: Query Delete (`query_delete`)
-
-.2+^h| Resource
-2+^h| Privileges
-
-h| Permissions
-h| Restrictions
-
-| *Servers* 
-| List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
-
-| *Buckets*
-| List buckets and view bucket settings.
-| Cannot list scopes or collections.
-Cannot edit bucket settings.
-
-| *Query*
-| Can execute `DELETE` statements to delete documents from one or more collections.
-| Cannot perform any other queries.
-Cannot use the Query Workbench in Couchbase Server Web Console.
-
-| *Settings*
-| View cluster settings
-| Cannot view any other settings or change settings.
-
-|===
-
-
-[#query-sequential-scan]
-=== Query Use Sequential Scan
-
-The Query Use Sequential Scan role allows users' queries to perform a sequential scan of a keyspace.
-The query planner only decides to use a sequential scan when there is no suitable index for the keyspace. 
-Only queries by users with this role can use a sequential scan to query data because scanning a large unindexed keyspace can be expensive.  
-See xref:learn:services-and-indexes/indexes/query-without-index.adoc#sequential-scans[] for more information.
-
-NOTE: Administrator roles automatically have permission to perform sequential scans when necessary.
-
-This role does not let the user log into Coucbase Server Web Console .
-
-[#table_query_use_sequential_scans_role,cols="1,2,2,hrows=3]
-|===
-3+^|  Role: Query Use Sequential Scan (`query_use_sequential_scans`)
-
-.2+^h| Resource
-2+^h| Privileges
-
-h| Permissions
-h| Restrictions
-
-| *Query*
-| Can execute a query in a collection that lacks a primary and secondary index.
-| Cannot perform any other queries.
-
-|===
-
-
-[#query-manage-index]
-=== Query Manage Index
-
-The Query Manage Index role allows the user to manage indexes for one or more collections.
-The administrator granting this role selects which collections for which the user can manage indexes.
-
-This role lets the user log into Couchbase Server Web Console.
-
-[#table_query_manage_index_role,cols="1,2,2,hrows=3]
-|===
-3+^| Role: Query Manage Index (`query_manage_index`)
-
-.2+^h| Resource
-2+^h| Privileges
-
-| *Servers* 
-| List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
-
-| *Buckets*
-| List buckets and view bucket settings.
-| Cannot list scopes or collections, create, drop, edit settings.
-Cannot read or write data.
-
-| *Index*
-| Can create, drop, and view indexes for the collections whose indexes they have been given permission to manage.
-| Cannot perform any other queries, including calling the functions.
-Cannot use the Query Workbench in Couchbase Server Web Console.
-
-| *Settings*
-| View cluster settings
-| Cannot view any other settings or change settings.
-
-|===
-
-
-[#execute-scope-functions]
-=== Execute Scope Functions
-
-The Execute Scope Functions role lets the user execute {sqlpp} user-defined functions defined within a scope.
-The administrator granting this role selects in which scopes the user can call user-defined functions the user can call.
-
-This role lets the user log into Couchbase Server Web Console.
-
-
-[#table_query_execute_functions_role,cols="1,2,2,hrows=3]
-|===
-
-3+^|   Role: Execute Scope Functions (`query_execute_functions`)
-
-.2+^h| Resource
-2+^h| Privileges
-
-h| Permissions
-h| Restrictions
-
-| *Servers* 
-| List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
-
-
-| *Query*
-| Can execute scope user-defined functions.
-| Cannot perform any other queries.
-Cannot use the Query Workbench in Couchbase Server Web Console.
-
-| *Settings*
-| View cluster settings
-| Cannot view any other settings or change settings.
-
-|===
-
-
-[#manage-global-external-functions]
-=== Manage Global External Functions
-
-The Manage Global External Functions role lets the user manage global external language functions.
-See xref:n1ql:n1ql-language-reference/createfunction.adoc#external-libraries[External Libraries] for more information about external functions.
-
-This role lets the user log into Couchbase Server Web Console.
-
-[#table_manage_global_external_functions_role,cols="1,2,2,hrows=3]
-|===
-
-3+^| Role: Manage Global External Functions (`query_manage_global_external_functions`)
-
-.2+^h| Resource
-2+^h| Privileges
-
-h| Permissions
-h| Restrictions
-
-| *Servers* 
-| List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
-
-
-| *Query*
-| Can execute `CREATE FUNCTION` statements to create global external functions.
-| Cannot perform any other queries.
-Cannot use the Query Workbench in Couchbase Server Web Console.
-
-| *Settings*
-| View cluster settings
-| Cannot view any other settings or change settings.
-
-|===
-
-
-[#execute-global-external-functions]
-=== Execute Global External Functions
-
-The Execute Global External Functions role lets a user execute globally-defined external functions.
-See xref:n1ql:n1ql-language-reference/createfunction.adoc#external-libraries[External Libraries] for more information about external functions.
-
-This role lets the user log into Couchbase Server Web Console.
-
-
-[#table_execute_global_external_functions_role,cols="1,2,2,hrows=3]
-|===
-
-3+^| Role: Execute Global External Functions (`query_execute_global_external_functions`)
-
-.2+^h| Resource
-2+^h| Privileges
-
-h| Permissions
-h| Restrictions
-
-| *Servers* 
-| List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
-
-
-| *Query*
-| Can execute globally defined external functions.
-| Cannot perform any other queries.
-Cannot use the Query Workbench in Couchbase Server Web Console.
-
-| *Settings*
-| View cluster settings
-| Cannot view any other settings or change settings.
-
-|===
-
-
-[#manage-scope-external-functions]
-=== Manage Scope External Functions
-
-The Manage Scope External Functions role lets the user create and drop external language functions defined at the scope level.
-The administrator granting this role chooses the scopes where the user can manage external functions.
-See xref:n1ql:n1ql-language-reference/createfunction.adoc#external-libraries[External Libraries] for more information about external functions.
-
-This role lets the user log into Couchbase Server Web Console.
-
-
-[#table_manage_external_functions_role,cols="1,2,2,hrows=3]
-|===
-
-3+^| Role: Manage Scope External Functions (`query_manage_external_functions`)
-
-.2+^h| Resource
-2+^h| Privileges
-
-h| Permissions
-h| Restrictions
-
-| *Servers* 
-| List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
-
-| *Query*
-| Can call globally defined external functions.
-| Cannot perform any other queries.
-Cannot use the Query Workbench in Couchbase Server Web Console.
-
-| *Settings*
-| View cluster settings
-| Cannot view any other settings or change settings.
-
-|===
-
-
-[#execute-scope-external-functions]
-=== Execute Scope External Functions
-
-The Execute Scope External Functions role lets the user call external functions defined in a scope. 
-The administrator granting this role chooses the scopes where the user can call external functions.
-See xref:n1ql:n1ql-language-reference/createfunction.adoc#external-libraries[External Libraries] for more information about external functions.
-
-This role lets the user log into Couchbase Server Web Console.
-
-[#table_execute_external_functions_role,cols="1,2,2,hrows=3]
-|===
-
-3+^| Role: Execute Scope External Functions (`query_execute_external_functions`)
-
-.2+^h| Resource
-2+^h| Privileges
-
-h| Permissions
-h| Restrictions
-
-| *Servers* 
-| List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
-
-| *Query*
-| Can call globally defined external functions.
-| Cannot perform any other queries.
-Cannot use the Query Workbench in Couchbase Server Web Console.
-
-| *Settings*
-| View cluster settings
-| Cannot view any other settings or change settings.
-
-|===
-
-
-== Analytics Roles
-
-[#analytics-reader]
-=== Analytics Reader
-
-The Analytics Reader role lets the user query all analytic datasets.
-For more information, see xref:analytics:introduction.adoc[].
-
-This role lets the user log into Couchbase Server Web Console.
-
-[#table_analytics_reader_role,cols="1,2,2,hrows=3]
-|===
-
-3+^| Role: Analytics Reader (`analytics_reader`)
-
-.2+^h| Resource
-2+^h| Privileges
-
-h| Permissions
-h| Restrictions
-
-| *Servers* 
-| List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
-
-| *Settings*
-| View cluster settings
-| Cannot view any other settings or change settings.
-
-
-| *Analytics*
-| Can read any analytic data.
-Can use the Couchbase Server Web Console's Analytics query editor.
-| Cannot change analytic configuration.
-
-|===
-
-
-[#analytics-admin]
-=== Analytics Admin
-
-The Analytics Admin role lets users manage Analytics Service links, scopes, and datasets. 
-For more information, see xref:analytics:introduction.adoc[].
- 
-
-This role lets the user log into Couchbase Server Web Console.
-
-[#table_analytics_admin_role,cols="1,2,2,hrows=3]
-|===
-
-3+^| Role: Analytics Admin (`analytics_admin`)
-
-.2+^h| Resource
-2+^h| Privileges
-
-h| Permissions
-h| Restrictions
-
-| *Servers* 
-| List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
-
-| *Settings*
-| View cluster settings
-| Cannot view any other settings or change settings.
-
-
-| *Analytics*
-| Can add or drop Analytics Service links, scopes, and dataset.
-Can use the Couchbase Server Web Console's Analytics query editor.
-| Cannot change analytic configuration.
-
-|===
-
-
 
 [#bucket-roles]
 == Bucket Roles
@@ -1353,6 +783,1247 @@ h| Restrictions
 
 |===
 
+
+== Data Roles
+
+These roles give users the ability to read and write data in buckets via key-value operations.
+
+[#data-reader]
+=== Data Reader
+
+The Data Reader role lets the user read data from one or more collections via key-value retrieval. 
+It does not grant the ability to run {sqlpp} queries (see <<#query-roles>> for roles that do).
+When granting this role, the administrator chooses the collections the user can read data from.
+Grant this role to users for applications that need to read data via key-value operations.
+
+This role does not let the user log into Couchbase Server Web Console. 
+
+[#table_data_reader_role,cols="1,2,2,hrows=3"]
+|===
+3+^| Role: Data Reader (`data_reader`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Buckets*
+| Read data from collections, scopes, and buckets to which they have been granted access.
+Can read some bucket metadata, XATTR mappings, and pools on buckets they have been granted access to.
+| Cannot write data
+
+| *Query*
+| None
+| All
+
+|===
+
+
+
+[#data-writer]
+=== Data Writer
+
+The Data Writer role lets the user write data to one or more collections via key-value operations. 
+It does not grant the ability to run {sqlpp} queries (see <<#query-roles>> for roles that do).
+When granting this role, the administrator chooses the collections the user can write data to.
+Grant this role to users for applications that need to write data via key-value operations.
+
+This role does not let the user log into Couchbase Server Web Console. 
+
+[#table_data_writer_role,cols="1,2,2,hrows=3"]
+|===
+3+^| Role: Data Writer (`data_writer`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Buckets*
+| Write data to collections, scopes, and buckets to which they have been granted access.
+| Cannot read data
+
+| *Query*
+| None
+| All
+
+|===
+
+
+[#data-dcp-reader]
+=== Data DCP Reader
+
+The Data DCP Reader role lets the user start a xref:learn:clusters-and-availability/intra-cluster-replication.adoc#database-change-protocol[Database Change Protocol (DCP)] stream for one or more collections, scopes, or buckets. 
+When granting this role, the administrator chooses the collections, scopes, and buckets where the user can start DCP streams.
+Grant this role to users for applications that need to start DCP streams.
+
+This role does not let the user log into Couchbase Server Web Console. 
+
+[#table_data_dcp_reader_role,cols="1,2,2,hrows=3"]
+|===
+3+^| Role: Data DCP Reader (`data_dcp_reader`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Buckets*
+| Can start DCP streams for collections, scopes, and buckets they have been granted access to.
+Can also read data and XATTRs from these collections, scopes, and buckets.
+| Cannot write data
+
+| *Query*
+| None
+| All
+
+|===
+
+
+
+
+
+[#data-monitor]
+=== Data Monitor
+
+The Data Monitor role lets the user read statistics for a bucket, scope, or collection.
+When granting the role, the administrator decides which statics the user can read.
+Use this role for applications that need to read statistics.
+
+NOTE: In versions of Couchbase Server prior to 5.5, this role was referred to as *Data Monitoring*.
+
+This role does not let the user log into Couchbase Server Web Console. 
+
+[#table_data_monitoring_role,cols="1,2,2,hrows=3"]
+|===
+3+^|  Role: Data Monitor (`data_monitoring`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Buckets*
+| Can read statistics for buckets, scopes, and collections they have been granted access to. 
+| None
+
+|===
+
+
+== Views Roles
+
+The following roles are used with Views.
+
+NOTE: Views were deprecated in Couchbase Server 7.0. 
+See xref:learn/views/views-intro.adoc[] for more information.
+
+
+[#views-admin]
+=== Views Admin
+
+The Views Admin role lets the user create, modify, and drop views in one or more buckets.  
+When granting this role, the administrator chooses the buckets where the user can manage views.
+
+This role lets the user log into Couchbase Server Web Console.
+
+[#table_views_admin_role,cols="1,2,2,hrows=3"]
+|===
+3+^|  Role: Views Admin (`views_admin`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Servers* 
+| View configuration and statistics
+| Cannot add, failover, remove, modify services, rebalance
+
+| *Buckets*
+| Can read, write, and edit views for the buckets they have been granted access to. 
+Can read data (via key-value), statistics, and settings in these buckets.
+| Cannot write data to buckets or alter bucket settings
+
+| *XDCR*
+| Can list outgoing replications
+| Cannot view incoming replications or change XDCR settings
+
+| *Settings*
+| View all settings
+| Cannot edit settings
+
+| *Logs*
+| Can view logs
+| Cannot collect data
+
+| *Query*
+| None
+| Cannot execute queries
+
+| *Search*
+| Can view Search indexes
+| Cannot edit or add Search indexes
+
+| *Views*
+| Can create, drop, and edit views in buckets they have been granted access to.
+| Cannot change views
+
+
+|===
+
+
+[#query-roles]
+== Query & Index Roles
+
+[#query-curl-access]
+=== Query CURL Access
+
+The Query CURL Access role lets the user call the {sqlpp} curl function in their queries.
+
+CAUTION: The Query CURL Access role allows users to run GET and POST requests to any system on the network Couchbase Server uses for client connections.
+If your cluster is not configured to use a private network for internal communication, they also have access to the entire cluster.  
+They can interact with any system on this network.
+
+
+This role only grants the user the ability to read data returned by the {sqlpp} curl function.
+Usually, you assign additional roles to the user to allow them to read and write data.
+
+For more information about the {sqlpp} curl function, see xref:n1ql:n1ql-language-reference/curl.adoc[].
+
+This role lets the user log into Couchbase Server Web Console. 
+
+[#table_query_external_access_role,cols="1,2,2,hrows=3]
+|===
+
+3+^| Role: Query Curl Access (`query_external_access`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+
+| *Buckets*
+| List buckets
+| Cannot list scopes or collections.
+Cannot create, drop, or edit buckets.
+Cannot read data other than the results of the {sqlpp} curl function call.
+Cannot write data.
+
+| *Query*
+| Can execute {sqlpp} curl function calls
+| Cannot execute any other queries.
+Cannot use the Query Workbench in Couchbase Server Web Console.
+
+|===
+
+
+[#query-system-catalog]
+=== Query System Catalog
+
+The Query System Catalog role lets the user query the system catalog using {sqlpp}.
+This access include querying `system:indexes`, `system:prepareds`, and tables listing current and past queries.
+Assign this role to developers who need to query these tables when troubleshooting and debugging queries.
+
+The role grants Couchbase Server Web Console access.
+
+[#table_query_system_catalog_role,cols="1,2,2,hrows=3]
+|===
+
+3+^|  Role: Query System Catalog (`query_system_catalog`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Servers* 
+| List servers.
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+
+| *Buckets*
+| List buckets and view bucket settings
+| Cannot list scopes or collections, create, drop, edit settings, read or write data
+
+| *Query*
+| Can query system tables
+| Cannot perform any other query actions.
+Cannot use the query workbench in Couchbase Server Web Console.
+
+|===
+
+[#manage-global-functions]
+=== Manage Global Functions
+
+The Manage Global Functions role lets the user create and drop global user-defined {sqlpp} functions. 
+See xref:n1ql:n1ql-language-reference/createfunction.adoc[].
+
+This role grants Couchbase Server Web Console access.
+
+[#table_manage_global_functions_role,cols="1,2,2,hrows=3]
+|===
+
+3+^|  Role: Manage Global Functions (`query_manage_global_functions`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+
+| *Buckets*
+| List buckets
+| Cannot list scopes or collections, create, drop, edit settings, read or write data
+
+| *Query*
+| Can execute `CREATE FUNCTION` and `DROP FUNCTION` statements
+| Cannot perform any other queries, including calling the global functions
+Cannot use the Query Workbench in Couchbase Server Web Console
+
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings
+
+|===
+
+
+[#execute-global-functions]
+=== Execute Global Functions
+
+The Execute Global Functions role lets the user call global {sqlpp} functions.
+
+This role lets the user log into Couchbase Server Web Console. 
+
+[#table_query_execute_global_functions_role,cols="1,2,2,hrows=3]
+|===
+
+3+^|   Role: Execute Global Functions (`query_execute_global_functions`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+
+| *Buckets*
+| List buckets
+| Cannot list scopes or collections, create, drop, edit settings, read or write data
+
+| *Query*
+| Can execute global user-defined functions
+| Cannot perform any other queries.
+Cannot use the Query Workbench in Couchbase Server Web Console.
+
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings
+
+|===
+
+
+[#manage-scope-functions]
+=== Manage Scope Functions (Query and Index)
+
+The Manage Scope Functions role lets the user create an drop user-defined {sqlpp} functions for one or more scopes.
+See xref:n1ql:n1ql-language-reference/createfunction.adoc[].
+
+This role lets the user log into Couchbase Server Web Console. 
+
+
+[#table_manage_scope_functions_role,cols="1,2,2,hrows=3]
+|===
+
+3+^| Role: Manage Scope Functions (`query_manage_functions`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+
+| *Buckets*
+| List buckets
+| Cannot list scopes or collections, create, drop, edit settings, read or write data
+
+| *Query*
+| Can execute `CREATE FUNCTION` and `DROP FUNCTION` statements to create user-defined functions in specific scopes
+| Cannot perform any other queries, including calling the functions.
+Cannot use the Query Workbench in Couchbase Server Web Console.
+
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings
+
+|===
+
+[#query-select]
+=== Query Select
+
+The Query Select role lets the user execute `SELECT` statements on the data in one or more collections.
+The administrator sets which collections the user can access when granting this role.
+See xref:guides:query.adoc[].
+
+This role lets the user log into Couchbase Server Web Console. 
+
+
+[#table_query_select_role,cols="1,2,2,hrows=3]
+|===
+
+3+^| Role: Query Select (`query_select`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
+
+| *Buckets*
+| Can list buckets.
+Can read data from specific collections.
+| Cannot list scopes or collections, create, drop, edit settings, read or write data
+
+| *Query*
+| Can execute `SELECT` statements on data in one or more collections.
+Can read data from one or more collections.
+| Cannot perform any other queries.
+Cannot use the Query Workbench in Couchbase Server Web Console.
+
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change any settings
+
+|===
+
+
+[#query-update]
+=== Query Update
+
+The Query Update role grants the user the ability to execute `UPDATE` statements to mutate existing documents in specific collections.  
+See xref:n1ql:n1ql-language-reference:update.adoc[] for more information.
+The administrator granting this role selects which collections contain documents the user can mutate.
+
+This role lets the user log into Couchbase Server Web Console. 
+
+
+[#table_query_update_role,cols="1,2,2,hrows=3]
+|===
+3+^| Role: Query Update (`query_update`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+
+| *Buckets*
+| List buckets and view bucket settings
+| Cannot list scopes or collections, create, drop, edit settings
+
+| *Query*
+| Can execute `UPDATE` statements on documents in one or more collections
+| Cannot perform any other queries.
+Cannot create new documents.
+Cannot use the Query Workbench in Couchbase Server Web Console.
+
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings
+
+|===
+
+[#query-insert]
+=== Query Insert
+
+The Query Insert role grants the user the ability to execute the {sqlpp} `INSERT` statement to add new documents to one or more collections.
+See xref:n1ql:n1ql-language-reference:insert.adoc[] for more information.
+The administrator granting this role selects which collections the user can add documents to.
+
+This role lets the user log into Couchbase Server Web Console.
+
+
+[#table_query_insert_role,cols="1,2,2,hrows=3]
+|===
+
+3+^|  Role: Query Insert (`query_insert`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+
+| *Buckets*
+| List buckets and view bucket settings
+| Cannot list scopes or collections, create, drop, edit settings
+
+| *Query*
+| Can execute `INSERT` statements to create documents in one or more collections
+| Cannot perform any other queries.
+Cannot mutate existing documents.
+Cannot use the Query Workbench in Couchbase Server Web Console
+
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings
+
+|===
+
+[#query-delete]
+=== Query Delete
+
+The Query Delete role grants the user the ability to execute the {sqlpp} `DELETE` to delete documents from one or more scopes.
+See xref:n1ql:n1ql-language-reference:delete.adoc[] for more information.
+The administrator granting this role selects which collections the user can delete documents from.
+
+This role lets the user log into Couchbase Server Web Console. 
+
+
+[#table_query_delete_role,cols="1,2,2,hrows=3]
+|===
+3+^|  Role: Query Delete (`query_delete`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+
+| *Buckets*
+| List buckets and view bucket settings
+| Cannot list scopes or collections.
+Cannot edit bucket settings.
+
+| *Query*
+| Can execute `DELETE` statements to delete documents from one or more collections
+| Cannot perform any other queries.
+Cannot use the Query Workbench in Couchbase Server Web Console.
+
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings
+
+|===
+
+
+[#query-sequential-scan]
+=== Query Use Sequential Scan
+
+The Query Use Sequential Scan role allows users' queries to perform a sequential scan of a keyspace.
+The query planner only decides to use a sequential scan when there is no suitable index for the keyspace. 
+Only queries by users with this role can use a sequential scan to query data because scanning a large unindexed keyspace can be expensive.  
+See xref:learn:services-and-indexes/indexes/query-without-index.adoc#sequential-scans[] for more information.
+
+NOTE: Administrator roles automatically have permission to perform sequential scans when necessary.
+
+This role does not let the user log into Couchbase Server Web Console .
+
+[#table_query_use_sequential_scans_role,cols="1,2,2,hrows=3]
+|===
+3+^|  Role: Query Use Sequential Scan (`query_use_sequential_scans`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Query*
+| Can execute a query in a collection that lacks a primary and secondary index
+| Cannot perform any other queries
+
+|===
+
+
+[#query-manage-index]
+=== Query Manage Index
+
+The Query Manage Index role allows the user to manage indexes for one or more collections.
+The administrator granting this role selects which collections for which the user can manage indexes.
+
+This role lets the user log into Couchbase Server Web Console.
+
+[#table_query_manage_index_role,cols="1,2,2,hrows=3]
+|===
+3+^| Role: Query Manage Index (`query_manage_index`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+
+| *Buckets*
+| List buckets and view bucket settings
+| Cannot list scopes or collections, create, drop, edit settings.
+Cannot read or write data.
+
+| *Index*
+| Can create, drop, and view indexes for the collections whose indexes they have been given permission to manage
+| Cannot perform any other queries, including calling the functions.
+Cannot use the Query Workbench in Couchbase Server Web Console.
+
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings
+
+|===
+
+[#query-list-index]
+=== Query List Index
+
+This role lets the user list indexes defined for one or more buckets, scopes, or collections.
+The administrator granting this role selects the buckets, scopes, or collections where the user can list indexes.
+
+This role lets the user log into Couchbase Server Web Console.
+
+[#table_query_list_index_role,cols="1,2,2,hrows=3]
+|===
+3+^| Role: Query List Index (`query_list_index`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+| *Servers* 
+| List servers and view statistics
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+
+| *Buckets*
+| List and view statistics for buckets, scopes, and collections
+| Cannot create, drop, or edit bucket, scope, or collection settings.
+Cannot read or write data.
+
+| *Index*
+| Can get list of indexes via the stats endpoint
+| Cannot add, drop, or edit indexes.
+Cannot use the Index Workbench in Couchbase Server Web Console.
+
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings
+
+|===
+
+[#execute-scope-functions]
+=== Execute Scope Functions
+
+The Execute Scope Functions role lets the user execute {sqlpp} user-defined functions defined within a scope.
+The administrator granting this role selects in which scopes the user can call user-defined functions the user can call.
+
+This role lets the user log into Couchbase Server Web Console.
+
+
+[#table_query_execute_functions_role,cols="1,2,2,hrows=3]
+|===
+
+3+^|   Role: Execute Scope Functions (`query_execute_functions`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+
+
+| *Query*
+| Can execute scope user-defined functions
+| Cannot perform any other queries.
+Cannot use the Query Workbench in Couchbase Server Web Console.
+
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings
+
+|===
+
+
+[#manage-global-external-functions]
+=== Manage Global External Functions
+
+The Manage Global External Functions role lets the user manage global external language functions.
+See xref:n1ql:n1ql-language-reference/createfunction.adoc#external-libraries[External Libraries] for more information about external functions.
+
+This role lets the user log into Couchbase Server Web Console.
+
+[#table_manage_global_external_functions_role,cols="1,2,2,hrows=3]
+|===
+
+3+^| Role: Manage Global External Functions (`query_manage_global_external_functions`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+
+
+| *Query*
+| Can execute `CREATE FUNCTION` statements to create global external functions
+| Cannot perform any other queries.
+Cannot use the Query Workbench in Couchbase Server Web Console.
+
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings
+
+|===
+
+
+[#execute-global-external-functions]
+=== Execute Global External Functions
+
+The Execute Global External Functions role lets a user execute globally defined external functions.
+See xref:n1ql:n1ql-language-reference/createfunction.adoc#external-libraries[External Libraries] for more information about external functions.
+
+This role lets the user log into Couchbase Server Web Console.
+
+
+[#table_execute_global_external_functions_role,cols="1,2,2,hrows=3]
+|===
+
+3+^| Role: Execute Global External Functions (`query_execute_global_external_functions`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
+
+
+| *Query*
+| Can execute globally defined external functions
+| Cannot perform any other queries.
+Cannot use the Query Workbench in Couchbase Server Web Console.
+
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings
+
+|===
+
+
+[#manage-scope-external-functions]
+=== Manage Scope External Functions
+
+The Manage Scope External Functions role lets the user create and drop external language functions defined at the scope level.
+The administrator granting this role chooses the scopes where the user can manage external functions.
+See xref:n1ql:n1ql-language-reference/createfunction.adoc#external-libraries[External Libraries] for more information about external functions.
+
+This role lets the user log into Couchbase Server Web Console.
+
+
+[#table_manage_external_functions_role,cols="1,2,2,hrows=3]
+|===
+
+3+^| Role: Manage Scope External Functions (`query_manage_external_functions`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+
+| *Query*
+| Can call globally defined external functions
+| Cannot perform any other queries.
+Cannot use the Query Workbench in Couchbase Server Web Console.
+
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings
+
+|===
+
+
+[#execute-scope-external-functions]
+=== Execute Scope External Functions
+
+The Execute Scope External Functions role lets the user call external functions defined in a scope. 
+The administrator granting this role chooses the scopes where the user can call external functions.
+See xref:n1ql:n1ql-language-reference/createfunction.adoc#external-libraries[External Libraries] for more information about external functions.
+
+This role lets the user log into Couchbase Server Web Console.
+
+[#table_execute_external_functions_role,cols="1,2,2,hrows=3]
+|===
+
+3+^| Role: Execute Scope External Functions (`query_execute_external_functions`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+
+| *Query*
+| Can call globally defined external functions
+| Cannot perform any other queries.
+Cannot use the Query Workbench in Couchbase Server Web Console.
+
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings
+
+|===
+
+[#query_manage_sequences]
+=== Query Manage Sequences
+
+This role lets the user manage sequences for one or more scopes. 
+The administrator granting this role chooses the scopes where the user can manage sequences.
+See xref:n1ql:n1ql-language-reference/sequenceops.adoc[] for more information about sequences.
+
+This role lets the user log into Couchbase Server Web Console.
+
+[#table_query_manage_sequences_role,cols="1,2,2,hrows=3]
+|===
+
+3+^| Role: Query Manage Sequences (`query_manage_sequences`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
+
+| *Query*
+| Can create and alter sequences in buckets to which they have been granted access
+| Cannot perform any other queries.
+Cannot use the Query Workbench in Couchbase Server Web Console.
+Cannot manage sequences in buckets to which they have not been granted access.
+
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings
+
+|===
+
+
+[#query_use_sequences]
+=== Query Use Sequences
+
+This role lets the user incorporate sequences into their queries in one or more scopes.
+The administrator granting this role chooses the scopes where the user can use sequences.
+See xref:n1ql:n1ql-language-reference/sequenceops.adoc[] for more information about sequences.
+
+This role lets the user log into Couchbase Server Web Console.
+
+[#table_query_use_sequences_role,cols="1,2,2,hrows=3]
+|===
+
+3+^| Role: Query Manage Sequences (`query_use_sequences`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+
+| *Query*
+| Can use sequences in scopes they have been granted access to.
+| Cannot perform any other queries.
+Cannot use the Query Workbench in Couchbase Server Web Console.
+Cannot manage sequences.
+
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings
+
+|===
+
+
+[#query_manage_system_catalog]
+=== Query Manage System Catalog
+
+This role lets a user manage all system catalogs for query automatic worload reports using {sqlpp} statements.
+
+// TODO: Add link to the query workload docs when completed
+
+This role lets the user log into Couchbase Server Web Console.
+
+[#table_query_manage_system_catalog_role,cols="1,2,2,hrows=3]
+|===
+
+3+^| Role: Query Manage System Catalog (`query_manage_system_catalog`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+
+| *Query*
+| Can manage query workload system catalogs
+| Cannot perform any other queries.
+Cannot use the Query Workbench in Couchbase Server Web Console.
+
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings.
+
+|===
+
+
+
+== Search Roles
+
+The following roles give users privileges to the xref:learn:services-and-indexes/services/search-service.adoc[] features.
+
+[#search-admin]
+=== Search Admin
+
+The Search Admin role lets the user manage the Search Service in one or more buckets.
+When granting this role, the administrator chooses the buckets where the user can manage search.
+
+NOTE: In versions of Couchbase Server earlier than 5.5, this role was referred to as *FTS Admin*.
+
+This role lets the user log into Couchbase Server Web Console.
+
+
+[#table_search_admin_role,cols="1,2,2,hrows=3"]
+|===
+3+^|  Role: Search Admin (`fts_admin`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Servers*
+| Can list servers.
+| Cannot view or edit server configuration or statstics.
+Cannot rebalance, failover, add, or remove servers.
+
+| *Buckets*
+| Can list buckets, scopes, and collections. 
+Can view documents. 
+| Cannot edit documents or change bucket settings
+
+| *Settings* 
+| Can view cluster settings
+| Cannot view other settings nor change any settings.
+
+| *Query*
+| None
+| All
+
+| *Search*
+| Can add, edit, and drop Search indexes on the buckets they have access to.
+| Cannot manage Search indexes of buckets they do not have access to.
+
+|===
+
+
+
+[#search-reader]
+=== Search Reader
+
+The Search Reader role lets the user execute searches using Full Text Search indexes in one or more buckets.
+When granting this role, the administrator chooses the buckets in which the user can execute searches.
+
+NOTE: In versions of Couchbase Server prior to 5.5, this role was referred to as *FTS Searcher*.
+
+This role lets the user log into Couchbase Server Web Console.
+
+[#table_fts_searcher_role,cols="1,2,2,hrows=3"]
+|===
+3+^|  Role: Search Reader (`fts_searcher`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Servers*
+| Can list servers.
+| Cannot view or edit server configuration or statstics.
+Cannot rebalance, failover, add, or remove servers.
+
+| *Buckets*
+| Can list buckets
+| Cannot read documents
+
+
+| *Settings* 
+| Can view cluster settings
+| Cannot view other settings nor change any settings.
+
+| *Query*
+| None
+| All
+
+| *Search*
+| Can use search indexes in the buckets they have access to.
+| Cannot add, drop, or change set4tings for search indexes.
+
+|===
+
+
+
+
+== Analytics Roles
+
+The following roles give uses privileges for the Analytics Service.
+See xref:learn:services-and-indexes/services/analytics-service.adoc[] for more information.
+
+[#analytics-reader]
+=== Analytics Reader
+
+The Analytics Reader role lets the user query all analytic datasets.
+For more information, see xref:analytics:introduction.adoc[].
+
+This role lets the user log into Couchbase Server Web Console.
+
+[#table_analytics_reader_role,cols="1,2,2,hrows=3]
+|===
+
+3+^| Role: Analytics Reader (`analytics_reader`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
+
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings.
+
+
+| *Analytics*
+| Can read any analytic data.
+Can use the Couchbase Server Web Console's Analytics query editor.
+| Cannot change analytic configuration.
+
+|===
+
+
+[#analytics-admin]
+=== Analytics Admin
+
+The Analytics Admin role lets users manage Analytics Service links, scopes, and datasets for all buckets. 
+For more information, see xref:analytics:introduction.adoc[].
+ 
+
+This role lets the user log into Couchbase Server Web Console.
+
+[#table_analytics_admin_role,cols="1,2,2,hrows=3]
+|===
+
+3+^| Role: Analytics Admin (`analytics_admin`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings
+
+
+| *Analytics*
+| Can add or drop Analytics Service links, scopes, and dataset
+
+| None
+
+|===
+
+[#analytics-select]
+=== Analytics Select
+
+The Analytics Select role lets the user query analytic datasets for one or more buckets, scopes, or collections.
+When granting this role, the administrator chooses the buckets, scopes, and collections where the user can execute queries.
+
+This role lets the user log into Couchbase Server Web Console.
+
+[#table_analytics_select_role,cols="1,2,2,hrows=3"]
+|===
+3+^|  Role: Analytics Select (`analytics_select`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Servers*
+| Can list servers.
+| Cannot view or edit server configuration or statstics.
+Cannot rebalance, failover, add, or remove servers.
+
+| *Settings* 
+| Can view cluster settings
+| Cannot view other settings nor change any settings.
+
+| *Analytics*
+| Can query analytics data in the buckets they have access to.
+| Cannot add or drop Analytic scopes, links, nor collections or change their settings.
+
+|===
+
+[#analytics-manager]
+=== Analytics Manager
+
+The Analytics Manager role lets the user manage and query the analytic datasets for one or more buckets.
+They can also manage xref:analytics:manage-datasets.adoc#creating-a-collection-on-a-local-link[Analytics Service local links].
+When granting this role, the administrator chooses the buckets where the user can manage and query analytics.
+
+This role lets the user log into Couchbase Server Web Console.
+
+
+[#table_analytics_manager_role,cols="1,2,2,hrows=3"]
+|===
+3+^|  Role: Analytics Manager (`analytics_manager`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Servers*
+| Can list servers.
+| Cannot view or edit server configuration or statstics.
+Cannot rebalance, failover, add, or remove servers.
+
+| *Settings* 
+| Can view cluster settings
+| Cannot view other settings nor change any settings.
+
+| *Analytics*
+| Can query analytics data in the buckets they have access to.
+Can manage analytics in these buckets, including local links and adding/dropping analytics collections. 
+| Cannot manage analytics in buckets they have not been granted access to.
+
+|===
+
+
+== Eventing Roles
+
+These roles control a user's access to the Eventing Service.
+Also, see <<#eventing-full-admin>> for the Eventing-related administrator role.
+For more information about Eventing, see xref:eventing:eventing-overview.adoc[].
+
+[#eventing-manage-functions]
+=== Eventing Manage Scope Functions
+
+The Eventing Manage Scope Functions role lets the user manage the eventing functions in one or more scopes. 
+When granting this role, the administrator chooses the scopes where the user can manage eventing functions.
+
+NOTE: In addition to this role, the user must have the <<#data-dcp-reader>> on the collections they want their functions to listen to. 
+They must also have read and write permissions on one or more collections to store the function's event data.
+
+This role lets the user log into Couchbase Server Web Console.
+
+[#table_eventing_manage_functions,cols="1,2,2,hrows=3"]
+|===
+3+^|  Role: Eventing Manage Scope Functions (`eventing_manage_functions`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Server*
+| Can list servers
+| Cannot view server settings or statistics.
+Cannot edit server settings, failover, or rebalance servers.
+
+| *Settings*
+| Can view cluster settings
+| Cannot view other settings or change any settings
+
+| *Eventing*
+| Can add Eventing functions to a scope they have been granted access to.
+Can change eventing settings for the scopes.
+| None
+
+
+|===
+
 == XDCR Roles
 
 The following roles give users the ability to manage XDCR settings and features.
@@ -1451,6 +2122,62 @@ h| Restrictions
 | *XDCR*
 | Can create inbound connections on buckets they have been granted permissions on.
 | Cannot create outbound connections or alter other XDCR settings.
+
+|===
+
+
+== Backup Roles
+
+The following role gives users the ability to backup and restopre data.
+Also see the Administrative role <<#backup-full-admin>>.
+
+[#data-backup-and-restore]
+=== Data Backup & Restore
+
+The Data Backup & Restore lets users back up and restore data in one or more buckets.  
+When granting this role, the administrator chooses the buckets the user can back up.
+This role is not intended for interactive users.
+Grant this role to users for applications that need to back up and restore data. 
+
+NOTE: This role does not let the user access some important cluster-level data, so it cannot fully backup the cluster. 
+See xref:backup-restore:cbbackupmgr-backup.adoc#bucket-level[Bucket Level] in the xref:backup-restore:cbbackupmgr-backup.adoc[] documentation for details.
+
+
+This role does not let the user log into Couchbase Server Web Console. 
+
+[#table_data_backup_role,cols="1,2,2,hrows=3"]
+|===
+3+^|  Role: Data Backup & Restore (`data_backup`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Buckets*
+| Can read, write, and manage buckets they have been granted access to. 
+| None
+
+|*Backup*
+| Can backup bucket data, bucket {sqlpp} metadata, and analytics
+| Cannot backup other data   
+
+| *Security* 
+| Can view settings for SAML, certificates, encryption at rest, audits, and other settings.
+| Cannot change settings.
+
+| *Indexes*
+| Can build, create, and list
+| Cannot backup, read, or manage
+
+| *Bucket Analytics*
+| Can manage and select buvket analytics
+| Cannot read bucket analytics
+
+| *Analytics*
+| Can select and back up analytics 
+| Cannot read analytics synonyms
 
 |===
 
@@ -1664,600 +2391,35 @@ h| Restrictions
 |===
 
 
-== Data Roles
 
-These roles give users the ability to read and write data in buckets via key-value operations.
-
-[#data-reader]
-=== Data Reader
-
-The Data Reader role lets the user read data from one or more collections via key-value retrieval. 
-It does not grant the ability to run {sqlpp} queries (see <<#query-roles>> for roles that do).
-When granting this role, the administrator chooses the collections the user can read data from.
-Grant this role to users for applications that need to read data via key-value operations.
-
-This role does not let the user log into Couchbase Server Web Console. 
-
-[#table_data_reader_role,cols="1,2,2,hrows=3"]
-|===
-3+^| Role: Data Reader (`data_reader`)
-
-.2+^h| Resource
-2+^h| Privileges
-
-h| Permissions
-h| Restrictions
-
-| *Buckets*
-| Read data from collections, scopes, and buckets to which they have been granted access.
-Can read some bucket metadata, XATTR mappings, and pools on buckets they have been granted access to.
-| Cannot write data
-
-| *Query*
-| None
-| All
-
-|===
-
-
-
-[#data-writer]
-=== Data Writer
-
-The Data Writer role lets the user write data to one or more collections via key-value operations. 
-It does not grant the ability to run {sqlpp} queries (see <<#query-roles>> for roles that do).
-When granting this role, the administrator chooses the collections the user can write data to.
-Grant this role to users for applications that need to write data via key-value operations.
-
-This role does not let the user log into Couchbase Server Web Console. 
-
-[#table_data_writer_role,cols="1,2,2,hrows=3"]
-|===
-3+^| Role: Data Writer (`data_writer`)
-
-.2+^h| Resource
-2+^h| Privileges
-
-h| Permissions
-h| Restrictions
-
-| *Buckets*
-| Write data to collections, scopes, and buckets to which they have been granted access.
-| Cannot read data
-
-| *Query*
-| None
-| All
-
-|===
-
-
-[#data-dcp-reader]
-=== Data DCP Reader
-
-The Data DCP Reader role lets the user start a xref:learn:clusters-and-availability/intra-cluster-replication.adoc#database-change-protocol[Database Change Protocol (DCP)] stream for one or more collections, scopes, or buckets. 
-When granting this role, the administrator chooses the collections, scopes, and buckets where the user can start DCP streams.
-Grant this role to users for applications that need to start DCP streams.
-
-This role does not let the user log into Couchbase Server Web Console. 
-
-[#table_data_dcp_reader_role,cols="1,2,2,hrows=3"]
-|===
-3+^| Role: Data DCP Reader (`data_dcp_reader`)
-
-.2+^h| Resource
-2+^h| Privileges
-
-h| Permissions
-h| Restrictions
-
-| *Buckets*
-| Can start DCP streams for collections, scopes, and buckets they have been granted access to.
-Can also read data and XATTRs from these collections, scopes, and buckets.
-| Cannot write data
-
-| *Query*
-| None
-| All
-
-|===
-
-
-
-[#data-backup-and-restore]
-=== Data Backup & Restore
-
-The Data Backup & Restore lets users back up and restore data in one or more buckets.  
-When granting this role, the administrator chooses the buckets the user can back up.
-This role is not intended for interactive users.
-Grant this role to users that applications use to back up and restore data. 
-
-NOTE: This role does not let the user access some important cluster-level data, so it cannot fully backup the cluster. 
-See xref:backup-restore:cbbackupmgr-backup.adoc#bucket-level[Bucket Level] in the xref:backup-restore:cbbackupmgr-backup.adoc[] documentation for details.
-
-
-This role does not let the user log into Couchbase Server Web Console. 
-
-[#table_data_backup_role,cols="1,2,2,hrows=3"]
-|===
-3+^|  Role: Data Backup & Restore (`data_backup`)
-
-.2+^h| Resource
-2+^h| Privileges
-
-h| Permissions
-h| Restrictions
-
-| *Buckets*
-| Can read, write, and manage buckets they have been granted access to. 
-| None
-
-|*Backup*
-| Can backup bucket data, bucket {sqlpp} metadata, and analytics
-| Cannot backup other data   
-
-| *Security* 
-| Can view settings for SAML, certificates, encryption at rest, audits, and other settings.
-| Cannot change settings.
-
-| *Indexes*
-| Can build, create, and list
-| Cannot backup, read, or manage
-
-| *Bucket Analytics*
-| Can manage and select buvket analytics
-| Cannot read bucket analytics
-
-| *Analytics*
-| Can select and back up analytics 
-| Cannot read analytics synonyms
-
-|===
-
-
-[#data-monitor]
-=== Data Monitor
-
-The Data Monitor role lets the user read statistics for a bucket, scope, or collection.
-When granting the role, the administrator decides which statics the user can read.
-Use this role for applications that need to read statistics.
-
-NOTE: In versions of Couchbase Server prior to 5.5, this role was referred to as *Data Monitoring*.
-
-This role does not let the user log into Couchbase Server Web Console. 
-
-[#table_data_monitoring_role,cols="1,2,2,hrows=3"]
-|===
-3+^|  Role: Data Monitor (`data_monitoring`)
-
-.2+^h| Resource
-2+^h| Privileges
-
-h| Permissions
-h| Restrictions
-
-| *Buckets*
-| Can read statistics for buckets, scopes, and collections they have been granted access to. 
-| None
-
-|===
-
-== Views Roles
-
-The following roles are used with Views.
-Views were deprecated in COuchbase Server 7.0. 
-See xref:learn/views/views-intro.adoc[] for more.
-
-
-[#views-admin]
-=== Views Admin
-
-The Views Admin role lets the user create, modify, and drop views in on eor more buckets.  
-
-The role allows access to Couchbase Web Console.
-
-[#table_views_admin_role,cols="15,8,8,8,8",hrows=3]
-|===
-5+^| Role: Views Admin (`views_admin`)
-
-.2+^h| Resources
-4+^h| Privileges
-
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
-
-^| Bucket Data (Views)
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-
-^| Bucket Data (Other)
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Bucket Statistics
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Bucket Settings
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Bucket ({sqlpp})
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-
-^| UI (Views)
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-
-^| UI (Other)
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-|===
 
 [#views-reader]
-== Views Reader
+=== Views Reader
 
-The *Views Reader* role (which is an Administrative role) allows data to be read from views, per bucket.
-This role does not allow access to Couchbase Web Console, and is intended to support applications, rather than users.
+The Views Reader role lets a user read data from views in one or more buckets.
+When granting this role, the administrator chooses which buckets contain views the user can read.
+Grant this role to users you create for applications that need to read data from views.
 
-[#table_views_reader_role,cols="15,8,8,8,8",hrows=3]
+This role does not let the user log into Couchbase Server Web Console. 
+ 
+[#table_views_reader_role,cols="1,2,2,hrows=3"]
 |===
-5+^| Role: Views Reader (`views_reader`)
+3+^|  Role: Views Reader (`views_reader`)
 
-.2+^h| Resources
-4+^h| Privileges
+.2+^h| Resource
+2+^h| Privileges
 
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
+h| Permissions
+h| Restrictions
 
-^| Bucket : Docs
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Buckets*
+| Can read data from views in the buckets they have access to. 
+Can read data via key-value from these buckets. 
+| Cannot write data to buckets, alter bucket settings, or alter views.
 
-^| Bucket : Views
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Views*
+| Can read data from views in buckets they have been granted access to.
+| Cannot change views
 
-^| Pools
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-|===
 
-
-[#eventing-full-admin]
-== Eventing Full Admin
-
-The *Eventing Full Admin* role (which is an Eventing role) allows creation and management of eventing functions.
-The role allows access to Couchbase Web Console.
-
-[#table_eventing_admin_role,cols="15,8,8,8,8",hrows=3]
-|===
-5+^| Role: Eventing Full Admin (`eventing_admin`)
-
-.2+^h| Resources
-4+^h| Privileges
-
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
-
-^| Data
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-
-^| {sqlpp}
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-
-^| Eventing
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-
-^| Analytics
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-
-^| UI
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-|===
-
-[#eventing-manage-functions]
-== Manage Scope Functions (Eventing)
-
-The *Manage Scope Functions* role (which is an Eventing role) allows eventing functions for a given scope to be managed.
-The role allows access to Couchbase Web Console.
-
-[#table_eventing_manage_functions,cols="15,8,8,8,8",hrows=3]
-|===
-5+^| Role: Manage Scope Functions (`eventing_manage_functions`)
-
-.2+^h| Resources
-4+^h| Privileges
-
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
-
-^| Bucket, Collection: Functions for Scope
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-
-^| Bucket Statistics
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-
-^| UI
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-|===
-
-
-[#backup-full-admin]
-== Backup Full Admin
-
-The *Backup Full Admin* role (which is a Backup role) allows performance of backup-related tasks.
-The role allows access to Couchbase Web Console.
-
-[#table_backup_admin_role,cols="15,8,8,8,8",hrows=3]
-|===
-5+^| Role: Backup Full Admin (`backup_admin`)
-
-.2+^h| Resources
-4+^h| Privileges
-
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
-
-^| Data
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-
-^| Cluster Settings
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-
-^| Bucket Settings
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-
-^| Backup Service
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-
-^| UI
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-|===
-
-[#search-admin]
-== Search Admin
-
-The *Search Admin* role (which is a Search role) allows management of all features of the Search Service, per bucket.
-The role allows access to Couchbase Web Console.
-
-In versions of Couchbase Server prior to 5.5, this role was referred to as *FTS Admin*.
-
-[#table_search_admin_role,cols="15,8,8,8,8",hrows=3]
-|===
-5+^| Role: Search Admin (`fts_admin`)
-
-.2+^h| Resources
-4+^h| Privileges
-
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
-
-^| Bucket Data (Search)
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-
-^| Bucket Data (Other)
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Bucket Settings
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Search Settings
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-
-^| UI (Other)
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Pools
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-|===
-
-[#search-reader]
-== Search Reader
-
-The role *Search Reader* (which is a Search role) allows Full Text Search indexes to be searched for bucket, scope, and collection.
-The role allows access to Couchbase Web Console, and supports the reading of data.
-
-In versions of Couchbase Server prior to 5.5, this role was referred to as *FTS Searcher*.
-
-[#table_fts_searcher_role,cols="15,8,8,8,8",hrows=3]
-|===
-5+^| Role: Search Reader (`fts_searcher`)
-
-.2+^h| Resources
-4+^h| Privileges
-
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
-
-^| Bucket : FTS
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Settings: FTS
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| UI
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Pools
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-|===
-
-[#analytics-select]
-== Analytics Select
-
-The *Analytics Select* role (which is an Analytics role) allows the querying of datasets  for bucket, scope. and collection.
-The role allows access to Couchbase Web Console, and permits the reading of some data.
-
-[#table_analytics_select_role,cols="15,8,8,8,8",hrows=3]
-|===
-5+^| Role: Analytics Select (`analytics_select`)
-
-.2+^h| Resources
-4+^h| Privileges
-
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
-
-^| Bucket : Analytics
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-
-^| UI
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Pools
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-|===
-
-[#analytics-manager]
-== Analytics Manager
-
-The *Analytics Manager* role (which is an Analytics role) allows the management and querying of datasets created per bucket; and the management of Analytics Service local links.
-The role allows access to Couchbase Web Console, and permits the reading of some data.
-
-[#table_analytics_manager_role,cols="15,8,8,8,8",hrows=3]
-|===
-5+^| Role: Analytics Manager (`analytics_manager`)
-
-.2+^h| Resources
-4+^h| Privileges
-
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
-
-^| Bucket : Analytics
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-
-^| UI
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Pools
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
 |===

--- a/modules/learn/pages/security/roles.adoc
+++ b/modules/learn/pages/security/roles.adoc
@@ -55,11 +55,11 @@ For example, only the Full Admin role lets a user access the entire **Security**
 Users with either the Local User Admin or the External User Admin roles can only see the **Users & Groups** tab on this screen.
 
 Applications::
-Applications need to have user accounts when interacting with Couchbase Server.
-You often assign these users roles that let them to read or write data or have other limited privileges.
+An applications needs to have a user account to authenticate with with Couchbase Server.
+You often assign these users roles that let them read or write data or other limited privileges.
 Most of the roles you grant applications do not allow them to log into Couchbase Server Web Console or modify cluster settings.
-For example, the <<#data-reader>> and <<#data-writer>> roles lets the user read and write data.
-You can restrict these privileges to one or more collections, scopes, or buckets.
+For example, the <<#data-reader>> and <<#data-writer>> roles lets the user read and write data using key-value operations.
+You can limit these privileges to one or more collections, scopes, or buckets.
 Other roles appropriate for applications are <<#manage-scopes>>, <<#data-dcp-reader>>, and <<#data-backup-and-restore>>.
 
 

--- a/modules/learn/pages/security/roles.adoc
+++ b/modules/learn/pages/security/roles.adoc
@@ -242,6 +242,11 @@ It does not grant the ability to read data.
 The role allows users to edit local users, but they cannot grant these users the Full Admin, Read-Only Admin,  Local User Admin, or External User Admin roles.
 They also cannot edit the accounts for any user with those roles (including their own account).
 
+NOTE: This role replaced the Local User Security Admin role in Couchbase Server 8.0.
+The Local User Security Admin role had additional administration privileges that were split off into the <<#security-admin>> role. 
+When upgrading to 8.0 or restoring a backup from a pre-8.0 version to Couchbase Server 8.0 or later, users with the Local User Security Admin role are granted this role and the <<#security-admin>> role.
+This conversion ensures the user retains the privileges they had in prior versions.
+
 This role lets users log into the Couchbase Server Web Console.
 
 [#table_security_admin_local_role,cols="1,2,2,hrows=2"]
@@ -457,6 +462,11 @@ It also lets the user manage groups and read all cluster statistics.
 Users with this role cannot grant external users or groups Full Admin, Read-Only Admin, Security Admin, or Local or External User Admin roles.
 They also cannot edit users with those roles. 
 
+NOTE: This role replaced the External User Security Admin role in Couchbase Server 8.0.
+The External User Security Admin role had additional administration privileges that were split off into the <<#security-admin>> role. 
+When upgrading to 8.0 or restoring a backup from a pre-8.0 version to Couchbase Server 8.0 or later, users with the External User Security Admin role are granted this role and the <<#security-admin>> role.
+This conversion ensures the user retains the privileges they had in prior versions.
+
 This role lets the user log into the Couchbase Server Web Console.
 
 [#table_security_admin_external_role,cols="1,2,2,hrows=2"]
@@ -485,7 +495,7 @@ h| Restrictions
 
 | *Security* 
 | Add, delete, edit external users.
-Add, delete. edit groups.
+Add, delete, and edit groups.
 | Cannot grant Full Admin, Read-Only Admin, Local or External User Admin, or Security Admin roles to groups or external users.
 Cannot access security resources besides users and groups.
 
@@ -599,6 +609,7 @@ This role does not let the user log into the Couchbase Server Web Console.
 
 [#table_external_stats_role,cols="1,2,2,hrows=2]
 |===
+
 3+^|  Role: External Stats Reader (`external_stats_reader`)
 
 h| Resource

--- a/modules/learn/pages/security/roles.adoc
+++ b/modules/learn/pages/security/roles.adoc
@@ -1,44 +1,63 @@
 = Roles
-:description: pass:q[A Couchbase role permits one or more resources to be accessed according to defined privileges.]
+:description: pass:q[Roles grant users access to one or more resources.]
 :page-aliases: security:security-roles,security:concepts-rba,security:concepts-rba-for-apps,security:rbac-ro-user,learn:security/resources-under-access-control,security:security-resources-under-access-control
+:page-toclevels: 3
 
 [abstract]
 {description}
+Administrators assign roles to users to enable them to perform the tasks they need to carry out when using Couchbase Server.
+
 
 [#roles-and-privileges]
 == Roles and Privileges
 
-Couchbase roles each have a fixed association with a set of one or more privileges.
-Each privilege is associated with a resource.
-Privileges are actions such as *Read*, *Write*, *Execute*, *Manage*, *Flush*, and *List*; or a combination of some or all of these.
+Each role grants one or more privileges to interact with a resource.
+A Privilege is an action that a user can take with a resource.
+They include:
 
-Roles are of the following kinds:
+* Execute
+* Flush
+* List
+* Manage
+* Read 
+* Write
 
-* Administative: Associated with cluster-wide privileges.
-Some of these roles are for administrators; who might manage cluster-configurations; or read statistics; or enforce security.
-Others are for users and user-defined applications that require access to specific, cluster-wide resources.
+Roles provide a set of privileges for interacting with a resource. 
+For example, the Data Writer role grants a user the ability to write data.
+This ability can be limited to specific collections, scopes, or buckets.
+This role does not grant the user the ability to read data.
+The Data Reader role grants that ability.
 
-* Bucket: Associated with bucket administration, collection management, and application access.
-Roles in this category can each be applied to one, to multiple, or to all buckets on the cluster.
+An administrator can grant a user a set of roles to precisely tailor their privileges so they can perform their tasks in the database.
 
-* Data, Views, and XDCR: Associated with the Data Service.
-This includes the reading, writing, monitoring, backing-up, and restoring of data; the administration of Views; and the administration of Cross Data-Center Replication (XDCR).
+Roles fall into the following categories:
 
-* Other Services: Roles for the administration of services other than the Data Service.
-These roles are organized under the following categories: Query & Index, Search, Analytics, and Backup.
+* Administrative roles have cluster-wide privileges.
+Some of these roles are for administrators who manage cluster-configurations, read statistics, or enforce security.
+Others are for users and user-defined applications that must access cluster-wide resources.
+
+* Bucket: roles have privileges for bucket administration, collection management, and application access.
+Roles in this category grant privileges to one, multiple, or all buckets in the cluster.
+
+* Data, Views, and XDCR roles have privileges associated with the Data Service.
+These privileges include reading, writing, monitoring, backing-up, and restoring data. 
+They also allow the administration of Views and Cross Datacenter Replication (XDCR) connections.
+
+* Other Services roles are for the administration of services other than the Data Service.
+These roles have the following subcategories: Query & Index, Search, Analytics, and Backup.
 (Eventing administration is covered within the Administrative category.)
 
-* Mobile: Associated with the administration of Sync Gateway.
+* Mobile roles are associated with the administration of Sync Gateway.
 
-When a user (meaning either an administrator or an application) attempts to access a resource, they must authenticate.
-The roles and privileges associated with the user-credentials thereby presented are checked by Couchbase Server.
-If the associated roles contain privileges that support the kind of access that is being attempted, access is granted; otherwise, it is denied.
+A user (including administrators and applications) authenticates when they attempt to access a resource.
+Couchbase Server checks the roles associated with the user's credentials.
+If the associated roles grant the user the right to access the resource, Couchbase Server allows the access.
 
 [#roles-in-relation-to-buckets]
 === Roles in Relation to Buckets
 
-All data within a bucket is contained within some collection, within some scope.
-Permissions conveyed by bucket-related roles may be restricted in any of the following ways:
+All data within a collection, which in urn is within a scope which is stored within a bucket. 
+Administrators granting bucket-related roles can restrict the user's privileges to access to data in any of the following ways:
 
 * By Bucket: Permissions apply to all data in the specified bucket: all scopes and collections are thus covered by the permissions.
 
@@ -46,727 +65,1055 @@ Permissions conveyed by bucket-related roles may be restricted in any of the fol
 
 * By Bucket, Scope, and Collection: Permissions apply only to the data within the specified collection (or collections), within the specified scope (or scopes), within the specified bucket.
 
-For detailed information on scopes and collections, see xref:learn:data/scopes-and-collections.adoc[Scopes and Collections].
+For detailed information about scopes and collections, see xref:learn:data/scopes-and-collections.adoc[].
 
 [#commonly-used-roles]
 === Commonly Used Roles
 
-Couchbase Server users can largely be categorized as administrators, developers, and applications.
-Each user-category is supported by a different subset of roles.
+Couchbase Server users fall into three categories: administrators, developers, and applications.
+Which roles you assign to a user normally depends on which category they fall into:
 
-* Administrators.
-Able to log into Couchbase Web Console and perform administrative tasks; but unable to read or write data.
+Administrators::
+Users with any of the administrator roles can log into Couchbase Server Web Console and perform administrative tasks.
+Besides the Full Admin role, these roles do not grant the ability to read or write data.
 +
-The administrative tasks available are divided into multiple `admin` roles.
-For example, the *Cluster Admin* role allows the management of all cluster features except security; while the *Read-Only Admin* role allows only the reading of statistics; and the *Bucket Admin* role allows management only of one or more buckets.
-See the *Admin* roles listed below for full details.
-Note that depending on the administrator's assigned roles, the content of Couchbase Web Console changes: for example, the entire *Security* screen is only visible to *Full Admin* administrators; and to administrators who possess both the *Local User Security Admin* and the *External User Security Admin* roles.
+The administrative roles grant their uses the ability to carry out specific tasks.
+For example, a user with the Cluster Admin role can manage of all cluster features except security.
+Users with the Read-Only Admin role can only read statistics.
+The Bucket Admin role allows management only of one or more buckets.
+See the <<#admin-roles>> for details.
++
+NOTE: The user interface of the Couchbase Web Console changes based on the administrative role the user has.
+For example, only the Full Admin role lets a user access the entire **Security** screen.
+Users with either the Local User Admin or the External User Admin roles can only see the **Users & Groups** tab on this screen.
 
-* Applications.
-Able to read or write data; but unable to log into Couchbase Web Console, or in any way modify cluster-settings.
-For example, the *Data Reader* and *Data Writer* roles allows data to be respectively read and written to one or more collections, within one or more scopes, within one or more buckets.
-Other application-intended roles are *Application Access*, *Data Writer*, *Data Backup & Restore*, and *Data Monitor*.
-See below for details on each.
+Applications::
+Application users are can read or write data.
+They cannot log into Couchbase Server Web Console or modify cluster settings.
+For example, the Data Reader and Data Writer roles lets the user read and write one or more collections, within one or more scopes, within one or more buckets.
+Other application roles are Application Access, Data Writer, Data Backup & Restore, and Data Monitor.
+See <<#>> for details on each.
 
-* Developers.
+Developers::
 Can be given a selection of roles, allowing the right degree of data and console access.
 For example, the *Read-Only Admin* role allows the reading of cluster-statistics, while the *Data Read* and *Data Write* roles allow access to data on one or more buckets.
 
-The following list contains all roles supported by Couchbase Server, Enterprise Edition.
-Each role is explained by means of a description and (in most cases) a table: the table lists the privileges in association with resources.
-The header of each table states the role's *name*, followed by its alias name in parentheses: alias names are used in commands and queries.
+The following list contains all roles supported by Couchbase Server Enterprise Edition.
 In each table-body, where a privilege is associated with a resource, this is indicated with a check-mark.
-Where a privilege is not associated with a resource (or where association would not be applicable), this is indicated with a cross.
-Resources not referred to in a particular table have no privileges associated with them in the context of the role being described.
 
 Note that some roles grant access to Couchbase Web Console; while others do not.
 The set of features displayed within the console varies, according to role.
 
-Note also that any authentication failure will be logged in the log file for the resource on which access was attempted.
+also that any authentication failure will be logged in the log file for the resource on which access was attempted.
 See xref:manage:manage-logging/manage-logging.adoc[Manage Logging], for detailed information on using log files.
 
-[#full-admin]
-== Full Admin
+== Role Overviews
 
-The *Full Admin* role (an Administrative role) supports full access to all Couchbase-Server features and resources, including those of security.
-The role allows access to Couchbase Web Console, and allows the reading and writing of bucket-data.
+The following sections describe the roles Defined by Couchbase Server. 
+Each description lists the resources the roles allow users to access, and any limitations on their access.
+
+NOTE: Most roles have a table listing resources and a summary of what the role permits and does not allow user to do with the resource.
+If a resource does not appear in this table, the role does not grant the user any access to it. 
+
+
+[#admin-roles]
+== Administrative Roles
+
+The following roles grant users the ability to administer some aspects of Couchbase Server.
+
+[#full-admin]
+=== Full Admin
+
+The Full Admin role  grants full access to all Couchbase Server features and resources, including security.
+The role grants access to Couchbase Server Web Console.
 
 This role is also available in Couchbase Server Community Edition.
 
-[#cluster-admin]
-== Cluster Admin
-
-The *Cluster Admin* role (an Administrative role) allows the management of all cluster features except security.
-The role allows access to Couchbase Web Console, but does not permit the writing of data.
-
-[#table_cluster_admin_role,cols="15,8,8,8,8",hrows=3]
-|===
-5+^| Role: Cluster Admin (`cluster_admin`)
-
-.2+^h| Resources
-4+^h| Privileges
-
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
-
-^| Cluster (except Passwords)
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-
-^| UI (except Passwords)
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-
-^| Security (except Passwords)
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Bucket Data
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-|===
-
-[#local-user-security-admin]
-== Local User Security Admin
-
-The *Local User Security Admin* role (an Administrative role) allows the management of local user roles and the reading of all cluster statistics.
-The role does not permit the granting of the *Full Admin*, the *Read-Only Admin*, the *Local User Security Admin*, or the *External User Security Admin* role; and does not permit the administrator to change their own role (which therefore remains *Local User Security Admin*).
-The role supports access to Couchbase Web Console, but does not support the reading of data.
-
-[#table_security_admin_local_role,cols="15,8,8,8,8",hrows=3]
-|===
-5+^| Role: Local User Security Admin (`security_admin_local`)
-
-.2+^h| Resources
-4+^h| Privileges
-
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
-
-^| Cluster
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| UI (except Local User and Group Security)
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Local User and Group Security (including UI)
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-
-^| Bucket Data
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-|===
-
-[#external-user-security-admin]
-== External User Security Admin
-
-The *External User Security Admin* role (an Administrative role) allows the management of external user roles and the reading of all cluster statistics.
-The role does not permit the granting of the *Full Admin*, the *Read-Only Admin*, the *Local User Security Admin*, or the *External User Security Admin* role; and does not permit the administrator to change their own role (which therefore remains *External User Security Admin*).
-The role supports access to Couchbase Web Console, but does not support the reading of data.
-
-[#table_security_admin_external_role,cols="15,8,8,8,8",hrows=3]
-|===
-5+^| Role: External User Security Admin (`security_admin_external`)
-
-.2+^h| Resources
-4+^h| Privileges
-
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
-
-^| Cluster
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| UI (except External User Security)
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Security (including UI)
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-
-^| Bucket Data
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-|===
-
 [#read-only-admin]
-== Read-Only Admin
+=== Read-Only Admin
 
-The *Read-Only Admin* role (an Administrative role) supports the reading of Couchbase Server statistics. 
+The Read-Only Admin role grants the user the ability to read Couchbase Server settings and statistics. 
 This information includes registered usernames with roles and authentication domains, but excludes passwords.
-ifeval::['{page-component-version}' == '7.6']
-Since Couchbase Server version 7.6.2, users with this role can also read Backup Service data to monitor backup plans and tasks.
-endif::[]
-ifeval::['{page-component-version}' != '7.6']
 Users with this role can also read Backup Service data to monitor backup plans and tasks.
-endif::[]
 The role allows access to Couchbase Server Web Console.
 
 This role is also available in Couchbase Server Community Edition.
 
-[#table_read_only_admin_role,cols="15,8,8,8,8",hrows=3]
+[#table_read_only_admin_role,cols="1,2,2,hrows=3"]
 |===
-5+^| Role: Read-Only Admin (`ro_admin`)
+3+^|  Role: Read-Only Admin (`ro_admin`)
 
-.2+^h| Resources
-4+^h| Privileges
+.2+^h| Resource
+2+^h| Privileges
 
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
+h| Permissions
+h| Restrictions
 
-^| Cluster
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Servers* 
+| View configuration and statistics
+| Cannot add, failover, remove, modify services, rebalance
 
-^| UI (except Passwords)
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Buckets*
+| List buckets, scopes, and collections
+| Cannot create, drop, edit settings, read or write data
 
-^| Security (except Passwords)
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Backup*
+| List repositories and plans
+| Cannot add or edit repositories or plans. 
 
-^| Bucket Data
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *XDCR* 
+| List remote clusters and outgoing replications 
+| Cannot list incoming replications, add or edit replications.
 
-^| Backup Service (tasks and plans) [.status]#Couchbase Server 7.6.2#
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Security* 
+| Can view settings for SAML, certificates, encryption at rest, audits, and other settings.
+| Cannot change settings.
+
+| *Settings*
+| View all settings
+| Cannot edit settings
+
+| *Logs*
+| View
+| Collect Information
+
+| *Indexes*
+| Can view index settings and stats
+| Cannot add, edit, or drop indexes
+
+| *Query*
+| None
+| All
+
+| *Search*
+| Can view Search indexes
+| Cannot edit or add Search indexes
+
+| *Analytics*
+| None
+| All
+
+| *Eventing*
+| None
+| All
+
+| *Views*
+| Can list defined views
+| Cannot change views
 
 |===
+
+[#cluster-admin]
+=== Cluster Admin
+
+The Cluster Admin role lets the user manage of all cluster features except security.
+The role grants access to Couchbase Server Web Console.
+Cluster Admins can create, edit, and drop buckets but cannot read or write data.
+
+[#table_cluster_admin_role,cols="1,2,2,hrows=3"]
+|===
+3+^| Role: Cluster Admin (`cluster_admin`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Servers* 
+| All
+| None
+
+| *Buckets*
+| Create, drop, edit settings
+| Read or write data
+
+| *Backup*
+| None
+| All
+
+| *XDCR* 
+| All
+| None
+
+| *Security* 
+| None
+| All
+
+| *Settings*
+| All
+| None
+
+| *Logs*
+| All
+| None
+
+| *Query*
+| None
+| All
+
+| *Search*
+| None
+| All
+
+| *Analytics*
+| None
+| All
+
+| *Eventing*
+| Import, Change Settings
+| Add, remove, edit functions (due inability to read/write data)
+
+| *Views*
+| None
+| All
+
+|===
+
+
+[#local-user-security-admin]
+=== Local User Admin
+
+The Local User Admin role grants a user the ability to manage users defined in the xref:learn:security/authentication-domains.adoc#local-domain[local authentication domain].
+It also grants the ability to read all cluster statistics such as the settings, logs, and buckets.
+It does not grant the ability to read data.
+The role allows users to edit local users, but they cannot grant these users the Full Admin, Read-Only Admin,  Local User Admin, or External User Admin roles.
+They also cannot edit the accounts for any user with those roles (including their own account).
+The role grants access to Couchbase Server Web Console.
+
+[#table_security_admin_local_role,cols="1,2,2,hrows=3"]
+|===
+3+^| Role: Local User Admin (`user_admin_local`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Servers* 
+| View statistics
+| Add, failover, remove, modify services, rebalance
+
+| *Buckets*
+| List buckets, scopes, and collections
+| Create, drop, edit settings, read or write data
+
+| *Backup*
+| None
+| All
+
+| *XDCR* 
+| All
+| None
+
+| *Security* 
+| Add, delete, edit local users. 
+Can add, delete, and edit groups.
+| Cannot grant Full Admin, Read-Only Admin, Local or External User Admin, or Security Admin roles to users or groups.
+Cannot access non-user and group security resources.
+
+| *Settings*
+| View
+| Change
+
+| *Logs*
+| View
+| Collect Information
+
+| *Query*
+| None
+| All
+
+| *Search*
+| None
+| All
+
+| *Analytics*
+| None
+| All
+
+| *Eventing*
+| None
+| All
+
+| *Views*
+| None
+| All
+
+|===
+
+[#external-user-security-admin]
+=== External User Admin
+
+The External User Admin role gives users the ability to manage external users.
+It also allows the user to manage groups and read all cluster statistics.
+Users with this role cannot grant external users or groups Full Admin, Read-Only Admin, Local or External User Admin, or Security Admin roles.
+They also cannot edit users with those roles. 
+
+This role grants Couchbase Server Web Console access.
+
+[#table_security_admin_external_role,cols="1,2,2,hrows=3"]
+|===
+3+^| Role: External User Admin (`user_admin_external`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Servers* 
+| View statistics
+| Add, failover, remove, modify services, rebalance
+
+| *Buckets*
+| List buckets, scopes, and collections
+| Create, drop, edit settings, read or write data
+
+| *Backup*
+| None
+| All
+
+| *XDCR* 
+| View list of outgoing replications
+| View incoming replications, remote clusters, add or edit connections.
+
+| *Security* 
+| Add, delete, edit external users.
+Add, delete. edit groups.
+| Cannot grant Full Admin, Read-Only Admin, Local or External User Admin, or Security Admin roles to groups or external users.
+Cannot access security resources besides users and groups.
+
+| *Settings*
+| View
+| Change
+
+| *Logs*
+| View
+| Collect Information
+
+| *Query*
+| None
+| All
+
+| *Search*
+| None
+| All
+
+| *Analytics*
+| None
+| All
+
+| *Eventing*
+| None
+| All
+
+| *Views*
+| None
+| All
+
+|===
+
+
+
+
+[#security-admin]
+=== Security Admin
+
+The Security Admin role grants the user the ability manage all security settings except for users and groups.
+
+The role grants Couchbase Server Web Console access.
+
+[#table_security_admin_role,cols="1,2,2,hrows=3]
+|===
+3+^| Role: Security Admin (`security_admin`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Servers* 
+| View configuration and statistics
+| Cannot add, failover, remove, modify services, rebalance
+
+| *Buckets*
+| List buckets, scopes, and collections
+| Cannot create, drop, edit settings, read or write data
+
+| *Backup*
+| None
+| All 
+
+| *XDCR* 
+| List outgoing replications
+| Cannot create, start, alter connections
+
+| *Security* 
+| Manage LDAP, SAML, certificates, encryption at rest, audit, and logging settings.
+| Cannot view or change users or groups.
+
+| *Settings*
+| View
+| Change
+
+| *Logs*
+| View
+| Collect Information
+
+| *Query*
+| None
+| All
+
+| *Search*
+| None
+| All
+
+| *Analytics*
+| None
+| All
+
+| *Eventing*
+| None
+| All
+
+| *Views*
+| None
+| All
+
+|===
+
 
 [#external-stats-reader]
-== External Stats Reader
+=== External Stats Reader
 
-The *External Stats Reader* role (an Administrative role) grants access to the `/metrics` and `/prometheus_sd_config` endpoints for Prometheus integration.
-All statistics for all services can be read.
-The role does not allow access to Couchbase Web Console.
+The External Stats Reader role only access to just the `/metrics` and `/prometheus_sd_config` REST API endpoints,
+Assign this role to a user to allow Prometheus to collect mestrics from all Couchbase Server services.
+See xref:manage:monitor/set-up-prometheus-for-monitoring.adoc[] for more information.
 
-[#table_external_stats_reader_role,cols="15,8,8,8,8",hrows=3]
+The role does not grant Couchbase Server Web Console access.
+
+[#table_external_stats_role,cols="1,2,2,hrows=3]
 |===
-5+^| Role: External Stats Reader (`external_stats_reader`)
+3+^|  Role: External Stats Reader (`external_stats_reader`)
 
-.2+^h| Resources
-4+^h| Privileges
+.2+^h| Resource
+2+^h| Privileges
 
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
+h| Permissions
+h| Restrictions
 
-^| Admin : stats_export
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Metrics API*
+| Able to call /metrics` and `/prometheus_sd_config` REST API endpoints
+| None
+
 |===
 
-[#xdcr-admin]
-== XDCR Admin
 
-The *XDCR Admin* role (an XDCR role) allows use of XDCR features, to create cluster references and replication streams.
-The role allows access to Couchbase Web Console and allows the reading of data.
 
-[#table_xdcr_admin_role,cols="15,8,8,8,8",hrows=3]
+[#application_telemetry_writer]
+=== Application Telemetry Writer
+
+This role lets the user report application telemetry through SDK calls.
+A user requires this role to send telemetry information to Couchbase Server via SDK calls.
+
+This role does not grant the user Couchbase Server Web Console access.
+
+[#table_application_telemetry_writer,cols="1,2,2,hrows=3]
 |===
-5+^| Role: XDCR Admin (`replication_admin`)
+3+^|  Role: Application Telemetry Writer (`application_telemetry_writer`)
 
-.2+^h| Resources
-4+^h| Privileges
+.2+^h| Resource
+2+^h| Privileges
 
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
+h| Permissions
+h| Restrictions
 
-^| XDCR for Cluster and Bucket
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
 
-^| Bucket Data
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Application Telemetry*
+| Able to write to telemetry metric websockets
+| None
 
-^| Bucket Settings
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Bucket Statistics
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| UI (XDCR)
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-
-^| UI (Other)
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
 |===
+
+
+[#query-roles]
+== Query & Index Roles
 
 [#query-curl-access]
-== Query Curl Access
+=== Query CURL Access
 
-The *Query Curl Access* role (a Query & Index role) allows the {sqlpp} CURL function to be executed by an externally authenticated user.
-The user can access Couchbase Web Console, but cannot read data, other than that returned by the {sqlpp} CURL function.
+The Query CURL Access role lets the user call the {sqlpp} curl function in their queries.
 
-Note that the *Query Curl Access* role should be assigned with caution, since it entails risk: CURL runs within the local Couchbase Server network; therefore, the assignee of the *Query Curl Access* role is permitted to run GET and POST requests on the internal network, while being themselves externally located.
+CAUTION: The Query CURL Access role allows users to run GET and POST requests to any system on the network Couchbase Server uses for client connections.
+If your cluster is not configured to use a private network for internal communication, they also have access to the entire cluster.  
+They can interact with any system on this network.
 
-For an account of limitations on CURL, see xref:n1ql:n1ql-language-reference/curl.adoc[CURL Function].
 
-In versions of Couchbase Server prior to 5.5, this role was referred to as *Query External Access*.
+This role only grants the user the ability to read data returned by the {sqlpp} curl function.
+Usually, you assign additional roles to the user to allow them to read and write data.
 
-[#table_query_external_access_role,cols="15,8,8,8,8",hrows=3]
+For more information about the {sqlpp} curl function, see xref:n1ql:n1ql-language-reference/curl.adoc[].
+
+This role lets the user log into Couchbase Server Web Console. 
+
+[#table_query_external_access_role,cols="1,2,2,hrows=3]
 |===
-5+^| Role: Query Curl Access (`query_external_access`)
 
-.2+^h| Resources
-4+^h| Privileges
+3+^| Role: Query Curl Access (`query_external_access`)
 
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
+.2+^h| Resource
+2+^h| Privileges
 
-^| Bucket : {sqlpp}, curl
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
+h| Permissions
+h| Restrictions
 
-^| Bucket settings
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
 
-^| UI
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Buckets*
+| List buckets
+| Cannot list scopes or collections.
+Cannot create, drop, or edit buckets.
+Cannot read data other than the results of the {sqlpp} curl function call.
+Cannot write data.
 
-^| Pools
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Query*
+| Can execute {sqlpp} curl function calls
+| Cannot execute any other queries.
+Cannot use the Query Workbench in Couchbase Server Web Console.
+
 |===
+
 
 [#query-system-catalog]
-== Query System Catalog
+=== Query System Catalog
 
-The *Query System Catalog* role (a Query & Index role) allows information to be looked up by means of {sqlpp} in the system catalog: this includes `system:indexes`, `system:prepareds`, and tables listing current and past queries.
-This role is designed for troubleshooters, who need to debug queries.
-The role allows access to Couchbase Web Console, but does not permit the reading of bucket-items.
+The Query System Catalog role lets the user query the system catalog using {sqlpp}.
+This access include querying `system:indexes`, `system:prepareds`, and tables listing current and past queries.
+Assign this role to developers who need to query these tables when troubleshooting and debugging queries.
 
-[#table_query_system_catalog_role,cols="15,8,8,8,8,8",hrows=3]
+The role grants Couchbase Server Web Console access.
+
+[#table_query_system_catalog_role,cols="1,2,2,hrows=3]
 |===
-6+^| Role: Query System Catalog (`query_system_catalog`)
 
-.2+^h| Resources
-5+^h| Privileges
+3+^|  Role: Query System Catalog (`query_system_catalog`)
 
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
-^h| *List*
+.2+^h| Resource
+2+^h| Privileges
 
-^| Bucket : {sqlpp}, INDEX
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
+| *Servers* 
+| List servers.
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
 
-^| Bucket : {sqlpp}, Meta
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Buckets*
+| List buckets and view bucket settings.
+| Cannot list scopes or collections, create, drop, edit settings, read or write data.
 
-^| Bucket Settings
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Query*
+| Can query system tables.
+| Cannot perform any other query actions.
+Cannot use the query workbench in Couchbase Server Web Console.
 
-^| UI
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Pools
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
 |===
 
 [#manage-global-functions]
-== Manage Global Functions
+=== Manage Global Functions
 
-The *Manage Global Functions* role (a Query & Index role) allows global {sqlpp} functions to be managed.
-The user can access Couchbase Web Console, but cannot read data.
+The Manage Global Functions role lets the user create and drop global user-defined {sqlpp} functions. 
+See xref:n1ql:n1ql-language-reference/createfunction.adoc[].
 
-[#table_manage_global_functions_role,cols="15,8,8,8,8",hrows=3]
+This role grants Couchbase Server Web Console access.
+
+[#table_manage_global_functions_role,cols="1,2,2,hrows=3]
 |===
-5+^| Role: Manage Global Functions (`query_manage_global_functions`)
 
-.2+^h| Resources
-4+^h| Privileges
+3+^|  Role: Manage Global Functions (`query_manage_global_functions`)
 
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
+.2+^h| Resource
+2+^h| Privileges
 
-^| {sqlpp}, udf
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
 
-^| UI
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Buckets*
+| List buckets
+| Cannot list scopes or collections, create, drop, edit settings, read or write data.
 
-^| Pools
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Query*
+| Can execute `CREATE FUNCTION` and `DROP FUNCTION` statements.
+| Cannot perform any other queries, including calling the global functions.
+Cannot use the Query Workbench in Couchbase Server Web Console.
+
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings.
+
 |===
+
 
 [#execute-global-functions]
-== Execute Global Functions
+=== Execute Global Functions
 
-The *Execute Global Functions* role (a Query & Index role) allows global {sqlpp} functions to be executed.
-The user can access Couchbase Web Console, but cannot read data.
+The Execute Global Functions role lets the user call global {sqlpp} functions.
 
-[#table_query_execute_global_functions_role,cols="15,8,8,8,8",hrows=3]
+This role lets the user log into Couchbase Server Web Console. 
+
+[#table_query_execute_global_functions_role,cols="1,2,2,hrows=3]
 |===
-5+^| Role: Execute Global Functions (`query_execute_global_functions`)
 
-.2+^h| Resources
-4+^h| Privileges
+3+^|   Role: Execute Global Functions (`query_execute_global_functions`)
 
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
+.2+^h| Resource
+2+^h| Privileges
 
-^| {sqlpp}, udf
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
 
-^| UI
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Buckets*
+| List buckets
+| Cannot list scopes or collections, create, drop, edit settings, read or write data.
 
-^| Pools
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Query*
+| Can execute global user-defined functions.
+| Cannot perform any other queries.
+Cannot use the Query Workbench in Couchbase Server Web Console.
+
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings.
+
 |===
+
 
 [#manage-scope-functions]
-== Manage Scope Functions (Query and Index)
+=== Manage Scope Functions (Query and Index)
 
-The *Manage Scope Functions* role (a Query & Index role) allows {sqlpp} and user defined functions to be managed for a given scope, given corresponding specification of bucket.
-The user can access Couchbase Web Console, but cannot read data.
+The Manage Scope Functions role lets the user create an drop user-defined {sqlpp} functions for one or more scopes.
+See xref:n1ql:n1ql-language-reference/createfunction.adoc[].
 
-[#table_manage_scope_functions_role,cols="15,8,8,8,8",hrows=3]
+This role lets the user log into Couchbase Server Web Console. 
+
+
+[#table_manage_scope_functions_role,cols="1,2,2,hrows=3]
 |===
-5+^| Role: Manage Scope Functions (`query_manage_functions`)
 
-.2+^h| Resources
-4+^h| Privileges
+3+^| Role: Manage Scope Functions (`query_manage_functions`)
 
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
+.2+^h| Resource
+2+^h| Privileges
 
-^| Bucket, Scope: {sqlpp}, udf
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
 
-^| UI
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Buckets*
+| List buckets
+| Cannot list scopes or collections, create, drop, edit settings, read or write data.
 
-^| Pools
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Query*
+| Can execute `CREATE FUNCTION` and `DROP FUNCTION` statements to create user-defined functions in specific scopes.
+| Cannot perform any other queries, including calling the functions.
+Cannot use the Query Workbench in Couchbase Server Web Console.
+
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings.
+
 |===
+
+[#query-select]
+=== Query Select
+
+The Query Select role lets the user execute `SELECT` statements on the data in one or more collections.
+The administrator sets which collections the user can access when granting this role.
+See xref:guides:query.adoc[].
+
+The role grants Couchbase Server Web Console access.
+
+
+[#table_query_select_role,cols="1,2,2,hrows=3]
+|===
+
+3+^| Role: Query Select (`query_select`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
+
+| *Buckets*
+| Can list buckets.
+Can read data from specific collections.
+| Cannot list scopes or collections, create, drop, edit settings, read or write data.
+
+| *Query*
+| Can execute `SELECT` statements on data in one or more collections.
+Can read data from one or more collections.
+| Cannot perform any other queries.
+Cannot use the Query Workbench in Couchbase Server Web Console.
+
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change any settings.
+
+|===
+
+
+[#query-update]
+=== Query Update
+
+The Query Update role grants the user the ability to execute `UPDATE` statements to mutate existing documents in specific collections.  
+See xref:n1ql:n1ql-language-reference:update.adoc[] for more information.
+The administrator granting this role selects which collections contain documents the user can mutate.
+
+This role lets the user log into Couchbase Server Web Console. 
+
+
+[#table_query_update_role,cols="1,2,2,hrows=3]
+|===
+3+^| Role: Query Update (`query_update`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
+
+| *Buckets*
+| List buckets and view bucket settings.
+| Cannot list scopes or collections, create, drop, edit settings.
+
+| *Query*
+| Can execute `UPDATE` statements on documents in one or more collections.
+| Cannot perform any other queries.
+Cannot create new documents.
+Cannot use the Query Workbench in Couchbase Server Web Console.
+
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings.
+
+|===
+
+[#query-insert]
+=== Query Insert
+
+The Query Insert role grants the user the ability to execute the {sqlpp} `INSERT` statement to add new documents to one or more collections.
+See xref:n1ql:n1ql-language-reference:insert.adoc[] for more information.
+The administrator granting this role selects which collections the user can add documents to.
+
+This role lets the user log into Couchbase Server Web Console.
+
+
+[#table_query_insert_role,cols="1,2,2,hrows=3]
+|===
+3+^|  Role: Query Insert (`query_insert`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
+
+| *Buckets*
+| List buckets and view bucket settings.
+| Cannot list scopes or collections, create, drop, edit settings.
+
+| *Query*
+| Can execute `INSERT` statements to create documents in one or more collections.
+| Cannot perform any other queries.
+Cannot mutate existing documents.
+Cannot use the Query Workbench in Couchbase Server Web Console.
+
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings.
+
+|===
+
+[#query-delete]
+=== Query Delete
+
+The Query Delete role grants the user the ability to execute the {sqlpp} `DELETE` to delete documents from one or more scopes.
+See xref:n1ql:n1ql-language-reference:delete.adoc[] for more information.
+The administrator granting this role selects which collections the user can delete documents from.
+
+This role lets the user log into Couchbase Server Web Console. 
+
+
+[#table_query_delete_role,cols="1,2,2,hrows=3]
+|===
+3+^|  Role: Query Delete (`query_delete`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
+
+| *Buckets*
+| List buckets and view bucket settings.
+| Cannot list scopes or collections.
+Cannot edit bucket settings.
+
+| *Query*
+| Can execute `DELETE` statements to delete documents from one or more collections.
+| Cannot perform any other queries.
+Cannot use the Query Workbench in Couchbase Server Web Console.
+
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings.
+
+|===
+
+
+[#query-sequential-scan]
+=== Query Use Sequential Scan
+
+The Query Use Sequential Scan role allows users' queries to perform a sequential scan of a keyspace.
+The query planner only decides to use a sequential scan when there is no suitable index for the keyspace. 
+Only queries by users with this role can use a sequential scan to query data because scanning a large unindexed keyspace can be expensive.  
+See xref:learn:services-and-indexes/indexes/query-without-index.adoc#sequential-scans[] for more information.
+
+NOTE: Administrator roles automatically have permission to perform sequential scans when necessary.
+
+This role does not let the user log into Coucbase Server Web Console .
+
+[#table_query_use_sequential_scans_role,cols="1,2,2,hrows=3]
+|===
+3+^|  Role: Query Use Sequential Scan (`query_use_sequential_scans`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+| *Query*
+| Can execute a query in a collection that lacks a primary and secondary index.
+| Cannot perform any other queries.
+
+|===
+
+
+[#query-manage-index]
+=== Query Manage Index
+
+The Query Manage Index role allows the user to manage indexes for one or more collections.
+The administrator granting this role selects which collections for which the user can manage indexes.
+
+The role lets the user log into Couchbase Server Web Console.
+
+[#table_query_manage_index_role,cols="1,2,2,hrows=3]
+|===
+3+^| Role: Query Manage Index (`query_manage_index`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
+
+| *Buckets*
+| List buckets and view bucket settings.
+| Cannot list scopes or collections, create, drop, edit settings.
+Cannot read or write data.
+
+| *Index*
+| Can create, drop, and view indexes for the collections whose indexes they have been given permission to manage.
+| Cannot perform any other queries, including calling the functions.
+Cannot use the Query Workbench in Couchbase Server Web Console.
+
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings.
+
+|===
+
 
 [#execute-scope-functions]
-== Execute Scope Functions
+=== Execute Scope Functions
 
-The *Execute Scope Functions* role (a Query & Index role) allows {sqlpp} and user defined functions to be executed for a given scope, given corresponding specification of bucket.
-The user can access Couchbase Web Console, but cannot read data.
+The Execute Scope Functions role lets the user execute {sqlpp} user-defined functions defined within a scope.
+The administrator granting this role selects in which scopes the user can call user-defined functions the user can call.
 
-[#table_execute_scope_functions_role,cols="15,8,8,8,8",hrows=3]
+The role lets the user log into Couchbase Server Web Console.
+
+
+[#table_query_execute_functions_role,cols="1,2,2,hrows=3]
 |===
-5+^| Role: Execute Scope Functions (`query_execute_functions`)
 
-.2+^h| Resources
-4+^h| Privileges
+3+^|   Role: Execute Scope Functions (`query_execute_functions`)
 
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
+.2+^h| Resource
+2+^h| Privileges
 
-^| Collection, Bucket, Scope: {sqlpp}, udf
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
 
-^| UI
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
 
-^| Pools
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Query*
+| Can execute scope user-defined functions.
+| Cannot perform any other queries.
+Cannot use the Query Workbench in Couchbase Server Web Console.
+
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings.
+
 |===
+
 
 [#manage-global-external-functions]
-== Manage Global External Functions
+=== Manage Global External Functions
 
-The *Manage Global External Functions* role (a Query & Index role) allows global external language functions to be managed.
-The user can access Couchbase Web Console, but cannot read data.
+The Manage Global External Functions role lets the user manage global external language functions.
+See xref:n1ql:n1ql-language-reference/createfunction.adoc#external-libraries[External Libraries] for more information about external functions.
 
-[#table_manage_global_external_functions_role,cols="15,8,8,8,8",hrows=3]
+The role lets the user log into Couchbase Server Web Console.
+
+[#table_manage_global_external_functions_role,cols="1,2,2,hrows=3]
 |===
-5+^| Role: Manage Global External Functions (`query_manage_global_external_functions`)
 
-.2+^h| Resources
-4+^h| Privileges
+3+^| Role: Manage Global External Functions (`query_manage_global_external_functions`)
 
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
+.2+^h| Resource
+2+^h| Privileges
 
-^| {sqlpp}, udf_external
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
 
-^| UI
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
 
-^| Pools
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Query*
+| Can execute `CREATE FUNCTION` statements to create global external functions.
+| Cannot perform any other queries.
+Cannot use the Query Workbench in Couchbase Server Web Console.
+
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings.
+
 |===
+
 
 [#execute-global-external-functions]
-== Execute Global External Functions
+=== Execute Global External Functions
 
-The *Execute Global External Functions* role (a Query & Index role) allows global {sqlpp} functions to be executed.
-The user can access Couchbase Web Console, but cannot read data.
+The Execute Global External Functions role lets a user execute globally-defined external functions.
+See xref:n1ql:n1ql-language-reference/createfunction.adoc#external-libraries[External Libraries] for more information about external functions.
 
-[#table_execute_global_external_functions_role,cols="15,8,8,8,8",hrows=3]
+The role lets the user log into Couchbase Server Web Console.
+
+
+[#table_execute_global_external_functions_role,cols="1,2,2,hrows=3]
 |===
-5+^| Role: Execute Global External Functions (`query_execute_global_external_functions`)
 
-.2+^h| Resources
-4+^h| Privileges
+3+^| Role: Execute Global External Functions (`query_execute_global_external_functions`)
 
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
+.2+^h| Resource
+2+^h| Privileges
 
-^| {sqlpp}, udf_external
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
 
-^| UI
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
 
-^| Pools
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Query*
+| Can execute globally defined external functions.
+| Cannot perform any other queries.
+Cannot use the Query Workbench in Couchbase Server Web Console.
+
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings.
+
 |===
+
 
 [#manage-scope-external-functions]
-== Manage Scope External Functions
+=== Manage Scope External Functions
 
-The *Manage Scope External Functions* role (a Query & Index role) allows external language functions to be managed for a given scope, given corresponding specification of bucket.
-The user can access Couchbase Web Console, but cannot read data.
+The Manage Scope External Functions role lets the user create and drop external language functions defined at the scope level.
+The administrator granting this role chooses the scopes where the user can manage external functions.
+See xref:n1ql:n1ql-language-reference/createfunction.adoc#external-libraries[External Libraries] for more information about external functions.
 
-[#table_manage_external_functions_role,cols="15,8,8,8,8",hrows=3]
+The role lets the user log into Couchbase Server Web Console.
+
+
+[#table_manage_external_functions_role,cols="1,2,2,hrows=3]
 |===
-5+^| Role: Manage Scope External Functions (`query_manage_external_functions`)
 
-.2+^h| Resources
-4+^h| Privileges
+3+^| Role: Manage Scope External Functions (`query_manage_external_functions`)
 
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
+.2+^h| Resource
+2+^h| Privileges
 
-^| Collection, Bucket, Scope: {sqlpp}, udf_external
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
 
-^| UI
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Query*
+| Can call globally defined external functions.
+| Cannot perform any other queries.
+Cannot use the Query Workbench in Couchbase Server Web Console.
 
-^| Pools
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings.
+
 |===
+
 
 [#execute-scope-external-functions]
-== Execute Scope External Functions
+=== Execute Scope External Functions
 
-The *Execute Scope External Functions* role (a Query & Index role) allows external language functions to be executed for a given scope, given corresponding specification of bucket.
-The user can access Couchbase Web Console, but cannot read data.
+The Execute Scope External Functions role lets the user call external functions defined in a scope. 
+The administrator granting this role chooses the scopes where the user can call external functions.
+See xref:n1ql:n1ql-language-reference/createfunction.adoc#external-libraries[External Libraries] for more information about external functions.
 
-[#table_execute_external_functions_role,cols="15,8,8,8,8",hrows=3]
+The role lets the user log into Couchbase Server Web Console.
+
+[#table_execute_external_functions_role,cols="1,2,2,hrows=3]
 |===
-5+^| Role: Execute Scope External Functions (`query_execute_external_functions`)
 
-.2+^h| Resources
-4+^h| Privileges
+3+^| Role: Execute Scope External Functions (`query_execute_external_functions`)
 
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
+.2+^h| Resource
+2+^h| Privileges
 
-^| Collection, Bucket, Scope: {sqlpp}, udf_external
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
 
-^| UI
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Query*
+| Can call globally defined external functions.
+| Cannot perform any other queries.
+Cannot use the Query Workbench in Couchbase Server Web Console.
 
-^| Pools
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings.
+
 |===
+
+
+== Analytics Roles
 
 [#analytics-reader]
-== Analytics Reader
+=== Analytics Reader
 
 The *Analytics Reader* role (an Analytics role) allows querying of shadow data-sets.
 The role allows access to Couchbase Web Console, and permits the reading of data.
@@ -803,7 +1150,7 @@ The role allows access to Couchbase Web Console, and permits the reading of data
 |===
 
 [#analytics-admin]
-== Analytics Admin
+=== Analytics Admin
 
 The *Analytics Admin* role (an Analytics role) allows management of dataverses; management of all Analytics Service links; and management of all datasets.
 The role allows access to Couchbase Web Console, but does not permit the reading of data.
@@ -851,8 +1198,11 @@ The role allows access to Couchbase Web Console, but does not permit the reading
 ^| image:introduction/no.png[]
 |===
 
+[#bucket-roles]
+== Bucket Roles
+
 [#bucket-admin]
-== Bucket Admin
+=== Bucket Admin
 
 The *Bucket Admin* role (which is a Bucket role) allows the management of all per bucket features (including starting and stopping XDCR).
 The role allows access to Couchbase Web Console, but does not permit the reading or writing of data.
@@ -901,7 +1251,7 @@ The role allows access to Couchbase Web Console, but does not permit the reading
 |===
 
 [#manage-scopes]
-== Manage Scopes
+=== Manage Scopes
 
 The *Manage Scopes* role (a Bucket role) allows the creation and deletion of scopes, and the creation and deletion of collections per scope, given the corresponding specification of bucket.
 The role allows no access to data, and does not permit access to Couchbase Web Console.
@@ -933,7 +1283,7 @@ The role is intended for application use only.
 |===
 
 [#application-access]
-== Application Access
+=== Application Access
 
 The *Application Access* role (a Bucket role) provides read and write access to data, per bucket.
 The role does not allow access to Couchbase Web Console: it is intended for applications, rather than users.
@@ -1005,8 +1355,80 @@ Note that in versions of Couchbase Server prior to 5.5, this role was referred t
 ^| image:introduction/no.png[]
 |===
 
+== XDCR Roles
+
+The following roles give users access to XDCR settings and features.
+
+[#xdcr-admin]
+=== XDCR Admin
+
+The XDCR Admin role grants the user the ability to manage XDCR connections.
+
+The role grants Couchbase Server Web Console access.
+
+[#table_xdcr_admin_role,cols="1,2,2,hrows=3]
+|===
+3+^| Role: XDCR Admin (`replication_admin`)
+
+.2+^h| Resource
+2+^h| Privileges
+
+h| Permissions
+h| Restrictions
+
+| *Servers* 
+| View configuration and statistics
+| Cannot add, failover, remove, modify services, rebalance
+
+| *Buckets*
+| List buckets, scopes, and collections
+| Cannot create, drop, edit settings, read or write data
+
+| *Backup*
+| None
+| All 
+
+| *XDCR* 
+| All
+| None
+
+| *Security* 
+| None
+| All
+
+| *Settings*
+| View
+| Change
+
+| *Logs*
+| View
+| Collect Information
+
+| *Query*
+| None
+| All
+
+| *Search*
+| None
+| All
+
+| *Analytics*
+| None
+| All
+
+| *Eventing*
+| None
+| All
+
+| *Views*
+| None
+| All
+
+|===
+
+
 [#xdcr-inbound]
-== XDCR Inbound
+=== XDCR Inbound
 
 The *XDCR Inbound* role (which is an XDCR role) allows the creation of inbound XDCR streams, per bucket.
 It does not allow access to Couchbase Web Console, and does not permit the reading of data.
@@ -1050,8 +1472,12 @@ In versions of Couchbase Server prior to 5.5, this role was referred to as *Repl
 ^| image:introduction/no.png[]
 |===
 
+== Mobile Roles
+
+The mobile roles give users access to Sync Gateway and related features.
+
 [#sync-gateway]
-== Sync Gateway
+=== Sync Gateway
 
 The *Sync Gateway* role (which is a Mobile role) allows full access to data per bucket, as required by Sync Gateway.
 The role does not allow access to Couchbase Web Console.
@@ -1131,7 +1557,7 @@ The user can, by means of Sync Gateway, read and write data, manage indexes and 
 |===
 
 [#sync-gateway-configurator]
-== Sync Gateway Architect
+=== Sync Gateway Architect
 
 The *Sync Gateway Architect* role (which is a Mobile role) allows management of Sync Gateway databases; and of Sync Gateway users and roles; and allows access to Sync Gateway's `/metrics` endpoint.
 The role does not allow access to Couchbase Web Console; and does not allow reading of application data.
@@ -1175,7 +1601,7 @@ For information on Sync Gateway users and roles, see http://docs.couchbase.com/s
 |===
 
 [#sync-gateway-app]
-== Sync Gateway Application
+=== Sync Gateway Application
 
 The *Sync Gateway Application* role (which is a Mobile role) allows management of Sync Gateway users and roles; and allows application data to be read and written through Sync Gateway.
 The role does not allow access to Couchbase Web Console.
@@ -1213,7 +1639,7 @@ For information on Sync Gateway users and roles, see http://docs.couchbase.com/s
 |===
 
 [#sync-gateway-application-read-only]
-== Sync Gateway Application Read Only
+=== Sync Gateway Application Read Only
 
 The *Sync Gateway Application Read Only* role (which is a Mobile role) allows reading of Sync Gateway users and roles; and allows application data to be read through Sync Gateway.
 The role does not allow access to Couchbase Web Console.
@@ -1251,7 +1677,7 @@ For information on Sync Gateway users and roles, see http://docs.couchbase.com/s
 |===
 
 [#sync-gateway-replicator]
-== Sync Gateway Replicator
+=== Sync Gateway Replicator
 
 The *Sync Gateway Replicator* role (which is a Mobile role) allows management of Sync Gateway replications.
 The role does not allow access to Couchbase Web Console.
@@ -1282,7 +1708,7 @@ The role does not allow access to Couchbase Web Console.
 |===
 
 [#sync-gateway-dev-ops]
-== Sync Gateway Dev Ops
+=== Sync Gateway Dev Ops
 
 The *Sync Gateway Dev Ops* role (which is a Mobile role) allows management of Sync Gateway node-level configuration; and allows access to Syn Gateway's `/metrics` endpoint, for Prometheus integration.
 The role does not allow access to Couchbase Web Console.
@@ -1318,8 +1744,12 @@ The role does not allow access to Couchbase Web Console.
 ^| image:introduction/no.png[]
 |===
 
+== Data Roles
+
+These roles give users the ability to read and write data in buckets.
+
 [#data-reader]
-== Data Reader
+=== Data Reader
 
 The *Data Reader* role (which is a Data role) allows data to be read per collection, given corresponding specifications for bucket and scope.
 Note that the role does not permit the running of {sqlpp} queries (such as SELECT) against data.
@@ -1363,7 +1793,7 @@ The role does not allow access to Couchbase Web Console: it is intended to suppo
 |===
 
 [#data-writer]
-== Data Writer
+=== Data Writer
 
 The *Data Writer* role (which is a Data role) allows data to be written per collection, given corresponding specifications for bucket and scope.
 The role does not allow access to Couchbase Web Console: it is intended to support applications, rather than users.
@@ -1400,7 +1830,7 @@ The role does not allow access to Couchbase Web Console: it is intended to suppo
 |===
 
 [#data-dcp-reader]
-== Data DCP Reader
+=== Data DCP Reader
 
 The *Data DCP Reader* role (which is a Data role) allows DCP streams to be initiated per collection, given corresponding specifications for bucket and scope.
 The role does not allow access to Couchbase Web Console: it is intended to support applications, rather than users.
@@ -1450,7 +1880,7 @@ The role does allow the reading of data.
 |===
 
 [#data-backup-and-restore]
-== Data Backup & Restore
+=== Data Backup & Restore
 
 The *Data Backup & Restore* role (which is a Data role) allows data to be backed up and restored, per bucket.
 The role supports the reading of data.
@@ -1587,7 +2017,7 @@ The privileges represented in this table are, from left to right, Read, Write, E
 |===
 
 [#data-monitor]
-== Data Monitor
+=== Data Monitor
 
 The *Data Monitor* role (which is a Data role) allows statistics to be read for a given bucket, scope, or collection.
 It does not allow access to Couchbase Web Console, and does not permit the reading of data.
@@ -1621,7 +2051,7 @@ In versions of Couchbase Server prior to 5.5, this role was referred to as *Data
 |===
 
 [#views-admin]
-== Views Admin
+=== Views Admin
 
 The *Views Admin* role (which is a Views role) allows the management of views, per bucket.
 The role allows access to Couchbase Web Console.
@@ -1718,313 +2148,6 @@ This role does not allow access to Couchbase Web Console, and is intended to sup
 ^| image:introduction/no.png[]
 |===
 
-[#query-select]
-== Query Select
-
-The *Query Select* role (which is a Query & Index role) allows the SELECT statement to be executed per collection, given corresponding specifications for bucket and scope.
-This role allows access to Couchbase Web Console; it also supports the reading of data, and of bucket settings.
-
-[#table_query_select_role,cols="15,8,8,8,8",hrows=3]
-|===
-5+^| Role: Query Select (`query_select`)
-
-.2+^h| Resources
-4+^h| Privileges
-
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
-
-^| Bucket : {sqlpp}, SELECT
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-
-^| Bucket : Docs
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Bucket Settings
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| UI
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Pools
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-|===
-
-[#query-update]
-== Query Update
-
-The *Query Update* role (which is a Query & Index role) allows the UPDATE statement to be executed per collection, given corresponding specifications for bucket and scope.
-The role supports access to Couchbase Web Console, and allows the writing (but not the reading) of data.
-It allows the reading of bucket settings.
-
-[#table_query_update_role,cols="15,8,8,8,8",hrows=3]
-|===
-5+^| Role: Query Update (`query_update`)
-
-.2+^h| Resources
-4+^h| Privileges
-
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
-
-^| Bucket : {sqlpp}, UPDATE
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-
-^| Bucket : Docs
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Bucket Settings
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| UI
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Pools
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-|===
-
-[#query-insert]
-== Query Insert
-
-The *Query Insert* role (which is a Query & Index role) allows the INSERT statement to be executed per collection, given corresponding specifications for bucket and scope.
-The role supports access to Couchbase Web Console, and allows the writing (but not the reading) of data.
-It allows the reading of bucket settings.
-
-[#table_query_insert_role,cols="15,8,8,8,8",hrows=3]
-|===
-5+^| Role: Query Insert (`query_insert`)
-
-.2+^h| Resources
-4+^h| Privileges
-
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
-
-^| Bucket : {sqlpp}, INSERT
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-
-^| Bucket : Docs
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Bucket Settings
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| UI
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Pools
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-|===
-
-[#query-delete]
-== Query Delete
-
-The *Query Delete* role (which is a Query & Index role) allows the DELETE statement to be executed per collection, given corresponding specifications for bucket and scope.
-The role supports access to Couchbase Server Web Console, and allows the deletion of data.
-It allows the reading of bucket settings.
-
-[#table_query_delete_role,cols="15,8,8,8,8",hrows=3]
-|===
-5+^| Role: Query Delete (`query_delete`)
-
-.2+^h| Resources
-4+^h| Privileges
-
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
-
-
-^| Bucket : {sqlpp}, DELETE
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-
-^| Bucket : Docs Delete
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-
-^| Bucket Settings
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| UI
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Pools
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-|===
-
-
-[#query-sequential-scan]
-== Query Use Sequential Scan
-
-The *Query Use Sequential Scan* role, located under Query & Index in the Web Console's roles list, allows users' queries to perform a sequential scan of a keyspace.
-The query planner only decides to use a sequential scan when there is no suitable index for the keyspace. 
-Only queries by users with this role can use a sequential scan to access data because scanning a large unindexed keyspace can be expensive.  
-This role does not grant the user the ability to read or mutate data or access to the Web Console. 
-Administrators' queries automatically have permission to perform sequential scans when necessary.
-
-[#table_query_delete_role,cols="15,8,8,8,8",hrows=3]
-|===
-5+^| Role: Query Use Sequential Scan (`query_use_sequential_scans`)
-
-.2+^h| Resources
-4+^h| Privileges
-
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
-
-^| Sequential Scans
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-
-^| Bucket : Docs
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Bucket Settings
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| UI
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Pools
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-|===
-
-[#query-manage-index]
-== Query Manage Index
-
-The *Query Manage Index* role (which is a Query & Index role) allows indexes to be managed per collection, given corresponding specifications for bucket and scope.
-The role allows access to Couchbase Web Console, but does not permit the reading of data.
-
-[#table_query_manage_index_role,cols="15,8,8,8,8",hrows=3]
-|===
-5+^| Role: Query Manage Index (`query_manage_index`)
-
-.2+^h| Resources
-4+^h| Privileges
-
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
-
-^| Bucket : {sqlpp}, INDEX
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-
-^| Bucket Settings
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Bucket Statistics
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Index Settings
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| UI
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Pools
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-|===
 
 [#eventing-full-admin]
 == Eventing Full Admin

--- a/modules/learn/pages/security/roles.adoc
+++ b/modules/learn/pages/security/roles.adoc
@@ -1180,7 +1180,7 @@ Cannot use the Query Workbench in Couchbase Server Web Console.
 === Query Update
 
 The Query Update role grants the user the ability to execute `UPDATE` statements to mutate existing documents in specific collections.  
-See xref:n1ql:n1ql-language-reference:update.adoc[] for more information.
+See xref:n1ql:n1ql-language-reference/update.adoc[] for more information.
 The administrator granting this role selects which collections contain documents the user can mutate.
 
 This role lets the user log into Couchbase Server Web Console. 

--- a/modules/learn/pages/security/roles.adoc
+++ b/modules/learn/pages/security/roles.adoc
@@ -30,42 +30,37 @@ Additionally, you can grant the user the Data Writer role, but limit them to wri
 [#roles-in-relation-to-buckets]
 === Roles in Relation to Buckets
 
-All data within a collection, which in turn is within a scope which is stored within a bucket. 
-Administrators granting bucket-related roles can restrict the user's privileges to access to data in any of the following ways:
-
-* By Bucket: Permissions apply to all data in the specified bucket: all scopes and collections are thus covered by the permissions.
-
-* By Bucket and Scope: Permissions apply only to the collections within the specified scope (or scopes), within the specified bucket.
-
-* By Bucket, Scope, and Collection: Permissions apply only to the data within the specified collection (or collections), within the specified scope (or scopes), within the specified bucket.
-
-
+Some roles provide privileges to resources across the entire cluster. 
+For example, most administrator roles grant the user access to resources cluster wide.
+Other roles, especially those dealing with managing data, let the administrator granting the role limit its privileges to specific buckets, scopes, or collections.
 
 [#commonly-used-roles]
 === Commonly Used Roles
 
 Couchbase Server users fall into three categories: administrators, developers, and applications.
-Which roles you assign to a user normally depends on which category they fall into:
+Which roles you assign to a user often depends on which category they fall into:
 
 Administrators::
 Users with any of the administrator roles can log into Couchbase Server Web Console and perform administrative tasks.
-Besides the Full Admin role, these roles do not grant the ability to read or write data.
+Most of  these roles do not grant the ability to read or write data.
 +
 The administrative roles grant their uses the ability to carry out specific tasks.
-For example, a user with the Cluster Admin role can manage of all cluster features except security.
-Users with the Read-Only Admin role can only read statistics.
+For example, a user with the Cluster Admin role can manage of all cluster features except for security.
+Users with the <<#read-only-admin,Read-Only Admin>> role can only read statistics.
 The Bucket Admin role allows management only of one or more buckets.
-See the <<#admin-roles>> for details.
+See <<#admin-roles>> for details.
 +
-NOTE: The user interface of the Couchbase Web Console changes based on the administrative role the user has.
+NOTE: The user interface of the Couchbase Web Console changes based on the role the user has.
 For example, only the Full Admin role lets a user access the entire **Security** screen.
 Users with either the Local User Admin or the External User Admin roles can only see the **Users & Groups** tab on this screen.
 
 Applications::
-Users you create to be used by applications when interacting with Couchbase Server often need to read or write data.
+Applications need to have user accounts when interacting with Couchbase Server.
+You often assign these users roles that let them to read or write data or have other limited privileges.
 Most of the roles you grant applications do not allow them to log into Couchbase Server Web Console or modify cluster settings.
-For example, the Data Reader and Data Writer roles lets the user read and write one or more collections, within one or more scopes, within one or more buckets.
-Other roles appropriate for applications are Application Access, Data Writer, Data Backup & Restore, and Data Monitor.
+For example, the <<#data-reader>> and <<#data-writer>> roles lets the user read and write data.
+You can restrict these privileges to one or more collections, scopes, or buckets.
+Other roles appropriate for applications are <<#manage-scopes>>, <<#data-dcp-reader>>, and <<#data-backup-and-restore>>.
 
 
 Developers::
@@ -73,16 +68,16 @@ User accounts for developers require more privileges to access data and manage r
 However, they should not have the unrestricted privileges that most Administrator roles grant.
 These roles do let users log into the Couchbase Server Web Console, so they can perform tasks in a GUI environment.
 You can tailor the roles you grant to developers so they have just enough privileges to perform their tasks.
-For example, the Analytics Admin and Manage Global External Functions roles were designed for interactive users.
-They let the user maintain some parts of your database.
-However, they lack the ability to change cluster settings or universally read data like most administrator roles.
+For example, the <<#analytics-admin>> and <<#manage-global-external-functions>> roles were designed for interactive users.
+They let them maintain some parts of your database.
+However, they lack the ability to change cluster settings like most administrator roles.
 
 == Role Overviews
 
 The following sections describe the roles Defined by Couchbase Server. 
-The list is broken into the same categories that appear within the COuchbase Server Web Console's *Edit User* dialog.
+The list is broken into the same categories that appear within the Couchbase Server Web Console's *Edit User* dialog.
 Each description has a table listing the resources the roles allow users to access, and any limitations on their access.
-If a resource does not appear in this table, the role does not grant the user any privileges to it. 
+If a resource does not appear in this table, the role does not grant the user any privileges for it. 
 
 
 [#admin-roles]

--- a/modules/learn/pages/security/roles.adoc
+++ b/modules/learn/pages/security/roles.adoc
@@ -23,19 +23,19 @@ You can also enable the user to write data to multiple collections, multiple sco
 For detailed information about scopes and collections, see xref:learn:data/scopes-and-collections.adoc[].
 
 You can grant a user a set of roles to precisely tailor their privileges so they can perform their tasks in the database.
-Some roles, such as Query List Index, are so limited that they are only useful 
-For example, you can grant a user the ability to read all data in a specific bucket va the Data Reader role.
-Additionally, you can grant the user the Data Writer role, but limit them to writing data into a specific collection within the bucket.
+Some roles, such as Query List Index, are so limited that they're only useful in conjuction with other roles.
+For example, you can grant a user the ability to read all data in a specific bucket via the Data Reader role.
+In addition, you can grant the user the Data Writer role, but limit them to writing data into a specific collection within the bucket.
 
 [#roles-in-relation-to-buckets]
 === Roles in Relation to Buckets
 
 Some roles provide privileges to resources across the entire cluster. 
 For example, most administrator roles grant the user access to resources cluster wide.
-Other roles, especially those dealing with managing data, let the administrator granting the role limit its privileges to specific buckets, scopes, or collections.
+Other roles, such as those dealing with managing data, let the administrator granting the role limit its privileges to specific buckets, scopes, or collections.
 
 [#commonly-used-roles]
-=== Commonly Used Roles
+=== User Categories
 
 Couchbase Server users fall into three categories: administrators, developers, and applications.
 Which roles you assign to a user often depends on which category they fall into:
@@ -44,9 +44,9 @@ Administrators::
 Users with any of the administrator roles can log into Couchbase Server Web Console and perform administrative tasks.
 Most of  these roles do not grant the ability to read or write data.
 +
-The administrative roles grant their uses the ability to carry out specific tasks.
-For example, a user with the Cluster Admin role can manage of all cluster features except for security.
-Users with the <<#read-only-admin,Read-Only Admin>> role can only read statistics.
+The administrative roles grant their users the ability to carry out specific tasks.
+For example, a user with the Cluster Admin role can manage all cluster features except for security.
+Users with the <<#read-only-admin,Read-Only Admin>> role can access the Couchbase Server Web Console to  read cluster settings, statistics, and backup plans, but not change them.
 The Bucket Admin role allows management only of one or more buckets.
 See <<#admin-roles>> for details.
 +
@@ -55,7 +55,7 @@ For example, only the Full Admin role lets a user access the entire **Security**
 Users with either the Local User Admin or the External User Admin roles can only see the **Users & Groups** tab on this screen.
 
 Applications::
-An applications needs to have a user account to authenticate with Couchbase Server.
+An application needs to have a user account to authenticate with Couchbase Server.
 You often assign these users roles that let them read or write data or other limited privileges.
 Most of the roles you grant applications do not allow them to log into Couchbase Server Web Console or modify cluster settings.
 For example, the <<#data-reader>> and <<#data-writer>> roles lets the user read and write data using key-value operations.
@@ -79,6 +79,9 @@ The list is broken into the same categories that appear within the Couchbase Ser
 Each description has a table listing the resources the roles allow users to access, and any limitations on their access.
 If a resource does not appear in this table, the role does not grant the user any privileges for it. 
 
+NOTE: THe majority of roles are only availabe in Couchbase Server Enterprise Edition. 
+The list indicates when a role is available in Community Edition.
+
 
 [#admin-roles]
 == Administrative Roles
@@ -89,7 +92,7 @@ The following roles grant users the ability to administer some aspects of Couchb
 === Full Admin
 
 The Full Admin role (`admin`) grants full privileges to all Couchbase Server features and resources, including security.
-The role grants lets the user log into to the Couchbase Server Web Console.
+The role lets the user log into to the Couchbase Server Web Console.
 
 This role is also available in Couchbase Server Community Edition.
 
@@ -114,7 +117,7 @@ h| Restrictions
 
 | *Servers* 
 | View configuration and statistics
-| Cannot add, failover, remove, modify services, rebalance
+| Cannot add, failover, remove, modify services, or rebalance
 
 | *Buckets*
 | List buckets, scopes, and collections
@@ -126,7 +129,7 @@ h| Restrictions
 
 | *XDCR* 
 | List remote clusters and outgoing replications 
-| Cannot list incoming replications, add or edit replications.
+| Cannot list incoming replications, or add or edit replications.
 
 | *Security* 
 | Can view settings for SAML, certificates, encryption at rest, audits, and other settings.
@@ -163,6 +166,231 @@ h| Restrictions
 | *Views*
 | Can list defined views
 | Cannot change views
+
+|===
+
+[#security-admin]
+=== Security Admin
+
+The Security Admin role grants the user the ability manage all security settings except for users and groups.
+
+This role lets the user log into the Couchbase Server Web Console.
+
+[#table_security_admin_role,cols="1,2,2,hrows=2]
+|===
+3+^| Role: Security Admin (`security_admin`)
+
+h| Resource
+h| Permissions
+h| Restrictions
+
+| *Servers* 
+| View configuration and statistics
+| Cannot add, failover, remove, modify services, rebalance
+
+| *Buckets*
+| List buckets, scopes, and collections
+| Cannot create, drop, edit settings, read or write data
+
+| *Backup*
+| None
+| All 
+
+| *XDCR* 
+| List outgoing replications
+| Cannot create, start, alter connections
+
+| *Security* 
+| Manage LDAP, SAML, certificates, encryption at rest, audit, and logging settings.
+| Cannot view or change users or groups.
+
+| *Settings*
+| View
+| Change
+
+| *Logs*
+| View
+| Collect Information
+
+| *Query*
+| None
+| All
+
+| *Search*
+| None
+| All
+
+| *Analytics*
+| None
+| All
+
+| *Eventing*
+| None
+| All
+
+| *Views*
+| None
+| All
+
+|===
+
+
+
+
+[#local-user-security-admin]
+=== Local User Admin
+
+The Local User Admin role lets a user manage users defined in the xref:learn:security/authentication-domains.adoc#local-domain[local authentication domain].
+It also grants the ability to read all cluster statistics such as the settings, logs, and buckets.
+It does not grant the ability to read data.
+
+NOTE: While this role does not allow the user to read or write data, they can create users that can read and write data.
+This could be considered a privilege escalation, but it's intentional behavior.
+This role is intended to manage all non-administratior roles, including those that can read or write data.
+You can address any possible privilege escalation concerns by auditing the actions of users with this role to see if they create users to get around the data access limitations. 
+
+This role allows users to edit local users, but they cannot grant these users the Full Admin, Read-Only Admin,  Local User Admin, or External User Admin roles.
+They also cannot edit the accounts for any user with those roles (including their own account).
+
+NOTE: This role replaced the Local User Security Admin role available in Couchbase Server prior to version 8.0.
+The Local User Security Admin role had additional administration privileges that were split off into the <<#security-admin>> role. 
+When upgrading to 8.0 or restoring a backup from a pre-8.0 version to Couchbase Server 8.0 or later, users with the Local User Security Admin role are granted this role and the <<#security-admin>> role.
+This conversion ensures the user retains the privileges they had in prior versions.
+
+This role lets users log into the Couchbase Server Web Console.
+
+[#table_security_admin_local_role,cols="1,2,2,hrows=2"]
+|===
+3+^| Role: Local User Admin (`user_admin_local`)
+
+h| Resource
+h| Permissions
+h| Restrictions
+
+| *Servers* 
+| View statistics
+| Add, failover, remove, modify services, rebalance
+
+| *Buckets*
+| List buckets, scopes, and collections
+| Create, drop, edit settings, read or write data
+
+| *Backup*
+| None
+| All
+
+| *XDCR* 
+| All
+| None
+
+| *Security* 
+| Add, delete, edit local users. 
+Can add, delete, and edit groups.
+| Cannot grant Full Admin, Read-Only Admin, Local or External User Admin, or Security Admin roles to users or groups.
+Cannot access non-user and group security resources.
+
+| *Settings*
+| View
+| Change
+
+| *Logs*
+| View
+| Collect Information
+
+| *Query*
+| None
+| All
+
+| *Search*
+| None
+| All
+
+| *Analytics*
+| None
+| All
+
+| *Eventing*
+| None
+| All
+
+| *Views*
+| None
+| All
+
+|===
+
+[#external-user-security-admin]
+=== External User Admin
+
+The External User Admin role lets users manage users defined in the xref:learn:security/authentication-domains.adoc#external_domain[external authentication domain].
+It also lets the user manage groups and read all cluster statistics.
+Users with this role cannot grant external users or groups Full Admin, Read-Only Admin, Security Admin, or Local or External User Admin roles.
+They also cannot edit users with those roles. 
+
+NOTE: This role replaced the External User Security Admin role available in Couchbase Server prior to version 8.0.
+The External User Security Admin role had additional administration privileges that were split off into the <<#security-admin>> role. 
+When upgrading to 8.0 or restoring a backup from a pre-8.0 version to Couchbase Server 8.0 or later, users with the External User Security Admin role are granted this role and the <<#security-admin>> role.
+This conversion ensures the user retains the privileges they had in prior versions.
+
+This role lets the user log into the Couchbase Server Web Console.
+
+[#table_security_admin_external_role,cols="1,2,2,hrows=2"]
+|===
+3+^| Role: External User Admin (`user_admin_external`)
+
+h| Resource
+h| Permissions
+h| Restrictions
+
+| *Servers* 
+| View statistics
+| Add, failover, remove, modify services, or rebalance servers
+
+| *Buckets*
+| List buckets, scopes, and collections
+| Create, drop, edit settings, read or write data
+
+| *Backup*
+| None
+| All
+
+| *XDCR* 
+| View list of outgoing replications
+| View incoming replications, remote clusters, add or edit connections
+
+| *Security* 
+| Add, delete, edit external users.
+Add, delete, and edit groups.
+| Cannot grant Full Admin, Read-Only Admin, Local or External User Admin, or Security Admin roles to groups or external users.
+Cannot access security resources besides users and groups.
+
+| *Settings*
+| View
+| Change
+
+| *Logs*
+| View
+| Collect Information
+
+| *Query*
+| None
+| All
+
+| *Search*
+| None
+| All
+
+| *Analytics*
+| None
+| All
+
+| *Eventing*
+| None
+| All
+
+| *Views*
+| None
+| All
 
 |===
 
@@ -231,84 +459,6 @@ h| Restrictions
 | All
 
 |===
-
-
-[#local-user-security-admin]
-=== Local User Admin
-
-The Local User Admin role lets a user manage users defined in the xref:learn:security/authentication-domains.adoc#local-domain[local authentication domain].
-It also grants the ability to read all cluster statistics such as the settings, logs, and buckets.
-It does not grant the ability to read data.
-The role allows users to edit local users, but they cannot grant these users the Full Admin, Read-Only Admin,  Local User Admin, or External User Admin roles.
-They also cannot edit the accounts for any user with those roles (including their own account).
-
-NOTE: This role replaced the Local User Security Admin role in Couchbase Server 8.0.
-The Local User Security Admin role had additional administration privileges that were split off into the <<#security-admin>> role. 
-When upgrading to 8.0 or restoring a backup from a pre-8.0 version to Couchbase Server 8.0 or later, users with the Local User Security Admin role are granted this role and the <<#security-admin>> role.
-This conversion ensures the user retains the privileges they had in prior versions.
-
-This role lets users log into the Couchbase Server Web Console.
-
-[#table_security_admin_local_role,cols="1,2,2,hrows=2"]
-|===
-3+^| Role: Local User Admin (`user_admin_local`)
-
-h| Resource
-h| Permissions
-h| Restrictions
-
-| *Servers* 
-| View statistics
-| Add, failover, remove, modify services, rebalance
-
-| *Buckets*
-| List buckets, scopes, and collections
-| Create, drop, edit settings, read or write data
-
-| *Backup*
-| None
-| All
-
-| *XDCR* 
-| All
-| None
-
-| *Security* 
-| Add, delete, edit local users. 
-Can add, delete, and edit groups.
-| Cannot grant Full Admin, Read-Only Admin, Local or External User Admin, or Security Admin roles to users or groups.
-Cannot access non-user and group security resources.
-
-| *Settings*
-| View
-| Change
-
-| *Logs*
-| View
-| Collect Information
-
-| *Query*
-| None
-| All
-
-| *Search*
-| None
-| All
-
-| *Analytics*
-| None
-| All
-
-| *Eventing*
-| None
-| All
-
-| *Views*
-| None
-| All
-
-|===
-
 
 [#eventing-full-admin]
 === Eventing Full Admin
@@ -388,6 +538,9 @@ Cannot add or edit replications.
 
 The Backup Full Admin role lets the user administer backup-related tasks as well as other aspects of Couchbase Server.
 
+NOTE: This role does not grant the ability to back up or restore users.
+For a user to be able to back up both data and users, you must assign them the <<#local-user-security-admin>> and the <<#external-user-security-admin>> roles in addition to this role.
+
 This role lets the user log into Couchbase Server Web Console.
 
 [#table_backup_admin_role,cols="1,2,2,hrows=2"]
@@ -453,95 +606,17 @@ h| Restrictions
 
 |===
 
+[#views-admin]
+=== Views Admin
 
-[#external-user-security-admin]
-=== External User Admin
+The Views Admin role lets the user create, modify, and drop views in one or more buckets.  
+When granting this role, you choose the buckets where the user can manage views.
 
-The External User Admin role lets users manage users defined in the xref:learn:security/authentication-domains.adoc#external_domain[external authentication domain].
-It also lets the user manage groups and read all cluster statistics.
-Users with this role cannot grant external users or groups Full Admin, Read-Only Admin, Security Admin, or Local or External User Admin roles.
-They also cannot edit users with those roles. 
+This role lets the user log into Couchbase Server Web Console.
 
-NOTE: This role replaced the External User Security Admin role in Couchbase Server 8.0.
-The External User Security Admin role had additional administration privileges that were split off into the <<#security-admin>> role. 
-When upgrading to 8.0 or restoring a backup from a pre-8.0 version to Couchbase Server 8.0 or later, users with the External User Security Admin role are granted this role and the <<#security-admin>> role.
-This conversion ensures the user retains the privileges they had in prior versions.
-
-This role lets the user log into the Couchbase Server Web Console.
-
-[#table_security_admin_external_role,cols="1,2,2,hrows=2"]
+[#table_views_admin_role,cols="1,2,2,hrows=2"]
 |===
-3+^| Role: External User Admin (`user_admin_external`)
-
-h| Resource
-h| Permissions
-h| Restrictions
-
-| *Servers* 
-| View statistics
-| Add, failover, remove, modify services, rebalance
-
-| *Buckets*
-| List buckets, scopes, and collections
-| Create, drop, edit settings, read or write data
-
-| *Backup*
-| None
-| All
-
-| *XDCR* 
-| View list of outgoing replications
-| View incoming replications, remote clusters, add or edit connections
-
-| *Security* 
-| Add, delete, edit external users.
-Add, delete, and edit groups.
-| Cannot grant Full Admin, Read-Only Admin, Local or External User Admin, or Security Admin roles to groups or external users.
-Cannot access security resources besides users and groups.
-
-| *Settings*
-| View
-| Change
-
-| *Logs*
-| View
-| Collect Information
-
-| *Query*
-| None
-| All
-
-| *Search*
-| None
-| All
-
-| *Analytics*
-| None
-| All
-
-| *Eventing*
-| None
-| All
-
-| *Views*
-| None
-| All
-
-|===
-
-
-
-
-[#security-admin]
-=== Security Admin
-
-The Security Admin role grants the user the ability manage all security settings except for users and groups.
-
-This role lets the user log into the Couchbase Server Web Console.
-
-[#table_security_admin_role,cols="1,2,2,hrows=2]
-|===
-3+^| Role: Security Admin (`security_admin`)
+3+^|  Role: Views Admin (`views_admin`)
 
 h| Resource
 h| Permissions
@@ -549,51 +624,37 @@ h| Restrictions
 
 | *Servers* 
 | View configuration and statistics
-| Cannot add, failover, remove, modify services, rebalance
+| Cannot add, failover, remove, modify services, or rebalance servers
 
 | *Buckets*
-| List buckets, scopes, and collections
-| Cannot create, drop, edit settings, read or write data
+| Can read, write, and edit views for the buckets they have been granted access to. 
+Can read data (via key-value), statistics, and settings in these buckets.
+| Cannot write data to buckets or alter bucket settings
 
-| *Backup*
-| None
-| All 
-
-| *XDCR* 
-| List outgoing replications
-| Cannot create, start, alter connections
-
-| *Security* 
-| Manage LDAP, SAML, certificates, encryption at rest, audit, and logging settings.
-| Cannot view or change users or groups.
+| *XDCR*
+| Can list outgoing replications
+| Cannot view incoming replications or change XDCR settings
 
 | *Settings*
-| View
-| Change
+| View all settings
+| Cannot edit settings
 
 | *Logs*
-| View
-| Collect Information
+| Can view logs
+| Cannot collect data
 
 | *Query*
 | None
-| All
+| Cannot execute queries
 
 | *Search*
-| None
-| All
-
-| *Analytics*
-| None
-| All
-
-| *Eventing*
-| None
-| All
+| Can view Search indexes
+| Cannot edit or add Search indexes
 
 | *Views*
-| None
-| All
+| Can create, drop, and edit views in buckets they have been granted access to.
+| Cannot change views
+
 
 |===
 
@@ -601,8 +662,8 @@ h| Restrictions
 [#external-stats-reader]
 === External Stats Reader
 
-The External Stats Reader role only access to just the `/metrics` and `/prometheus_sd_config` REST API endpoints,
-Assign this role to a user to allow Prometheus to collect metrics from all Couchbase Server services.
+The External Stats Reader role grants only allows the user to call the `/metrics` and `/prometheus_sd_config` REST API endpoints.
+Assign this role to the user Prometheus uses when authenticating with Couchbase Server. 
 See xref:manage:monitor/set-up-prometheus-for-monitoring.adoc[] for more information.
 
 This role does not let the user log into the Couchbase Server Web Console.
@@ -650,7 +711,7 @@ h| Restrictions
 [#bucket-roles]
 == Bucket Roles
 
-The following roles give users priviliges to manage or access buckets. 
+The following roles give users privileges to manage or access buckets. 
 See xref:learn:buckets-memory-and-storage/buckets.adoc[] for more information about buckets.
 
 [#bucket-admin]
@@ -658,7 +719,7 @@ See xref:learn:buckets-memory-and-storage/buckets.adoc[] for more information ab
 
 The Bucket Admin role lets the user manage one or more buckets. 
 These management abilities include stopping and starting XDCR for a bucket.
-The administrator granting this role chooses which buckets the user can manage.
+When granting this role, you choose which buckets the user can manage.
 
 This role lets the user log into Couchbase Server Web Console.
 
@@ -709,7 +770,7 @@ Can add, edit, and drop scopes and collections in the buckets.
 === Manage Scopes
 
 The Manage Scopes role lets a user create and delete scopes and collections within one or more buckets.
-The administrator granting this role chooses the buckets where the user can create scopes and collections.
+When granting this role, you choose the buckets where the user can create scopes and collections.
 The user does not have the ability to read, write, or alter data.
 Use this role to allow applications to manage a bucket's scopes and collections.
 
@@ -736,10 +797,10 @@ h| Restrictions
 
 The Application Access role lets a user read and write data in one or more buckets.
 This role does not grant the ability to query data via {sqlpp}&#8212;the user can only access data via keys.
-The administrator granting this role chooses the buckets where the user can read and write data.
+When granting this role, you choose the buckets where the user can read and write data.
 As its name implies, this role is intended for use by applications instead of interactive users.
 
-[NOTE]
+[IMPORTANT]
 ====
 This role is deprecated. 
 Couchbase Server 5.0 added this role to replace an old method of password authentication to access buckets.
@@ -747,8 +808,9 @@ To transition away from bucket passwords, the upgrade process to Couchbase Serve
 Do not grant this role to users.
 Instead, use one of the query or data roles.
 
-Versions of Couchbase Server prior to 5.5 referred to this role as Bucket Full Access.
 ====
+
+Versions of Couchbase Server prior to 5.5 referred to this role as Bucket Full Access.
 
 This role does not let the user log into Couchbase Server Web Console.
 
@@ -777,7 +839,7 @@ See xref:guides:kv-operations.adoc[] to learn about key-value operations.
 
 The Data Reader role lets the user read data from one or more collections via key-value retrieval. 
 It does not grant the ability to run {sqlpp} queries (see <<#query-roles>> for roles that do).
-When granting this role, the administrator chooses the collections the user can read data from.
+When granting this role, you choose the collections where the user can read data.
 Grant this role to users for applications that need to read data via key-value operations.
 
 This role does not let the user log into Couchbase Server Web Console. 
@@ -808,7 +870,7 @@ Can read some bucket metadata, XATTR mappings, and pools on buckets they have be
 
 The Data Writer role lets the user write data to one or more collections via key-value operations. 
 It does not grant the ability to run {sqlpp} queries (see <<#query-roles>> for roles that do).
-When granting this role, the administrator chooses the collections the user can write data to.
+When granting this role, you choose the collections where the user can write data.
 Grant this role to users for applications that need to write data via key-value operations.
 
 This role does not let the user log into Couchbase Server Web Console. 
@@ -836,7 +898,7 @@ h| Restrictions
 === Data DCP Reader
 
 The Data DCP Reader role lets the user start a xref:learn:clusters-and-availability/intra-cluster-replication.adoc#database-change-protocol[Database Change Protocol (DCP)] stream for one or more collections, scopes, or buckets. 
-When granting this role, the administrator chooses the collections, scopes, and buckets where the user can start DCP streams.
+When granting this role, you choose the collections, scopes, and buckets where the user can start DCP streams.
 Grant this role to users for applications that need to start DCP streams.
 
 This role does not let the user log into Couchbase Server Web Console. 
@@ -861,17 +923,14 @@ Can also read data and XATTRs from these collections, scopes, and buckets.
 |===
 
 
-
-
-
 [#data-monitor]
 === Data Monitor
 
 The Data Monitor role lets the user read statistics for a bucket, scope, or collection.
-When granting the role, the administrator decides which statics the user can read.
+When granting the role, you decide which statistics the user can read.
 Use this role for applications that need to read statistics.
 
-NOTE: In versions of Couchbase Server prior to 5.5, this role was referred to as *Data Monitoring*.
+NOTE: In versions of Couchbase Server prior to 5.5, this role was called Data Monitoring.
 
 This role does not let the user log into Couchbase Server Web Console. 
 
@@ -892,58 +951,38 @@ h| Restrictions
 
 == Views Roles
 
-The following roles grant useres privileges with Views.
+The following roles grant users privileges with Views.
+Also see the related administrator role <<#views-admin>>.
 
-NOTE: Views were deprecated in Couchbase Server 7.0. 
+IMPORTANT: Views were deprecated in Couchbase Server 7.0. 
 See xref:learn:views/views-intro.adoc[] for more information.
 
-[#views-admin]
-=== Views Admin
 
-The Views Admin role lets the user create, modify, and drop views in one or more buckets.  
-When granting this role, the administrator chooses the buckets where the user can manage views.
 
-This role lets the user log into Couchbase Server Web Console.
+[#views-reader]
+=== Views Reader
 
-[#table_views_admin_role,cols="1,2,2,hrows=2"]
+The Views Reader role lets a user read data from views in one or more buckets.
+When granting this role, you choose which buckets contain views the user can read.
+Grant this role to users you create for applications that need to read data from views.
+
+This role does not let the user log into Couchbase Server Web Console. 
+ 
+[#table_views_reader_role,cols="1,2,2,hrows=2"]
 |===
-3+^|  Role: Views Admin (`views_admin`)
+3+^|  Role: Views Reader (`views_reader`)
 
 h| Resource
 h| Permissions
 h| Restrictions
 
-| *Servers* 
-| View configuration and statistics
-| Cannot add, failover, remove, modify services, rebalance
-
 | *Buckets*
-| Can read, write, and edit views for the buckets they have been granted access to. 
-Can read data (via key-value), statistics, and settings in these buckets.
-| Cannot write data to buckets or alter bucket settings
-
-| *XDCR*
-| Can list outgoing replications
-| Cannot view incoming replications or change XDCR settings
-
-| *Settings*
-| View all settings
-| Cannot edit settings
-
-| *Logs*
-| Can view logs
-| Cannot collect data
-
-| *Query*
-| None
-| Cannot execute queries
-
-| *Search*
-| Can view Search indexes
-| Cannot edit or add Search indexes
+| Can read data from views in the buckets they have access to. 
+Can read data via key-value from these buckets. 
+| Cannot write data to buckets, alter bucket settings, or alter views.
 
 | *Views*
-| Can create, drop, and edit views in buckets they have been granted access to.
+| Can read data from views in buckets they have been granted access to.
 | Cannot change views
 
 
@@ -953,6 +992,8 @@ Can read data (via key-value), statistics, and settings in these buckets.
 [#query-roles]
 == Query & Index Roles
 
+These roles grant users the ability to perform queries and work with indexes.
+
 [#query-curl-access]
 === Query CURL Access
 
@@ -961,7 +1002,6 @@ The Query CURL Access role lets the user call the {sqlpp} curl function in their
 CAUTION: The Query CURL Access role allows users to run GET and POST requests to any system on the network Couchbase Server uses for client connections.
 If your cluster is not configured to use a private network for internal communication, they also have access to the entire cluster.  
 They can interact with any system on this network.
-
 
 This role only grants the user the ability to read data returned by the {sqlpp} curl function.
 Usually, you assign additional roles to the user to allow them to read and write data.
@@ -981,7 +1021,7 @@ h| Restrictions
 
 | *Servers* 
 | List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+| Cannot view configuration or add, failover, remove, modify services, or rebalance servers
 
 | *Buckets*
 | List buckets
@@ -1018,7 +1058,8 @@ h| Restrictions
 
 | *Servers* 
 | List servers.
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+| Cannot view configuration.
+Cannot add, failover, remove, modify services, or rebalance servers.
 
 | *Buckets*
 | List buckets and view bucket settings
@@ -1027,7 +1068,7 @@ h| Restrictions
 | *Query*
 | Can query system tables
 | Cannot perform any other query actions.
-Cannot use the query workbench in Couchbase Server Web Console.
+Cannot use the Query Workbench in Couchbase Server Web Console.
 
 |===
 
@@ -1050,7 +1091,8 @@ h| Restrictions
 
 | *Servers* 
 | List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+| Cannot view configuration.
+Cannot add, failover, remove, modify services, or rebalance servers.
 
 | *Buckets*
 | List buckets
@@ -1058,8 +1100,8 @@ h| Restrictions
 
 | *Query*
 | Can execute `CREATE FUNCTION` and `DROP FUNCTION` statements
-| Cannot perform any other queries, including calling the global functions
-Cannot use the Query Workbench in Couchbase Server Web Console
+| Cannot perform any other queries, including calling global functions.
+Cannot use the Query Workbench in Couchbase Server Web Console.
 
 | *Settings*
 | View cluster settings
@@ -1071,7 +1113,7 @@ Cannot use the Query Workbench in Couchbase Server Web Console
 [#execute-global-functions]
 === Execute Global Functions
 
-The Execute Global Functions role lets the user call global {sqlpp} functions.
+The Execute Global Functions role lets the user call global {sqlpp} user-defined functions.
 
 This role lets the user log into Couchbase Server Web Console. 
 
@@ -1086,7 +1128,8 @@ h| Restrictions
 
 | *Servers* 
 | List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+| Cannot view configuration.
+Cannot add, failover, remove, modify services, or rebalance servers.
 
 | *Buckets*
 | List buckets
@@ -1107,7 +1150,8 @@ Cannot use the Query Workbench in Couchbase Server Web Console.
 [#manage-scope-functions]
 === Manage Scope Functions (Query and Index)
 
-The Manage Scope Functions role lets the user create an drop user-defined {sqlpp} functions for one or more scopes.
+The Manage Scope Functions role lets the user create and drop user-defined {sqlpp} functions for one or more scopes.
+When granting this role, You select the scopes where  the user can manage user-defined functions.
 See xref:n1ql:n1ql-language-reference/createfunction.adoc[].
 
 This role lets the user log into Couchbase Server Web Console. 
@@ -1124,7 +1168,8 @@ h| Restrictions
 
 | *Servers* 
 | List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+| Cannot view configuration.
+Cannot add, failover, remove, modify services, or rebalance servers.
 
 | *Buckets*
 | List buckets
@@ -1145,8 +1190,9 @@ Cannot use the Query Workbench in Couchbase Server Web Console.
 === Query Select
 
 The Query Select role lets the user execute `SELECT` statements on the data in one or more collections.
-The administrator sets which collections the user can access when granting this role.
 See xref:guides:query.adoc[].
+When granting this role, you choose the collections where the user execute `SELECT` statements.
+
 
 This role lets the user log into Couchbase Server Web Console. 
 
@@ -1162,7 +1208,8 @@ h| Restrictions
 
 | *Servers* 
 | List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
+| Cannot view configuration.
+Cannot add, failover, remove, modify services, or rebalance servers.
 
 | *Buckets*
 | Can list buckets.
@@ -1185,9 +1232,9 @@ Cannot use the Query Workbench in Couchbase Server Web Console.
 [#query-update]
 === Query Update
 
-The Query Update role grants the user the ability to execute `UPDATE` statements to mutate existing documents in specific collections.  
+The Query Update role lets the user execute `UPDATE` statements to mutate existing documents in specific collections.  
 See xref:n1ql:n1ql-language-reference/update.adoc[] for more information.
-The administrator granting this role selects which collections contain documents the user can mutate.
+When granting this role, you select which collections contain documents the user can mutate.
 
 This role lets the user log into Couchbase Server Web Console. 
 
@@ -1202,7 +1249,8 @@ h| Restrictions
 
 | *Servers* 
 | List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+| Cannot view configuration.
+Cannot  add, failover, remove, modify services, or rebalance servers.
 
 | *Buckets*
 | List buckets and view bucket settings
@@ -1223,9 +1271,9 @@ Cannot use the Query Workbench in Couchbase Server Web Console.
 [#query-insert]
 === Query Insert
 
-The Query Insert role grants the user the ability to execute the {sqlpp} `INSERT` statement to add new documents to one or more collections.
+The Query Insert role lets the user execute the {sqlpp} `INSERT` statement to add new documents to one or more collections.
 See xref:n1ql:n1ql-language-reference/insert.adoc[] for more information.
-The administrator granting this role selects which collections the user can add documents to.
+When granting this role, you select the collections where the user can add documents.
 
 This role lets the user log into Couchbase Server Web Console.
 
@@ -1241,7 +1289,8 @@ h| Restrictions
 
 | *Servers* 
 | List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+| Cannot view configuration.
+Cannot add, failover, remove, modify services, or rebalance servers.
 
 | *Buckets*
 | List buckets and view bucket settings
@@ -1251,7 +1300,7 @@ h| Restrictions
 | Can execute `INSERT` statements to create documents in one or more collections
 | Cannot perform any other queries.
 Cannot mutate existing documents.
-Cannot use the Query Workbench in Couchbase Server Web Console
+Cannot use the Query Workbench in Couchbase Server Web Console.
 
 | *Settings*
 | View cluster settings
@@ -1262,9 +1311,9 @@ Cannot use the Query Workbench in Couchbase Server Web Console
 [#query-delete]
 === Query Delete
 
-The Query Delete role grants the user the ability to execute the {sqlpp} `DELETE` to delete documents from one or more scopes.
+The Query Delete role lets the user execute the {sqlpp} `DELETE` satatement to delete documents from one or more scopes.
 See xref:n1ql:n1ql-language-reference/delete.adoc[] for more information.
-The administrator granting this role selects which collections the user can delete documents from.
+When granting this role, you  select the collections where the user can delete documents.
 
 This role lets the user log into Couchbase Server Web Console. 
 
@@ -1279,7 +1328,8 @@ h| Restrictions
 
 | *Servers* 
 | List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+| Cannot view configuration.
+Cannot add, failover, remove, modify services, or rebalance servers.
 
 | *Buckets*
 | List buckets and view bucket settings
@@ -1302,7 +1352,7 @@ Cannot use the Query Workbench in Couchbase Server Web Console.
 === Query Use Sequential Scan
 
 The Query Use Sequential Scan role allows users' queries to perform a sequential scan of a keyspace.
-The query planner only decides to use a sequential scan when there is no suitable index for the keyspace. 
+The query planner only uses a sequential scan when no suitable index exists for the keyspace. 
 Only queries by users with this role can use a sequential scan to query data because scanning a large unindexed keyspace can be expensive.  
 See xref:indexes:query-without-index.adoc#sequential-scans[Sequential Scans] for more information.
 
@@ -1329,7 +1379,7 @@ h| Restrictions
 === Query Manage Index
 
 The Query Manage Index role allows the user to manage indexes for one or more collections.
-The administrator granting this role selects the collections where the user can manage indexes.
+When granting this role, you select the collections where the user can manage indexes.
 
 This role lets the user log into Couchbase Server Web Console.
 
@@ -1343,7 +1393,8 @@ h| Restrictions
 
 | *Servers* 
 | List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+| Cannot view configuration.
+Cannot add, failover, remove, modify services, or rebalance servers.
 
 | *Buckets*
 | List buckets and view bucket settings
@@ -1352,8 +1403,7 @@ Cannot read or write data.
 
 | *Index*
 | Can create, drop, and view indexes for the collections whose indexes they have been given permission to manage
-| Cannot perform any other queries, including calling the functions.
-Cannot use the Query Workbench in Couchbase Server Web Console.
+| Cannot use the Query Workbench in Couchbase Server Web Console
 
 | *Settings*
 | View cluster settings
@@ -1365,7 +1415,7 @@ Cannot use the Query Workbench in Couchbase Server Web Console.
 === Query List Index
 
 This role lets the user list indexes defined for one or more buckets, scopes, or collections.
-The administrator granting this role selects the buckets, scopes, or collections where the user can list indexes.
+When granting this role, you select the buckets, scopes, or collections where the user can list indexes.
 
 This role lets the user log into Couchbase Server Web Console.
 
@@ -1379,7 +1429,8 @@ h| Restrictions
 
 | *Servers* 
 | List servers and view statistics
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+| Cannot view configuration.
+Cannot add, failover, remove, modify services, or rebalance servers.
 
 | *Buckets*
 | List and view statistics for buckets, scopes, and collections
@@ -1401,7 +1452,7 @@ Cannot use the Index Workbench in Couchbase Server Web Console.
 === Execute Scope Functions
 
 The Execute Scope Functions role lets the user execute {sqlpp} user-defined functions defined within a scope.
-The administrator granting this role selects in which scopes the user can call user-defined functions the user can call.
+When you grant this role, you select the scopes where the user can call user-defined functions.
 
 This role lets the user log into Couchbase Server Web Console.
 
@@ -1417,11 +1468,12 @@ h| Restrictions
 
 | *Servers* 
 | List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+| Cannot view configuration.
+Cannot add, failover, remove, modify services, or rebalance servers.
 
 
 | *Query*
-| Can execute scope user-defined functions
+| Can execute scope user-defined functions in specific scopes
 | Cannot perform any other queries.
 Cannot use the Query Workbench in Couchbase Server Web Console.
 
@@ -1451,7 +1503,8 @@ h| Restrictions
 
 | *Servers* 
 | List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+| Cannot view configuration.
+Cannot add, failover, remove, modify services, or rebalance servers.
 
 
 | *Query*
@@ -1486,7 +1539,8 @@ h| Restrictions
 
 | *Servers* 
 | List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
+| Cannot view configuration.
+Cannot add, failover, remove, modify services, or rebalance servers.
 
 
 | *Query*
@@ -1505,7 +1559,7 @@ Cannot use the Query Workbench in Couchbase Server Web Console.
 === Manage Scope External Functions
 
 The Manage Scope External Functions role lets the user create and drop external language functions defined at the scope level.
-The administrator granting this role chooses the scopes where the user can manage external functions.
+When you grant this role, you choose the scopes where the user can manage external functions.
 See xref:n1ql:n1ql-language-reference/createfunction.adoc#external-libraries[External Libraries] for more information about external functions.
 
 This role lets the user log into Couchbase Server Web Console.
@@ -1522,7 +1576,8 @@ h| Restrictions
 
 | *Servers* 
 | List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+| Cannot view configuration.
+Cannot add, failover, remove, modify services, or rebalance servers.
 
 | *Query*
 | Can call globally defined external functions
@@ -1540,7 +1595,7 @@ Cannot use the Query Workbench in Couchbase Server Web Console.
 === Execute Scope External Functions
 
 The Execute Scope External Functions role lets the user call external functions defined in a scope. 
-The administrator granting this role chooses the scopes where the user can call external functions.
+When you grant this role, you choose the scopes where the user can call external functions.
 See xref:n1ql:n1ql-language-reference/createfunction.adoc#external-libraries[External Libraries] for more information about external functions.
 
 This role lets the user log into Couchbase Server Web Console.
@@ -1556,7 +1611,8 @@ h| Restrictions
 
 | *Servers* 
 | List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+| Cannot view configuration.
+Cannot add, failover, remove, modify services, or rebalance servers.
 
 | *Query*
 | Can call globally defined external functions
@@ -1573,8 +1629,8 @@ Cannot use the Query Workbench in Couchbase Server Web Console.
 === Query Manage Sequences
 
 This role lets the user manage sequences for one or more scopes. 
-The administrator granting this role chooses the scopes where the user can manage sequences.
 See xref:n1ql:n1ql-language-reference/sequenceops.adoc[] for more information about sequences.
+When you grant this role, you  choose the scopes where the user can manage sequences.
 
 This role lets the user log into Couchbase Server Web Console.
 
@@ -1589,7 +1645,8 @@ h| Restrictions
 
 | *Servers* 
 | List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
+| Cannot view configuration.
+Cannot add, failover, remove, modify services, or rebalance servers.
 
 | *Query*
 | Can create and alter sequences in buckets to which they have been granted access
@@ -1608,7 +1665,7 @@ Cannot manage sequences in buckets to which they have not been granted access.
 === Query Use Sequences
 
 This role lets the user incorporate sequences into their queries in one or more scopes.
-The administrator granting this role chooses the scopes where the user can use sequences.
+When you grant this role, you choose the scopes where the user can use sequences.
 See xref:n1ql:n1ql-language-reference/sequenceops.adoc[] for more information about sequences.
 
 This role lets the user log into Couchbase Server Web Console.
@@ -1624,7 +1681,8 @@ h| Restrictions
 
 | *Servers* 
 | List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+| Cannot view configuration.
+Cannot add, failover, remove, modify services, or rebalance servers
 
 | *Query*
 | Can use sequences in scopes they have been granted access to.
@@ -1642,7 +1700,7 @@ Cannot manage sequences.
 [#query_manage_system_catalog]
 === Query Manage System Catalog
 
-This role lets a user manage all system catalogs for query automatic worload reports using {sqlpp} statements.
+This role lets a user manage all system catalogs for query automatic workload reports using {sqlpp} statements.
 
 // TODO: Add link to the query workload docs when completed
 
@@ -1659,7 +1717,8 @@ h| Restrictions
 
 | *Servers* 
 | List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+| Cannot view configuration.
+Cannot add, failover, remove, modify services, or rebalance servers.
 
 | *Query*
 | Can manage query workload system catalogs
@@ -1682,9 +1741,9 @@ The following roles give users privileges to the xref:learn:services-and-indexes
 === Search Admin
 
 The Search Admin role lets the user manage the Search Service in one or more buckets.
-When granting this role, the administrator chooses the buckets where the user can manage search.
+When you grant this role, you choose the buckets where the user can manage search.
 
-NOTE: In versions of Couchbase Server earlier than 5.5, this role was referred to as *FTS Admin*.
+NOTE: In versions of Couchbase Server earlier than 5.5, this role was named FTS Admin.
 
 This role lets the user log into Couchbase Server Web Console.
 
@@ -1709,7 +1768,7 @@ Can view documents.
 
 | *Settings* 
 | Can view cluster settings
-| Cannot view other settings nor change any settings.
+| Cannot view other settings nor change any settings
 
 | *Query*
 | None
@@ -1726,10 +1785,10 @@ Can view documents.
 [#search-reader]
 === Search Reader
 
-The Search Reader role lets the user execute searches using Full Text Search indexes in one or more buckets.
-When granting this role, the administrator chooses the buckets in which the user can execute searches.
+The Search Reader role lets the user execute searches using Full-Text Search indexes in one or more buckets.
+When you grant this role, you choose the buckets in which the user can execute searches.
 
-NOTE: In versions of Couchbase Server prior to 5.5, this role was referred to as *FTS Searcher*.
+NOTE: In versions of Couchbase Server prior to 5.5, this role was referred to as FTS Searcher.
 
 This role lets the user log into Couchbase Server Web Console.
 
@@ -1753,15 +1812,15 @@ Cannot rebalance, failover, add, or remove servers.
 
 | *Settings* 
 | Can view cluster settings
-| Cannot view other settings nor change any settings.
+| Cannot view other settings nor change any settings
 
 | *Query*
 | None
 | All
 
 | *Search*
-| Can use search indexes in the buckets they have access to.
-| Cannot add, drop, or change set4tings for search indexes.
+| Can use search indexes in the buckets they have access to
+| Cannot add, drop, or change set4tings for search indexes
 
 |===
 
@@ -1792,7 +1851,8 @@ h| Restrictions
 
 | *Servers* 
 | List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
+| Cannot view configuration.
+Cannot add, failover, remove, modify services, or rebalance servers.
 
 | *Settings*
 | View cluster settings
@@ -1827,7 +1887,8 @@ h| Restrictions
 
 | *Servers* 
 | List servers
-| Cannot view configuration, add, failover, remove, modify services, or rebalance servers
+| Cannot view configuration.
+Cannot add, failover, remove, modify services, or rebalance servers.
 
 | *Settings*
 | View cluster settings
@@ -1845,7 +1906,7 @@ h| Restrictions
 === Analytics Select
 
 The Analytics Select role lets the user query analytic datasets for one or more buckets, scopes, or collections.
-When granting this role, the administrator chooses the buckets, scopes, and collections where the user can execute queries.
+When you grant this role, you choose the buckets, scopes, and collections where the user can execute queries.
 
 This role lets the user log into Couchbase Server Web Console.
 
@@ -1864,11 +1925,11 @@ Cannot rebalance, failover, add, or remove servers.
 
 | *Settings* 
 | Can view cluster settings
-| Cannot view other settings nor change any settings.
+| Cannot view other settings nor change any settings
 
 | *Analytics*
-| Can query analytics data in the buckets they have access to.
-| Cannot add or drop Analytic scopes, links, nor collections or change their settings.
+| Can query analytics data in the buckets they have access to
+| Cannot add or drop Analytic scopes, links, nor collections or change their settings
 
 |===
 
@@ -1877,7 +1938,7 @@ Cannot rebalance, failover, add, or remove servers.
 
 The Analytics Manager role lets the user manage and query the analytic datasets for one or more buckets.
 They can also manage xref:analytics:manage-datasets.adoc#creating-a-collection-on-a-local-link[Analytics Service local links].
-When granting this role, the administrator chooses the buckets where the user can manage and query analytics.
+When you grant this role, you choose the buckets where the user can manage and query analytics.
 
 This role lets the user log into Couchbase Server Web Console.
 
@@ -1897,12 +1958,12 @@ Cannot rebalance, failover, add, or remove servers.
 
 | *Settings* 
 | Can view cluster settings
-| Cannot view other settings nor change any settings.
+| Cannot view other settings nor change any settings
 
 | *Analytics*
 | Can query analytics data in the buckets they have access to.
 Can manage analytics in these buckets, including local links and adding/dropping analytics collections. 
-| Cannot manage analytics in buckets they have not been granted access to.
+| Cannot manage analytics in buckets they have not been granted access to
 
 |===
 
@@ -1917,7 +1978,7 @@ For more information about Eventing, see xref:eventing:eventing-overview.adoc[].
 === Eventing Manage Scope Functions
 
 The Eventing Manage Scope Functions role lets the user manage the eventing functions in one or more scopes. 
-When granting this role, the administrator chooses the scopes where the user can manage eventing functions.
+When you grant this role, you choose the scopes where the user can manage eventing functions.
 
 NOTE: In addition to this role, the user must have the <<#data-dcp-reader>> on the collections they want their functions to listen to. 
 They must also have read and write permissions on one or more collections to store the function's event data.
@@ -1970,7 +2031,7 @@ h| Restrictions
 
 | *Servers* 
 | View configuration and statistics
-| Cannot add, failover, remove, modify services, rebalance
+| Cannot add, failover, remove, modify services, or rebalance servers
 
 | *Buckets*
 | List buckets, scopes, and collections
@@ -2023,7 +2084,7 @@ h| Restrictions
 === XDCR Inbound
 
 The XDCR Inbound role lets the user create inbound XDCR streams for one or more buckets.
-The administrator granting this role chooses the buckets where the user can create inbound XDCR connections.
+When granting this role, you choose the buckets where the user can create inbound XDCR connections.
 Assign this role to the user that you'll specify when creating an XDCR reference. 
 See xref:manage:manage-xdcr/create-xdcr-reference.adoc[Create a Reference] for more information. 
 
@@ -2049,14 +2110,14 @@ h| Restrictions
 
 == Backup Roles
 
-The following role gives users the ability to backup and restopre data.
+The following role gives users the ability to backup and restore data.
 Also see the Administrative role <<#backup-full-admin>>.
 
 [#data-backup-and-restore]
 === Data Backup & Restore
 
 The Data Backup & Restore lets users back up and restore data in one or more buckets.  
-When granting this role, the administrator chooses the buckets the user can back up.
+When you grant this role, you choose the buckets the user can back up.
 This role is not intended for interactive users.
 Grant this role to users for applications that need to back up and restore data. 
 
@@ -2083,8 +2144,8 @@ h| Restrictions
 | Cannot backup other data   
 
 | *Security* 
-| Can view settings for SAML, certificates, encryption at rest, audits, and other settings.
-| Cannot change settings.
+| Can view settings for SAML, certificates, encryption at rest, audits, and other settings
+| Cannot change settings
 
 | *Indexes*
 | Can build, create, and list
@@ -2111,10 +2172,9 @@ See the xref:sync-gateway::introduction.adoc[Sync Gateway Introduction] for more
 
 The Sync Gateway role gives the user full access to the data Sync Gateway's data stored in Couchbase Server.
 This role also lets the user manage indexes and read some cluster information.
-Only assign this role to the user that you create for the Sync Gateway's to use when connecting to Couchbase Server.
+Only assign this role to the user that you create for the Sync Gateway to use when connecting to Couchbase Server.
+Choose one or more buckets that contain mobile data that you want this user to manage. 
 See xref:sync-gateway::get-started-prepare.adoc#configure-server[Configure Server for Sync Gateway] for more information.
-
-
 
 This role does not let the user log into Couchbase Server Web Console. 
 
@@ -2128,21 +2188,21 @@ h| Permissions
 h| Restrictions
 
 | *Sync Gateway Data*
-| Can perform all actions on data (including flushing) and views on the Sync Gateway data stored in Couchbase Server.
+| Can perform all actions on data (including flushing) and views on the Sync Gateway data stored in the Couchbase Server buckets you grant them access to.
 Can view settings of these buckets.
-| Cannot change bucket settings.
+| Cannot change bucket settings
 
 | *Query*
-| Can execute queries on data in buckets containing Sync Gateway data.
+| Can execute queries on data in buckets containing Sync Gateway data
 | None
 
 | *Indexes*
-| Add and drop indexes and view index statistics in the buckets containing Sync Gateway data.
+| Add and drop indexes and view index statistics in the buckets containing Sync Gateway data
 | None.
 
 | *Settings*
-| View cluster settings.
-| Cannot view any other settings or change settings.
+| View cluster settings
+| Cannot view any other settings or change settings
 
 |===
 
@@ -2151,7 +2211,8 @@ Can view settings of these buckets.
 === Sync Gateway Architect
 
 The Sync Gateway Architect role lets the user manage Sync Gateway databases, users, and roles.
-It also grants access to the Sync Gateway's metrics via the `/metrics` REST API endpoint.
+You choose one or more collections, scopes, or buckets where the user can manage Sync Gateway data.
+This role also grants access to the Sync Gateway's metrics via the `/metrics` REST API endpoint.
 For information about Sync Gateway users and roles, see xref:sync-gateway::access-control-concepts.adoc[Access Control Concepts].
 
 This role does not let the user log into Couchbase Server Web Console. 
@@ -2185,8 +2246,9 @@ h| Restrictions
 [#sync-gateway-app]
 === Sync Gateway Application
 
-The Sync Gateway Application role lets the user manage Sync Gateway users and roles.
+The Sync Gateway Application role lets the user manage Sync Gateway users, roles, and data.
 It also allows the user to read and write application data through the Sync Gateway.
+You choose one or more collections, scopes, or buckets where this user can manage mobile users and roles.
 For information about Sync Gateway users and roles, see xref:sync-gateway::access-control-concepts.adoc[Access Control Concepts].
 
 This role does not let the user log into Couchbase Server Web Console. 
@@ -2237,7 +2299,7 @@ h| Restrictions
 | Cannot write application data
 
 | *Sync Gateway Users & Roles*
-| Can read edit Sync Gateway users and roles
+| Can read Sync Gateway users and roles
 | Cannot add, drop, or edit users or roles
 
 |===
@@ -2246,7 +2308,7 @@ h| Restrictions
 [#sync-gateway-replicator]
 === Sync Gateway Replicator
 
-The Sync Gateway Replicator role lets the user manage Sync Gateway replications by granting full access to the .
+The Sync Gateway Replicator role lets the user manage Sync Gateway replications.
 
 This role does not let the user log into Couchbase Server Web Console. 
 
@@ -2294,37 +2356,5 @@ h| Restrictions
 | *Sync Gateway Metrics*
 | Can read metrics
 | Cannot change metric settings
-
-|===
-
-
-
-
-[#views-reader]
-=== Views Reader
-
-The Views Reader role lets a user read data from views in one or more buckets.
-When granting this role, the administrator chooses which buckets contain views the user can read.
-Grant this role to users you create for applications that need to read data from views.
-
-This role does not let the user log into Couchbase Server Web Console. 
- 
-[#table_views_reader_role,cols="1,2,2,hrows=2"]
-|===
-3+^|  Role: Views Reader (`views_reader`)
-
-h| Resource
-h| Permissions
-h| Restrictions
-
-| *Buckets*
-| Can read data from views in the buckets they have access to. 
-Can read data via key-value from these buckets. 
-| Cannot write data to buckets, alter bucket settings, or alter views.
-
-| *Views*
-| Can read data from views in buckets they have been granted access to.
-| Cannot change views
-
 
 |===

--- a/modules/learn/pages/security/roles.adoc
+++ b/modules/learn/pages/security/roles.adoc
@@ -109,13 +109,11 @@ The role lets the user log into the Couchbase Server Web Console.
 
 This role is also available in Couchbase Server Community Edition.
 
-[#table_read_only_admin_role,cols="1,2,2,hrows=3"]
+[#table_read_only_admin_role,cols="1,2,2,hrows=2"]
 |===
 3+^|  Role: Read-Only Admin (`ro_admin`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -181,13 +179,11 @@ Cluster Admins can create, edit, and drop buckets but cannot read or write data.
 
 This role lets users log into the Couchbase Server Web Console.
 
-[#table_cluster_admin_role,cols="1,2,2,hrows=3"]
+[#table_cluster_admin_role,cols="1,2,2,hrows=2"]
 |===
 3+^| Role: Cluster Admin (`cluster_admin`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -253,13 +249,11 @@ They also cannot edit the accounts for any user with those roles (including thei
 
 This role lets users log into the Couchbase Server Web Console.
 
-[#table_security_admin_local_role,cols="1,2,2,hrows=3"]
+[#table_security_admin_local_role,cols="1,2,2,hrows=2"]
 |===
 3+^| Role: Local User Admin (`user_admin_local`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -323,13 +317,11 @@ The Eventing Full Admin role lets a user create and manage eventing functions as
 
 The role lets the user log into the Couchbase Server Web Console.
 
-[#table_eventing_admin_role,cols="1,2,2,hrows=3"]
+[#table_eventing_admin_role,cols="1,2,2,hrows=2"]
 |===
 3+^|  Role: Eventing Full Admin (`eventing_admin`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -398,13 +390,11 @@ The Backup Full Admin role lets the user administer backup-related tasks as well
 
 This role lets the user log into Couchbase Server Web Console.
 
-[#table_backup_admin_role,cols="1,2,2,hrows=3"]
+[#table_backup_admin_role,cols="1,2,2,hrows=2"]
 |===
 3+^|  Role: Backup Full Admin (`backup_admin`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -474,13 +464,11 @@ They also cannot edit users with those roles.
 
 This role lets the user log into the Couchbase Server Web Console.
 
-[#table_security_admin_external_role,cols="1,2,2,hrows=3"]
+[#table_security_admin_external_role,cols="1,2,2,hrows=2"]
 |===
 3+^| Role: External User Admin (`user_admin_external`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -546,13 +534,11 @@ The Security Admin role grants the user the ability manage all security settings
 
 This role lets the user log into the Couchbase Server Web Console.
 
-[#table_security_admin_role,cols="1,2,2,hrows=3]
+[#table_security_admin_role,cols="1,2,2,hrows=2]
 |===
 3+^| Role: Security Admin (`security_admin`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -616,13 +602,11 @@ See xref:manage:monitor/set-up-prometheus-for-monitoring.adoc[] for more informa
 
 This role does not let the user log into the Couchbase Server Web Console.
 
-[#table_external_stats_role,cols="1,2,2,hrows=3]
+[#table_external_stats_role,cols="1,2,2,hrows=2]
 |===
 3+^|  Role: External Stats Reader (`external_stats_reader`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -642,13 +626,11 @@ Assign this role to application users that need to report telemetry information 
 
 This role does not let the user log into Couchbase Server Web Console.
 
-[#table_application_telemetry_writer,cols="1,2,2,hrows=3]
+[#table_application_telemetry_writer,cols="1,2,2,hrows=2]
 |===
 3+^|  Role: Application Telemetry Writer (`application_telemetry_writer`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -662,24 +644,25 @@ h| Restrictions
 [#bucket-roles]
 == Bucket Roles
 
+The following roles give users priviliges to manage or access buckets. 
+See xref:learn:buckets-memory-and-storage/buckets.adoc[] for more information about buckets.
+
 [#bucket-admin]
 === Bucket Admin
 
 The Bucket Admin role lets the user manage one or more buckets. 
-These management ability includes stopping at starting XDCR for a bucket.
+These management abilities include stopping and starting XDCR for a bucket.
 The administrator granting this role chooses which buckets the user can manage.
 
 This role lets the user log into Couchbase Server Web Console.
 
-[#table_bucket_admin_role,cols="1,2,2,hrows=3]
+[#table_bucket_admin_role,cols="1,2,2,hrows=2]
 |===
 
 3+^| Role: Bucket Admin (`bucket_admin`)
 
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -693,7 +676,7 @@ Can add, edit, and drop scopes and collections in the buckets.
 | Cannot read, insert, or mutate documents.
 
 | *XDCR*
-| Can starty and stop replications for buckets they have been granted access to.
+| Can start and stop replications for buckets they have been granted access to.
 | Cannot add, remove, or edit XDCR connections.
 
 | *Settings*
@@ -706,8 +689,8 @@ Can add, edit, and drop scopes and collections in the buckets.
 | Cannot collect information 
 
 | *Search*
-| Can list search indexes.
-| Cannot create, drop, or edit search indexes.
+| Can list Search indexes.
+| Cannot create, drop, or edit Search indexes.
 
 | *Eventing*
 | All
@@ -726,15 +709,12 @@ Use this role to allow applications to manage a bucket's scopes and collections.
 
 This role does not let the user log into Couchbase Server Web Console.
 
-[#table_scope_admin_role,cols="1,2,2,hrows=3]
+[#table_scope_admin_role,cols="1,2,2,hrows=2]
 |===
 
 3+^| Role: Manage Scopes (`scope_admin`)
 
-
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -749,7 +729,7 @@ h| Restrictions
 === Application Access
 
 The Application Access role lets a user read and write data in one or more buckets.
-This role does not grant the ability to query data via {sqlpp}--the user can only access data via keys.
+This role does not grant the ability to query data via {sqlpp}&#8212;the user can only access data via keys.
 The administrator granting this role chooses the buckets where the user can read and write data.
 As its name implies, this role is intended for use by applications instead of interactive users.
 
@@ -766,14 +746,12 @@ Versions of Couchbase Server prior to 5.5 referred to this role as Bucket Full A
 
 This role does not let the user log into Couchbase Server Web Console.
 
-[#table_bucket_full_access_role,cols="1,2,2,hrows=3]
+[#table_bucket_full_access_role,cols="1,2,2,hrows=2]
 |===
 
 3+^| Role: Application Access (`bucket_full_access`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -783,10 +761,10 @@ h| Restrictions
 
 |===
 
-
 == Data Roles
 
 These roles give users the ability to read and write data in buckets via key-value operations.
+See xref:guides:kv-operations.adoc[] to learn about key-value operations.
 
 [#data-reader]
 === Data Reader
@@ -798,13 +776,11 @@ Grant this role to users for applications that need to read data via key-value o
 
 This role does not let the user log into Couchbase Server Web Console. 
 
-[#table_data_reader_role,cols="1,2,2,hrows=3"]
+[#table_data_reader_role,cols="1,2,2,hrows=2"]
 |===
 3+^| Role: Data Reader (`data_reader`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -831,13 +807,11 @@ Grant this role to users for applications that need to write data via key-value 
 
 This role does not let the user log into Couchbase Server Web Console. 
 
-[#table_data_writer_role,cols="1,2,2,hrows=3"]
+[#table_data_writer_role,cols="1,2,2,hrows=2"]
 |===
 3+^| Role: Data Writer (`data_writer`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -861,13 +835,11 @@ Grant this role to users for applications that need to start DCP streams.
 
 This role does not let the user log into Couchbase Server Web Console. 
 
-[#table_data_dcp_reader_role,cols="1,2,2,hrows=3"]
+[#table_data_dcp_reader_role,cols="1,2,2,hrows=2"]
 |===
 3+^| Role: Data DCP Reader (`data_dcp_reader`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -897,13 +869,11 @@ NOTE: In versions of Couchbase Server prior to 5.5, this role was referred to as
 
 This role does not let the user log into Couchbase Server Web Console. 
 
-[#table_data_monitoring_role,cols="1,2,2,hrows=3"]
+[#table_data_monitoring_role,cols="1,2,2,hrows=2"]
 |===
 3+^|  Role: Data Monitor (`data_monitoring`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -916,11 +886,10 @@ h| Restrictions
 
 == Views Roles
 
-The following roles are used with Views.
+The following roles grant useres privileges with Views.
 
 NOTE: Views were deprecated in Couchbase Server 7.0. 
-See xref:learn/views/views-intro.adoc[] for more information.
-
+See xref:learn:views/views-intro.adoc[] for more information.
 
 [#views-admin]
 === Views Admin
@@ -930,13 +899,11 @@ When granting this role, the administrator chooses the buckets where the user ca
 
 This role lets the user log into Couchbase Server Web Console.
 
-[#table_views_admin_role,cols="1,2,2,hrows=3"]
+[#table_views_admin_role,cols="1,2,2,hrows=2"]
 |===
 3+^|  Role: Views Admin (`views_admin`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -997,14 +964,12 @@ For more information about the {sqlpp} curl function, see xref:n1ql:n1ql-languag
 
 This role lets the user log into Couchbase Server Web Console. 
 
-[#table_query_external_access_role,cols="1,2,2,hrows=3]
+[#table_query_external_access_role,cols="1,2,2,hrows=2]
 |===
 
 3+^| Role: Query Curl Access (`query_external_access`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -1036,14 +1001,12 @@ Assign this role to developers who need to query these tables when troubleshooti
 
 The role grants Couchbase Server Web Console access.
 
-[#table_query_system_catalog_role,cols="1,2,2,hrows=3]
+[#table_query_system_catalog_role,cols="1,2,2,hrows=2]
 |===
 
 3+^|  Role: Query System Catalog (`query_system_catalog`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -1070,14 +1033,12 @@ See xref:n1ql:n1ql-language-reference/createfunction.adoc[].
 
 This role grants Couchbase Server Web Console access.
 
-[#table_manage_global_functions_role,cols="1,2,2,hrows=3]
+[#table_manage_global_functions_role,cols="1,2,2,hrows=2]
 |===
 
 3+^|  Role: Manage Global Functions (`query_manage_global_functions`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -1108,14 +1069,12 @@ The Execute Global Functions role lets the user call global {sqlpp} functions.
 
 This role lets the user log into Couchbase Server Web Console. 
 
-[#table_query_execute_global_functions_role,cols="1,2,2,hrows=3]
+[#table_query_execute_global_functions_role,cols="1,2,2,hrows=2]
 |===
 
 3+^|   Role: Execute Global Functions (`query_execute_global_functions`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -1148,14 +1107,12 @@ See xref:n1ql:n1ql-language-reference/createfunction.adoc[].
 This role lets the user log into Couchbase Server Web Console. 
 
 
-[#table_manage_scope_functions_role,cols="1,2,2,hrows=3]
+[#table_manage_scope_functions_role,cols="1,2,2,hrows=2]
 |===
 
 3+^| Role: Manage Scope Functions (`query_manage_functions`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -1188,14 +1145,12 @@ See xref:guides:query.adoc[].
 This role lets the user log into Couchbase Server Web Console. 
 
 
-[#table_query_select_role,cols="1,2,2,hrows=3]
+[#table_query_select_role,cols="1,2,2,hrows=2]
 |===
 
 3+^| Role: Query Select (`query_select`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -1231,13 +1186,11 @@ The administrator granting this role selects which collections contain documents
 This role lets the user log into Couchbase Server Web Console. 
 
 
-[#table_query_update_role,cols="1,2,2,hrows=3]
+[#table_query_update_role,cols="1,2,2,hrows=2]
 |===
 3+^| Role: Query Update (`query_update`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -1265,20 +1218,18 @@ Cannot use the Query Workbench in Couchbase Server Web Console.
 === Query Insert
 
 The Query Insert role grants the user the ability to execute the {sqlpp} `INSERT` statement to add new documents to one or more collections.
-See xref:n1ql:n1ql-language-reference:insert.adoc[] for more information.
+See xref:n1ql:n1ql-language-reference/insert.adoc[] for more information.
 The administrator granting this role selects which collections the user can add documents to.
 
 This role lets the user log into Couchbase Server Web Console.
 
 
-[#table_query_insert_role,cols="1,2,2,hrows=3]
+[#table_query_insert_role,cols="1,2,2,hrows=2]
 |===
 
 3+^|  Role: Query Insert (`query_insert`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -1306,19 +1257,17 @@ Cannot use the Query Workbench in Couchbase Server Web Console
 === Query Delete
 
 The Query Delete role grants the user the ability to execute the {sqlpp} `DELETE` to delete documents from one or more scopes.
-See xref:n1ql:n1ql-language-reference:delete.adoc[] for more information.
+See xref:n1ql:n1ql-language-reference/delete.adoc[] for more information.
 The administrator granting this role selects which collections the user can delete documents from.
 
 This role lets the user log into Couchbase Server Web Console. 
 
 
-[#table_query_delete_role,cols="1,2,2,hrows=3]
+[#table_query_delete_role,cols="1,2,2,hrows=2]
 |===
 3+^|  Role: Query Delete (`query_delete`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -1349,19 +1298,17 @@ Cannot use the Query Workbench in Couchbase Server Web Console.
 The Query Use Sequential Scan role allows users' queries to perform a sequential scan of a keyspace.
 The query planner only decides to use a sequential scan when there is no suitable index for the keyspace. 
 Only queries by users with this role can use a sequential scan to query data because scanning a large unindexed keyspace can be expensive.  
-See xref:learn:services-and-indexes/indexes/query-without-index.adoc#sequential-scans[] for more information.
+See xref:indexes:query-without-index.adoc#sequential-scans[Sequential Scans] for more information.
 
 NOTE: Administrator roles automatically have permission to perform sequential scans when necessary.
 
-This role does not let the user log into Couchbase Server Web Console .
+This role does not let the user log into Couchbase Server Web Console.
 
-[#table_query_use_sequential_scans_role,cols="1,2,2,hrows=3]
+[#table_query_use_sequential_scans_role,cols="1,2,2,hrows=2]
 |===
 3+^|  Role: Query Use Sequential Scan (`query_use_sequential_scans`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -1376,16 +1323,17 @@ h| Restrictions
 === Query Manage Index
 
 The Query Manage Index role allows the user to manage indexes for one or more collections.
-The administrator granting this role selects which collections for which the user can manage indexes.
+The administrator granting this role selects the collections where the user can manage indexes.
 
 This role lets the user log into Couchbase Server Web Console.
 
-[#table_query_manage_index_role,cols="1,2,2,hrows=3]
+[#table_query_manage_index_role,cols="1,2,2,hrows=2]
 |===
 3+^| Role: Query Manage Index (`query_manage_index`)
 
-.2+^h| Resource
-2+^h| Privileges
+h| Resource
+h| Permissions
+h| Restrictions
 
 | *Servers* 
 | List servers
@@ -1415,12 +1363,13 @@ The administrator granting this role selects the buckets, scopes, or collections
 
 This role lets the user log into Couchbase Server Web Console.
 
-[#table_query_list_index_role,cols="1,2,2,hrows=3]
+[#table_query_list_index_role,cols="1,2,2,hrows=2]
 |===
 3+^| Role: Query List Index (`query_list_index`)
 
-.2+^h| Resource
-2+^h| Privileges
+h| Resource
+h| Permissions
+h| Restrictions
 
 | *Servers* 
 | List servers and view statistics
@@ -1432,7 +1381,7 @@ This role lets the user log into Couchbase Server Web Console.
 Cannot read or write data.
 
 | *Index*
-| Can get list of indexes via the stats endpoint
+| Can get list of indexes via the stats endpoint  (see xref:index-rest-stats:index.adoc[])
 | Cannot add, drop, or edit indexes.
 Cannot use the Index Workbench in Couchbase Server Web Console.
 
@@ -1451,14 +1400,12 @@ The administrator granting this role selects in which scopes the user can call u
 This role lets the user log into Couchbase Server Web Console.
 
 
-[#table_query_execute_functions_role,cols="1,2,2,hrows=3]
+[#table_query_execute_functions_role,cols="1,2,2,hrows=2]
 |===
 
 3+^|   Role: Execute Scope Functions (`query_execute_functions`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -1487,14 +1434,12 @@ See xref:n1ql:n1ql-language-reference/createfunction.adoc#external-libraries[Ext
 
 This role lets the user log into Couchbase Server Web Console.
 
-[#table_manage_global_external_functions_role,cols="1,2,2,hrows=3]
+[#table_manage_global_external_functions_role,cols="1,2,2,hrows=2]
 |===
 
 3+^| Role: Manage Global External Functions (`query_manage_global_external_functions`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -1524,14 +1469,12 @@ See xref:n1ql:n1ql-language-reference/createfunction.adoc#external-libraries[Ext
 This role lets the user log into Couchbase Server Web Console.
 
 
-[#table_execute_global_external_functions_role,cols="1,2,2,hrows=3]
+[#table_execute_global_external_functions_role,cols="1,2,2,hrows=2]
 |===
 
 3+^| Role: Execute Global External Functions (`query_execute_global_external_functions`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -1562,14 +1505,12 @@ See xref:n1ql:n1ql-language-reference/createfunction.adoc#external-libraries[Ext
 This role lets the user log into Couchbase Server Web Console.
 
 
-[#table_manage_external_functions_role,cols="1,2,2,hrows=3]
+[#table_manage_external_functions_role,cols="1,2,2,hrows=2]
 |===
 
 3+^| Role: Manage Scope External Functions (`query_manage_external_functions`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -1598,14 +1539,12 @@ See xref:n1ql:n1ql-language-reference/createfunction.adoc#external-libraries[Ext
 
 This role lets the user log into Couchbase Server Web Console.
 
-[#table_execute_external_functions_role,cols="1,2,2,hrows=3]
+[#table_execute_external_functions_role,cols="1,2,2,hrows=2]
 |===
 
 3+^| Role: Execute Scope External Functions (`query_execute_external_functions`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -1633,14 +1572,12 @@ See xref:n1ql:n1ql-language-reference/sequenceops.adoc[] for more information ab
 
 This role lets the user log into Couchbase Server Web Console.
 
-[#table_query_manage_sequences_role,cols="1,2,2,hrows=3]
+[#table_query_manage_sequences_role,cols="1,2,2,hrows=2]
 |===
 
 3+^| Role: Query Manage Sequences (`query_manage_sequences`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -1670,14 +1607,12 @@ See xref:n1ql:n1ql-language-reference/sequenceops.adoc[] for more information ab
 
 This role lets the user log into Couchbase Server Web Console.
 
-[#table_query_use_sequences_role,cols="1,2,2,hrows=3]
+[#table_query_use_sequences_role,cols="1,2,2,hrows=2]
 |===
 
 3+^| Role: Query Manage Sequences (`query_use_sequences`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -1707,14 +1642,12 @@ This role lets a user manage all system catalogs for query automatic worload rep
 
 This role lets the user log into Couchbase Server Web Console.
 
-[#table_query_manage_system_catalog_role,cols="1,2,2,hrows=3]
+[#table_query_manage_system_catalog_role,cols="1,2,2,hrows=2]
 |===
 
 3+^| Role: Query Manage System Catalog (`query_manage_system_catalog`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -1750,13 +1683,11 @@ NOTE: In versions of Couchbase Server earlier than 5.5, this role was referred t
 This role lets the user log into Couchbase Server Web Console.
 
 
-[#table_search_admin_role,cols="1,2,2,hrows=3"]
+[#table_search_admin_role,cols="1,2,2,hrows=2"]
 |===
 3+^|  Role: Search Admin (`fts_admin`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -1796,13 +1727,11 @@ NOTE: In versions of Couchbase Server prior to 5.5, this role was referred to as
 
 This role lets the user log into Couchbase Server Web Console.
 
-[#table_fts_searcher_role,cols="1,2,2,hrows=3"]
+[#table_fts_searcher_role,cols="1,2,2,hrows=2"]
 |===
 3+^|  Role: Search Reader (`fts_searcher`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -1846,14 +1775,12 @@ For more information, see xref:analytics:introduction.adoc[].
 
 This role lets the user log into Couchbase Server Web Console.
 
-[#table_analytics_reader_role,cols="1,2,2,hrows=3]
+[#table_analytics_reader_role,cols="1,2,2,hrows=2]
 |===
 
 3+^| Role: Analytics Reader (`analytics_reader`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -1883,14 +1810,12 @@ For more information, see xref:analytics:introduction.adoc[].
 
 This role lets the user log into Couchbase Server Web Console.
 
-[#table_analytics_admin_role,cols="1,2,2,hrows=3]
+[#table_analytics_admin_role,cols="1,2,2,hrows=2]
 |===
 
 3+^| Role: Analytics Admin (`analytics_admin`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -1918,13 +1843,11 @@ When granting this role, the administrator chooses the buckets, scopes, and coll
 
 This role lets the user log into Couchbase Server Web Console.
 
-[#table_analytics_select_role,cols="1,2,2,hrows=3"]
+[#table_analytics_select_role,cols="1,2,2,hrows=2"]
 |===
 3+^|  Role: Analytics Select (`analytics_select`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -1953,13 +1876,11 @@ When granting this role, the administrator chooses the buckets where the user ca
 This role lets the user log into Couchbase Server Web Console.
 
 
-[#table_analytics_manager_role,cols="1,2,2,hrows=3"]
+[#table_analytics_manager_role,cols="1,2,2,hrows=2"]
 |===
 3+^|  Role: Analytics Manager (`analytics_manager`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -1997,13 +1918,11 @@ They must also have read and write permissions on one or more collections to sto
 
 This role lets the user log into Couchbase Server Web Console.
 
-[#table_eventing_manage_functions,cols="1,2,2,hrows=3"]
+[#table_eventing_manage_functions,cols="1,2,2,hrows=2"]
 |===
 3+^|  Role: Eventing Manage Scope Functions (`eventing_manage_functions`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -2035,13 +1954,11 @@ The XDCR Admin role grants the user the ability to manage XDCR connections.
 
 This role lets the user log into Couchbase Server Web Console.
 
-[#table_xdcr_admin_role,cols="1,2,2,hrows=3]
+[#table_xdcr_admin_role,cols="1,2,2,hrows=2]
 |===
 3+^| Role: XDCR Admin (`replication_admin`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -2108,14 +2025,12 @@ NOTE: Versions of Couchbase Server prior to 5.5 called this role Replication Tar
 
 This role does not let the user log into Couchbase Server Web Console.
 
-[#table_replication_target_role,cols="1,2,2,hrows=3]
+[#table_replication_target_role,cols="1,2,2,hrows=2]
 |===
 
 3+^| Role: XDCR Inbound (`replication_target`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -2145,13 +2060,11 @@ See xref:backup-restore:cbbackupmgr-backup.adoc#bucket-level[Bucket Level] in th
 
 This role does not let the user log into Couchbase Server Web Console. 
 
-[#table_data_backup_role,cols="1,2,2,hrows=3"]
+[#table_data_backup_role,cols="1,2,2,hrows=2"]
 |===
 3+^|  Role: Data Backup & Restore (`data_backup`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -2199,14 +2112,12 @@ See xref:sync-gateway::get-started-prepare.adoc#configure-server[Configure Serve
 
 This role does not let the user log into Couchbase Server Web Console. 
 
-[#table_sync_gateway_role,cols="1,2,2,hrows=3]
+[#table_sync_gateway_role,cols="1,2,2,hrows=2]
 |===
 
 3+^| Role: Sync Gateway (`mobile_sync_gateway`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -2240,14 +2151,12 @@ For information about Sync Gateway users and roles, see xref:sync-gateway::acces
 This role does not let the user log into Couchbase Server Web Console. 
 
 
-[#table_sync_gateway_configurator_role,cols="1,2,2,hrows=3]
+[#table_sync_gateway_configurator_role,cols="1,2,2,hrows=2]
 |===
 
 3+^| Role: Sync Gateway Architect (`sync_gateway_configurator`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -2277,14 +2186,12 @@ For information about Sync Gateway users and roles, see xref:sync-gateway::acces
 This role does not let the user log into Couchbase Server Web Console. 
 
 
-[#table_sync_gateway_app_role,cols="1,2,2,hrows=3]
+[#table_sync_gateway_app_role,cols="1,2,2,hrows=2]
 |===
 
 3+^| Role: Sync Gateway Application (`sync_gateway_app`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -2309,14 +2216,12 @@ For information about Sync Gateway users and roles, see xref:sync-gateway::acces
 
 This role does not let the user log into Couchbase Server Web Console. 
 
-[#table_sync_gateway_app_ro_role,cols="1,2,2,hrows=3]
+[#table_sync_gateway_app_ro_role,cols="1,2,2,hrows=2]
 |===
 
 3+^| Role: Sync Gateway Application Read Only (`sync_gateway_app_ro`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -2340,14 +2245,12 @@ The Sync Gateway Replicator role lets the user manage Sync Gateway replications 
 This role does not let the user log into Couchbase Server Web Console. 
 
 
-[#table_sync_gateway_replicator_role,cols="1,2,2,hrows=3]
+[#table_sync_gateway_replicator_role,cols="1,2,2,hrows=2]
 |===
 
 3+^| Role: Sync Gateway Replicator (`sync_gateway_replicator`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -2368,14 +2271,12 @@ This role does not let the user log into Couchbase Server Web Console.
 
 
 
-[#table_sync_gateway_dev_ops_role,cols="1,2,2,hrows=3]
+[#table_sync_gateway_dev_ops_role,cols="1,2,2,hrows=2]
 |===
 
 3+^| Role: Sync Gateway Dev Ops (`sync_gateway_dev_ops`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 
@@ -2402,13 +2303,11 @@ Grant this role to users you create for applications that need to read data from
 
 This role does not let the user log into Couchbase Server Web Console. 
  
-[#table_views_reader_role,cols="1,2,2,hrows=3"]
+[#table_views_reader_role,cols="1,2,2,hrows=2"]
 |===
 3+^|  Role: Views Reader (`views_reader`)
 
-.2+^h| Resource
-2+^h| Privileges
-
+h| Resource
 h| Permissions
 h| Restrictions
 

--- a/modules/learn/pages/security/roles.adoc
+++ b/modules/learn/pages/security/roles.adoc
@@ -22,10 +22,10 @@ For example, when granting a user the Data Writer role, you can limit the user s
 You can also enable the user to write data to multiple collections, multiple scopes, or even to all buckets.
 For detailed information about scopes and collections, see xref:learn:data/scopes-and-collections.adoc[].
 
-You can grant a user a set of roles to precisely tailor their privileges so they can perform their tasks in the database.
-Some roles, such as Query List Index, are so limited that they're only useful in conjuction with other roles.
-For example, you can grant a user the ability to read all data in a specific bucket via the Data Reader role.
-In addition, you can grant the user the Data Writer role, but limit them to writing data into a specific collection within the bucket.
+You can grant a user multiple roles to tailor their privileges for the tasks they need to perform.
+For example, you can grant a user the <<#data-reader>> role to let them read all data in a specific bucket.
+In addition, you can grant them the <<#data-writer>> role, but limit them to writing data into a specific collection within the bucket.
+Some roles, such as <<#query-list-index>>, are so limited that they're only useful when combined with other roles (<<#query-select>>, for example).
 
 [#roles-in-relation-to-buckets]
 === Roles in Relation to Buckets
@@ -45,7 +45,7 @@ Users with any of the administrator roles can log into Couchbase Server Web Cons
 Most of  these roles do not grant the ability to read or write data.
 +
 The administrative roles grant their users the ability to carry out specific tasks.
-For example, a user with the Cluster Admin role can manage all cluster features except for security.
+For example, a user with the <<#cluster-admin>> role can manage all cluster features except for security.
 Users with the <<#read-only-admin,Read-Only Admin>> role can access the Couchbase Server Web Console to  read cluster settings, statistics, and backup plans, but not change them.
 The Bucket Admin role allows management only of one or more buckets.
 See <<#admin-roles>> for details.
@@ -79,8 +79,8 @@ The list is broken into the same categories that appear within the Couchbase Ser
 Each description has a table listing the resources the roles allow users to access, and any limitations on their access.
 If a resource does not appear in this table, the role does not grant the user any privileges for it. 
 
-NOTE: THe majority of roles are only availabe in Couchbase Server Enterprise Edition. 
-The list indicates when a role is available in Community Edition.
+NOTE: THe majority of roles are only available in Couchbase Server Enterprise Edition. 
+The list indicates when a role is available in Couchbase Server Community Edition.
 
 
 [#admin-roles]
@@ -627,7 +627,7 @@ h| Restrictions
 | Cannot add, failover, remove, modify services, or rebalance servers
 
 | *Buckets*
-| Can read, write, and edit views for the buckets they have been granted access to. 
+| Can read, write, and edit views for the buckets assigned to them. 
 Can read data (via key-value), statistics, and settings in these buckets.
 | Cannot write data to buckets or alter bucket settings
 
@@ -652,7 +652,7 @@ Can read data (via key-value), statistics, and settings in these buckets.
 | Cannot edit or add Search indexes
 
 | *Views*
-| Can create, drop, and edit views in buckets they have been granted access to.
+| Can create, drop, and edit views in buckets assigned to them.
 | Cannot change views
 
 
@@ -678,7 +678,7 @@ h| Permissions
 h| Restrictions
 
 | *Metrics API*
-| Able to call /metrics` and `/prometheus_sd_config` REST API endpoints
+| Able to call `/metrics` and `/prometheus_sd_config` REST API endpoints
 | None
 
 |===
@@ -738,12 +738,12 @@ h| Restrictions
 | Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
 
 | *Buckets*
-| Can drop, compact and edit buckets they have been granted access to.
+| Can drop, compact and edit buckets assigned to them.
 Can add, edit, and drop scopes and collections in the buckets. 
 | Cannot read, insert, or mutate documents.
 
 | *XDCR*
-| Can start and stop replications for buckets they have been granted access to.
+| Can start and stop replications for buckets assigned to them.
 | Cannot add, remove, or edit XDCR connections.
 
 | *Settings*
@@ -786,7 +786,7 @@ h| Permissions
 h| Restrictions
 
 | *Buckets*
-| Can add and drop scopes and collections in the buckets they have been granted access to.
+| Can add and drop scopes and collections in the buckets assigned to them.
 | Cannot read, insert, or mutate documents.
 
 |===
@@ -824,7 +824,7 @@ h| Permissions
 h| Restrictions
 
 | *Buckets*
-| Can read and write data in buckets they have been granted access to.
+| Can read and write data in buckets assigned to them.
 | Cannot alter bucket, scope, or collection settings.
 
 |===
@@ -853,8 +853,8 @@ h| Permissions
 h| Restrictions
 
 | *Buckets*
-| Read data from collections, scopes, and buckets to which they have been granted access.
-Can read some bucket metadata, XATTR mappings, and pools on buckets they have been granted access to.
+| Read data from collections, scopes, and buckets assigned to them.
+Can read some bucket metadata, XATTR mappings, and pools on buckets assigned to them.
 | Cannot write data
 
 | *Query*
@@ -884,7 +884,7 @@ h| Permissions
 h| Restrictions
 
 | *Buckets*
-| Write data to collections, scopes, and buckets to which they have been granted access.
+| Write data to collections, scopes, and buckets assigned to them.
 | Cannot read data
 
 | *Query*
@@ -912,7 +912,7 @@ h| Permissions
 h| Restrictions
 
 | *Buckets*
-| Can start DCP streams for collections, scopes, and buckets they have been granted access to.
+| Can start DCP streams for collections, scopes, and buckets assigned to them.
 Can also read data and XATTRs from these collections, scopes, and buckets.
 | Cannot write data
 
@@ -943,7 +943,7 @@ h| Permissions
 h| Restrictions
 
 | *Buckets*
-| Can read statistics for buckets, scopes, and collections they have been granted access to. 
+| Can read statistics for buckets, scopes, and collections assigned to them. 
 | None
 
 |===
@@ -982,7 +982,7 @@ Can read data via key-value from these buckets.
 | Cannot write data to buckets, alter bucket settings, or alter views.
 
 | *Views*
-| Can read data from views in buckets they have been granted access to.
+| Can read data from views in buckets assigned to them.
 | Cannot change views
 
 
@@ -1649,10 +1649,10 @@ h| Restrictions
 Cannot add, failover, remove, modify services, or rebalance servers.
 
 | *Query*
-| Can create and alter sequences in buckets to which they have been granted access
+| Can create and alter sequences in buckets assigned to them
 | Cannot perform any other queries.
 Cannot use the Query Workbench in Couchbase Server Web Console.
-Cannot manage sequences in buckets to which they have not been granted access.
+Cannot manage sequences in buckets they do have not assigned to them.
 
 | *Settings*
 | View cluster settings
@@ -1685,7 +1685,7 @@ h| Restrictions
 Cannot add, failover, remove, modify services, or rebalance servers
 
 | *Query*
-| Can use sequences in scopes they have been granted access to.
+| Can use sequences in scopes assigned to them.
 | Cannot perform any other queries.
 Cannot use the Query Workbench in Couchbase Server Web Console.
 Cannot manage sequences.
@@ -1963,7 +1963,7 @@ Cannot rebalance, failover, add, or remove servers.
 | *Analytics*
 | Can query analytics data in the buckets they have access to.
 Can manage analytics in these buckets, including local links and adding/dropping analytics collections. 
-| Cannot manage analytics in buckets they have not been granted access to
+| Cannot manage analytics in other buckets
 
 |===
 
@@ -2003,7 +2003,7 @@ Cannot edit server settings, failover, or rebalance servers.
 | Cannot view other settings or change any settings
 
 | *Eventing*
-| Can add Eventing functions to a scope they have been granted access to.
+| Can add Eventing functions to a scope assigned to them.
 Can change eventing settings for the scopes.
 | None
 
@@ -2136,7 +2136,7 @@ h| Permissions
 h| Restrictions
 
 | *Buckets*
-| Can read, write, and manage buckets they have been granted access to. 
+| Can read, write, and manage buckets assigned to them. 
 | None
 
 |*Backup*

--- a/modules/learn/pages/security/roles.adoc
+++ b/modules/learn/pages/security/roles.adoc
@@ -174,8 +174,8 @@ h| Restrictions
 | Cannot edit settings
 
 | *Logs*
-| View
-| Collect Information
+| View logs
+| Cannot collect information
 
 | *Indexes*
 | Can view index settings and stats
@@ -262,7 +262,7 @@ h| Restrictions
 
 | *Eventing*
 | Import, Change Settings
-| Add, remove, edit functions (due inability to read/write data)
+| Add, remove, edit functions 
 
 | *Views*
 | None
@@ -606,6 +606,9 @@ The role grants Couchbase Server Web Console access.
 .2+^h| Resource
 2+^h| Privileges
 
+h| Permissions
+h| Restrictions
+
 | *Servers* 
 | List servers.
 | Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
@@ -636,6 +639,9 @@ This role grants Couchbase Server Web Console access.
 
 .2+^h| Resource
 2+^h| Privileges
+
+h| Permissions
+h| Restrictions
 
 | *Servers* 
 | List servers
@@ -671,6 +677,9 @@ This role lets the user log into Couchbase Server Web Console.
 
 .2+^h| Resource
 2+^h| Privileges
+
+h| Permissions
+h| Restrictions
 
 | *Servers* 
 | List servers
@@ -709,6 +718,9 @@ This role lets the user log into Couchbase Server Web Console.
 .2+^h| Resource
 2+^h| Privileges
 
+h| Permissions
+h| Restrictions
+
 | *Servers* 
 | List servers
 | Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
@@ -735,7 +747,7 @@ The Query Select role lets the user execute `SELECT` statements on the data in o
 The administrator sets which collections the user can access when granting this role.
 See xref:guides:query.adoc[].
 
-The role grants Couchbase Server Web Console access.
+This role lets the user log into Couchbase Server Web Console. 
 
 
 [#table_query_select_role,cols="1,2,2,hrows=3]
@@ -745,6 +757,9 @@ The role grants Couchbase Server Web Console access.
 
 .2+^h| Resource
 2+^h| Privileges
+
+h| Permissions
+h| Restrictions
 
 | *Servers* 
 | List servers
@@ -785,6 +800,9 @@ This role lets the user log into Couchbase Server Web Console.
 .2+^h| Resource
 2+^h| Privileges
 
+h| Permissions
+h| Restrictions
+
 | *Servers* 
 | List servers
 | Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
@@ -817,10 +835,14 @@ This role lets the user log into Couchbase Server Web Console.
 
 [#table_query_insert_role,cols="1,2,2,hrows=3]
 |===
+
 3+^|  Role: Query Insert (`query_insert`)
 
 .2+^h| Resource
 2+^h| Privileges
+
+h| Permissions
+h| Restrictions
 
 | *Servers* 
 | List servers
@@ -858,6 +880,9 @@ This role lets the user log into Couchbase Server Web Console.
 
 .2+^h| Resource
 2+^h| Privileges
+
+h| Permissions
+h| Restrictions
 
 | *Servers* 
 | List servers
@@ -899,6 +924,9 @@ This role does not let the user log into Coucbase Server Web Console .
 .2+^h| Resource
 2+^h| Privileges
 
+h| Permissions
+h| Restrictions
+
 | *Query*
 | Can execute a query in a collection that lacks a primary and secondary index.
 | Cannot perform any other queries.
@@ -912,7 +940,7 @@ This role does not let the user log into Coucbase Server Web Console .
 The Query Manage Index role allows the user to manage indexes for one or more collections.
 The administrator granting this role selects which collections for which the user can manage indexes.
 
-The role lets the user log into Couchbase Server Web Console.
+This role lets the user log into Couchbase Server Web Console.
 
 [#table_query_manage_index_role,cols="1,2,2,hrows=3]
 |===
@@ -948,7 +976,7 @@ Cannot use the Query Workbench in Couchbase Server Web Console.
 The Execute Scope Functions role lets the user execute {sqlpp} user-defined functions defined within a scope.
 The administrator granting this role selects in which scopes the user can call user-defined functions the user can call.
 
-The role lets the user log into Couchbase Server Web Console.
+This role lets the user log into Couchbase Server Web Console.
 
 
 [#table_query_execute_functions_role,cols="1,2,2,hrows=3]
@@ -958,6 +986,9 @@ The role lets the user log into Couchbase Server Web Console.
 
 .2+^h| Resource
 2+^h| Privileges
+
+h| Permissions
+h| Restrictions
 
 | *Servers* 
 | List servers
@@ -982,7 +1013,7 @@ Cannot use the Query Workbench in Couchbase Server Web Console.
 The Manage Global External Functions role lets the user manage global external language functions.
 See xref:n1ql:n1ql-language-reference/createfunction.adoc#external-libraries[External Libraries] for more information about external functions.
 
-The role lets the user log into Couchbase Server Web Console.
+This role lets the user log into Couchbase Server Web Console.
 
 [#table_manage_global_external_functions_role,cols="1,2,2,hrows=3]
 |===
@@ -991,6 +1022,9 @@ The role lets the user log into Couchbase Server Web Console.
 
 .2+^h| Resource
 2+^h| Privileges
+
+h| Permissions
+h| Restrictions
 
 | *Servers* 
 | List servers
@@ -1015,7 +1049,7 @@ Cannot use the Query Workbench in Couchbase Server Web Console.
 The Execute Global External Functions role lets a user execute globally-defined external functions.
 See xref:n1ql:n1ql-language-reference/createfunction.adoc#external-libraries[External Libraries] for more information about external functions.
 
-The role lets the user log into Couchbase Server Web Console.
+This role lets the user log into Couchbase Server Web Console.
 
 
 [#table_execute_global_external_functions_role,cols="1,2,2,hrows=3]
@@ -1025,6 +1059,9 @@ The role lets the user log into Couchbase Server Web Console.
 
 .2+^h| Resource
 2+^h| Privileges
+
+h| Permissions
+h| Restrictions
 
 | *Servers* 
 | List servers
@@ -1050,7 +1087,7 @@ The Manage Scope External Functions role lets the user create and drop external 
 The administrator granting this role chooses the scopes where the user can manage external functions.
 See xref:n1ql:n1ql-language-reference/createfunction.adoc#external-libraries[External Libraries] for more information about external functions.
 
-The role lets the user log into Couchbase Server Web Console.
+This role lets the user log into Couchbase Server Web Console.
 
 
 [#table_manage_external_functions_role,cols="1,2,2,hrows=3]
@@ -1060,6 +1097,9 @@ The role lets the user log into Couchbase Server Web Console.
 
 .2+^h| Resource
 2+^h| Privileges
+
+h| Permissions
+h| Restrictions
 
 | *Servers* 
 | List servers
@@ -1084,7 +1124,7 @@ The Execute Scope External Functions role lets the user call external functions 
 The administrator granting this role chooses the scopes where the user can call external functions.
 See xref:n1ql:n1ql-language-reference/createfunction.adoc#external-libraries[External Libraries] for more information about external functions.
 
-The role lets the user log into Couchbase Server Web Console.
+This role lets the user log into Couchbase Server Web Console.
 
 [#table_execute_external_functions_role,cols="1,2,2,hrows=3]
 |===
@@ -1093,6 +1133,9 @@ The role lets the user log into Couchbase Server Web Console.
 
 .2+^h| Resource
 2+^h| Privileges
+
+h| Permissions
+h| Restrictions
 
 | *Servers* 
 | List servers
@@ -1115,88 +1158,76 @@ Cannot use the Query Workbench in Couchbase Server Web Console.
 [#analytics-reader]
 === Analytics Reader
 
-The *Analytics Reader* role (an Analytics role) allows querying of shadow data-sets.
-The role allows access to Couchbase Web Console, and permits the reading of data.
+The Analytics Reader role lets the user query all analytic datasets.
+For more information, see xref:analytics:introduction.adoc[].
 
-[#table_analytics_reader_role,cols="15,8,8,8,8",hrows=3]
+This role lets the user log into Couchbase Server Web Console.
+
+[#table_analytics_reader_role,cols="1,2,2,hrows=3]
 |===
-5+^| Role: Analytics Reader (`analytics_reader`)
 
-.2+^h| Resources
-4+^h| Privileges
+3+^| Role: Analytics Reader (`analytics_reader`)
 
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
+.2+^h| Resource
+2+^h| Privileges
 
-^| Bucket : Analytics
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
+h| Permissions
+h| Restrictions
 
-^| UI
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
 
-^| Pools
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings.
+
+
+| *Analytics*
+| Can read any analytic data.
+Can use the Couchbase Server Web Console's Analytics query editor.
+| Cannot change analytic configuration.
+
 |===
+
 
 [#analytics-admin]
 === Analytics Admin
 
-The *Analytics Admin* role (an Analytics role) allows management of dataverses; management of all Analytics Service links; and management of all datasets.
-The role allows access to Couchbase Web Console, but does not permit the reading of data.
+The Analytics Admin role lets users manage Analytics Service links, scopes, and datasets. 
+For more information, see xref:analytics:introduction.adoc[].
+ 
 
-[#table_analytics_admin_role,cols="15,8,8,8,8",hrows=3]
+This role lets the user log into Couchbase Server Web Console.
+
+[#table_analytics_admin_role,cols="1,2,2,hrows=3]
 |===
-5+^| Role: Analytics Admin (`analytics_admin`)
 
-.2+^h| Resources
-4+^h| Privileges
+3+^| Role: Analytics Admin (`analytics_admin`)
 
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
+.2+^h| Resource
+2+^h| Privileges
 
-^| Dataverse : Analytics
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
+h| Permissions
+h| Restrictions
 
-^| Bucket : Analytics
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
+| *Servers* 
+| List servers
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
 
-^| Bucket : UI
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Settings*
+| View cluster settings
+| Cannot view any other settings or change settings.
 
-^| Other : UI
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
 
-^| Pools
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Analytics*
+| Can add or drop Analytics Service links, scopes, and dataset.
+Can use the Couchbase Server Web Console's Analytics query editor.
+| Cannot change analytic configuration.
+
 |===
+
+
 
 [#bucket-roles]
 == Bucket Roles
@@ -1204,167 +1235,134 @@ The role allows access to Couchbase Web Console, but does not permit the reading
 [#bucket-admin]
 === Bucket Admin
 
-The *Bucket Admin* role (which is a Bucket role) allows the management of all per bucket features (including starting and stopping XDCR).
-The role allows access to Couchbase Web Console, but does not permit the reading or writing of data.
+The Bucket Admin role lets the user manage one or more buckets. 
+These management ability includes stopping at starting XDCR for a bucket.
+The administrator granting this role chooses which buckets the user can manage.
 
-[#table_bucket_admin_role,cols="15,8,8,8,8",hrows=3]
+This role lets the user log into Couchbase Server Web Console.
+
+[#table_bucket_admin_role,cols="1,2,2,hrows=3]
 |===
-5+^| Role: Bucket Admin (`bucket_admin`)
 
-.2+^h| Resources
-4+^h| Privileges
+3+^| Role: Bucket Admin (`bucket_admin`)
 
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
 
-^| Cluster
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+.2+^h| Resource
+2+^h| Privileges
 
-^| Bucket (including XDCR)
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
+h| Permissions
+h| Restrictions
 
-^| Bucket Data
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Servers* 
+| List servers, view server configuration
+| Cannot view configuration, add, failover, remove, modify services, or rebalance servers.
 
-^| Bucket UI
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
+| *Buckets*
+| Can drop, compact and edit buckets they have been granted access to.
+Can add, edit, and drop scopes and collections in the buckets. 
+| Cannot read, insert, or mutate documents.
 
-^| Other UI
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *XDCR*
+| Can starty and stop replications for buckets they have been granted access to.
+| Cannot add, remove, or edit XDCR connections.
+
+| *Settings*
+| View all cluster settings
+| Cannot change cluster settings.
+
+
+| *Logs*
+| Can view logs.
+| Cannot collect information 
+
+| *Search*
+| Can list search indexes.
+| Cannot create, drop, or edit search indexes.
+
+| *Eventing*
+| All
+| None
+
 |===
+
 
 [#manage-scopes]
 === Manage Scopes
 
-The *Manage Scopes* role (a Bucket role) allows the creation and deletion of scopes, and the creation and deletion of collections per scope, given the corresponding specification of bucket.
-The role allows no access to data, and does not permit access to Couchbase Web Console.
-The role is intended for application use only.
+The Manage Scopes role lets a user create and delete scopes and collections within one or more buckets.
+The administrator granting this role chooses the buckets where the user can create scopes and collections.
+The user does not have the ability to read, write, or alter data.
+Use this role to allow applications to manage a bucket's scopes and collections.
 
-[#table_scope_admin_role,cols="15,8,8,8,8",hrows=3]
+This role does not let the user log into Couchbase Server Web Console.
+
+[#table_scope_admin_role,cols="1,2,2,hrows=3]
 |===
-5+^| Role: Manage Scopes (`scope_admin`)
 
-.2+^h| Resources
-4+^h| Privileges
+3+^| Role: Manage Scopes (`scope_admin`)
 
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
 
-^| Manage Scopes
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
+.2+^h| Resource
+2+^h| Privileges
 
-^| UI
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+h| Permissions
+h| Restrictions
+
+| *Buckets*
+| Can add and drop scopes and collections in the buckets they have been granted access to.
+| Cannot read, insert, or mutate documents.
+
 |===
+
 
 [#application-access]
 === Application Access
 
-The *Application Access* role (a Bucket role) provides read and write access to data, per bucket.
-The role does not allow access to Couchbase Web Console: it is intended for applications, rather than users.
-Note that this role is also available in the Community Edition of Couchbase Server.
+The Application Access role lets a user read and write data in one or more buckets.
+This role does not grant the ability to query data via {sqlpp}--the user can only access data via keys.
+The administrator granting this role chooses the buckets where the user can read and write data.
+As its name implies, this role is intended for use by applications instead of interactive users.
 
-The role is provided in support of buckets that were created on versions of Couchbase Server prior to 5.0.
-Such buckets were accessed by specifying bucket-name and bucket-password: however, bucket-passwords are not recognized by Couchbase Server 5.0 and after.
-Therefore, for each pre-existing bucket, the upgrade-process for 5.0 and after creates a new user, whose username is identical to the bucket-name; and whose password is identical to the former bucket-password, if one existed.
-If no bucket-password existed, the user is created with no password.
-This migration-process allows the same name-combination as before to be used in authentication.
-To ensure backwards compatibility, each system-created user is assigned the [.ui]*Application Access* role, which authorizes the same read-write access to bucket-data as was granted before 5.0.
+[NOTE]
+====
+This role is deprecated. 
+Couchbase Server 5.0 added this role to replace an old method of password authentication to access buckets.
+To transition away from bucket passwords, the upgrade process to Couchbase Server 5.0 created new users with the bucket's name and password and assigned this role.
+Do not grant this role to users.
+Instead, use one of the query or data roles.
 
-Use of the [.ui]*Application Access* role is deprecated for buckets created on Couchbase Server 5.0 and after: use the other bucket-access roles provided.
-Note that in versions of Couchbase Server prior to 5.5, this role was referred to as *Bucket Full Access*.
+Versions of Couchbase Server prior to 5.5 referred to this role as Bucket Full Access.
+====
 
-[#table_bucket_full_access_role,cols="15,8,8,8,8,8",hrows=3]
+This role does not let the user log into Couchbase Server Web Console.
+
+[#table_bucket_full_access_role,cols="1,2,2,hrows=3]
 |===
-6+^| Role: Application Access (`bucket_full_access`)
 
-.2+^h| Resources
-5+^h| Privileges
+3+^| Role: Application Access (`bucket_full_access`)
 
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
-^h| *Flush*
+.2+^h| Resource
+2+^h| Privileges
 
-^| Bucket Data
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
+h| Permissions
+h| Restrictions
 
-^| Bucket Views
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
+| *Buckets*
+| Can read and write data in buckets they have been granted access to.
+| Cannot alter bucket, scope, or collection settings.
 
-^| {sqlpp}: Index
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-
-^| {sqlpp}: Other
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Bucket
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-
-^| Pools
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
 |===
 
 == XDCR Roles
 
-The following roles give users access to XDCR settings and features.
+The following roles give users the ability to manage XDCR settings and features.
 
 [#xdcr-admin]
 === XDCR Admin
 
 The XDCR Admin role grants the user the ability to manage XDCR connections.
 
-The role grants Couchbase Server Web Console access.
+This role lets the user log into Couchbase Server Web Console.
 
 [#table_xdcr_admin_role,cols="1,2,2,hrows=3]
 |===
@@ -1430,630 +1428,432 @@ h| Restrictions
 [#xdcr-inbound]
 === XDCR Inbound
 
-The *XDCR Inbound* role (which is an XDCR role) allows the creation of inbound XDCR streams, per bucket.
-It does not allow access to Couchbase Web Console, and does not permit the reading of data.
+The XDCR Inbound role lets the user create inbound XDCR streams for one or more buckets.
+The administrator granting this role chooses the buckets where the user can create inbound XDCR connections.
+Assign this role to the user that you'll specify when creating an XDCR reference. 
+See xref:manage:manage-xdcr/create-xdcr-reference.adoc[Create a Reference] for more information. 
 
-In versions of Couchbase Server prior to 5.5, this role was referred to as *Replication Target*.
+NOTE: Versions of Couchbase Server prior to 5.5 called this role Replication Target.
 
-[#table_replication_target_role,cols="15,8,8,8,8",hrows=3]
+This role does not let the user log into Couchbase Server Web Console.
+
+[#table_replication_target_role,cols="1,2,2,hrows=3]
 |===
-5+^| Role: XDCR Inbound (`replication_target`)
 
-.2+^h| Resources
-4+^h| Privileges
+3+^| Role: XDCR Inbound (`replication_target`)
 
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
+.2+^h| Resource
+2+^h| Privileges
 
-^| Bucket : Settings
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+h| Permissions
+h| Restrictions
 
-^| Bucket : Meta
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *XDCR*
+| Can create inbound connections on buckets they have been granted permissions on.
+| Cannot create outbound connections or alter other XDCR settings.
 
-^| Bucket : Stats
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Pools
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
 |===
 
 == Mobile Roles
 
-The mobile roles give users access to Sync Gateway and related features.
+The mobile roles support connections with the Sync Gateway and related features.
+See the xref:sync-gateway::introduction.adoc[Sync Gateway Introduction] for more information.
+
 
 [#sync-gateway]
 === Sync Gateway
 
-The *Sync Gateway* role (which is a Mobile role) allows full access to data per bucket, as required by Sync Gateway.
-The role does not allow access to Couchbase Web Console.
-The user can, by means of Sync Gateway, read and write data, manage indexes and views, and read some cluster information.
+The Sync Gateway role gives the user full access to the data Sync Gateway's data stored in Couchbase Server.
+This role also lets the user manage indexes and read some cluster information.
+Only assign this role to the user that you create for the Sync Gateway's to use when connecting to Couchbase Server.
+See xref:sync-gateway::get-started-prepare.adoc#configure-server[Configure Server for Sync Gateway] for more information.
 
-[#table_sync_gateway_role,cols="15,8,8,8,8",hrows=3]
+
+
+This role does not let the user log into Couchbase Server Web Console. 
+
+[#table_sync_gateway_role,cols="1,2,2,hrows=3]
 |===
-5+^| Role: Sync Gateway (`mobile_sync_gateway`)
 
-.2+^h| Resources
-4+^h| Privileges
+3+^| Role: Sync Gateway (`mobile_sync_gateway`)
 
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
+.2+^h| Resource
+2+^h| Privileges
 
-^| UI
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+h| Permissions
+h| Restrictions
 
-^| Bucket : Data
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
+| *Sync Gateway Data*
+| Can perform all actions on data (including flushing) and views on the Sync Gateway data stored in Couchbase Server.
+Can view settings of these buckets.
+| Cannot change bucket settings.
 
-^| Bucket : Views
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
+| *Query*
+| Can execute queries on data in buckets containing Sync Gateway data.
+| None
 
-^| Bucket : Indexes
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
+| *Indexes*
+| Add and drop indexes and view index statistics in the buckets containing Sync Gateway data.
+| None.
 
-^| Bucket : Query
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
+| *Settings*
+| View cluster settings.
+| Cannot view any other settings or change settings.
 
-^| Bucket : Flush
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-
-^| Bucket : Settings
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Auto-compaction
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Admin: Memcached: Idle
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Pools
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
 |===
+
 
 [#sync-gateway-configurator]
 === Sync Gateway Architect
 
-The *Sync Gateway Architect* role (which is a Mobile role) allows management of Sync Gateway databases; and of Sync Gateway users and roles; and allows access to Sync Gateway's `/metrics` endpoint.
-The role does not allow access to Couchbase Web Console; and does not allow reading of application data.
-For information on Sync Gateway users and roles, see http://docs.couchbase.com/sync-gateway/3.0/access-control-concepts.html[Access Control Concepts^].
+The Sync Gateway Architect role lets the user manage Sync Gateway databases, users, and roles.
+It also grants access to the Sync Gateway's metrics via the `/metrics` REST API endpoint.
+For information about Sync Gateway users and roles, see xref:sync-gateway::access-control-concepts.adoc[Access Control Concepts].
 
-[#table_sync_gateway_configurator_role,cols="15,8,8,8,8",hrows=3]
+This role does not let the user log into Couchbase Server Web Console. 
+
+
+[#table_sync_gateway_configurator_role,cols="1,2,2,hrows=3]
 |===
-5+^| Role: Sync Gateway Architect (`sync_gateway_configurator`)
 
-.2+^h| Resources
-4+^h| Privileges
+3+^| Role: Sync Gateway Architect (`sync_gateway_configurator`)
 
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
+.2+^h| Resource
+2+^h| Privileges
 
-^| UI
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+h| Permissions
+h| Restrictions
 
-^| Collection: Data
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
 
-^| Collection: Sync Gateway Users and Roles
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
+| *Sync Gateway Data*
+| None
+| Cannot read or write Sync Gateway application data
 
-^| Metrics: Sync Gateway
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Sync Gateway Users & Roles*
+| Can add, remove, and edit Sync Gateway users and roles
+| None
+
+| *Sync Gateway Metrics*
+| Can read metrics
+| Cannot change metric settings
+
 |===
+
 
 [#sync-gateway-app]
 === Sync Gateway Application
 
-The *Sync Gateway Application* role (which is a Mobile role) allows management of Sync Gateway users and roles; and allows application data to be read and written through Sync Gateway.
-The role does not allow access to Couchbase Web Console.
-For information on Sync Gateway users and roles, see http://docs.couchbase.com/sync-gateway/3.0/access-control-concepts.html[Access Control Concepts^].
+The Sync Gateway Application role lets the user manage Sync Gateway users and roles.
+It also allows the user to read and write application data through the Sync Gateway.
+For information about Sync Gateway users and roles, see xref:sync-gateway::access-control-concepts.adoc[Access Control Concepts].
 
-[#table_sync_gateway_app_role,cols="15,8,8,8,8",hrows=3]
+This role does not let the user log into Couchbase Server Web Console. 
+
+
+[#table_sync_gateway_app_role,cols="1,2,2,hrows=3]
 |===
-5+^| Role: Sync Gateway Application (`sync_gateway_app`)
 
-.2+^h| Resources
-4+^h| Privileges
+3+^| Role: Sync Gateway Application (`sync_gateway_app`)
 
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
+.2+^h| Resource
+2+^h| Privileges
 
-^| UI
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+h| Permissions
+h| Restrictions
 
-^| Collection: Sync Gateway Users and Roles
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
 
-^| Collection: Sync Gateway Application Data
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
+| *Collection: Data*
+| Can read and write application data
+| None
+
+| *Sync Gateway Users & Roles*
+| Can add, remove, and edit Sync Gateway users and roles
+| None
+
 |===
+
 
 [#sync-gateway-application-read-only]
 === Sync Gateway Application Read Only
 
-The *Sync Gateway Application Read Only* role (which is a Mobile role) allows reading of Sync Gateway users and roles; and allows application data to be read through Sync Gateway.
-The role does not allow access to Couchbase Web Console.
-For information on Sync Gateway users and roles, see http://docs.couchbase.com/sync-gateway/3.0/access-control-concepts.html[Access Control Concepts^].
+The Sync Gateway Application Read Only role lets the user read Sync Gateway users and role settings.
+It also lets them read Sync Gateway data.
+For information about Sync Gateway users and roles, see xref:sync-gateway::access-control-concepts.adoc[Access Control Concepts].
 
-[#table_sync_gateway_app_ro_role,cols="15,8,8,8,8",hrows=3]
+This role does not let the user log into Couchbase Server Web Console. 
+
+[#table_sync_gateway_app_ro_role,cols="1,2,2,hrows=3]
 |===
-5+^| Role: Sync Gateway Application Read Only (`sync_gateway_app_ro`)
 
-.2+^h| Resources
-4+^h| Privileges
+3+^| Role: Sync Gateway Application Read Only (`sync_gateway_app_ro`)
 
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
+.2+^h| Resource
+2+^h| Privileges
 
-^| UI
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+h| Permissions
+h| Restrictions
 
-^| Collection: Sync Gateway Users and Roles
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
 
-^| Collection: Sync Gateway Application Data
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Collection: Data*
+| Can read application data
+| Cannot write application data
+
+| *Sync Gateway Users & Roles*
+| Can read edit Sync Gateway users and roles
+| Cannot add, drop, or edit users or roles
+
 |===
+
 
 [#sync-gateway-replicator]
 === Sync Gateway Replicator
 
-The *Sync Gateway Replicator* role (which is a Mobile role) allows management of Sync Gateway replications.
-The role does not allow access to Couchbase Web Console.
+The Sync Gateway Replicator role lets the user manage Sync Gateway replications by granting full access to the .
 
-[#table_sync_gateway_replicator_role,cols="15,8,8,8,8",hrows=3]
+This role does not let the user log into Couchbase Server Web Console. 
+
+
+[#table_sync_gateway_replicator_role,cols="1,2,2,hrows=3]
 |===
-5+^| Role: Sync Gateway Replicator (`sync_gateway_replicator`)
 
-.2+^h| Resources
-4+^h| Privileges
+3+^| Role: Sync Gateway Replicator (`sync_gateway_replicator`)
 
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
+.2+^h| Resource
+2+^h| Privileges
 
-^| UI
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+h| Permissions
+h| Restrictions
 
-^| Collection: Sync Gateway Replications
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
+
+| *Sync Gateway Replication Collection*
+| Can read and write replication settings
+| None
+
 |===
 
 [#sync-gateway-dev-ops]
 === Sync Gateway Dev Ops
 
-The *Sync Gateway Dev Ops* role (which is a Mobile role) allows management of Sync Gateway node-level configuration; and allows access to Syn Gateway's `/metrics` endpoint, for Prometheus integration.
-The role does not allow access to Couchbase Web Console.
+The Sync Gateway Dev Ops role lets the user manage the Sync Gateway's node-level configuration.
+It also grants access to Sync Gateway's `/metrics` endpoint for Prometheus integration.
 
-[#table_sync_gateway_dev_ops_role,cols="15,8,8,8,8",hrows=3]
+This role does not let the user log into Couchbase Server Web Console. 
+
+
+
+[#table_sync_gateway_dev_ops_role,cols="1,2,2,hrows=3]
 |===
-5+^| Role: Sync Gateway Dev Ops (`sync_gateway_dev_ops`)
 
-.2+^h| Resources
-4+^h| Privileges
+3+^| Role: Sync Gateway Dev Ops (`sync_gateway_dev_ops`)
 
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
+.2+^h| Resource
+2+^h| Privileges
 
-^| UI
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+h| Permissions
+h| Restrictions
 
-^| Dev Ops: Sync Gateway
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
 
-^| Metrics: Sync Gateway
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Sync Gateway Node Configuration*
+| Can read and write node-level settings
+| None
+
+| *Sync Gateway Metrics*
+| Can read metrics
+| Cannot change metric settings
+
 |===
+
 
 == Data Roles
 
-These roles give users the ability to read and write data in buckets.
+These roles give users the ability to read and write data in buckets via key-value operations.
 
 [#data-reader]
 === Data Reader
 
-The *Data Reader* role (which is a Data role) allows data to be read per collection, given corresponding specifications for bucket and scope.
-Note that the role does not permit the running of {sqlpp} queries (such as SELECT) against data.
-The role does not allow access to Couchbase Web Console: it is intended to support applications, rather than users.
+The Data Reader role lets the user read data from one or more collections via key-value retrieval. 
+It does not grant the ability to run {sqlpp} queries (see <<#query-roles>> for roles that do).
+When granting this role, the administrator chooses the collections the user can read data from.
+Grant this role to users for applications that need to read data via key-value operations.
 
-[#table_data_reader_role,cols="15,8,8,8,8",hrows=3]
+This role does not let the user log into Couchbase Server Web Console. 
+
+[#table_data_reader_role,cols="1,2,2,hrows=3"]
 |===
-5+^| Role: Data Reader (`data_reader`)
+3+^| Role: Data Reader (`data_reader`)
 
-.2+^h| Resources
-4+^h| Privileges
+.2+^h| Resource
+2+^h| Privileges
 
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
+h| Permissions
+h| Restrictions
 
-^| Bucket Docs
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Buckets*
+| Read data from collections, scopes, and buckets to which they have been granted access.
+Can read some bucket metadata, XATTR mappings, and pools on buckets they have been granted access to.
+| Cannot write data
 
-^| Bucket : Meta
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Query*
+| None
+| All
 
-^| Bucket : Xattr
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Pools
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
 |===
+
+
 
 [#data-writer]
 === Data Writer
 
-The *Data Writer* role (which is a Data role) allows data to be written per collection, given corresponding specifications for bucket and scope.
-The role does not allow access to Couchbase Web Console: it is intended to support applications, rather than users.
+The Data Writer role lets the user write data to one or more collections via key-value operations. 
+It does not grant the ability to run {sqlpp} queries (see <<#query-roles>> for roles that do).
+When granting this role, the administrator chooses the collections the user can write data to.
+Grant this role to users for applications that need to write data via key-value operations.
 
-[#table_data_writer_role,cols="15,8,8,8,8",hrows=3]
+This role does not let the user log into Couchbase Server Web Console. 
+
+[#table_data_writer_role,cols="1,2,2,hrows=3"]
 |===
-5+^| Role: Data Writer (`data_writer`)
+3+^| Role: Data Writer (`data_writer`)
 
-.2+^h| Resources
-4+^h| Privileges
+.2+^h| Resource
+2+^h| Privileges
 
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
+h| Permissions
+h| Restrictions
 
-^| Bucket : Docs
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Buckets*
+| Write data to collections, scopes, and buckets to which they have been granted access.
+| Cannot read data
 
-^| Bucket : Xattr
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Query*
+| None
+| All
 
-^| Pools
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
 |===
+
 
 [#data-dcp-reader]
 === Data DCP Reader
 
-The *Data DCP Reader* role (which is a Data role) allows DCP streams to be initiated per collection, given corresponding specifications for bucket and scope.
-The role does not allow access to Couchbase Web Console: it is intended to support applications, rather than users.
-The role does allow the reading of data.
+The Data DCP Reader role lets the user start a xref:learn:clusters-and-availability/intra-cluster-replication.adoc#database-change-protocol[Database Change Protocol (DCP)] stream for one or more collections, scopes, or buckets. 
+When granting this role, the administrator chooses the collections, scopes, and buckets where the user can start DCP streams.
+Grant this role to users for applications that need to start DCP streams.
 
-[#table_data_dcp_reader_role,cols="2,1,1,1,1",hrows=3]
+This role does not let the user log into Couchbase Server Web Console. 
+
+[#table_data_dcp_reader_role,cols="1,2,2,hrows=3"]
 |===
-5+^| Role: Data DCP Reader (`data_dcp_reader`)
+3+^| Role: Data DCP Reader (`data_dcp_reader`)
 
-.2+^h| Resources
-4+^h| Privileges
+.2+^h| Resource
+2+^h| Privileges
 
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
+h| Permissions
+h| Restrictions
 
-^| Bucket: : Data
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Buckets*
+| Can start DCP streams for collections, scopes, and buckets they have been granted access to.
+Can also read data and XATTRs from these collections, scopes, and buckets.
+| Cannot write data
 
-^| Bucket: : DCP
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Query*
+| None
+| All
 
-^| Bucket: : Sxattr
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Admin: Memcached: Idle
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Pools
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
 |===
+
+
 
 [#data-backup-and-restore]
 === Data Backup & Restore
 
-The *Data Backup & Restore* role (which is a Data role) allows data to be backed up and restored, per bucket.
-The role supports the reading of data.
-The role does not allow access to Couchbase Web Console: it is intended to support applications, rather than users.
+The Data Backup & Restore lets users back up and restore data in one or more buckets.  
+When granting this role, the administrator chooses the buckets the user can back up.
+This role is not intended for interactive users.
+Grant this role to users that applications use to back up and restore data. 
 
-The privileges represented in this table are, from left to right, Read, Write, Execute, Manage, Select, Backup, Create, List, and Build.
+NOTE: This role does not let the user access some important cluster-level data, so it cannot fully backup the cluster. 
+See xref:backup-restore:cbbackupmgr-backup.adoc#bucket-level[Bucket Level] in the xref:backup-restore:cbbackupmgr-backup.adoc[] documentation for details.
 
-[#table_data_backup_role,cols="8,3,3,3,3,3,3,3,3,3",hrows=3]
+
+This role does not let the user log into Couchbase Server Web Console. 
+
+[#table_data_backup_role,cols="1,2,2,hrows=3"]
 |===
-10+^| Role: Data Backup & Restore (`data_backup`)
+3+^|  Role: Data Backup & Restore (`data_backup`)
 
-.2+^h| Resources
-9+^h| Privileges
+.2+^h| Resource
+2+^h| Privileges
 
-^h| *Rd*
-^h| *Wrt*
-^h| *Exec*
-^h| *Mng*
-^h| *Slct*
-^h| *Bckp*
-^h| *Crt*
-^h| *Lst*
-^h| *Bld*
+h| Permissions
+h| Restrictions
 
-^| Bucket: : Data
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
+| *Buckets*
+| Can read, write, and manage buckets they have been granted access to. 
+| None
 
-^| Bucket: : Views
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+|*Backup*
+| Can backup bucket data, bucket {sqlpp} metadata, and analytics
+| Cannot backup other data   
 
-^| Bucket: : FTS
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Security* 
+| Can view settings for SAML, certificates, encryption at rest, audits, and other settings.
+| Cannot change settings.
 
-^| Bucket: : Stats
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Indexes*
+| Can build, create, and list
+| Cannot backup, read, or manage
 
-^| Bucket: : Settings
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Bucket Analytics*
+| Can manage and select buvket analytics
+| Cannot read bucket analytics
 
-^| Bucket: : {sqlpp}, Index
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
+| *Analytics*
+| Can select and back up analytics 
+| Cannot read analytics synonyms
 
-^| Bucket: : {sqlpp}, Meta
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Bucket: : Analytics
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Analytics:
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-
-^| Pools
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
 |===
+
 
 [#data-monitor]
 === Data Monitor
 
-The *Data Monitor* role (which is a Data role) allows statistics to be read for a given bucket, scope, or collection.
-It does not allow access to Couchbase Web Console, and does not permit the reading of data.
-This role is intended to support application-access, rather than user-access.
+The Data Monitor role lets the user read statistics for a bucket, scope, or collection.
+When granting the role, the administrator decides which statics the user can read.
+Use this role for applications that need to read statistics.
 
-In versions of Couchbase Server prior to 5.5, this role was referred to as *Data Monitoring*.
+NOTE: In versions of Couchbase Server prior to 5.5, this role was referred to as *Data Monitoring*.
 
-[#table_data_monitoring_role,cols="15,8,8,8,8",hrows=3]
+This role does not let the user log into Couchbase Server Web Console. 
+
+[#table_data_monitoring_role,cols="1,2,2,hrows=3"]
 |===
-5+^| Role: Data Monitor (`data_monitoring`)
+3+^|  Role: Data Monitor (`data_monitoring`)
 
-.2+^h| Resources
-4+^h| Privileges
+.2+^h| Resource
+2+^h| Privileges
 
-^h| *Read*
-^h| *Write*
-^h| *Execute*
-^h| *Manage*
+h| Permissions
+h| Restrictions
 
-^| Bucket : Stats
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
+| *Buckets*
+| Can read statistics for buckets, scopes, and collections they have been granted access to. 
+| None
 
-^| Pools
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
 |===
+
+== Views Roles
+
+The following roles are used with Views.
+Views were deprecated in COuchbase Server 7.0. 
+See xref:learn/views/views-intro.adoc[] for more.
+
 
 [#views-admin]
 === Views Admin
 
-The *Views Admin* role (which is a Views role) allows the management of views, per bucket.
+The Views Admin role lets the user create, modify, and drop views in on eor more buckets.  
+
 The role allows access to Couchbase Web Console.
 
 [#table_views_admin_role,cols="15,8,8,8,8",hrows=3]

--- a/modules/learn/pages/security/roles.adoc
+++ b/modules/learn/pages/security/roles.adoc
@@ -17,7 +17,7 @@ For example, the Data Writer role lets a user write data using key-value operati
 This role does not let the user read data.
 The Data Reader role grants that ability.
 
-Some roles let the you limit the privileges a role grants to specific collections, scopes, or buckets.
+Some roles let you limit the privileges a role grants to specific collections, scopes, or buckets.
 For example, when granting a user the Data Writer role, you can limit the user so they can only write to a specific collection. 
 You can also enable the user to write data to multiple collections, multiple scopes, or even to all buckets.
 For detailed information about scopes and collections, see xref:learn:data/scopes-and-collections.adoc[].
@@ -38,48 +38,48 @@ Other roles, such as those dealing with managing data, let the administrator gra
 === User Categories
 
 Couchbase Server users fall into three categories: administrators, developers, and applications.
-Which roles you assign to a user often depends on which category they fall into:
+Which roles you assign to a user often depend on which category they fall into:
 
 Administrators::
 Users with any of the administrator roles can log into Couchbase Server Web Console and perform administrative tasks.
-Most of  these roles do not grant the ability to read or write data.
+Most of these roles do not grant the ability to read or write data.
 +
 The administrative roles grant their users the ability to carry out specific tasks.
 For example, a user with the <<#cluster-admin>> role can manage all cluster features except for security.
-Users with the <<#read-only-admin,Read-Only Admin>> role can access the Couchbase Server Web Console to  read cluster settings, statistics, and backup plans, but not change them.
+Users with the <<#read-only-admin,Read-Only Admin>> role can log into the Couchbase Server Web Console to read cluster settings, statistics, and backup plans, but not change them.
 The Bucket Admin role allows management only of one or more buckets.
 See <<#admin-roles>> for details.
 +
 NOTE: The user interface of the Couchbase Web Console changes based on the role the user has.
-For example, only the Full Admin role lets a user access the entire **Security** screen.
+For example, Couchbase Server only displays the the entire **Security** page to a user with the Full Admin role.
 Users with either the Local User Admin or the External User Admin roles can only see the **Users & Groups** tab on this screen.
 
 Applications::
 An application needs to have a user account to authenticate with Couchbase Server.
 You often assign these users roles that let them read or write data or other limited privileges.
 Most of the roles you grant applications do not allow them to log into Couchbase Server Web Console or modify cluster settings.
-For example, the <<#data-reader>> and <<#data-writer>> roles lets the user read and write data using key-value operations.
+For example, the <<#data-reader>> and <<#data-writer>> roles let the user read and write data using key-value operations.
 You can limit these privileges to one or more collections, scopes, or buckets.
 Other roles appropriate for applications are <<#manage-scopes>>, <<#data-dcp-reader>>, and <<#data-backup-and-restore>>.
 
 
 Developers::
-User accounts for developers require more privileges to access data and manage resources than applications.
+Developers require more privileges for greater access to data and to manage resources than do applications.
 However, they should not have the unrestricted privileges that most Administrator roles grant.
 These roles do let users log into the Couchbase Server Web Console, so they can perform tasks in a GUI environment.
 You can tailor the roles you grant to developers so they have just enough privileges to perform their tasks.
 For example, the <<#analytics-admin>> and <<#manage-global-external-functions>> roles were designed for interactive users.
-They let them maintain some parts of your database.
+They let them maintain some parts of the database.
 However, they lack the ability to change cluster settings like most administrator roles.
 
 == Role Overviews
 
-The following sections describe the roles Defined by Couchbase Server. 
+The following sections describe the roles defined by Couchbase Server. 
 The list is broken into the same categories that appear within the Couchbase Server Web Console's *Edit User* dialog.
-Each description has a table listing the resources the roles allow users to access, and any limitations on their access.
+Each description has a table listing what resources a user with the role can access and any limitations on their access.
 If a resource does not appear in this table, the role does not grant the user any privileges for it. 
 
-NOTE: THe majority of roles are only available in Couchbase Server Enterprise Edition. 
+NOTE: The majority of roles are only available in Couchbase Server Enterprise Edition. 
 The list indicates when a role is available in Couchbase Server Community Edition.
 
 
@@ -92,7 +92,7 @@ The following roles grant users the ability to administer some aspects of Couchb
 === Full Admin
 
 The Full Admin role (`admin`) grants full privileges to all Couchbase Server features and resources, including security.
-The role lets the user log into to the Couchbase Server Web Console.
+The role allows the user to log into the Couchbase Server Web Console.
 
 This role is also available in Couchbase Server Community Edition.
 
@@ -172,11 +172,11 @@ h| Restrictions
 [#security-admin]
 === Security Admin
 
-The Security Admin role grants the user the ability manage all security settings except for users and groups.
+The Security Admin role allows the user to manage all security settings except for users and groups.
 
 This role lets the user log into the Couchbase Server Web Console.
 
-[#table_security_admin_role,cols="1,2,2,hrows=2]
+[#table_security_admin_role,cols="1,2,2,hrows=2"]
 |===
 3+^| Role: Security Admin (`security_admin`)
 
@@ -186,11 +186,11 @@ h| Restrictions
 
 | *Servers* 
 | View configuration and statistics
-| Cannot add, failover, remove, modify services, rebalance
+| Cannot add, failover, remove, modify services, or rebalance
 
 | *Buckets*
 | List buckets, scopes, and collections
-| Cannot create, drop, edit settings, read or write data
+| Cannot create, drop, or edit settings, or read or write data
 
 | *Backup*
 | None
@@ -235,8 +235,6 @@ h| Restrictions
 |===
 
 
-
-
 [#local-user-security-admin]
 === Local User Admin
 
@@ -246,7 +244,7 @@ It does not grant the ability to read data.
 
 NOTE: While this role does not allow the user to read or write data, they can create users that can read and write data.
 This could be considered a privilege escalation, but it's intentional behavior.
-This role is intended to manage all non-administratior roles, including those that can read or write data.
+This role is intended to manage all non-administrator roles, including those that can read or write data.
 You can address any possible privilege escalation concerns by auditing the actions of users with this role to see if they create users to get around the data access limitations. 
 
 This role allows users to edit local users, but they cannot grant these users the Full Admin, Read-Only Admin,  Local User Admin, or External User Admin roles.
@@ -280,11 +278,11 @@ h| Restrictions
 | All
 
 | *XDCR* 
-| All
-| None
+| View list of outgoing replications
+| View incoming replications, remote clusters, add or edit connections
 
 | *Security* 
-| Add, delete, edit local users. 
+| Add, delete, and edit local users. 
 Can add, delete, and edit groups.
 | Cannot grant Full Admin, Read-Only Admin, Local or External User Admin, or Security Admin roles to users or groups.
 Cannot access non-user and group security resources.
@@ -1758,7 +1756,7 @@ h| Restrictions
 
 | *Servers*
 | Can list servers.
-| Cannot view or edit server configuration or statstics.
+| Cannot view or edit server configuration or statistics.
 Cannot rebalance, failover, add, or remove servers.
 
 | *Buckets*
@@ -1802,7 +1800,7 @@ h| Restrictions
 
 | *Servers*
 | Can list servers.
-| Cannot view or edit server configuration or statstics.
+| Cannot view or edit server configuration or statistics.
 Cannot rebalance, failover, add, or remove servers.
 
 | *Buckets*
@@ -1819,8 +1817,8 @@ Cannot rebalance, failover, add, or remove servers.
 | All
 
 | *Search*
-| Can use search indexes in the buckets they have access to
-| Cannot add, drop, or change set4tings for search indexes
+| Can use Search indexes in the buckets they have access to
+| Cannot add, drop, or change settings for Search indexes
 
 |===
 
@@ -1920,7 +1918,7 @@ h| Restrictions
 
 | *Servers*
 | Can list servers.
-| Cannot view or edit server configuration or statstics.
+| Cannot view or edit server configuration or statistics.
 Cannot rebalance, failover, add, or remove servers.
 
 | *Settings* 
@@ -1929,7 +1927,7 @@ Cannot rebalance, failover, add, or remove servers.
 
 | *Analytics*
 | Can query analytics data in the buckets they have access to
-| Cannot add or drop Analytic scopes, links, nor collections or change their settings
+| Cannot add or drop Analytic scopes, links, or collections or change their settings
 
 |===
 
@@ -1953,7 +1951,7 @@ h| Restrictions
 
 | *Servers*
 | Can list servers.
-| Cannot view or edit server configuration or statstics.
+| Cannot view or edit server configuration or statistics.
 Cannot rebalance, failover, add, or remove servers.
 
 | *Settings* 

--- a/modules/learn/pages/security/roles.adoc
+++ b/modules/learn/pages/security/roles.adoc
@@ -55,7 +55,7 @@ For example, only the Full Admin role lets a user access the entire **Security**
 Users with either the Local User Admin or the External User Admin roles can only see the **Users & Groups** tab on this screen.
 
 Applications::
-An applications needs to have a user account to authenticate with with Couchbase Server.
+An applications needs to have a user account to authenticate with Couchbase Server.
 You often assign these users roles that let them read or write data or other limited privileges.
 Most of the roles you grant applications do not allow them to log into Couchbase Server Web Console or modify cluster settings.
 For example, the <<#data-reader>> and <<#data-writer>> roles lets the user read and write data using key-value operations.

--- a/preview/HEAD.yml
+++ b/preview/HEAD.yml
@@ -15,7 +15,7 @@ sources:
       #branches: HEAD
       branches: master
       startPaths: docs/    
-#    analytics:
-#      url: ../../docs-includes/docs-analytics
-#      branches: HEAD
+    #analytics:
+    #  url: ../../docs-includes/docs-analytics
+    #  branches: HEAD
 

--- a/preview/HEAD.yml
+++ b/preview/HEAD.yml
@@ -1,0 +1,21 @@
+sources:
+    docs-devex:
+      branches: DOC-12565_vector_search_concepts
+    docs-analytics:
+      branches: release/8.0
+    couchbase-cli:
+      # url: ../../docs-includes/couchbase-cli
+      url: https://github.com/couchbaselabs/couchbase-cli-doc
+      # branches: HEAD
+      branches: master
+      startPaths: docs/
+    backup:
+      # url: ../../docs-includes/backup
+      url: https://github.com/couchbaselabs/backup-docs.git
+      #branches: HEAD
+      branches: master
+      startPatha: docs    
+#    analytics:
+#      url: ../../docs-includes/docs-analytics
+#      branches: HEAD
+

--- a/preview/HEAD.yml
+++ b/preview/HEAD.yml
@@ -14,7 +14,7 @@ sources:
       url: https://github.com/couchbaselabs/backup-docs.git
       #branches: HEAD
       branches: master
-      startPatha: docs    
+      startPaths: docs/    
 #    analytics:
 #      url: ../../docs-includes/docs-analytics
 #      branches: HEAD

--- a/preview/HEAD.yml
+++ b/preview/HEAD.yml
@@ -18,4 +18,8 @@ sources:
     #analytics:
     #  url: ../../docs-includes/docs-analytics
     #  branches: HEAD
+    cb-swagger:
+      rl: https://github.com/couchbaselabs/cb-swagger
+      branches: release/8.0
+      start_path: docs
 


### PR DESCRIPTION
This PR covers changes to the Roles page. It does the following:

-  Remove the "checkmark and red X" privileges tables. These were too ambiguous (what does "execute" mean for a bucket?) and too limited. We have plenty of corner cases where you can perform some actions but with minor limitations. For example, some Administrator roles let you edit users and assign them roles, except you cannot assign them some of the more powerful administrator roles.
- Update the language to meet our company style guide.
- Add in some missing roles. Specifically, there were two roles that were added in 7.6 whose JIRA tickets lacked the necessary settings to flag the need for documentation (query_use_sequences, query_manage_sequences).
- Handle new and changed roles for Morpheus. These include:
    - [DOC-12511](https://jira.issues.couchbase.com/browse/DOC-12511) Changes to user admin roles that only allows privileges for administering local and external users.
    - The Application Telemetry Writer role added in [MB-64960](https://jira.issues.couchbase.com/browse/MB-64960) for the SDK Telemetry Collection in Server
    - [DOC-12794](https://jira.issues.couchbase.com/browse/DOC-12794) Documentation for Create RBAC role for Management of Query System Catalogs
    - [MB-65045](https://jira.issues.couchbase.com/browse/MB-65045) adding Query List Index.

The following pages changed in this PR (links lead to a preview build):

* The [Roles](https://preview.docs-test.couchbase.com/docs-server-DOC-12511-morpheus_role_changes/server/current/learn/security/roles.html) page was heavily edit.
* Added an entry for the Roles updated to the [What's New](https://preview.docs-test.couchbase.com/docs-server-DOC-12511-morpheus_role_changes/server/current/introduction/whats-new.html#section-new-features-800-roles) page.

There's also a quickly thrown together Python script with help from ChatGPT here that checks the list of roles in the roles.adoc file against the results of calling the server REST API to get the current list of roles. This helped spotting the missing 7.6 roles. Not sure it needs any sort of code review, as it's not for public consumption.

There is some remaining work to be done through out the doc to ensure all references to the old roles are eliminated. That will be in a follow up PR.

[DOC-12511]: https://couchbasecloud.atlassian.net/browse/DOC-12511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MB-64960]: https://couchbasecloud.atlassian.net/browse/MB-64960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ