### PR TITLE
corrected formatting error

### DIFF
--- a/modules/rest-api/pages/rest-bucket-create.adoc
+++ b/modules/rest-api/pages/rest-bucket-create.adoc
@@ -1222,7 +1222,6 @@ curl -v -X POST http://10.143.201.101:8091/pools/default/buckets/testBucket \
 
 If successful, the call returns a `200 OK` notification.
 No object is returned.
-=======
 
 [[encryptionAtRestKeyId]]
 === encryptionAtRestKeyId


### PR DESCRIPTION
Correct formatting error in the page: https://preview.docs-test.couchbase.com/docs-server-release/8.0/server/current/rest-api/rest-bucket-create.html#general-parameters

Before the heading encryptionAtRestKeyId.

Before merging a PR, people must resolve conflicts and verify the output properly.