### PR TITLE
[DOC-12884] Feedback-on-Data-Service-Metrics--Couchbase-Docs

### DIFF
--- a/modules/metrics-reference/attachments/kv_metrics_metadata.json
+++ b/modules/metrics-reference/attachments/kv_metrics_metadata.json
@@ -56,7 +56,21 @@
     "stability": "committed",
     "type": "gauge"
   },
-  "kv_cmd_duration_seconds": {
+  "kv_cmd_duration_seconds_bucket": {
+    "added": "7.0.0",
+    "help": "Per-opcode histogram of time taken to execute operations",
+    "stability": "committed",
+    "type": "histogram",
+    "unit": "seconds"
+  },
+  "kv_cmd_duration_seconds_count": {
+    "added": "7.0.0",
+    "help": "Per-opcode histogram of time taken to execute operations",
+    "stability": "committed",
+    "type": "histogram",
+    "unit": "seconds"
+  },
+  "kv_cmd_duration_seconds_sum": {
     "added": "7.0.0",
     "help": "Per-opcode histogram of time taken to execute operations",
     "stability": "committed",

--- a/modules/metrics-reference/attachments/kv_metrics_metadata.json
+++ b/modules/metrics-reference/attachments/kv_metrics_metadata.json
@@ -56,21 +56,7 @@
     "stability": "committed",
     "type": "gauge"
   },
-  "kv_cmd_duration_seconds_bucket": {
-    "added": "7.0.0",
-    "help": "Per-opcode histogram of time taken to execute operations",
-    "stability": "committed",
-    "type": "histogram",
-    "unit": "seconds"
-  },
-  "kv_cmd_duration_seconds_count": {
-    "added": "7.0.0",
-    "help": "Per-opcode histogram of time taken to execute operations",
-    "stability": "committed",
-    "type": "histogram",
-    "unit": "seconds"
-  },
-  "kv_cmd_duration_seconds_sum": {
+  "kv_cmd_duration_seconds": {
     "added": "7.0.0",
     "help": "Per-opcode histogram of time taken to execute operations",
     "stability": "committed",

--- a/modules/metrics-reference/pages/backup-service-metrics.adoc
+++ b/modules/metrics-reference/pages/backup-service-metrics.adoc
@@ -6,6 +6,9 @@
 
 The following Backup Service metrics can be queried by means of the REST APIs described in xref:rest-api:rest-statistics.adoc[Statistics].
 
+include::partial$histogram-sidebar.adoc[]
+
+
 [template,attachment$backup_metrics_metadata.json]
 --
 include::partial$metrics.hbs[]

--- a/modules/metrics-reference/pages/data-service-metrics.adoc
+++ b/modules/metrics-reference/pages/data-service-metrics.adoc
@@ -8,18 +8,7 @@ The following Data Service metrics can be queried by means of the REST APIs desc
 
 See xref:data-service-metrics-cross-reference.adoc[] if you are looking for a metric name you know from an alternative supported or legacy tool.
 
-[sidebar]
-.Histograms
-****
-Note that all histogram metrics will generate time series for:
-
-* `_count`
-* `_sum`
-* `_bucket`
-
-Please refer to https://prometheus.io/docs/practices/histograms/[Prometheus Histograms and Summaries] for more information.
-****
-
+include::partial$histogram-sidebar.adoc[]
 
 [template,attachment$kv_metrics_metadata.json]
 --

--- a/modules/metrics-reference/pages/data-service-metrics.adoc
+++ b/modules/metrics-reference/pages/data-service-metrics.adoc
@@ -8,7 +8,22 @@ The following Data Service metrics can be queried by means of the REST APIs desc
 
 See xref:data-service-metrics-cross-reference.adoc[] if you are looking for a metric name you know from an alternative supported or legacy tool.
 
+[sidebar]
+.Histograms
+****
+Note that all histogram metrics will generate time series for:
+
+* `_count`
+* `_sum`
+* `_bucket`
+
+Please refer to https://prometheus.io/docs/practices/histograms/[Prometheus Histograms and Summaries] for more information.
+****
+
+
 [template,attachment$kv_metrics_metadata.json]
 --
 include::partial$metrics.hbs[]
 --
+
+

--- a/modules/metrics-reference/pages/ns-server-metrics.adoc
+++ b/modules/metrics-reference/pages/ns-server-metrics.adoc
@@ -6,6 +6,8 @@
 
 The following Cluster Manager metrics can be queried by means of the REST APIs described in xref:rest-api:rest-statistics.adoc[Statistics].
 
+include::partial$histogram-sidebar.adoc[]
+
 [template,attachment$cm_metrics_metadata.json]
 --
 include::partial$metrics.hbs[]

--- a/modules/metrics-reference/partials/histogram-sidebar.adoc
+++ b/modules/metrics-reference/partials/histogram-sidebar.adoc
@@ -1,0 +1,12 @@
+[sidebar]
+.Histograms
+****
+Note that each histogram metric will generate three time series,
+with the following suffixes:
+
+* `_count`
+* `_sum`
+* `_bucket`
+
+Please refer to https://prometheus.io/docs/practices/histograms/[Prometheus Histograms and Summaries] for more information.
+****


### PR DESCRIPTION
### Summary

This pull request updates `kv_metrics_metadata.json` and related documentation to:  
- Consolidate and expand histogram metric definitions for improved clarity.  
- Add Prometheus histogram references for better metric integration.  

Preview URL:
https://preview.docs-test.couchbase.com/docs-server-DOC-12884-Feedback-on-Data-Service-Metrics--Couchbase-Docs

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.
### Related Issues

N/A