### PR TITLE
DOC-11938 RBAC-API-for-creating-external-user-is-wrong-in-the-lookup-page

### DIFF
--- a/modules/rest-api/partials/rest-security-authorization-table.adoc
+++ b/modules/rest-api/partials/rest-security-authorization-table.adoc
@@ -27,7 +27,7 @@
 | xref:rest-api:rbac.adoc#create-a-local-user-and-assign-roles[Create a Local User]
 
 | `PUT`
-| `/settings/rbac/users/local/<new-username>`
+| `/settings/rbac/users/external/<new-username>`
 | xref:rest-api:rbac.adoc#create-an-external-user-and-assign-roles[Create an External User]
 
 | `PUT`


### PR DESCRIPTION
Made the change in 8.0 which is approved by the requester. Now porting it to other Server branches. https://github.com/couchbase/docs-server/pull/3882/files