### PR TITLE
DOC-11708 Deprecated REST API endpoint for bucket stats

### DIFF
--- a/modules/rest-api/pages/rest-bucket-stats.adoc
+++ b/modules/rest-api/pages/rest-bucket-stats.adoc
@@ -1,10 +1,15 @@
 = Getting Bucket Statistics
-:description: pass:q[To retrieve bucket statistics, use the `GET` operation with the `/pools/default/buckets/bucket_name/stats` URI.]
+:description: pass:q[See the IMPORTANT note.]
 :page-topic-type: reference
 :page-aliases: rest-api:rest-node-retrieve-stats
 
+[.deprecated]#Deprecated#
+
 [abstract]
 {description}
+
+IMPORTANT: As of Couchbase Server 8.0, the REST API endpoint `GET /pools/default/buckets/<bucket-name>/stats` is deprecated.
+For retrieving bucket statistics details, use xref:rest-api:rest-statistics-single.adoc[Getting a Single Statistic] or xref:rest-api:rest-statistics-multiple.adoc[Getting Multiple Statistics] instead.
 
 == HTTP method and URI
 

--- a/modules/rest-api/partials/rest-buckets-table.adoc
+++ b/modules/rest-api/partials/rest-buckets-table.adoc
@@ -23,8 +23,8 @@
 | xref:rest-api:rest-retrieve-bucket-nodes.adoc[Listing Nodes by Bucket]
 
 | `GET`
-| `/pools/default/buckets/[bucket-name]/stats`
-| xref:rest-api:rest-bucket-stats.adoc[Getting Bucket Statistics]
+| `pools/default/stats/range`
+| xref:rest-api:rest-statistics.adoc[Statistics]
 
 | `GET`
 | `/pools/default/buckets/default`

--- a/modules/rest-api/partials/rest-buckets-table.adoc
+++ b/modules/rest-api/partials/rest-buckets-table.adoc
@@ -23,7 +23,7 @@
 | xref:rest-api:rest-retrieve-bucket-nodes.adoc[Listing Nodes by Bucket]
 
 | `GET`
-| `pools/default/stats/range`
+| `/pools/default/stats/range`
 | xref:rest-api:rest-statistics.adoc[Statistics]
 
 | `GET`

--- a/modules/rest-api/partials/rest-buckets-table.adoc
+++ b/modules/rest-api/partials/rest-buckets-table.adoc
@@ -23,8 +23,12 @@
 | xref:rest-api:rest-retrieve-bucket-nodes.adoc[Listing Nodes by Bucket]
 
 | `GET`
+| `/pools/default/stats/range/[metric_name]/[function-expression]`
+| xref:rest-api:rest-statistics-single.adoc[Getting a Single Statistic]
+
+| `POST`
 | `/pools/default/stats/range`
-| xref:rest-api:rest-statistics.adoc[Statistics]
+| xref:rest-api:rest-statistics-multiple.adoc[Getting Multiple Statistics]
 
 | `GET`
 | `/pools/default/buckets/default`

--- a/modules/rest-api/partials/rest-xdcr-table.adoc
+++ b/modules/rest-api/partials/rest-xdcr-table.adoc
@@ -44,7 +44,7 @@
 
 
 | `GET`
-| `/pools/defaults/stats/range/[source_bucket]/stats/[destination_endpoint]`
-| xref:rest-api:rest-xdcr-statistics.adoc[Getting Statistics]
+| `/pools/default/stats/range/[statistics_name]`
+| xref:rest-api:rest-statistics-single.adoc[Getting a Single Statistic]
 
 |===

--- a/modules/rest-api/partials/rest-xdcr-table.adoc
+++ b/modules/rest-api/partials/rest-xdcr-table.adoc
@@ -44,7 +44,7 @@
 
 
 | `GET`
-| `/pools/default/buckets/[source_bucket]/stats/[destination_endpoint]`
+| `/pools/defaults/stats/range/[source_bucket]/stats/[destination_endpoint]`
 | xref:rest-api:rest-xdcr-statistics.adoc[Getting Statistics]
 
 |===


### PR DESCRIPTION
DOC-11708

For details about added contents, see [this comment](https://github.com/couchbase/docs-server/pull/3894#issue-3443514932).