### PR TITLE
[DOC-13374]: Noted SLES 12.x deprecation in Couchbase Server 7.2

### DIFF
--- a/modules/install/pages/install-platforms.adoc
+++ b/modules/install/pages/install-platforms.adoc
@@ -49,7 +49,7 @@ ARM64 support requires ARMv8 CPUs, such as the Amazon Graviton series.
 | 9.x
 
 | SUSE Linux Enterprise Server (SLES)
-| 12.x
+| 12.x (deprecated in Couchbase Server{nbsp}7.2)
 
 15.x
 

--- a/modules/release-notes/partials/docs-server-7.2.0-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.2.0-release-note.adoc
@@ -20,6 +20,8 @@ include::introduction:partial$new-features-72.adoc[]
 
 ** Oracle Linux 7
 
+** SUSE Linux Enterprise Server Version 12
+
 ** Ubuntu 18 LTS
 
 * MacOS 11 Big Sur is deprecated.

--- a/modules/release-notes/partials/docs-server-7.2.0-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.2.0-release-note.adoc
@@ -20,9 +20,9 @@ include::introduction:partial$new-features-72.adoc[]
 
 ** Oracle Linux 7
 
-** SUSE Linux Enterprise Server Version 12
-
 ** Ubuntu 18 LTS
+
+* SUSE Linux Enterprise Server Version 12 is deprecated.
 
 * MacOS 11 Big Sur is deprecated.
 

--- a/modules/release-notes/partials/docs-server-7.2.7-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.2.7-release-note.adoc
@@ -1,10 +1,21 @@
 [#release-727]
 == Release 7.2.7 (March 2025)
 
-Couchbase Server 7.2.7 was released in March 2025.
-This maintenance release contains the following fixes.
+[#deprecated-features-and-platforms-720]
+=== Deprecated and Removed Features and Platforms
+
+* The following operating systems are no longer supported:
+
+** SUSE Linux Enterprise Server Version 12
+
++
+See xref:install:install-platforms.adoc[Supported Platforms] for the complete list of supported platforms.
+
 
 === Fixed Issues
+
+Couchbase Server 7.2.7 was released in March 2025.
+This maintenance release contains the following fixes.
 
 ==== Storage Engine
 [#table-fixed-issues-727-storage-engine, cols="10,40,40"]

--- a/modules/release-notes/partials/docs-server-7.2.7-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.2.7-release-note.adoc
@@ -1,17 +1,6 @@
 [#release-727]
 == Release 7.2.7 (March 2025)
 
-[#deprecated-features-and-platforms-720]
-=== Deprecated and Removed Features and Platforms
-
-* The following operating systems are no longer supported:
-
-** SUSE Linux Enterprise Server Version 12
-
-+
-See xref:install:install-platforms.adoc[Supported Platforms] for the complete list of supported platforms.
-
-
 === Fixed Issues
 
 Couchbase Server 7.2.7 was released in March 2025.


### PR DESCRIPTION

Added note explaining that support for SLES 12.x has been deprecated