### PR TITLE
Avx2 deprecation pt2

### DIFF
--- a/modules/install/pages/pre-install.adoc
+++ b/modules/install/pages/pre-install.adoc
@@ -16,7 +16,7 @@ This section explains the minimum requirements for of these platforms.
 .deprecation notice
 [IMPORTANT]
 ====
-The use of older x86 processors that do not implement the https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#AVX2[Advanced Vector Extensions 2 (AVX2)] instruction set is deprecated in Couchbase Server 7.6.x.
+The use of older x86 processors that do not implement the https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#AVX2[Advanced Vector Extensions 2 (AVX2)] instruction set are deprecated in Couchbase Server 7.6.x.
 Future versions will require processors that have AVX2 support.
 This requirements is only for x86 processors--ARM processors have a separate set of vector instructions.
 

--- a/modules/install/pages/pre-install.adoc
+++ b/modules/install/pages/pre-install.adoc
@@ -18,13 +18,26 @@ This section explains the minimum requirements for of these platforms.
 ====
 The use of older x86 processors that do not implement the https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#AVX2[Advanced Vector Extensions 2 (AVX2)] instruction set is deprecated in Couchbase Server 7.6.x.
 Future versions will require processors that have AVX2 support.
-The earliest processors that support these instructions include:
+This requirements is only for x86 processors--ARM processors have a separate set of vector instructions.
+
+The earliest processors that support AVX2 instructions include:
 
 * Intel 4th generation (Haswell) Core processors released in 2013.
 * Intel 11th generation (Tiger Lake) Celeron and Pentium processors released in 2020.
 * AMD Excavator processors released in 2015.
 
 Processors from these or later generations will be required to run Couchbase Server in the future.
+
+You can tell if your processor has the AVX2 instructions by executing the following command:
+
+[source,bash]
+----
+grep -q -i 'avx2' /proc/cpuinfo && \
+     echo "Processor has AVX2" || echo "AVX2 not found"
+----
+
+If the command returns the text `Processor has AVX2`, your processor has AVX2 support and is supported in future Couchbase Server releases.
+If the command returns `AVX2 not found`, your processor does not support AVX2 and will not be supported in future Couchbase Server versions.
 ====
 
 

--- a/modules/install/pages/pre-install.adoc
+++ b/modules/install/pages/pre-install.adoc
@@ -4,14 +4,36 @@
 [abstract]
 {description}
 
-[tabs]
+## CPU Requirements
+
+Couchbase Server can run on x96 and ARM processors (including Apple Silicon processors). 
+This section explains the minimum requirements for of these platforms.
+
+### x86 Processors
+
+
+[#avx2-requirements]
+.deprecation notice
+[IMPORTANT]
 ====
-x86 Processors::
-+
---
+The use of older x86 processors that do not implement the https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#AVX2[Advanced Vector Extensions 2 (AVX2)] instruction set is deprecated in Couchbase Server 7.6.x.
+Future versions will require processors that have AVX2 support.
+The earliest processors that support these instructions include:
+
+* Intel 4th generation (Haswell) Core processors released in 2013.
+* Intel 11th generation (Tiger Lake) Celeron and Pentium processors released in 2020.
+* AMD Excavator processors released in 2015.
+
+Processors from these or later generations will be required to run Couchbase Server in the future.
+====
+
+
+Couchbase Server has the following requirements when running on x86 processors.
+
+
 [cols="80,180,180"]
 |===
-| | Minimum Specifications* | Recommended Specifications**
+| | Minimum Specifications<<#note1,*>> | Recommended Specifications<<#note2,**>>
 
 | *CPU*
 | 2 GHz dual core x86_64 CPU supporting SSE4.2
@@ -33,14 +55,15 @@ a|
 
 Network file systems such as CIFS and NFS are not supported.
 |===
---
 
-ARM Processors::
-+
---
+### ARM Processors
+
+Couchbase Server has the following requirements when running on ARM-based platforms.
+
+
 [cols="80,180,180"]
 |===
-| | Minimum Specifications* | Recommended Specifications**
+| | Minimum Specifications<<#note1,*>> | Recommended Specifications<<#note2,**>>
 
 | *CPU*
 | 2 Ghz dual core 64bit ARM v8 CPU
@@ -60,39 +83,52 @@ a|
 
 Network file systems such as CIFS and NFS are not supported.
 |===
---
-====
 
-
-
-*_You can reduce the CPU and RAM resources below the Minimum Specifications for development and testing purposes.
+[#note1]
+^*^You can reduce the CPU and RAM resources below the Minimum Specifications for development and testing purposes.
 Resources can be as low as 1 GB of free RAM beyond operating system requirements, and a single CPU core.
 However, you must adhere to the Minimum Specifications for production._
 
-**_The Recommended Specifications don't take into account your intended workload.
-You should follow the xref:sizing-general.adoc[sizing guidelines] when determining system specifications for your Couchbase Server deployment._
+[#note2]
+^**^The Recommended Specifications do not take into account your intended workload.
+You should follow the xref:sizing-general.adoc[sizing guidelines] when determining system specifications for your Couchbase Server deployment.
 
 [#clock-source-linux]
-Clock Source on Linux:: The Query service uses the OS monotonic clock for profiling and network timeout purposes. 
-+
-The Linux kernel uses the _Clock Source_ to obtain the current clock value and this information is stored in `/sys/devices/system/clocksource/clocksource0/current_clocksource`. There are several clock sources (TSC, XEN, and others), which are used depending on the hardware clock capabilities, and the OS installation. The XEN source, which is seen to be the default on AWS setups, can use up to 25% of all available CPU time to obtain the current timestamp. The TSC clock source, on the other hand, incurs very little CPU cost. We recommend changing the clock source to TSC if it is set to anything else.
-+
-Check the clock source on your Linux OS using the following command:
+## Clock Source on Linux 
+
+The Query Service relies on the Linux operating system's monotonic clock when profiling and managing network timeouts. 
+
+The Linux kernel uses a clock source to track elapsed time, handle scheduling and timers, and to get the current time. 
+It can use one of several possible sources, such as Time Stamp Counter (TSC), the XEN build into the Xen virtualization framework, and others.
+See https://docs.kernel.org/timers/timekeeping.html[Clock sources, Clock events, sched_clock() and delay timers^] for more information about clock sources.
+Which source the kernel uses depends on the hardware clock capabilities and Linux configuration settings. 
+
+Some virtualization environments, such as older AWS EC2 clusters, use the XEN clock source.
+This source can cause performance issues because reading it requires an expensive system call to the hypervisor.
+In some cases, a XEN clock source has used up to 25% of CPU time when timers are in heavy use.
+
+The TSC clock source incurs little CPU cost because it's a CPU instruction instead of a kernel or hypervisor call. 
+If your platform has a reliable and invariant implementation of TSC, use it as the clock source.
+Consult the documentation for your platform for more information about its TSC implementation.
+
+Use the following command to see which clock source Linux is using:
+
 [source, bash]
 ----
 cat /sys/devices/system/clocksource/clocksource0/current_clocksource
 ----
-+
-Change the clock source using the following commands:
+
+You can change the clock source to TSC by running the following command as root: 
+
 [source,bash]
 ----
 echo tsc > /sys/devices/system/clocksource/clocksource0/current_clocksource
 ----
-+
-To verify the current setting of the clock source, use:
+
+Verify the current setting of the clock source, read the `current_clocksource` again:
 [source,bash]
 ----
 cat /sys/devices/system/clocksource/clocksource0/current_clocksource
 ----
-+
+ 
 The output should read `tsc`.

--- a/modules/install/pages/pre-install.adoc
+++ b/modules/install/pages/pre-install.adoc
@@ -6,7 +6,7 @@
 
 ## CPU Requirements
 
-Couchbase Server can run on x96 and ARM processors (including Apple Silicon processors). 
+Couchbase Server can run on x86 and ARM processors (including Apple Silicon processors). 
 This section explains the minimum requirements for of these platforms.
 
 ### x86 Processors

--- a/modules/install/pages/pre-install.adoc
+++ b/modules/install/pages/pre-install.adoc
@@ -28,7 +28,7 @@ The earliest processors that support AVX2 instructions include:
 
 Processors from these or later generations will be required to run Couchbase Server in the future.
 
-You can tell if your processor has the AVX2 instructions by executing the following command:
+On Linux, you can tell if your processor has the AVX2 instructions by executing the following command:
 
 [source,bash]
 ----
@@ -36,8 +36,8 @@ grep -q -i 'avx2' /proc/cpuinfo && \
      echo "Processor has AVX2" || echo "AVX2 not found"
 ----
 
-If the command returns the text `Processor has AVX2`, your processor has AVX2 support and is supported in future Couchbase Server releases.
-If the command returns `AVX2 not found`, your processor does not support AVX2 and will not be supported in future Couchbase Server versions.
+If the command returns the text `Processor has AVX2`, your processor is supported in future Couchbase Server releases.
+If the command returns `AVX2 not found`, your processor does not have AVX2 instructions and will not be supported in future Couchbase Server versions.
 ====
 
 

--- a/modules/introduction/pages/whats-new.adoc
+++ b/modules/introduction/pages/whats-new.adoc
@@ -8,6 +8,14 @@
 
 For information about platform support changes, deprecation notifications, notable improvements, and fixed and known issues, refer to the xref:release-notes:relnotes.adoc[Release Notes].
 
+.deprecation notice
+[IMPORTANT]
+====
+Using older x86 processors that do not have the AVX2 instruction set is deprecated in Couchbase Server 7.6.x.
+Deprecated processors include pre-2013 Intel Core processors, pre-2020 Celeron or Pentium processors, and pre-2015 AMD processors.
+See xref:install:pre-install.adoc[] for details.
+====
+
 .note regarding `cbbackupmgr`
 [IMPORTANT]
 ====


### PR DESCRIPTION
Adding deprecation notice to 7.6. about the requirement for AVX2 instructions on x86 platforms in future server releases.

Preview:

- [What’s New](https://preview.docs-test.couchbase.com/docs-server-avx2-deprecation-pt2/server/current/introduction/whats-new.html) changes
- [System Resource Requirements](https://preview.docs-test.couchbase.com/docs-server-avx2-deprecation-pt2/server/current/install/pre-install.html) changes