### PR TITLE
[DOC-12746]: We need to add info to the current documentation to let customers know how audit log records events

### DIFF
--- a/modules/learn/pages/security/auditing.adoc
+++ b/modules/learn/pages/security/auditing.adoc
@@ -55,6 +55,9 @@ For example, `"Unsuccessful attempt to login to couchbase cluster"`, `"Node was 
 | Object
 | Contains key-value pairs for `"domain"` (specifying `"local"`; `"external"`; `"builtin"` &#8212; for the administrator who set up the cluster; or `"rejected"` &#8212; for a user who has been denied access); and `"user"` (specifying the id of the user who generated the event).
 
+3+a|
+include::partial$user-audit-warning.adoc[]
+
 | `"local"`
 | Object
 | Contains key-value pairs for `"ip"` and incoming `"port"`, for the node on which the event was processed.

--- a/modules/learn/partials/user-audit-warning.adoc
+++ b/modules/learn/partials/user-audit-warning.adoc
@@ -1,0 +1,9 @@
+[IMPORTANT]
+.The occurrence of a system id in the audit log.
+====
+In some instances, 
+the server will carry out an audited function 
+using a system identifier for the `user` field instead of the actual user logged into the system.
+
+This may show up in the audit logs as `"user":"@ns_server"` for example.
+====

--- a/preview/HEAD.yml
+++ b/preview/HEAD.yml
@@ -1,4 +1,6 @@
 sources:
   docs-devex:
     branches: release/7.6
+  docs-capella:
+    branches: DOC-12746-We-need-to-add-info-to-the-current-documentation-to-let-customers-know-how-audit-log-records-events
 


### PR DESCRIPTION
- Added notes to the documentation to inform users how audit logs record events.  
