### PR TITLE
Add REST API delete function for memcached global settings

### DIFF
--- a/modules/introduction/partials/new-features-80.adoc
+++ b/modules/introduction/partials/new-features-80.adoc
@@ -89,6 +89,11 @@ curl --get -u <username:password> \
     -d clusterLabels=none|uuidOnly|uuidAndName
 ----
 
+https://jira.issues.couchbase.com/browse/MB-65779[MB-65779]::
+Couchbase supports the REST API `DELETE pools/default/settings/memcached/global/setting/[setting_name]` for some of the settings that are not always passed from the Cluster Manager to memcached.
++
+For more information, see xref:rest-api:rest-manage-cluster-connections.adoc[Managing Cluster Connections].
+
 [#section-new-feature-800-services]
 === Services
 

--- a/modules/rest-api/pages/rest-manage-cluster-connections.adoc
+++ b/modules/rest-api/pages/rest-manage-cluster-connections.adoc
@@ -14,6 +14,23 @@ POST /pools/default/settings/memcached/global
 GET /pools/default/settings/memcached/global
 ----
 
+[NOTE]
+====
+Couchbase supports the REST API `DELETE pools/default/settings/memcached/global/setting/[setting_name]` for the following settings that are not always passed from the Cluster Manager to memcached:
+
+* `default_reqs_per_event`
+* `reqs_per_event_high_priority`
+* `reqs_per_event_med_priority`
+* `reqs_per_event_low_priority`
+* `threads`
+* `dcp_disconnect_when_stuck_timeout_seconds`
+* `dcp_disconnect_when_stuck_name_regex`
+* `external_auth_request_timeout`
+* `not_locked_returns_tmpfail`
+* `clustermap_push_notifications_enabled`
+* `magma_blind_write_optimisation_enabled`
+====
+
 == Description
 
 A Couchbase-Server cluster allows connections to be established, both for memcached and for authenticated system-users.


### PR DESCRIPTION
DOC-13559

This is an information-only content.

Doc preview:
- Added a NOTE for the DELETE function in the page "Managing Cluster Connections" > [HTTP Methods and URIs](https://preview.docs-test.couchbase.com/DOC-13559/server/current/rest-api/rest-manage-cluster-connections.html#http-methods-and-uris).
- What's New [entry](https://preview.docs-test.couchbase.com/DOC-13559/server/current/introduction/whats-new.html#section-new-feature-800-couchbase-cluster). See the content associated with MB-65779.

Preview doc [login credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords).