### PR TITLE
[DOC-13460]: Clarify deprecated support for Advanced Vector Extensions 2 in the 7.6.3 release note.

### DIFF
--- a/modules/install/pages/pre-install.adoc
+++ b/modules/install/pages/pre-install.adoc
@@ -115,7 +115,11 @@ Network file systems such as CIFS and NFS are not supported.
 [IMPORTANT]
 .Backup Nodes
 =====
-If the node is used for administering backups, then be aware that the resource requirements will be higher:
+If the node is used for administering backups, then be aware that the resource requirements will be higher.
+
+The minimum hardware requirement is four CPU cores and 8GiB RAM. 
+
+The recommended hardware is sixteen CPU cores, 16GiB RAM, and SSD disks.
 =====
 
 

--- a/modules/install/pages/pre-install.adoc
+++ b/modules/install/pages/pre-install.adoc
@@ -6,7 +6,7 @@
 
 == CPU Requirements
 
-Couchbase Server can run on x86 and ARM processors, (including Apple Silicon processors). 
+Couchbase Server can run on x86 and ARM processors (including Apple Silicon processors). 
 This section explains the minimum requirements for of these platforms.
 
 [#x86-processors]

--- a/modules/install/pages/pre-install.adoc
+++ b/modules/install/pages/pre-install.adoc
@@ -4,12 +4,13 @@
 [abstract]
 {description}
 
-## CPU Requirements
+== CPU Requirements
 
-Couchbase Server can run on x86 and ARM processors (including Apple Silicon processors). 
+Couchbase Server can run on x86 and ARM processors, (including Apple Silicon processors). 
 This section explains the minimum requirements for of these platforms.
 
-### x86 Processors
+[#x86-processors]
+=== x86 Processors
 
 
 [#avx2-requirements]
@@ -18,7 +19,7 @@ This section explains the minimum requirements for of these platforms.
 ====
 The use of older x86 processors that do not implement the https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#AVX2[Advanced Vector Extensions 2 (AVX2)] instruction set are deprecated in Couchbase Server 7.6.x.
 Future versions will require processors that have AVX2 support.
-This requirements is only for x86 processors--ARM processors have a separate set of vector instructions.
+This requirement is only for x86 processors--ARM processors have a separate set of vector instructions.
 
 The earliest processors that support AVX2 instructions include:
 
@@ -83,7 +84,7 @@ The recommended hardware is sixteen CPU cores, 16GiB RAM, and SSD disks.
 
 |===
 
-### ARM Processors
+=== ARM Processors
 
 Couchbase Server has the following requirements when running on ARM-based platforms.
 
@@ -146,13 +147,13 @@ However, you must adhere to the Minimum Specifications for production._
 You should follow the xref:sizing-general.adoc[sizing guidelines] when determining system specifications for your Couchbase Server deployment.
 
 [#clock-source-linux]
-## Clock Source on Linux 
+== Clock Source on Linux 
 
 The Query Service relies on the Linux operating system's monotonic clock when profiling and managing network timeouts. 
 
 The Linux kernel uses a clock source to track elapsed time, handle scheduling and timers, and to get the current time. 
 It can use one of several possible sources, such as Time Stamp Counter (TSC), the XEN build into the Xen virtualization framework, and others.
-See https://docs.kernel.org/timers/timekeeping.html[Clock sources, Clock events, sched_clock() and delay timers^] for more information about clock sources.
+See https://docs.kernel.org/timers/timekeeping.html[Clock sources, Clock events, `sched_clock()` and delay timers^] for more information about clock sources.
 Which source the kernel uses depends on the hardware clock capabilities and Linux configuration settings. 
 
 Some virtualization environments, such as older AWS EC2 clusters, use the XEN clock source.

--- a/modules/install/pages/pre-install.adoc
+++ b/modules/install/pages/pre-install.adoc
@@ -118,23 +118,7 @@ Network file systems such as CIFS and NFS are not supported.
 If the node is used for administering backups, then be aware that the resource requirements will be higher:
 =====
 
-| *CPU*
-| 2 GHz quad-core x86_64 CPU supporting SSE4.2
-| 3 GHz sixteen-core x86_64 CPU supporting SSE4.2 and above
 
-| *RAM*
-| 8 GiB (physical)
-| 16 GiB (physical) and above
-
-| *Storage (disk space)*
-a|
-8 GiB (block-based; HDD, SSD, EBS, iSCSI)
-
-Network file systems such as CIFS and NFS are not supported.
-a|
-16 GiB and above (SSD)
-
-Network file systems such as CIFS and NFS are not supported.
 |===
 
 [#note1]

--- a/modules/release-notes/partials/docs-server-7.6.3-release-note.adoc
+++ b/modules/release-notes/partials/docs-server-7.6.3-release-note.adoc
@@ -8,8 +8,9 @@ For detailed information on new features and enhancements, please see xref:intro
 === Deprecated Platforms
 
 The use of x86 processors that do not support Advanced Vector Extensions 2 (AVX2) is deprecated in version 7.6.3.
-Future versions of Vector Search will rely on these instructions to improve performance.
 These instructions are available in most Intel processors produced since 2013 and AMD processors produced since 2015.
+See xref:install:pre-install.adoc#x86-processors[System Requirements] for details.
+
 
 [#fixed-issues-763]
 === Fixed Issues


### PR DESCRIPTION

Clarified the deprecation note.
Tidied up the grammar.

----

Preview URL:
https://preview.docs-test.couchbase.com/docs-server-DOC-13460-Clarify-deprecated-support-for-Advanced-Vector-Extensions-2-in-7.6.3-release-note/server/current/release-notes/relnotes.html#release-7-6-3-september-2024

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.