### PR TITLE
Updated table reference ID for Query Service known issues in 7.6.6 release notes.

### DIFF
--- a/modules/release-notes/partials/docs-server-7.6.6-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6.6-release-note.adoc
@@ -156,7 +156,7 @@ resulting in ingestion errors.
 
 === Query Service
 
-[#table-known-issues-765-query-service,cols="10,40,40"]
+[#table-known-issues-766-query-service,cols="10,40,40"]
 |===
 |Issue | Description | Workaround
 


### PR DESCRIPTION

A quick fix for an error being flagged on a duplicate ID name.
