### PR TITLE
[DOC-13153]: Feedback on Query Service Metrics | Couchbase Docs

### DIFF
--- a/modules/metrics-reference/pages/query-service-metrics.adoc
+++ b/modules/metrics-reference/pages/query-service-metrics.adoc
@@ -6,7 +6,7 @@
 
 The following Query Service metrics can be queried by means of the REST APIs described in xref:rest-api:rest-statistics.adoc[Statistics].
 
-As a brief introduction however, we will first look at how you would go about building a REST command for the `n1ql_active_requests` metric.
+As a brief introduction however, this is how you would go about building a REST command for the `n1ql_active_requests` metric.
 
 '''
 .Using CURL to retrieve Query Service metrics

--- a/modules/metrics-reference/pages/query-service-metrics.adoc
+++ b/modules/metrics-reference/pages/query-service-metrics.adoc
@@ -6,6 +6,20 @@
 
 The following Query Service metrics can be queried by means of the REST APIs described in xref:rest-api:rest-statistics.adoc[Statistics].
 
+As a brief introduction however, we will first look at how you would go about building a REST command for the `n1ql_active_requests` metric.
+
+'''
+.Using CURL to retrieve Query Service metrics
+
+Run the following command from your shell console to get the total number of active requests.
+
+[source, shell]
+----
+curl -X GET --location "http://localhost:8091/pools/default/stats/range/n1ql_active_requests" \
+    --basic --user Administrator:password
+----
+
+'''
 See xref:query-service-metrics-cross-reference.adoc[] if you are looking for a metric name you know from an alternative supported or legacy tool.
 
 [template,attachment$n1ql_metrics_metadata.json]


### PR DESCRIPTION

Added short example demonstrating how to use CURL to retrieve a query metric.

Preview URL:
https://preview.docs-test.couchbase.com/docs-server-DOC-13153-Feedback-on-Query-Service-Metrics--Couchbase-Docs/server/current/metrics-reference/query-service-metrics.html

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.