### PR TITLE
DOC-11938 RBAC-API-for-creating-external-user-is-wrong-in-the-lookup-page

### DIFF
--- a/modules/rest-api/pages/rbac.adoc
+++ b/modules/rest-api/pages/rbac.adoc
@@ -431,7 +431,7 @@ If successful, the call creates local user `sdavis` and adds them to the `Cluste
 [#create-an-external-user-and-assign-roles]
 === Create an External User, and Assign Roles
 
-To create an external user, and assign them one or more roles, use the `PUT` method with the `/settings/rbac/users/local/<new-username>` URI.
+To create an external user, and assign them one or more roles, use the `PUT` method with the `/settings/rbac/users/external/<new-username>` URI.
 The curl syntax is as follows:
 
 ----

--- a/modules/rest-api/pages/rbac.adoc
+++ b/modules/rest-api/pages/rbac.adoc
@@ -431,7 +431,7 @@ If successful, the call creates local user `sdavis` and adds them to the `Cluste
 [#create-an-external-user-and-assign-roles]
 === Create an External User, and Assign Roles
 
-To create an external user, and assign them one or more roles, use the `PUT` method with the `/settings/rbac/users/external/<new-username>` URI.
+To create an external user, and assign them one or more roles, use the `PUT` method with the `/settings/rbac/users/local/<new-username>` URI.
 The curl syntax is as follows:
 
 ----

--- a/modules/rest-api/partials/rest-security-authorization-table.adoc
+++ b/modules/rest-api/partials/rest-security-authorization-table.adoc
@@ -27,7 +27,7 @@
 | xref:rest-api:rbac.adoc#create-a-local-user-and-assign-roles[Create a Local User]
 
 | `PUT`
-| `/settings/rbac/users/local/<new-username>`
+| `/settings/rbac/users/external/<new-username>`
 | xref:rest-api:rbac.adoc#create-an-external-user-and-assign-roles[Create an External User]
 
 | `PUT`


### PR DESCRIPTION
'/settings/rbac/users/external/<new-username>' needs to be updated at https://docs.couchbase.com/server/current/rest-api/rbac.html#create-an-external-user-and-assign-roles