### PR TITLE
DOC-13411 update supported platforms

### DIFF
--- a/modules/install/pages/install-platforms.adoc
+++ b/modules/install/pages/install-platforms.adoc
@@ -10,11 +10,11 @@
 
 Choose an operating system from the following list for your Couchbase Server deployment.
 
-NOTE: Couchbase clusters on mixed platforms are not supported.
-Nodes in a Couchbase cluster should all be running on the same OS.
-Be sure to apply the same OS updates to all nodes the cluster.
+NOTE: Couchbase clusters do not support mixed platforms.
+Nodes in a Couchbase cluster must all run on the same OS and the same version.
+When updating the OS, apply the updates to all nodes the cluster.
 
-ARM64 support requires ARMv8 CPUs, such as the Amazon Graviton series.
+For hardware requirements, see xref:install:pre-install.adoc[].
 
 .Supported Operating Systems for Development, Testing, and Production
 [cols="100,135",options="header"]
@@ -22,43 +22,42 @@ ARM64 support requires ARMv8 CPUs, such as the Amazon Graviton series.
 | Operating System | Supported Versions (64-bit)
 
 | Alma Linux
-a|* 9.x
-| Amazon Linux 2
-a|* LTS (x86-64, ARM64) (deprecated in Couchbase Server 7.6)
+a| * 10.x
+* 9.x
 
 | Amazon Linux 2023
 a|* AL2023 (x86-64, ARM64)
 
 | Debian
-a| * 12.x
+a| * 13.x
+* 12.x
 * 11.x
 
 | Oracle Linux{empty}footnote:[Only the Red Hat Compatible Kernel (RHCK) is supported.
 The Unbreakable Enterprise Kernel (UEK) is not supported.]
-a|* 9.x
+a| * 10.x
+* 9.x
 * 8.x
 
 | Red Hat Enterprise Linux (RHEL)
-a|* 9.x
+a| * 10.x
+* 9.x
 * 8.x
 
 | Rocky Linux
-a|* 9.x
+a| * 10.x
+* 9.x
 
 | SUSE Linux Enterprise Server (SLES)
 a|* 15.x 
-* 12.x (Deprecated in Couchbase Server{nbsp}7.6)
-
-NOTE: Versions earlier than 12 SP2 are no longer supported in Couchbase Server 7.2 and later.
 
 | Ubuntu
 a|* 24.04 LTS (x86, ARM64)
 * 22.x LTS (x86, ARM64)
-* 20.04 LTS (x86, ARM64) (deprecated in Couchbase Server 7.6)
 
 | Windows Server
-a|* 2022
-* 2019 (deprecated in Couchbase Server 7.6)
+a| * 2025
+* 2022
 
 |===
 
@@ -68,13 +67,12 @@ a|* 2022
 | Operating System | Supported Versions (64-bit)
 
 | macOS
-a|* 14 "Sonoma"
+a| * 15 "Sequoia"
+* 14 "Sonoma"
 * 13 "Ventura"
-* 12 "Monterey" (x86-64 and Apple Silicon ARM64) deprecated in Couchbase Server 7.6.0
 
 | Windows Desktop
 a|* 11
-* 10 (requires Anniversary Update) Deprecated in 7.6.4
 |===
 
 == Supported Virtualization and Container Platforms

--- a/modules/install/pages/install-platforms.adoc
+++ b/modules/install/pages/install-platforms.adoc
@@ -53,7 +53,7 @@ a|* 15.x
 
 | Ubuntu
 a|* 24.04 LTS (x86, ARM64)
-* 22.x LTS (x86, ARM64)
+* 22.04 LTS (x86, ARM64)
 
 | Windows Server
 a| * 2025

--- a/modules/introduction/partials/new-features-80.adoc
+++ b/modules/introduction/partials/new-features-80.adoc
@@ -1,3 +1,27 @@
+[#section-new-feature-800-platform-support]
+=== Platform Support
+
+Couchbase Server 8.0 adds support for the following operating systems:
+
+* Alma Linux 10
+* Debian Linux 13
+* macOS 15 "Sequoia" (for development and testing only)
+* Oracle Linux 10
+* RHEL 10
+* Rocky Linux 10
+* Windows Server 2025
+
+Couchbase Server 8.0 no longer supports the following operating systems:
+
+* Amazon Linux 2
+* macOS 12 "Monterey"
+* SUSE Linux Enterprise Server (SLES) 12
+* Ubuntu 20.04 LTS
+* Windows 10
+* Windows Server 2019
+
+For more information about supported operating systems, see xref:install:install-platforms.adoc[].
+
 [#section-new-feature-800-couchbase-cluster]
 === Couchbase Cluster
 


### PR DESCRIPTION
This PR updates the supported OS list for Morpheus.

Preview URL:
https://preview.docs-test.couchbase.com/docs-server-DOC-13411_update_supported_platforms

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.

Summary of changes:

- Added [What's New ](https://preview.docs-test.couchbase.com/docs-server-DOC-13411_update_supported_platforms/server/current/introduction/whats-new.html#section-new-feature-800-platform-support)entry.
- Updated [Support Operating Systems](https://preview.docs-test.couchbase.com/docs-server-DOC-13411_update_supported_platforms/server/current/install/install-platforms.html#oses).