### PR TITLE
Removed erroneous server guardrails info

### DIFF
--- a/modules/install/pages/sizing-general.adoc
+++ b/modules/install/pages/sizing-general.adoc
@@ -108,40 +108,6 @@ A reliable high-speed network for intra-cluster and inter-cluster communications
 +
 Most deployments can achieve optimal performance with 1 Gbps interconnects, but some may need 10 Gbps.
 
-
-[#guardrails]
-==== Couchbase Server Guardrails
-
-For safe and reliable cluster operations, and to minimize the severity of cluster outages, clusters using Couchbase Server 7.6 or later have guardrails in place.
-These guardrails proactively monitor for specific system thresholds.
-When a cluster meets these thresholds, these guardrails automatically prevent the following cluster operations, which during these conditions can put the cluster at severe risk of outage and downtime:
-
-* Bucket writes
-* Bucket creation
-* Collection creation
-* Topology changes that involve rebalancing
-
-Server-level enforcement thresholds are designed to ensure the optimal and reliable usage of available system resources by various workloads.
-These thresholds are as follows:
-
-[Attributes]
-|===
-|Cluster Metric |Threshold
-
-|Data Service Resident Ratio (Couchstore)
-|\<= 1%
-
-|Data Service Resident Ratio (Magma)
-|\<= 0.1%
-
-|Free Disk Space
-|\<= 4%
-
-|Number of Buckets
-|\<= 0.2 cores per bucket
-
-|===
-
 == Sizing Data Service Nodes
 
 Data Service nodes handle data service operations, such as create/read/update/delete (CRUD).


### PR DESCRIPTION
Removed section. Original ticket suggested guardrails were for Server as well as Capella, which was not true.