### PR TITLE
DOC-11708 Deprecated REST API endpoint for bucket stats

### DIFF
--- a/modules/rest-api/partials/rest-buckets-table.adoc
+++ b/modules/rest-api/partials/rest-buckets-table.adoc
@@ -23,8 +23,8 @@
 | xref:rest-api:rest-retrieve-bucket-nodes.adoc[Listing Nodes by Bucket]
 
 | `GET`
-| `/pools/default/buckets/[bucket-name]/stats`
-| xref:rest-api:rest-bucket-stats.adoc[Getting Bucket Statistics]
+| `/pools/default/stats/range`
+| xref:rest-api:rest-statistics.adoc[Statistics]
 
 | `GET`
 | `/pools/default/buckets/default`

--- a/modules/rest-api/partials/rest-xdcr-table.adoc
+++ b/modules/rest-api/partials/rest-xdcr-table.adoc
@@ -44,7 +44,7 @@
 
 
 | `GET`
-| `/pools/default/buckets/[source_bucket]/stats/[destination_endpoint]`
+| `/pools/defaults/stats/range/[source_bucket]/stats/[destination_endpoint]`
 | xref:rest-api:rest-xdcr-statistics.adoc[Getting Statistics]
 
 |===


### PR DESCRIPTION
Had made changes for 7.6 which have been approved by reporter porting the changes to other versions of Server
https://github.com/couchbase/docs-server/pull/3859/files