### PR TITLE
DOC-12946 Initialize cluster

### DIFF
--- a/modules/rest-api/pages/rest-initialize-cluster.adoc
+++ b/modules/rest-api/pages/rest-initialize-cluster.adoc
@@ -54,7 +54,7 @@ curl -X POST http://<ip-address-or-domain-name>:8091/clusterInit
   -d afamily=[ 'ipv4' | 'ipv6' ]
   -d afamilyOnly=[ true | false ]
   -d nodeEncryption=[ 'on' | 'off' ]
-  -d indexerStorageMode=[ 'plasma' | 'magma' ]
+  -d indexerStorageMode=[ 'plasma' | 'magma' | 'forestdb' ]
   -d port='SAME'
   -d allowedHosts=<list-of-naming-conventions>
 ----


### PR DESCRIPTION
DOC-12946 Initialize cluster: indexerStorageMode=forestdb option is missing in the example