### PR TITLE
DOC-12720 change URL to constant in eventing-Terminologies.adoc

### DIFF
--- a/modules/eventing/pages/eventing-Terminologies.adoc
+++ b/modules/eventing/pages/eventing-Terminologies.adoc
@@ -1,4 +1,4 @@
-Terminology
+= Terminology
 :description: While using Eventing Service, the following terminologies are used.
 :page-edition: Enterprise Edition
 

--- a/modules/eventing/pages/eventing-Terminologies.adoc
+++ b/modules/eventing/pages/eventing-Terminologies.adoc
@@ -1,4 +1,4 @@
-f= Terminology
+Terminology
 :description: While using Eventing Service, the following terminologies are used.
 :page-edition: Enterprise Edition
 

--- a/modules/eventing/pages/eventing-Terminologies.adoc
+++ b/modules/eventing/pages/eventing-Terminologies.adoc
@@ -1,4 +1,4 @@
-= Terminology
+f= Terminology
 :description: While using Eventing Service, the following terminologies are used.
 :page-edition: Enterprise Edition
 
@@ -212,7 +212,7 @@ You can add URL bindings via the 'URL alias' choice then entering the following:
 
 These bindings are utilized by the Eventing Function's JavaScript code as global variables.
 
-You can add URL bindings via the 'Constant alias' choice then entering an alias-name and value. The value can be either an integer, decimal number, string, boolean, or a JSON object.  For example you might have an alias of _debug_ with a value of _true_ (or _false_) to control verbose logging this would act just like adding a statement `const debug = true;` at the beginning of your JavaScript code (_although the Eventing syntax wouldn't allow this global to be added to the actual JavaScript_).
+You can add constant bindings via the 'Constant alias' choice then entering an alias-name and value. The value can be either an integer, decimal number, string, boolean, or a JSON object.  For example you might have an alias of _debug_ with a value of _true_ (or _false_) to control verbose logging this would act just like adding a statement `const debug = true;` at the beginning of your JavaScript code (_although the Eventing syntax wouldn't allow this global to be added to the actual JavaScript_).
 
 == Operations
 

--- a/preview/HEAD.yml
+++ b/preview/HEAD.yml
@@ -1,0 +1,3 @@
+sources:
+  docs-devex:
+    branches: release/7.2


### PR DESCRIPTION
DOC-12720 Changed the instance of URL to constant in eventing-Terminologies page.

You can find the required credentials in the Preview docs for Internal Couchbase Reviews section in the following page:
https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords