### PR TITLE
DOC-13427 Update Eventing Note in XDCR Active-Active SGW doc

### DIFF
--- a/modules/learn/pages/clusters-and-availability/xdcr-active-active-sgw.adoc
+++ b/modules/learn/pages/clusters-and-availability/xdcr-active-active-sgw.adoc
@@ -22,9 +22,10 @@ This is due to an internal limitation of managing extended attributes in a docum
 If you try to use the feature _XDCR Active-Active with Sync Gateway_ when you have more than 10 user xattrs in your document, the XDCR replication **silently skips** replicating that document.
 As a result, the data in the replication-skipped document will not be consistent between the target and source clusters.
 The only way you will know this skip occured is because the Prometheus stat `subdoc_cmd_docs_skipped` will be incremented and the document will _not_ be consistent between the target and source.
-* Eventing Service cannot be used with Sync Gateway in bi-directional XDCR.
-If used with the _Sync Gateway in a bi-directional, active-active XDCR_ environment, the updates of Eventing Service metadata in the source and the target clusters causes XDCR to ping-pong and never stop replicating.
-One-way replication is possible.
+
+* If you use Eventing Service functions that update documents in XDCR-replicated buckets (Eventing source bucket mutations), ensure your functions do not cause continuous replication loops.
+In active-active XDCR environments, Eventing functions that trigger document updates can lead to "ping-pong" replication unless you implement logic to prevent infinite loops.
+Always add safeguards to avoid redundant updates and unwanted replication behavior in bi-directional setups. For more information, see xref:sync-gateway:xdcr-active-active-eventing.adoc[XDCR Active-Active and Eventing].
 ====
 
 You can configure XDCR Active-Active with Sync Gateway for XDCR-Mobile interoperability using one of the following methods:

--- a/modules/learn/pages/clusters-and-availability/xdcr-active-active-sgw.adoc
+++ b/modules/learn/pages/clusters-and-availability/xdcr-active-active-sgw.adoc
@@ -23,8 +23,8 @@ If you try to use the feature _XDCR Active-Active with Sync Gateway_ when you ha
 As a result, the data in the replication-skipped document will not be consistent between the target and source clusters.
 The only way you will know this skip occured is because the Prometheus stat `subdoc_cmd_docs_skipped` will be incremented and the document will _not_ be consistent between the target and source.
 
-* If you use Eventing Service functions that update documents in XDCR-replicated buckets (Eventing source bucket mutations), ensure your functions do not cause continuous replication loops.
-In active-active XDCR environments, Eventing functions that trigger document updates can lead to "ping-pong" replication unless you implement logic to prevent infinite loops.
+* If you use Eventing service functions that update documents in XDCR-replicated buckets (Eventing source bucket mutations), ensure your functions do not cause continuous replication loops.
+In bi-directional active-active XDCR environments, Eventing functions that trigger document updates can lead to "ping-pong" replication unless you implement logic to prevent infinite loops.
 Always add safeguards to avoid redundant updates and unwanted replication behavior in bi-directional setups. For more information, see xref:sync-gateway:xdcr-active-active-eventing.adoc[XDCR Active-Active and Eventing].
 ====
 


### PR DESCRIPTION
DOC-13427

Login [credentials here](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords).

Preview document:
- [XDCR Active-Active with Sync Gateway](https://preview.docs-test.couchbase.com/DOC-13427/server/current/learn/clusters-and-availability/xdcr-active-active-sgw.html)