### PR TITLE
DOC-13425-Update-the-tools-download-link-for-7.6.7

### DIFF
--- a/modules/cli/pages/cli-intro.adoc
+++ b/modules/cli/pages/cli-intro.adoc
@@ -1,6 +1,6 @@
 = CLI Reference
 :description: The command-line interface (CLI) tools let you manage and monitor your Couchbase Server installation including clusters, servers, vBuckets, and XDCR.
-:tools-ver: 7.6.6
+:tools-ver: 7.6.7
 
 [abstract]
 {description}

--- a/preview/HEAD.yml
+++ b/preview/HEAD.yml
@@ -3,4 +3,7 @@ sources:
     branches: release/7.6
   cb-swagger:
     branches: release/7.6
+  docs-capella:
+    branches: DOC-13425-Update-the-tools-download-link-for-7.6.7
+    
 


### PR DESCRIPTION

Updated examples and links

----

Preview URL:
https://preview.docs-test.couchbase.com/docs-server-DOC-13425-Update-the-tools-download-link-for-7.6.7/server/current/cli/cli-intro.html

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.