### PR TITLE
[DOC-11000] Query rebalance improvements for 7.2

### DIFF
--- a/modules/learn/pages/clusters-and-availability/rebalance.adoc
+++ b/modules/learn/pages/clusters-and-availability/rebalance.adoc
@@ -226,7 +226,7 @@ If needed, you can retry these requests on another Query node that is still in t
 In Couchbase Server 7.2.1 and later, the Query Service waits for in-flight transactions and requests that were active at the start of the rebalance operation to complete.
 Additional requests sent after the rebalance begins are accepted, but not waited on. 
 They do not delay the rebalance and can be terminated abruptly once the initial in-flight requests complete.
-For each such request, the Query Service writes a message to the diagnostic log indicating that the request may be terminated because it was received after the rebalance started.
+For each such request, there will be a message in the Query Service diagnostic log indicating that the request was terminated as it was received after the rebalance started.
 
 [#rebalancing-the-eventing-service]
 === Eventing Service

--- a/modules/learn/pages/clusters-and-availability/rebalance.adoc
+++ b/modules/learn/pages/clusters-and-availability/rebalance.adoc
@@ -225,8 +225,8 @@ If needed, you can retry these requests on another Query node that is still in t
 
 In Couchbase Server 7.2.1 and later, the Query Service waits for in-flight transactions and requests that were active at the start of the rebalance operation to complete.
 Additional requests sent after the rebalance begins are accepted, but not waited on. 
-These requests do not delay the rebalance and may be terminated abruptly once the initial in-flight requests complete.
-For such requests, the Query Service diagnostic log will include a message indicating that the request was terminated. 
+They do not delay the rebalance and can be terminated abruptly once the initial in-flight requests complete.
+For each such request, the Query Service writes a message to the diagnostic log indicating that the request may be terminated because it was received after the rebalance started.
 
 [#rebalancing-the-eventing-service]
 === Eventing Service

--- a/modules/learn/pages/clusters-and-availability/rebalance.adoc
+++ b/modules/learn/pages/clusters-and-availability/rebalance.adoc
@@ -207,10 +207,26 @@ See xref:rest-api:rest-fts-partition-file-transfer.adoc[Rebalance Based on File 
 [#rebalancing-the-query-service]
 === Query Service
 
-When a node is removed and rebalanced, the Query Service will allow existing queries and transactions to complete before shutting down, which may result in the rebalancing operation taking longer to complete.
-  The Query Service diagnostic log on the node(s) being removed will contain messages indicating how many transactions and queries are still running.
-  Any new connection attempts to nodes that are shutting down will receive error 1180 (`E_SERVICE_SHUTTING_DOWN`), and may receive error 1181 (`E_SERVICE_SHUT_DOWN`) in the brief period between the completion of the last statement or transaction and the service exiting.
-  Such rejected requests will have HTTP status code 503 (`service unavailable`) set.
+When you remove a node from a cluster and rebalance it, the Query Service allows existing queries and transactions to complete before shutting down.
+This can increase the overall time required for the rebalance operation, depending on how long the active requests and transactions take to complete.
+
+To monitor the shutdown progress, you can check the Query Service diagnostic log on the node being removed.
+These logs contain messages that indicate the number of ongoing transactions and queries. 
+
+At the start of the rebalance operation, the Query Service stops accepting new requests. 
+Any new requests sent to the node return error 1180 (`E_SERVICE_SHUTTING_DOWN`), indicating that the service is shutting down. 
+However, requests that are part of existing transactions continue to be accepted until those transactions complete.
+
+For a brief period after all active requests and transactions are handled, and just before the service exits, requests may return error 1181 (`E_SERVICE_SHUT_DOWN`), indicating that the service has shut down.
+In both cases, rejected requests will have an HTTP status code 503 (`service unavailable`).
+If needed, you can retry these requests on another Query node that is still in the cluster.
+
+[.status]#Couchbase Server 7.2.1#
+
+In Couchbase Server 7.2.1 and later, the Query Service waits for in-flight transactions and requests that were active at the start of the rebalance operation to complete.
+Additional requests sent after the rebalance begins are accepted, but not waited on. 
+These requests do not delay the rebalance and may be terminated abruptly once the initial in-flight requests complete.
+For such requests, the Query Service diagnostic log will include a message indicating that the request was terminated. 
 
 [#rebalancing-the-eventing-service]
 === Eventing Service


### PR DESCRIPTION
This PR updates the existing query service rebalance documentation (version 7.2) to better explain the process to users.

Doc Jira: [DOC-11000](https://jira.issues.couchbase.com/browse/DOC-11000)
Preview:[Query Service Rebalance](https://preview.docs-test.couchbase.com/docs-server-DOC-11000-query-rebalance-7.2/server/current/learn/clusters-and-availability/rebalance.html#rebalancing-the-query-service)
Preview credentials: [Preview docs for internal review](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-review)

[DOC-11000]: https://couchbasecloud.atlassian.net/browse/DOC-11000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ