### PR TITLE
Fixing broken What's New page and misc.

### DIFF
--- a/modules/introduction/partials/new-features-80.adoc
+++ b/modules/introduction/partials/new-features-80.adoc
@@ -175,6 +175,13 @@ For more information, see xref:rest-api:rest-xdcr-adv-settings.adoc[XDCR Advance
 
 [#section-new-features-800-security-authentication]
 === Security and Authentication
+
+https://jira.issues.couchbase.com/browse/MB-16143[MB-16143]::
+Couchbase Server Enterprise now supports native encryption at rest.
+You can encrypt bucket data, audits, and most logging and configuration information.
+You choose which buckets to encrypt and which remain unencrypted.
+See xref:learn:security/native-encryption-at-rest-overview.adoc[] for more information.
+
 https://jira.issues.couchbase.com/browse/MB-50939[MB-50939]::
 Added support for the Hybrid authentication mode in the certificate-based client authentication.
 When Hybrid is selected:
@@ -188,7 +195,7 @@ When Hybrid is selected:
 This mode enhances flexibility for clients while enforcing strict security for node-to-node communication.
 +
 For more information, see xref:manage:manage-security/enable-client-certificate-handling.adoc[Enable Client Certificate Handling].
-=======
+
 
 https://jira.issues.couchbase.com/browse/MB-11575[MB-11575]::
 XDCR now supports the identification of Incoming Replications on a cluster.
@@ -311,10 +318,6 @@ It is now possible to change the plan used by a repository.
 The repository first needs to be paused, and then the plan can be changed,
 and the repository resumed, where it will now execute the tasks from its new plan.
 
-=== Security
 
-https://jira.issues.couchbase.com/browse/MB-16143[MB-16143]::
-Couchbase Server Enterprise now supports native encryption at rest.
-You can encrypt bucket data, audits, and most logging and configuration information.
-You choose which buckets to encrypt and which remain unencrypted.
-See xref:learn:security/native-encryption-at-rest-overview.adoc[] for more information.
+
+

--- a/modules/learn/pages/security/native-encryption-at-rest-overview.adoc
+++ b/modules/learn/pages/security/native-encryption-at-rest-overview.adoc
@@ -1,4 +1,4 @@
-= Native Encryption at Rest Overview
+= Native Encryption at Rest
 :description: Couchbase Server can encrypt data, configuration, logs, and audit information it saves to disk. This encryption can help reduce the chances of or severity of data breaches.
 :page-toclevels: 2
 :page-edition: Enterprise Edition


### PR DESCRIPTION
* Fixed broken What's New page.
* Moved the Native Encryption at Rest entry under Security and Authentication.
* Also removed "Overview" from the Native Encryption at Rest title.