### PR TITLE
[DOC-13372]: Create release note for docs-server:7.2.8

### DIFF
--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -1,4 +1,7 @@
 = Release Notes for Couchbase Server 7.2
+:stem:
+
+include::partial$docs-server-7.2.8-release-note.adoc[]
 
 include::partial$docs-server-7.2.7-release-note.adoc[]
 

--- a/modules/release-notes/partials/docs-server-7.2.8-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.2.8-release-note.adoc
@@ -1,0 +1,130 @@
+
+
+[#release-728]
+== Release 7.2.8 (August 2025)
+
+Couchbase Server 7.2.8 was released in August 2025.
+This maintenance release contains fixes to issues.
+
+== Fixed Issues
+
+
+
+
+
+
+=== Data Service
+
+[#table-known-issues-728-data-service, cols="10,40,40"]
+|===
+|Issue | Description | Resolution
+
+
+| https://jira.issues.couchbase.com/browse/MB-67762[MB-67762]
+a|There is an integer overflow bug in buckets using the Magma storage engine. 
+This bug can potentially cause a subset of mutations to become invisible to read operations after approximately 500 billion to 2 trillion mutations per bucket.  
+| For details, please refer to https://jira.issues.couchbase.com/browse/MB-67762[MB-67762]
+
+
+|===
+
+
+
+
+=== XDCR
+
+[#table-known-issues-728-xdcr, cols="10,40,40"]
+|===
+|Issue | Description | Resolution
+
+
+| https://jira.issues.couchbase.com/browse/MB-66650/[MB-66650]
+
+a| When modifying filter expressions or mapping configurations (explicit/migration), race conditions may prevent proper replication from the source. This can result in source bucket documents failing to replicate to the target bucket.
+To address this issue, the system now displays an alert when detecting replication resuming from  stale checkpoints. This alert notifies users to delete and recreate the affected replication.
+IMPORTANT: Do not dismiss this alert by pausing and resuming the replication, as this will hide the warning without resolving the underlying issue.
+
+| Issue resolved
+
+
+|===
+
+
+=== Query Service
+
+[#table-known-issues-728-query-service, cols="10,40,40"]
+|===
+|Issue | Description | Resolution
+
+
+| https://jira.issues.couchbase.com/browse/MB-67849/[MB-67849]
+
+a| The recent builds of Couchbase Server versions 7.2.7 through 8.1.0 and Enterprise Analytics 2.1.0 include updates from the go_json library to address int64 overflow issues reported under MB-67849. The updates involve implementing proper checks for int64 overflow in order to properly represent large numbers (greater than stem:[2^63] or less than stem:[-2^63]).
+
+| Issue resolved
+
+
+|===
+
+
+
+
+
+
+=== Index Service
+
+[#table-known-issues-728-index-service, cols="10,40,40"]
+|===
+|Issue | Description | Resolution
+
+
+| https://jira.issues.couchbase.com/browse/MB-66034/[MB-66034]
+
+a| Previously, during smart batching, the calculation of `max concurrent builds per node` incorrectly considered all indexer nodes as potential destinations; even those not participating in index movement during the rebalance. As a result, the destination node count was inflated, causing the batch size to be divided across more nodes than necessary. This led to smaller batch sizes and fewer tokens per batch on the actual recipient nodes.
+With this fix, only indexer nodes that are actively receiving index transfers are considered in the destination node count. This results in more accurate batch sizing and improved efficiency during index rebalance operations.
+
+| Issue resolved
+
+
+
+| https://jira.issues.couchbase.com/browse/MB-67116/[MB-67116]
+
+a| A race condition in the projector service  could cause a deadlock when closing streams with high mutation rates. The issue, present since version 7.2.2, didn't affect functionality but resulted in increased memory consumption as mutations in the pipeline couldn't be released properly. 
+With this fix, memory usage has been restored to normal levels.
+
+| Issue resolved
+
+
+
+| https://jira.issues.couchbase.com/browse/MB-67118/[MB-67118]
+
+a| `DropInstanceToken` increased in size due to changes in the definition. With more partitions, its size can increase beyond the `metakv` size limit. 
+This ticket fixes the issue by using `BigValueGet` with `DropInstanceToken` which splits the tokens in parts, stores them  in `metakv`, and retrieves the token by combining the parts. 
+Before this patch, replica drops were failing when the token increased in size  as retrieval was failing.
+
+| Issue resolved
+
+
+|===
+
+
+
+
+=== Tools
+
+[#table-known-issues-728-tools, cols="10,40,40"]
+|===
+|Issue | Description | Resolution
+
+
+| https://jira.issues.couchbase.com/browse/MB-57755/[MB-57755]
+
+a| Beginning with Server 7.2.8/7.6.7, when installing on a Linux system using cgroups v1, Server will set the `memory.swappiness` cgroups parameter to `0` for the `couchbase-server` service slice. This ensures best performance without affecting any other services that may be running on the system.
+For Linux systems using cgroups v2 (which is the default for the more recent releases of most Linux distributions), there is no `memory.swappiness` parameter for individual service slices. Therefore it is still highly recommended to set kernel swappiness to `0` globally on each node, as explained in the documentation: https://docs.couchbase.com/server/current/install/install-swap-space.html
+
+| Issue resolved
+
+
+|===
+
+


### PR DESCRIPTION

Release note for `docs-server` 7.2.8

Preview URL:
https://preview.docs-test.couchbase.com/docs-server-DOC-13372-Create-release-note-for-docs-server-7.2.8

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.