### PR TITLE
[DOC-11000] Query rebalance improvements for 7.1

### DIFF
--- a/modules/learn/pages/clusters-and-availability/rebalance.adoc
+++ b/modules/learn/pages/clusters-and-availability/rebalance.adoc
@@ -206,10 +206,17 @@ See xref:rest-api:rest-fts-partition-file-transfer.adoc[Rebalance Based on File 
 [#rebalancing-the-query-service]
 === Query Service
 
-When a node is removed and rebalanced, the Query Service will allow existing queries and transactions to complete before shutting down, which may result in the rebalancing operation taking longer to complete.
-  The Query Service diagnostic log on the node(s) being removed will contain messages indicating how many transactions and queries are still running.
-  Any new connection attempts to nodes that are shutting down will receive error 1180 (`E_SERVICE_SHUTTING_DOWN`), and may receive error 1181 (`E_SERVICE_SHUT_DOWN`) in the brief period between the completion of the last statement or transaction and the service exiting.
-  Such rejected requests will have HTTP status code 503 (`service unavailable`) set.
+When you remove a node from a cluster and rebalance it, the Query Service allows existing queries and transactions to complete before shutting down.
+This can increase the overall time required for the rebalance operation, depending on how long the active requests and transactions take to complete.
+
+To monitor the shutdown progress, you can check the Query Service diagnostic log on the node being removed.
+These logs contain messages that indicate the number of ongoing transactions and queries. 
+
+At the start of the rebalance operation, the Query Service stops accepting new requests and returns error 1180 (`E_SERVICE_SHUTTING_DOWN`), indicating that the service is shutting down. 
+However, requests that are part of existing transactions continue to be accepted until those transactions complete.
+For a brief period after all active requests and transactions have been handled, and just before the service exits, you may receive error 1181 (`E_SERVICE_SHUT_DOWN`), indicating that the service has shut down.
+In both cases, rejected requests will have an HTTP status code 503 (`service unavailable`).
+You can retry these requests on another Query node that is not being removed from the cluster.
 
 [#rebalancing-the-eventing-service]
 === Eventing Service

--- a/modules/learn/pages/clusters-and-availability/rebalance.adoc
+++ b/modules/learn/pages/clusters-and-availability/rebalance.adoc
@@ -212,11 +212,13 @@ This can increase the overall time required for the rebalance operation, dependi
 To monitor the shutdown progress, you can check the Query Service diagnostic log on the node being removed.
 These logs contain messages that indicate the number of ongoing transactions and queries. 
 
-At the start of the rebalance operation, the Query Service stops accepting new requests and returns error 1180 (`E_SERVICE_SHUTTING_DOWN`), indicating that the service is shutting down. 
+At the start of the rebalance operation, the Query Service stops accepting new requests. 
+Any new requests sent to the node return error 1180 (`E_SERVICE_SHUTTING_DOWN`), indicating that the service is shutting down. 
 However, requests that are part of existing transactions continue to be accepted until those transactions complete.
-For a brief period after all active requests and transactions have been handled, and just before the service exits, you may receive error 1181 (`E_SERVICE_SHUT_DOWN`), indicating that the service has shut down.
+
+For a brief period after all active requests and transactions are handled, and just before the service exits, you may receive error 1181 (`E_SERVICE_SHUT_DOWN`), indicating that the service has shut down.
 In both cases, rejected requests will have an HTTP status code 503 (`service unavailable`).
-You can retry these requests on another Query node that is not being removed from the cluster.
+If needed, you can retry these requests on another Query node that is still in the cluster.
 
 [#rebalancing-the-eventing-service]
 === Eventing Service

--- a/modules/learn/pages/clusters-and-availability/rebalance.adoc
+++ b/modules/learn/pages/clusters-and-availability/rebalance.adoc
@@ -216,7 +216,7 @@ At the start of the rebalance operation, the Query Service stops accepting new r
 Any new requests sent to the node return error 1180 (`E_SERVICE_SHUTTING_DOWN`), indicating that the service is shutting down. 
 However, requests that are part of existing transactions continue to be accepted until those transactions complete.
 
-For a brief period after all active requests and transactions are handled, and just before the service exits, you may receive error 1181 (`E_SERVICE_SHUT_DOWN`), indicating that the service has shut down.
+For a brief period after all active requests and transactions are handled, and just before the service exits, requests may return error 1181 (`E_SERVICE_SHUT_DOWN`), indicating that the service has shut down.
 In both cases, rejected requests will have an HTTP status code 503 (`service unavailable`).
 If needed, you can retry these requests on another Query node that is still in the cluster.
 


### PR DESCRIPTION
This PR updates the existing query service rebalance documentation (version 7.1) to better explain the process to users.

Doc Jira: [DOC-11000](https://jira.issues.couchbase.com/browse/DOC-11000)
Preview:[Query Service Rebalance](https://preview.docs-test.couchbase.com/docs-server-DOC-11000-query-rebalance-7.1/server/current/learn/clusters-and-availability/rebalance.html#rebalancing-the-query-service)
Preview credentials: [Preview docs for internal review](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-review)

[DOC-11000]: https://couchbasecloud.atlassian.net/browse/DOC-11000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ