### PR TITLE
Doc 12890 remove cent os from server docs

### DIFF
--- a/modules/cli/pages/cbepctl-intro.adoc
+++ b/modules/cli/pages/cbepctl-intro.adoc
@@ -13,8 +13,8 @@ That means that the IP address of a node in the cluster and a named bucket must 
 If a named bucket is not provided, the server applies the setting to any default bucket that exists at the specified node.
 To perform this operation for an entire cluster, perform the command for every node/bucket combination that exists for that cluster.
 
-For example, when a bucket is shared by two nodes, issue this command twice and provide the different host names and ports for each node along with the bucket name.
-Similarly, when two data buckets are on the same node, issue the command twice for each bucket.
+For example, issue this command twice and provide different hostname and port for each node along with the bucket name, when a bucket is shared by 2 nodes.
+Similarly, when 2 data buckets are on the same node, issue the command twice for each bucket.
 If a bucket is not specified, the command applies to the default bucket or returns an error if a default bucket does not exist.
 
 IMPORTANT: Changes to the cluster configuration using `cbepctl` are not persisted over a cluster restart.

--- a/modules/cli/pages/cbft-bleve-moss.adoc
+++ b/modules/cli/pages/cbft-bleve-moss.adoc
@@ -9,7 +9,7 @@ The top-level syntax for `cbft-bleve` is provided at xref:cli:cbft-bleve.adoc[cb
 All commands except xref:cli:cbft-bleve-scorch.adoc[scorch] and xref:cli:cbft-bleve-zap.adoc[zap] apply to _Moss_ indexes, and are described on this page.
 Examples are for Linux.
 
-Note that the `check`, `count`, `dictionary`, `fields`, `mapping`, `query`, and `registry` command-values can also be used to return information on _Scorch_ index partitions &#8212; other than on _CentOS_ and _Ubuntu_: the syntax and required path-format is in each case identical to that demonstrated for _Moss_ index partitions on this page.
+Note that the `check`, `count`, `dictionary`, `fields`, `mapping`, `query`, and `registry` command-values can also be used to return information on _Scorch_ index partitions &#8212; other than on _Red Hat-based distributions_ and _Ubuntu_: the syntax and required path-format is in each case identical to that demonstrated for _Moss_ index partitions on this page.
 
 [#check]
 == check

--- a/modules/cli/pages/cbft-bleve-scorch.adoc
+++ b/modules/cli/pages/cbft-bleve-scorch.adoc
@@ -18,7 +18,7 @@ Examples are for MacOS.
 
 === Using Top Level Command-Values
 
-The top-level xref:cli:cbft-bleve.adoc#syntax[Syntax] for `cbft-bleve` permits the following to be specified as values for the principal `command`, and to be used alike on _Moss_ index partitions (on all Couchbase-Server supported platforms) and on _Scorch_ index partitions (on all platforms except _CentOS_ and _Ubuntu_): xref:cli:cbft-bleve-moss.adoc#check[check], xref:cli:cbft-bleve-moss.adoc#count[count], xref:cli:cbft-bleve-moss.adoc#dictionary[dictionary], xref:cli:cbft-bleve-moss.adoc#fields[fields], xref:cli:cbft-bleve-moss.adoc#mapping[mapping], xref:cli:cbft-bleve-moss.adoc#query[query], and xref:cli:cbft-bleve-moss.adoc#registry[registry].
+The top-level xref:cli:cbft-bleve.adoc#syntax[Syntax] for `cbft-bleve` permits the following to be specified as values for the principal `command`, and to be used alike on _Moss_ index partitions (on all Couchbase-Server supported platforms) and on _Scorch_ index partitions (on all platforms except _Red Hat-based distributions_ and _Ubuntu_): xref:cli:cbft-bleve-moss.adoc#check[check], xref:cli:cbft-bleve-moss.adoc#count[count], xref:cli:cbft-bleve-moss.adoc#dictionary[dictionary], xref:cli:cbft-bleve-moss.adoc#fields[fields], xref:cli:cbft-bleve-moss.adoc#mapping[mapping], xref:cli:cbft-bleve-moss.adoc#query[query], and xref:cli:cbft-bleve-moss.adoc#registry[registry].
 
 For a description of the syntax entailed by each value, and instances of command-output, see the examples provided for _Moss_ index partitions, in xref:cli:cbft-bleve-moss.adoc[cbft-bleve for Moss Indexes].
 

--- a/modules/cli/pages/cbft-bleve.adoc
+++ b/modules/cli/pages/cbft-bleve.adoc
@@ -21,19 +21,19 @@ The `command` specified as the principal argument to `cbft-bleve` can be any one
 | `check`
 | Checks the contents of a specified index partition.
 Can be used on a _Moss_ index partition.
-Can be used on a _Scorch_ index partition, but only on platforms other than _CentOS_ and _Ubuntu_ Linux.
+Can be used on a _Scorch_ index partition, but only on platforms other than _Red Hat-based distributions_ and _Ubuntu_ Linux.
 Cannot be used on a _Zap_ file.
 
 | `count`
 | Counts the number of documents referenced by a specified index partition.
 Can be used on a _Moss_ index partition.
-Can be used on a _Scorch_ index partition, but only on platforms other than _CentOS_ and _Ubuntu_ Linux.
+Can be used on a _Scorch_ index partition, but only on platforms other than _Red Hat-based distributions_ and _Ubuntu_ Linux.
 Cannot be used on a _Zap_ file.
 
 | `dictionary`
 | Prints to standard output the _term dictionary_ for a specified field in a specified index partition.
 Can be used on a _Moss_ index partition.
-Can be used on a _Scorch_ index partition, but only on platforms other than _CentOS_ and _Ubuntu_ Linux.
+Can be used on a _Scorch_ index partition, but only on platforms other than _Red Hat-based distributions_ and _Ubuntu_ Linux.
 Cannot be used on a _Zap_ file.
 
 | `dump`
@@ -45,25 +45,25 @@ Cannot be used on a _Zap_ file.
 | `fields`
 | Lists the fields in a specified index partition.
 Can be used on a _Moss_ index partition.
-Can be used on a _Scorch_ index partition, but only on platforms other than _CentOS_ and _Ubuntu_ Linux.
+Can be used on a _Scorch_ index partition, but only on platforms other than _Red Hat-based distributions_ and _Ubuntu_ Linux.
 Cannot be used on a _Zap_ file.
 
 | `mapping`
 | Prints to standard output the _mapping_ used for a specified index partition.
 Can be used on a _Moss_ index partition.
-Can also be used on a _Scorch_ index partition, but only on platforms other than _CentOS_ and _Ubuntu_ Linux.
+Can also be used on a _Scorch_ index partition, but only on platforms other than _Red Hat-based distributions_ and _Ubuntu_ Linux.
 Cannot be used on a _Zap_ file.
 
 | `query`
 | Executes a specified query against a specified index partition.
 Can be used on a _Moss_ index partition.
-Can also be used on a _Scorch_ index partition, but only on platforms other than _CentOS_ and _Ubuntu_ Linux.
+Can also be used on a _Scorch_ index partition, but only on platforms other than _Red Hat-based distributions_ and _Ubuntu_ Linux.
 Cannot be used on a _Zap_ file.
 
 | `registry`
 | Prints to standard output the _analyzers_, _tokenizers_ and other components used by a specified index partition.
 Can be used on a _Moss_ index partition.
-Can also be used on a _Scorch_ index partition, but only on platforms other than _CentOS_ and _Ubuntu_ Linux.
+Can also be used on a _Scorch_ index partition, but only on platforms other than _Red Hat-based distributions_ and _Ubuntu_ Linux.
 Cannot be used on a _Zap_ file.
 
 | `scorch`

--- a/modules/install/pages/install-linux.adoc
+++ b/modules/install/pages/install-linux.adoc
@@ -6,11 +6,11 @@
 
 == Supported Linux Platforms
 
-Couchbase Server can be installed and run on Red Hat, CentOS, Ubuntu, Debian, SUSE Enterprise, Oracle Enterprise, and Amazon Linux.
+Couchbase Server can be installed and run on Red Hat-based distributions, Ubuntu, Debian, SUSE Enterprise, Oracle Enterprise, and Amazon Linux.
 
 The following procedures use Couchbase packages, and require the user who performs the install to have _root_ or _sudo_ privileges:
 
-* xref:install:rhel-suse-install-intro.adoc[Install on Red Hat Enterprise and CentOS].
+* xref:install:rhel-suse-install-intro.adoc[Install on Red Hat-based distributions].
 
 * xref:install:ubuntu-debian-install.adoc[Install on Ubuntu and Debian].
 
@@ -20,7 +20,7 @@ The following procedures use Couchbase packages, and require the user who perfor
 
 * xref:install:amazon-linux2-install.adoc[Install on Amazon Linux 2].
 
-Additionally, a _non-package-based_ install can be performed on all the above platforms.
+Additionally, a _non-package-based_ install is performed on all the above platforms.
 Unlike the package-based install, this does _not_ require root or sudo privileges.
 After the non-package-based install, the same user can stop, start, and get status on the server; and can also perform upgrade.
 

--- a/modules/install/pages/install-uninstalling.adoc
+++ b/modules/install/pages/install-uninstalling.adoc
@@ -36,7 +36,7 @@ Refer to xref:startup-shutdown.adoc#start-stop-linux[Start and Stop Couchbase Se
 +
 [{tabs}]
 ====
-RHEL, CentOS, SUSE, Oracle, and Amazon Linux::
+RHEL, Red Hat-based distributions, SUSE, Oracle, and Amazon Linux::
 +
 --
 [source,console]

--- a/modules/install/pages/startup-shutdown.adoc
+++ b/modules/install/pages/startup-shutdown.adoc
@@ -45,7 +45,7 @@ sudo service couchbase-server stop
 //Removed because it likely doesn't apply to any OS configuration that is still supported by Couchbase.
 [NOTE]
 ====
-On CentOS, you may see a failure when trying to run `service couchbase-server start` as a root user:
+On Red Hat-based distributions, you may see a failure when trying to run `service couchbase-server start` as a root user:
 
 [source,console]
 ----

--- a/modules/install/pages/thp-disable.adoc
+++ b/modules/install/pages/thp-disable.adoc
@@ -96,7 +96,7 @@ sudo chmod 755 /etc/init.d/disable-thp
 +
 [tabs] 
 ==== 
-Red Hat, CentOS, & Amazon Linux::
+Red Hat-based distributions & Amazon Linux::
 +
 --
 [source,console]
@@ -126,21 +126,21 @@ sudo insserv /etc/init.d/disable-thp
 
 . Override `tuned` and `ktune`, if necessary.
 +
-If you are using `tuned` or `ktune` (for example, if you are running Red Hat/CentOS 7+) you must also <<tuned-ktune,configure them to preserve the above settings after reboot>>.
+If you are using `tuned` or `ktune` (for example, if you are running Red Hat-based distributions 7+) you must also <<tuned-ktune,configure them to preserve the above settings after reboot>>.
 
 . Reboot the system and <<verify-thp,verify that THP is disabled>>.
 
 [#tuned-ktune]
 === If Using `tuned` and `ktune`
 
-`tuned` and `ktune` are system monitoring and tuning tools available on Red Hat and CentOS.
+`tuned` and `ktune` are system monitoring and tuning tools available on Red Hat-based distributions.
 When they are in use on a system, they can be used to enable and disable THP.
 
 To disable THP in `tuned` and `ktune`, you need to edit or create a new _profile_ that sets THP to `never`.
 
 [tabs] 
 ==== 
-Red Hat/CentOS 7:: 
+Red Hat-based distributions 7:: 
 +
 --
 . Create a new `tuned` directory for the new profile.
@@ -178,7 +178,7 @@ sudo tuned-adm profile no-thp
 ----
 --
 ////
-Red Hat/CentOS 6:: 
+Red Hat-based distributions 6:: 
 +
 --
 . Create a new profile from an existing default profile by copying the relevant directory.
@@ -221,7 +221,7 @@ sudo tuned-adm profile no-thp
 
 You can check the THP status by issuing the following commands.
 
-* Red Hat, CentOS, & Amazon Linux
+* Red Hat-based distributions & Amazon Linux
 +
 [source,console]
 ----

--- a/modules/install/pages/upgrade-cluster-offline.adoc
+++ b/modules/install/pages/upgrade-cluster-offline.adoc
@@ -110,7 +110,7 @@ Proceed as follows, for the appropriate platform:
 +
 [{tabs}]
 ====
-RedHat & Centos::
+RedHat & RedHat derivatives::
 +
 --
 
@@ -170,7 +170,7 @@ If using a downloaded package-archive, enter the command appropriate for the pla
 +
 [{tabs}]
 ====
-RedHat & Centos::
+RedHat & RedHat derivatives::
 +
 --
 [source,bash]
@@ -206,7 +206,7 @@ Proceed as follows for the appropriate platform:
 +
 [{tabs}]
 ====
-RedHat & Centos::
+RedHat & RedHat derivatives::
 +
 --
 Add the `couchbase-server` (or `couchbase-server-community`) package to the `exclude` section of `/etc/yum/yum.conf`.

--- a/modules/install/pages/upgrade-cluster-online-full-capacity.adoc
+++ b/modules/install/pages/upgrade-cluster-online-full-capacity.adoc
@@ -130,7 +130,7 @@ Note that the following examples remove _Enterprise Edition_ of Couchbase Server
 +
 [{tabs}]
 ====
-RedHat & Centos::
+Red Hat-based distributions::
 +
 --
 
@@ -178,7 +178,7 @@ This ensures that no further upgrade can occur to this node until the next time 
 [{tabs}]
 ====
 
-RedHat & Centos::
+Red Hat-based distributions::
 +
 --
 For Couchbase Server Enterprise Edition, ensure that the package-name appears in the list that follows the `exclude` statement, in the file `/etc/yum/yum.conf`.

--- a/modules/install/pages/upgrade-cluster-online-reduced-capacity.adoc
+++ b/modules/install/pages/upgrade-cluster-online-reduced-capacity.adoc
@@ -124,7 +124,7 @@ Note that the following examples remove _Enterprise Edition_ of Couchbase Server
 +
 [{tabs}]
 ====
-RedHat & Centos::
+Red Hat-based distributions::
 +
 --
 
@@ -171,7 +171,7 @@ This ensures that no further upgrade can occur to this node until the next time 
 [{tabs}]
 ====
 
-RedHat & Centos::
+Red Hat-based distributions::
 +
 --
 For Couchbase Server Enterprise Edition, ensure that the package-name appears in the list that follows the `exclude` statement, in the file `/etc/yum/yum.conf`.

--- a/modules/install/pages/upgrade.adoc
+++ b/modules/install/pages/upgrade.adoc
@@ -1,5 +1,5 @@
 = Upgrade
-:description: To upgrade a Couchbase-Server cluster means to upgrade the version of Couchbase Server that is running on every node.
+:description: To upgrade a Couchbase-Server cluster means to upgrade the version of Couchbase Server that's running on every node.
 
 :erlang-upgrade-note: The upgrade to Erlang support in Couchbase Server 8.0 requires that you first upgrade Couchbase to version 7.2 before upgrading to version 8.0
 
@@ -39,8 +39,10 @@ Before upgrading, resolve the mixed-mode networking issue.
 
 === Upgrading from Pre-7.1 Versions of Couchbase Server
 
-You cannot upgrade directly from a version of Couchbase Server earlier than 7.1 to version 7.2.4 or later. 
+You cannot upgrade directly from a version of Couchbase Server earlier than 7.1 to version 7.2.4 or later.
+
 For example, you can directly upgrade from version 6.6 to version 7.2.3.
+
 You cannot directly upgrade from version 6.6 to version 7.2.4. 
 A compatibility issue with the Erlang version used by these earlier server versions prevents a direct upgrade to later versions of the server. 
 To upgrade from server versions 6.5, 6.6, or 7.0 to version 7.6 or later, first upgrade to a version between 7.1 and 7.2.3. 
@@ -49,12 +51,13 @@ Then upgrade to version 7.6 or later.
 [#understanding-upgrade]
 == Understanding Upgrade
 
-To _upgrade_ a Couchbase-Server cluster means to upgrade the version of the server that is running on every node.
+To _upgrade_ a Couchbase-Server cluster means to upgrade the version of the server that's running on every node.
 For example, modifying a cluster where all of its nodes are running Couchbase Server Enterprise Edition Version 6.6,
 so that each of its nodes subsequently runs Couchbase Server Enterprise Edition Version 7.6.x.
 
 An _upgrade procedure_, like an _install_ procedure, involves both preparation routines and specific upgrade commands that are performed on each node.
-To be upgraded, a cluster must have each of its nodes individually upgraded in turn; and the upgrade procedure for the cluster must therefore be selected in regard to whether the cluster is required to continue serving data, or to cease serving data, during the cluster-upgrade.
+To be upgraded, a cluster must have each of its nodes individually upgraded in turn. 
+The upgrade procedure for the cluster must be selected in regard to whether the cluster is required to continue serving data, or to cease serving data, during the cluster-upgrade.
 A review of the factors that determine the appropriateness of an upgrade-procedure is provided in xref:install:upgrade-procedure-selection.adoc[Upgrade Procedure-Selection].
 
 [#supported-upgrade-paths]

--- a/modules/manage/pages/manage-security/configure-pam.adoc
+++ b/modules/manage/pages/manage-security/configure-pam.adoc
@@ -30,7 +30,7 @@ Proceed as follows:
 
 . Bring up a terminal, and install the `saslauthd` library for your Linux distribution:
 
-** *CentOS/RHEL*
+** *Red Hat-based distributions/RHEL*
 +
 [source,bash]
 ----
@@ -67,7 +67,7 @@ usermod -aG sasl couchbase
 
 . In the `saslauthd` configuration file, verify that `saslauthd` is set up to use PAM, by using the `grep` command, and examining the output, using one of the following procedures:
 
-** *CentOS/RHEL*
+** *Red Hat-based distributions/RHEL*
 +
 [source,bash]
 ----
@@ -87,7 +87,7 @@ MECHANISMS="pam"
 +
 If output to the above command does not confirm that `MECHANISMS` is set to `pam`, bring up the configuration file `/etc/default/saslauthd` in an editor, and manually set the `MECHANISMS` parameter to `pam`.
 
-. If you are running Centos 7.x or 8.x, or are running RHEL 8.x, add the following lines to the file `/etc/pam.d/passwd`:
+. If you are running Red Hat-based distributions or are running RHEL 8.x, add the following lines to the file `/etc/pam.d/passwd`:
 +
 ----
 auth       include    system-auth
@@ -172,7 +172,7 @@ The user you created is now logged into Couchbase Server, as an administrator.
 
 If login does not succeed, bring up the file `/etc/default/saslauthd` in an editor, and ensure it contains the line `START=yes`.
 If the line reads `START=no`, change it to `START=yes`.
-Also confirm that the `MECH` (for CentOS/RHEL) or `MECHANISM` (for Ubuntu/Debian) parameter is set to `pam`.
+Also confirm that the `MECH` (for Red Hat-based distributions/RHEL) or `MECHANISM` (for Ubuntu/Debian) parameter is set to `pam`.
 Save the file, and exit.
 Then, restart both `saslauthd` and `couchbase-server`, as described above.
 Finally, re-attempt login.

--- a/modules/manage/pages/manage-security/configure-pam.adoc
+++ b/modules/manage/pages/manage-security/configure-pam.adoc
@@ -87,7 +87,7 @@ MECHANISMS="pam"
 +
 If output to the above command does not confirm that `MECHANISMS` is set to `pam`, bring up the configuration file `/etc/default/saslauthd` in an editor, and manually set the `MECHANISMS` parameter to `pam`.
 
-. If you are running Red Hat-based distributions or are running RHEL 8.x, add the following lines to the file `/etc/pam.d/passwd`:
+. If you're running RHEL 8.x or a distribution derived from it, add the following lines to the file `/etc/pam.d/passwd`:
 +
 ----
 auth       include    system-auth

--- a/modules/manage/pages/manage-security/configure-saslauthd.adoc
+++ b/modules/manage/pages/manage-security/configure-saslauthd.adoc
@@ -109,7 +109,7 @@ Then, enable external authentication on the cluster, using the Couchbase CLI `se
 +
 [source,bash]
 ----
-/opt/couchbase/bin/couchbase-cli setting-saslauthd -c 10.143.192.101 
+/opt/couchbase/bin/couchbase-cli setting-saslauthd -c 10.143.192.101 \
 -u Administrator \
 -p password \
 --enabled 1

--- a/modules/manage/pages/manage-security/configure-saslauthd.adoc
+++ b/modules/manage/pages/manage-security/configure-saslauthd.adoc
@@ -66,11 +66,7 @@ If you have chosen to support external authentication by means of `saslauthd`, i
 Make sure that you have the prerequisites for the LDAP software you are installing, such as OpenLDAP libraries.
 On RPM-based distros, installation packages are a part of `cyrus-sasl rpm`, so make sure that it is installed.
 
-//CentOS 6:: `saslauthd 2.1.23` or higher
-
-CentOS 7:: `saslauthd 2.1.26` or higher
-
-Ubuntu:: `saslauthd 2.1.25` or higher
+//Ubuntu:: `saslauthd 2.1.25` or higher
 
 SUSE:: `saslauthd 2.1.23` or higher
 
@@ -99,8 +95,8 @@ The location of the mux file varies, according to distribution.
 Couchbase Server checks for the file at two locations, which are `/var/run/sasl2/mux` and `/var/run/saslauthd/mux`.
 
 * _Debian/Ubuntu_: By default, the file is located at `/var/run/sasl2/mux`.
-//* _RHEL/CentOS 6_: By default, the file is located at at `/var/run/saslauthd/mux`.
-* _RHEL/CentOS 7_: By default, the file is located at `/run/saslauthd/mux`; but a symlink from `/var/run` to `/run/` allows Couchbase Server to access the file at `/var/run/saslauthd/mux`.
+//* _RHEL/Red Hat-based distributions: By default, the file is located at at `/var/run/saslauthd/mux`. 
+However, a symlink from `/var/run` to `/run/` allows Couchbase Server to access the file at `/var/run/saslauthd/mux`.
 
 If, on your system, the location of the mux file is neither `/var/run/sasl2/mux` nor `/var/run/saslauthd/mux`, set the `CBAUTH_SOCKPATH` environment variable to the mux file's actual location.
 Couchbase Server will attempt to access the mux file there.
@@ -113,7 +109,7 @@ Then, enable external authentication on the cluster, using the Couchbase CLI `se
 +
 [source,bash]
 ----
-/opt/couchbase/bin/couchbase-cli setting-saslauthd -c 10.143.192.101 \
+/opt/couchbase/bin/couchbase-cli setting-saslauthd -c 10.143.192.101 
 -u Administrator \
 -p password \
 --enabled 1

--- a/modules/manage/pages/manage-security/configure-saslauthd.adoc
+++ b/modules/manage/pages/manage-security/configure-saslauthd.adoc
@@ -125,7 +125,7 @@ When successfully executed, the command provides the following notification: `SU
 
 . Configure the `MECHANISMS` option for `ldap`.
 +
-*Red Hat Enterprise Linux, CentOS, and Amazon Linux AMI* edit [.path]_/etc/sysconfig/saslauthd_ (`/etc/default/saslauthd` on Debian/Ubuntu) to set the mechanism `MECH` to `ldap`:
+*Red Hat Enterprise Linux, Red Hat-based distributions, and Amazon Linux AMI* edit [.path]_/etc/sysconfig/saslauthd_ (`/etc/default/saslauthd` on Debian/Ubuntu) to set the mechanism `MECH` to `ldap`:
 +
 ----
 MECH=ldap

--- a/modules/manage/pages/troubleshoot/core-files.adoc
+++ b/modules/manage/pages/troubleshoot/core-files.adoc
@@ -81,7 +81,7 @@ On RHEL 6, run the following command and then reboot the system.
 echo "DAEMON_COREFILE_LIMIT='unlimited'" >> /etc/sysconfig/init
 ----
 
-Earlier RHEL derivative operating systems such as RHEL 4, RHEL 5, F7, and CentOS, need a modification to their startup scripts.
+Earlier RHEL derivative operating systems such as RHEL 4, RHEL 5, F7, and Red Hat-based distributions, need a modification to their startup scripts.
 By default, these operating systems hard set the core size to zero in the [.path]_/etc/profile_ file.
 To fix this, edit the following line in the file [.path]_/etc/profile_ from `ulimit -S -c 0 > /dev/null 2>&1` to `ulimit -S -c unlimited > /dev/null 2>&1`.
 Then reboot the system.


### PR DESCRIPTION
Preview URL: https://preview.docs-test.couchbase.com/docs-server-DOC-12890_Remove-CentOS-from-Server-docs 

[DOC-12890](https://jira.issues.couchbase.com/browse/DOC-12890) --> Removing instances of Centos from the 8.0 server docs. 

You will need the Login credentials on (https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) to preview the docs.

[DOC-12890]: https://couchbasecloud.atlassian.net/browse/DOC-12890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ