### PR TITLE
[DOC-13129]: Feedback on Supported Platforms | Couchbase Docs

### DIFF
--- a/modules/install/pages/install-platforms.adoc
+++ b/modules/install/pages/install-platforms.adoc
@@ -56,9 +56,11 @@ ARM64 support requires ARMv8 CPUs, such as the Amazon Graviton series.
 (Note that versions earlier than SP2 are no longer supported in Couchbase Server 7.2.)
 
 | Ubuntu
-| 20.04 LTS (x86, ARM64)
+| 24.04 LTS (x86, ARM64) 
 
-22.x LTS (x86, ARM64)
+ 22.x LTS (x86, ARM64) 
+ 
+ 20.04 LTS (x86, ARM64) (deprecated in Couchbase Server 7.6)
 
 | Windows Server
 | 2022


### PR DESCRIPTION
Added Ubuntu 24.04 LTS (x86, ARM64) to the list of supported platforms to ensure documentation reflects current support