### PR TITLE
[DOC-13180] Update the Roles page in the Server docs to include query_use_sequences and query_manage_sequence

### DIFF
--- a/modules/learn/pages/security/roles.adoc
+++ b/modules/learn/pages/security/roles.adoc
@@ -2014,12 +2014,6 @@ It does allow access to Couchbase Server Web Console.
 ^| image:introduction/no.png[]
 ^| image:introduction/no.png[]
 ^| image:introduction/no.png[]
-
-^| App Telemetry
-^| image:introduction/no.png[]
-^| image:introduction/yes.png[]
-^| image:introduction/no.png[]
-^| image:introduction/no.png[]
 |===
 
 [#query-manage-sequences]

--- a/modules/learn/pages/security/roles.adoc
+++ b/modules/learn/pages/security/roles.adoc
@@ -1971,6 +1971,103 @@ Administrators' queries automatically have permission to perform sequential scan
 ^| image:introduction/no.png[]
 |===
 
+[#query-use-sequences]
+== Use Sequences
+
+The *Use Sequences* role allows users to use sequences within a specific scope. 
+Users with this role can execute {sqlpp} NEXTVAL and PREVVAL functions.
+This role does not allow creating or managing sequences.
+It does allow access to Couchbase Server Web Console.
+
+[#table_query_delete_role,cols="15,8,8,8,8",hrows=3]
+|===
+5+^| Role: Use Sequences (`query_use_sequences`)
+
+.2+^h| Resources
+4+^h| Privileges
+
+^h| *Read*
+^h| *Write*
+^h| *Execute*
+^h| *Manage*
+
+^| Bucket, Scope: {sqlpp}, Sequences
+^| image:introduction/no.png[]
+^| image:introduction/no.png[]
+^| image:introduction/yes.png[]
+^| image:introduction/no.png[]
+
+^| Bucket, Scope: Collections
+^| image:introduction/yes.png[]
+^| image:introduction/no.png[]
+^| image:introduction/no.png[]
+^| image:introduction/no.png[]
+
+^| UI
+^| image:introduction/yes.png[]
+^| image:introduction/no.png[]
+^| image:introduction/no.png[]
+^| image:introduction/no.png[]
+
+^| Pools
+^| image:introduction/yes.png[]
+^| image:introduction/no.png[]
+^| image:introduction/no.png[]
+^| image:introduction/no.png[]
+
+^| App Telemetry
+^| image:introduction/no.png[]
+^| image:introduction/yes.png[]
+^| image:introduction/no.png[]
+^| image:introduction/no.png[]
+|===
+
+[#query-manage-sequences]
+== Manage Sequences
+
+The *Manage Sequences* role allows users to manage sequences for a given scope.
+Manage these sequences with CREATE, ALTER, and DROP statements. 
+This role does not allow executing sequences.
+It does allow access to Couchbase Server Web Console.
+
+[#table_scope_admin_role,cols="15,8,8,8,8",hrows=3]
+|===
+5+^| Role: Manage Sequences (`query_manage_sequences`)
+
+.2+^h| Resources
+4+^h| Privileges
+
+^h| *Read*
+^h| *Write*
+^h| *Execute*
+^h| *Manage*
+
+^| Bucket, Scope: {sqlpp}, Sequences
+^| image:introduction/no.png[]
+^| image:introduction/no.png[]
+^| image:introduction/no.png[]
+^| image:introduction/yes.png[]
+
+^| Bucket, Scope: Collections
+^| image:introduction/yes.png[]
+^| image:introduction/no.png[]
+^| image:introduction/no.png[]
+^| image:introduction/no.png[]
+
+^| UI
+^| image:introduction/yes.png[]
+^| image:introduction/no.png[]
+^| image:introduction/no.png[]
+^| image:introduction/no.png[]
+
+^| Pools
+^| image:introduction/yes.png[]
+^| image:introduction/no.png[]
+^| image:introduction/no.png[]
+^| image:introduction/no.png[]
+|===
+
+
 [#query-manage-index]
 == Query Manage Index
 


### PR DESCRIPTION
Update this [page](https://docs.couchbase.com/cloud/clusters/manage-database-users.html#about-database-user-permissions) to include role mappings query_use_sequences and query_manage_sequence for Server. As per AV-60009: [AUTH] CB 7.6, query_manage_sequences and query_use_sequences roles
Released
  this got introduced in 7.6 for Capella.

Currently, the Capella Roles page is updated with the role mapping but was not able to include links to the Server roles page as they were not included yet. 

This ticket is for Server to add roles:

Query Manage Sequences

Query Use Sequences

Working with the resources and role privileges shown in the commit here: [MB-58036 Add query sequences roles. · couchbase/ns_server@fbedde2](https://github.com/couchbase/ns_server/commit/fbedde2600d179038140710e0422ba4a6b075800) 

Also found in the menalaus_roles.erl file: [ns_server/apps/ns_server/src/menelaus_roles.erl at master · couchbase/ns_server](https://github.com/couchbase/ns_server/blob/master/apps/ns_server/src/menelaus_roles.erl)

Images of local build: 
<img width="967" height="567" alt="Screenshot 2025-09-09 at 5 17 11 PM" src="https://github.com/user-attachments/assets/03d1f4a2-3ed9-490f-b79a-79f70cbb7117" />


<img width="862" height="579" alt="Screenshot 2025-09-09 at 4 13 15 PM" src="https://github.com/user-attachments/assets/d1b741a6-29ac-4e14-9e2e-e01323a51a07" />
