### PR TITLE
[DOC-12688]: Add a warning regarding reading /proc/<pid of memcached>/smaps

### DIFF
--- a/modules/manage/pages/monitor/set-up-prometheus-for-monitoring.adoc
+++ b/modules/manage/pages/monitor/set-up-prometheus-for-monitoring.adoc
@@ -39,15 +39,15 @@ When you configure your Prometheus job to collect metrics from Couchbase Server,
 If you do not want to Prometheus to use the secure ports, you can change the port number the discovery API call returns. 
 See xref:rest-api:rest-discovery-api.adoc[Prometheus Discovery API].
 
-[sidebar]
+[CAUTION]
 .Prometheus exporter: use with Couchbase data and index services.
-****
+====
 We strongly recommend against reading `/proc/[pid]/smaps` for processes with large RSS; for example, Couchbase Server's Data and Index Services (memcached and indexer).
 This has been known to cause significant pauses in such processes.
 These are proportional to RSS, but for large values we have seen delays of 10–20 seconds.
 Use of `/proc/[pid]/smaps` is found in monitoring software such as the Prometheus project’s process_exporter when `gather-smaps` is enabled,
  as well as other products that embed process_exporter such as Grafana Alloy (prometheus.exporter.process), and its predecessor, Grafana Agent (prometheus.exporter.process)
-****
+====
 
 == Call the Discovery API
 

--- a/modules/manage/pages/monitor/set-up-prometheus-for-monitoring.adoc
+++ b/modules/manage/pages/monitor/set-up-prometheus-for-monitoring.adoc
@@ -37,7 +37,17 @@ Save the file to a location in your Prometheus host.
 When you configure your Prometheus job to collect metrics from Couchbase Server, add the file to the job definition's `tls_config` section. 
 
 If you do not want to Prometheus to use the secure ports, you can change the port number the discovery API call returns. 
-See xref:rest-api:rest-discovery-api.adoc[Prometheus Discovery API]. 
+See xref:rest-api:rest-discovery-api.adoc[Prometheus Discovery API].
+
+[sidebar]
+.Prometheus exporter: use with Couchbase data and index services.
+****
+We strongly recommend against reading `/proc/[pid]/smaps` for processes with large RSS; for example, Couchbase Server's Data and Index Services (memcached and indexer).
+This has been known to cause significant pauses in such processes.
+These are proportional to RSS, but for large values we have seen delays of 10–20 seconds.
+Use of `/proc/[pid]/smaps` is found in monitoring software such as the Prometheus project’s process_exporter when `gather-smaps` is enabled,
+ as well as other products that embed process_exporter such as Grafana Alloy (prometheus.exporter.process), and its predecessor, Grafana Agent (prometheus.exporter.process)
+****
 
 == Call the Discovery API
 

--- a/preview/DOC-12688-Add-a-warning-regarding-reading--proc--pid-of-memcached----smaps.yml
+++ b/preview/DOC-12688-Add-a-warning-regarding-reading--proc--pid-of-memcached----smaps.yml
@@ -1,0 +1,3 @@
+sources:
+  docs-server:
+    branches: [DOC-12688-Add-a-warning-regarding-reading--proc--pid-of-memcached----smaps]


### PR DESCRIPTION
### Description of Change

This pull request adds a warning to the documentation regarding reading `/proc/<pid>/smaps` for the Data and Index services in Prometheus monitoring. 

### Testing

N/A

### Checklist

- [ ] Code builds correctly
- [ ] Changes are covered by tests
- [x] Documentation changes are included where applicable
- [ ] Any dependent changes have been merged and published in downstream modules

----

Preview URL:
https://preview.docs-test.couchbase.com/docs-server-DOC-12688-Add-a-warning-regarding-reading--proc--pid-of-memcached----smaps/server/current/manage/monitor/set-up-prometheus-for-monitoring.html

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.