### PR TITLE
DOC-12707-fix Typo in the rebalance-reference page

### DIFF
--- a/modules/rebalance-reference/pages/rebalance-reference.adoc
+++ b/modules/rebalance-reference/pages/rebalance-reference.adoc
@@ -16,7 +16,7 @@ On conclusion of the rebalance, the report can be accessed in any of the followi
 
 * By means of the REST API, as described in xref:rest-api:rest-get-cluster-tasks.adoc[Getting Cluster Tasks].
 
-* By accessing the directory `/opt/couchbase/var/lib/couchbase/logs/reblance` on _any_ of the cluster nodes.
+* By accessing the directory `/opt/couchbase/var/lib/couchbase/logs/rebalance` on _any_ of the cluster nodes.
 A rebalance report is maintained here for (up to) the last _five_ rebalances performed.
 Each report is provided as a `*.json` file, whose name indicates the time at which the report was run &#8212; for example, `rebalance_report_2020-03-17T11:10:17Z.json`.
 +


### PR DESCRIPTION
[DOC-12707](https://jira.issues.couchbase.com/browse/DOC-12707) Trying to fix a typo in the directory name specified in line 19

[Docs Preview](https://preview.docs-test.couchbase.com/docs-server-DOC-12707-fixing-typo/server/current/rebalance-reference/rebalance-reference.html)

You can find the required credentials in the Preview docs for Internal Couchbase Reviews section in the following page: 
https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords 

[DOC-12707]: https://couchbasecloud.atlassian.net/browse/DOC-12707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ