### PR TITLE
DOC-11409_Edit preserve_expiration parameter to preserve_expiry_for_release_7.1

### DIFF
--- a/modules/n1ql/pages/n1ql-language-reference/merge.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/merge.adoc
@@ -5,7 +5,7 @@
 
 :authorization-overview: xref:learn:security/authorization-overview.adoc
 :bucket-expiration: xref:learn:data/expiration.adoc
-:preserve_expiration: xref:settings:query-settings.adoc#preserve_expiration
+:preserve_expiry: xref:settings:query-settings.adoc#preserve_expiry
 :logical-hierarchy: xref:n1ql-intro/sysinfo.adoc#logical-hierarchy
 :selectclause: xref:n1ql-language-reference/selectclause.adoc
 :subqueries: xref:n1ql-language-reference/subqueries.adoc
@@ -744,7 +744,7 @@ If the airport does not exist in the `airport` keyspace, a new record is created
 include::example$dml/ansi-merge-expire.n1ql[]
 ----
 
-Note that in Couchbase Server 7.1 and later, it is possible to preserve the document expiration using the request-level {preserve_expiration}[preserve_expiration] parameter.
+Note that in Couchbase Server 7.1 and later, it is possible to preserve the document expiration using the request-level {preserve_expiry}[preserve_expiry] parameter.
 ====
 
 .Lookup merge with expression source

--- a/modules/n1ql/pages/n1ql-language-reference/update.adoc
+++ b/modules/n1ql/pages/n1ql-language-reference/update.adoc
@@ -10,7 +10,7 @@
 :meta: xref:n1ql-language-reference/metafun.adoc#meta
 :returning-clause: xref:n1ql-language-reference/insert.adoc#returning-clause
 :use-keys-clause: xref:n1ql-language-reference/hints.adoc#use-keys-clause
-:preserve_expiration: xref:settings:query-settings.adoc#preserve_expiration
+:preserve_expiry: xref:settings:query-settings.adoc#preserve_expiry
 
 :from: xref:n1ql-language-reference/from.adoc
 :from-keyspace-ref: {from}#from-keyspace-ref
@@ -171,7 +171,7 @@ expiration::
 An integer, or an expression resolving to an integer, representing the {document-expiration}[document expiration] in seconds.
 
 [NOTE]
-If the document expiration is not specified, the document expiration is set according to the request-level {preserve_expiration}[preserve_expiration] parameter.
+If the document expiration is not specified, the document expiration is set according to the request-level {preserve_expiry}[preserve_expiry] parameter.
 If this is `true`, the existing document expiration is preserved; if `false`, the document expiration defaults to `0`, meaning the document expiration is the same as the {bucket-expiration}[bucket expiration].
 
 [[unset-clause]]
@@ -195,7 +195,7 @@ update-for:: <<update-for>> icon:caret-down[]
 [NOTE]
 You cannot use the UNSET clause to unset the document expiration.
 To unset the document expiration, set the document expiration to `0`.
-Alternatively, if the request-level {preserve_expiration}[preserve_expiration] parameter is set to `false`, simply update the document without specifying the document expiration.
+Alternatively, if the request-level {preserve_expiry}[preserve_expiry] parameter is set to `false`, simply update the document without specifying the document expiration.
 
 [[update-for]]
 === FOR Clause
@@ -378,7 +378,7 @@ include::example$dml/update-set-expire.n1ql[]
 include::example$dml/update-preserve-expire.n1ql[]
 ----
 
-Note that in Couchbase Server 7.1 and later, it is possible to preserve the document expiration using the request-level {preserve_expiration}[preserve_expiration] parameter.
+Note that in Couchbase Server 7.1 and later, it is possible to preserve the document expiration using the request-level {preserve_expiry}[preserve_expiry] parameter.
 ====
 
 [[example-9]]
@@ -393,7 +393,7 @@ Set the document expiration to 0 to unset the document expiration.
 include::example$dml/update-unset-expire.n1ql[]
 ----
 
-Alternatively, if the request-level {preserve_expiration}[preserve_expiration] parameter is set to `false`, and you update the document without specifying the document expiration, the document expiration defaults to 0.
+Alternatively, if the request-level {preserve_expiry}[preserve_expiry] parameter is set to `false`, and you update the document without specifying the document expiration, the document expiration defaults to 0.
 
 .Query
 [source,n1ql]


### PR DESCRIPTION
JIRA: [[DOC-11409](https://jira.issues.couchbase.com/browse/DOC-11409)]
Changed the reference parameter from "preserve_expiration" to "preserve_expiry" in the Release 7.1 documents.

Docs Preview: [Docs Preview](https://preview.docs-test.couchbase.com/docs-server-DOC-11409_edit_parameter_reference_for_7.1)

You can find the required credentials in the Preview docs for Internal Couchbase Reviews section in the following page:
https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords

[DOC-11409]: https://couchbasecloud.atlassian.net/browse/DOC-11409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ