### PR TITLE
Updated metrics from Morpheus build #3773

### DIFF
--- a/modules/metrics-reference/attachments/backup_metrics_metadata.json
+++ b/modules/metrics-reference/attachments/backup_metrics_metadata.json
@@ -32,6 +32,16 @@
     ],
     "type": "counter"
   },
+  "backup_request_duration_seconds": {
+    "added": "8.0.0",
+    "help": "Histogram of the request duration",
+    "labels": [
+      "request_method",
+      "route_name",
+      "status_code"
+    ],
+    "type": "histogram"
+  },
   "backup_task_duration_seconds": {
     "added": "7.0.0",
     "help": "Histogram of the task duration",

--- a/modules/metrics-reference/attachments/cbas_metrics_metadata.json
+++ b/modules/metrics-reference/attachments/cbas_metrics_metadata.json
@@ -2,7 +2,20 @@
   "cbas_active_links": {
     "added": "7.2.4",
     "help": "Number of active links.",
-    "type": "gauge"
+    "type": "gauge",
+    "unit": "number"
+  },
+  "cbas_backup_requests_failed_total": {
+    "added": "7.6.2",
+    "help": "Total number of failed backup requests.",
+    "type": "counter",
+    "unit": "count"
+  },
+  "cbas_backup_requests_total": {
+    "added": "7.6.2",
+    "help": "Total number of backup requests.",
+    "type": "counter",
+    "unit": "count"
   },
   "cbas_direct_memory_used_bytes": {
     "added": "7.0.2",
@@ -30,6 +43,23 @@
     "type": "gauge",
     "unit": "seconds"
   },
+  "cbas_driver_uptime_seconds_total": {
+    "added": "7.6.1",
+    "help": "Total driver uptime in seconds.",
+    "type": "counter",
+    "unit": "seconds"
+  },
+  "cbas_extra_incoming_records_total": {
+    "added": "7.6.6",
+    "help": "Total number of incoming records that were processed multiple times due to DCP snapshot alignment.",
+    "labels": [
+      "bucket",
+      "scope",
+      "link"
+    ],
+    "type": "counter",
+    "unit": "count"
+  },
   "cbas_failed_to_parse_records_count": {
     "added": "7.0.0",
     "deprecated": "7.6.0",
@@ -40,7 +70,8 @@
       "link"
     ],
     "notes": "Will be removed in the 8.0 release. Use cbas_failed_to_parse_records_total",
-    "type": "gauge"
+    "type": "gauge",
+    "unit": "number"
   },
   "cbas_failed_to_parse_records_total": {
     "added": "7.6.0",
@@ -50,12 +81,14 @@
       "scope",
       "link"
     ],
-    "type": "counter"
+    "type": "counter",
+    "unit": "count"
   },
   "cbas_gc_count_total": {
     "added": "7.0.0",
     "help": "Total number of garbage collections.",
-    "type": "counter"
+    "type": "counter",
+    "unit": "count"
   },
   "cbas_gc_time_milliseconds_total": {
     "added": "7.0.0",
@@ -77,6 +110,12 @@
     "type": "gauge",
     "unit": "bytes"
   },
+  "cbas_heap_memory_max_bytes": {
+    "added": "7.2.7",
+    "help": "Heap memory max in bytes.",
+    "type": "gauge",
+    "unit": "bytes"
+  },
   "cbas_heap_memory_used_bytes": {
     "added": "7.0.0",
     "help": "Heap memory used in bytes.",
@@ -89,12 +128,20 @@
     "labels": [
       "code"
     ],
-    "type": "counter"
+    "type": "counter",
+    "unit": "count"
+  },
+  "cbas_http_requests_timeout_total": {
+    "added": "7.6.2",
+    "help": "Total number of HTTP requests timeouts.",
+    "type": "counter",
+    "unit": "count"
   },
   "cbas_http_requests_total": {
     "added": "7.6.0",
     "help": "Total number of http requests.",
-    "type": "counter"
+    "type": "counter",
+    "unit": "count"
   },
   "cbas_incoming_records_count": {
     "added": "7.0.0",
@@ -106,7 +153,8 @@
       "link"
     ],
     "notes": "Will be removed in the 8.0 release. Use cbas_incoming_records_total",
-    "type": "gauge"
+    "type": "gauge",
+    "unit": "count"
   },
   "cbas_incoming_records_total": {
     "added": "7.6.0",
@@ -116,92 +164,167 @@
       "scope",
       "link"
     ],
-    "type": "counter"
+    "type": "counter",
+    "unit": "count"
   },
   "cbas_io_reads_total": {
     "added": "7.0.0",
     "help": "Total number of IO reads.",
-    "type": "counter"
+    "type": "counter",
+    "unit": "count"
   },
   "cbas_io_writes_total": {
     "added": "7.0.0",
     "help": "Total number of IO writes.",
-    "type": "counter"
+    "type": "counter",
+    "unit": "count"
+  },
+  "cbas_jobs_total": {
+    "added": "7.6.2",
+    "help": "Total number of successful, failed, cancelled and rejected jobs.",
+    "labels": [
+      "result"
+    ],
+    "type": "counter",
+    "unit": "count"
+  },
+  "cbas_link_connect_failed_total": {
+    "added": "7.6.2",
+    "help": "Total number of link connect failures.",
+    "labels": [
+      "link",
+      "code"
+    ],
+    "type": "counter",
+    "unit": "count"
+  },
+  "cbas_link_disconnect_failed_total": {
+    "added": "7.6.2",
+    "help": "Total number of link disconnect failures.",
+    "labels": [
+      "link",
+      "code"
+    ],
+    "type": "counter",
+    "unit": "count"
+  },
+  "cbas_link_invalid_credentials_total": {
+    "added": "7.6.2",
+    "help": "Total number of link invalid credentials.",
+    "labels": [
+      "link",
+      "code",
+      "action"
+    ],
+    "type": "counter",
+    "unit": "count"
   },
   "cbas_pending_flush_ops": {
     "added": "7.0.0",
     "help": "Total number of pending flush operations.",
-    "type": "gauge"
+    "type": "gauge",
+    "unit": "number"
   },
   "cbas_pending_merge_ops": {
     "added": "7.0.0",
     "help": "Total number of pending merge operations.",
-    "type": "gauge"
+    "type": "gauge",
+    "unit": "number"
   },
   "cbas_pending_replicate_ops": {
     "added": "7.1.0",
     "help": "Total number of pending replication operations.",
-    "type": "gauge"
+    "type": "gauge",
+    "unit": "number"
   },
   "cbas_pending_requests": {
     "added": "7.2.4",
     "help": "Number of pending requests.",
-    "type": "gauge"
+    "type": "gauge",
+    "unit": "number"
   },
   "cbas_queued_http_requests_size": {
     "added": "7.6.0",
     "help": "Number of queued http requests.",
-    "type": "gauge"
+    "type": "gauge",
+    "unit": "number"
   },
   "cbas_queued_jobs": {
     "added": "7.2.4",
     "help": "Number of queued jobs.",
-    "type": "gauge"
+    "type": "gauge",
+    "unit": "number"
   },
   "cbas_rebalance_cancelled_total": {
     "added": "7.6.0",
     "help": "Total number of cancelled rebalances.",
-    "type": "counter"
+    "type": "counter",
+    "unit": "count"
   },
   "cbas_rebalance_failed_total": {
     "added": "7.6.0",
     "help": "Total number of rebalance failures.",
-    "type": "counter"
+    "type": "counter",
+    "unit": "count"
   },
   "cbas_rebalance_successful_total": {
     "added": "7.6.0",
     "help": "Total number of successful rebalances.",
-    "type": "counter"
+    "type": "counter",
+    "unit": "count"
+  },
+  "cbas_requests_failed_total": {
+    "added": "7.6.2",
+    "help": "Total number of failed requests.",
+    "type": "counter",
+    "unit": "count"
   },
   "cbas_requests_total": {
     "added": "7.2.4",
     "help": "Total number of received requests.",
-    "type": "counter"
+    "type": "counter",
+    "unit": "count"
   },
   "cbas_running_jobs": {
     "added": "7.2.4",
     "help": "Number of running jobs.",
-    "type": "gauge"
+    "type": "gauge",
+    "unit": "number"
+  },
+  "cbas_scan_consistency_timeout_total": {
+    "added": "7.6.2",
+    "help": "Total number of scan consistency timeouts.",
+    "type": "counter",
+    "unit": "count"
   },
   "cbas_system_load_average": {
     "added": "7.0.0",
     "help": "System work load.",
-    "type": "gauge"
+    "type": "gauge",
+    "unit": "number"
   },
   "cbas_thread_count": {
     "added": "7.0.0",
     "help": "Number of threads in use.",
-    "type": "gauge"
+    "type": "gauge",
+    "unit": "number"
   },
   "cbas_virtual_buffer_cache_used_pages": {
     "added": "7.0.0",
     "help": "Total number of used memory pages in the virtual buffer cache.",
-    "type": "gauge"
+    "type": "gauge",
+    "unit": "number"
   },
   "cbas_wrapper_boot_timestamp_seconds": {
     "added": "7.6.0",
     "help": "Analytics wrapper process boot timestamp in seconds since Unix epoch.",
     "type": "gauge",
+    "unit": "seconds"
+  },
+  "cbas_wrapper_uptime_seconds_total": {
+    "added": "7.6.1",
+    "help": "Total wrapper uptime in seconds.",
+    "type": "counter",
     "unit": "seconds"
   }
 }

--- a/modules/metrics-reference/attachments/cm_metrics_metadata.json
+++ b/modules/metrics-reference/attachments/cm_metrics_metadata.json
@@ -11,6 +11,12 @@
     "stability": "committed",
     "type": "counter"
   },
+  "cm_app_telemetry_curr_connections": {
+    "added": "8.0.0",
+    "help": "Number of active app telemetry connections",
+    "stability": "internal",
+    "type": "gauge"
+  },
   "cm_auth_cache_current_items": {
     "added": "7.6.0",
     "help": "Current number of items available in cbauth auth cache",
@@ -48,19 +54,19 @@
     "type": "counter"
   },
   "cm_auto_failover_count": {
-    "added": "7.6.2",
+    "added": "7.2.6",
     "help": "Number of auto-failovers",
     "stability": "committed",
     "type": "gauge"
   },
   "cm_auto_failover_enabled": {
-    "added": "7.6.2",
+    "added": "7.2.6",
     "help": "Indicates if auto-failover is enabled (1 = true, 0 = false)",
     "stability": "committed",
     "type": "gauge"
   },
   "cm_auto_failover_max_count": {
-    "added": "7.6.2",
+    "added": "7.2.6",
     "help": "Maximum number of auto-failovers before being disabled",
     "stability": "committed",
     "type": "gauge"
@@ -114,6 +120,102 @@
     "help": "Total number of cbauth client_cert cache misses",
     "type": "counter"
   },
+  "cm_encr_at_rest_data_status": {
+    "added": "8.0.0",
+    "help": "Encryption at rest status per data type (1 - encrypted, 0.5 - partially encrypted, 0 - unencrypted, -1 - unknown)",
+    "labels": [
+      {
+        "help": "Encrypted data type (config, logs, audit, bucket_<bucket_name>)",
+        "name": "data_type"
+      }
+    ],
+    "stability": "internal",
+    "type": "gauge"
+  },
+  "cm_encr_at_rest_deks_in_use": {
+    "added": "8.0.0",
+    "help": "Number of data keys in use per data type",
+    "labels": [
+      {
+        "help": "Data encryption key (DEK) type (configDek, logDek, auditDek, bucketDek_<bucket_name>)",
+        "name": "type"
+      }
+    ],
+    "stability": "internal",
+    "type": "gauge"
+  },
+  "cm_encr_at_rest_drop_deks_events_total": {
+    "added": "8.0.0",
+    "help": "Total number drop DEKs events (when some DEK expires and the system tries to stop using that DEK by re-encrypting data)",
+    "labels": [
+      {
+        "help": "Data encryption key (DEK) type (configDek, logDek, auditDek, bucketDek_<bucket_name>)",
+        "name": "type"
+      }
+    ],
+    "stability": "internal",
+    "type": "counter"
+  },
+  "cm_encr_at_rest_generate_dek_failures_total": {
+    "added": "8.0.0",
+    "help": "Total number of data key generation failures",
+    "labels": [
+      {
+        "help": "Data encryption key (DEK) type (configDek, logDek, auditDek, bucketDek_<bucket_name>)",
+        "name": "type"
+      }
+    ],
+    "stability": "internal",
+    "type": "counter"
+  },
+  "cm_encr_at_rest_generate_dek_total": {
+    "added": "8.0.0",
+    "help": "Total number of successful data key generation events",
+    "labels": [
+      {
+        "help": "Data encryption key (DEK) type (configDek, logDek, auditDek, bucketDek_<bucket_name>)",
+        "name": "type"
+      }
+    ],
+    "stability": "internal",
+    "type": "counter"
+  },
+  "cm_encryption_key_rotation_failures_total": {
+    "added": "8.0.0",
+    "help": "Total number of encryption key rotation failures",
+    "labels": [
+      {
+        "help": "Name of the encryption key",
+        "name": "key_name"
+      }
+    ],
+    "stability": "internal",
+    "type": "counter"
+  },
+  "cm_encryption_key_rotations_total": {
+    "added": "8.0.0",
+    "help": "Total number of encryption key rotations",
+    "labels": [
+      {
+        "help": "Name of the encryption key",
+        "name": "key_name"
+      }
+    ],
+    "stability": "internal",
+    "type": "counter"
+  },
+  "cm_encryption_service_failures_total": {
+    "added": "8.0.0",
+    "help": "Total number of encryption service failures",
+    "labels": [
+      {
+        "help": "Type of failure (e.g. read_key_error, encrypt_key_error, store_key_error, etc...)",
+        "name": "failure_type"
+      }
+    ],
+    "stability": "internal",
+    "type": "counter"
+  },
   "cm_erlang_port_count": {
     "added": "7.6.0",
     "help": "The number of ports in use by the erlang VM",
@@ -152,7 +254,7 @@
     "type": "gauge"
   },
   "cm_failover_total": {
-    "added": "7.6.2",
+    "added": "7.2.6",
     "help": "Number of non-graceful failover results",
     "labels": [
       {
@@ -169,7 +271,7 @@
     "type": "histogram"
   },
   "cm_graceful_failover_total": {
-    "added": "7.6.2",
+    "added": "7.2.6",
     "help": "Number of graceful failover results",
     "labels": [
       {
@@ -224,7 +326,7 @@
     "type": "counter"
   },
   "cm_is_balanced": {
-    "added": "7.6.2",
+    "added": "7.2.6",
     "help": "Indicates if cluster is balanced (1 = true, 0 = false). Only reported by the orchestrator node and only updated once every 30 seconds",
     "stability": "committed",
     "type": "gauge"
@@ -499,13 +601,13 @@
     "type": "counter"
   },
   "cm_rebalance_in_progress": {
-    "added": "7.6.2",
+    "added": "7.2.6",
     "help": "Indicates if a rebalance is running (1 = true, 0 = false). Only reported by the orchestrator node.",
     "stability": "committed",
     "type": "gauge"
   },
   "cm_rebalance_progress": {
-    "added": "7.6.2",
+    "added": "7.2.6",
     "help": "Estimate of the rebalance progress (0 - 1) for each stage. Only reported by the orchestrator node.",
     "labels": [
       {
@@ -524,7 +626,7 @@
     "type": "gauge"
   },
   "cm_rebalance_total": {
-    "added": "7.6.2",
+    "added": "7.2.6",
     "help": "Number of rebalance results",
     "labels": [
       {
@@ -714,6 +816,12 @@
     "type": "gauge",
     "unit": "bytes"
   },
+  "sdk_invalid_metric_total": {
+    "added": "8.0.0",
+    "help": "Number of invalid metrics received from app telemetry clients",
+    "stability": "internal",
+    "type": "counter"
+  },
   "sys_allocstall": {
     "added": "7.0.0",
     "help": "Number of alloc stalls",
@@ -724,7 +832,7 @@
     "added": "7.2.0",
     "deprecated": "7.6.0",
     "help": "Rate at which CPUs overran their quota",
-    "notes": "Will be removed in the 8.0 release",
+    "notes": "Will be removed in a future release",
     "stability": "committed",
     "type": "gauge"
   },
@@ -764,7 +872,7 @@
     "added": "7.2.4",
     "deprecated": "7.6.0",
     "help": "Idle CPU utilization rate in the host",
-    "notes": "Will be removed in the 8.0 release",
+    "notes": "Will be removed in a future release",
     "stability": "committed",
     "type": "gauge"
   },
@@ -772,7 +880,7 @@
     "added": "7.2.4",
     "deprecated": "7.6.0",
     "help": "Other (not idle/user/sys/irq/stolen) CPU utilization rate in the host",
-    "notes": "Will be removed in the 8.0 release",
+    "notes": "Will be removed in a future release",
     "stability": "committed",
     "type": "gauge"
   },
@@ -781,7 +889,7 @@
     "help": "Number of CPU seconds utilized in the host, by mode",
     "labels": [
       {
-        "help": "type of usage (busy, idle, user, sys, irq, stolen, other)",
+        "help": "type of usage (idle, iowait, user, sys, irq, stolen, other)",
         "name": "mode"
       }
     ],
@@ -793,7 +901,7 @@
     "added": "7.1.1",
     "deprecated": "7.6.0",
     "help": "System CPU utilization rate in the host",
-    "notes": "Will be removed in the 8.0 release",
+    "notes": "Will be removed in a future release",
     "stability": "committed",
     "type": "gauge"
   },
@@ -801,7 +909,7 @@
     "added": "7.1.1",
     "deprecated": "7.6.0",
     "help": "User space CPU utilization rate in the host",
-    "notes": "Will be removed in the 8.0 release",
+    "notes": "Will be removed in a future release",
     "stability": "committed",
     "type": "gauge"
   },
@@ -809,7 +917,7 @@
     "added": "7.1.1",
     "deprecated": "7.6.0",
     "help": "CPU utilization rate in the host",
-    "notes": "Will be removed in the 8.0 release",
+    "notes": "Will be removed in a future release",
     "stability": "committed",
     "type": "gauge"
   },
@@ -817,7 +925,7 @@
     "added": "7.0.0",
     "deprecated": "7.6.0",
     "help": "IRQ rate",
-    "notes": "Will be removed in the 8.0 release",
+    "notes": "Will be removed in a future release",
     "stability": "committed",
     "type": "gauge"
   },
@@ -825,7 +933,7 @@
     "added": "7.0.0",
     "deprecated": "7.6.0",
     "help": "CPU stolen rate",
-    "notes": "Will be removed in the 8.0 release",
+    "notes": "Will be removed in a future release",
     "stability": "committed",
     "type": "gauge"
   },
@@ -833,7 +941,7 @@
     "added": "7.0.0",
     "deprecated": "7.6.0",
     "help": "System CPU utilization rate in the control group",
-    "notes": "Will be removed in the 8.0 release",
+    "notes": "Will be removed in a future release",
     "stability": "committed",
     "type": "gauge"
   },
@@ -841,7 +949,7 @@
     "added": "7.2.0",
     "deprecated": "7.6.0",
     "help": "Rate at which CPUs were throttled",
-    "notes": "Will be removed in the 8.0 release",
+    "notes": "Will be removed in a future release",
     "stability": "committed",
     "type": "gauge"
   },
@@ -849,7 +957,7 @@
     "added": "7.0.0",
     "deprecated": "7.6.0",
     "help": "User space CPU utilization rate in the control group",
-    "notes": "Will be removed in the 8.0 release",
+    "notes": "Will be removed in a future release",
     "stability": "committed",
     "type": "gauge"
   },
@@ -857,7 +965,7 @@
     "added": "7.0.0",
     "deprecated": "7.6.0",
     "help": "CPU utilization rate in the control group",
-    "notes": "Will be removed in the 8.0 release",
+    "notes": "Will be removed in a future release",
     "stability": "committed",
     "type": "gauge"
   },
@@ -1019,7 +1127,16 @@
   },
   "sys_mem_free": {
     "added": "7.0.0",
+    "deprecated": "8.0.0",
     "help": "Amount of system memory free, excluding buffers/cache",
+    "notes": "Will be removed in a future release. Use sys_mem_free_sys",
+    "stability": "committed",
+    "type": "gauge",
+    "unit": "bytes"
+  },
+  "sys_mem_free_sys": {
+    "added": "8.0.0",
+    "help": "Amount of free system memory (not being used for anything including buffers/cache)",
     "stability": "committed",
     "type": "gauge",
     "unit": "bytes"
@@ -1028,7 +1145,7 @@
     "added": "7.0.0",
     "deprecated": "7.6.0",
     "help": "System memory limit",
-    "notes": "Will be removed in the 8.0 release. Use sys_mem_total or sys_mem_cgroup_limit",
+    "notes": "Will be removed in a future release. Use sys_mem_total or sys_mem_cgroup_limit",
     "stability": "committed",
     "type": "gauge",
     "unit": "bytes"
@@ -1132,7 +1249,7 @@
         "name": "proc"
       }
     ],
-    "notes": "Will be removed in  8.0. Use irate of sysproc_cpu_seconds_total for user/sys modes.",
+    "notes": "Will be removed in a future release. Use irate of sysproc_cpu_seconds_total for user/sys modes.",
     "stability": "committed",
     "type": "gauge"
   },

--- a/modules/metrics-reference/attachments/fts_metrics_metadata.json
+++ b/modules/metrics-reference/attachments/fts_metrics_metadata.json
@@ -1,5 +1,6 @@
 {
   "fts_avg_grpc_queries_latency": {
+    "added": "7.2.0",
     "help": "Average latency per query, using gRPC for streaming, for an index",
     "labels": [
       "bucket",
@@ -11,6 +12,7 @@
     "unit": "milliseconds"
   },
   "fts_avg_internal_queries_latency": {
+    "added": "7.2.0",
     "help": "Average latency of inter-node queries per unit time for an index",
     "labels": [
       "bucket",
@@ -22,6 +24,7 @@
     "unit": "milliseconds"
   },
   "fts_avg_queries_latency": {
+    "added": "7.2.0",
     "help": "Average latency of queries per unit time for an index",
     "labels": [
       "bucket",
@@ -34,23 +37,109 @@
     "unit": "milliseconds"
   },
   "fts_batch_bytes_added": {
+    "added": "7.2.0",
     "help": "Total number of bytes from batches yet to be indexed.",
     "type": "counter",
     "unit": "bytes"
   },
   "fts_batch_bytes_removed": {
+    "added": "7.2.0",
     "help": "Total number of bytes from batches which have been indexed.",
     "notes": "This stat is associated with the fts_batch_bytes_added stat, in that they represent the completion and queuing of an indexing operation respectively.",
     "type": "counter",
     "unit": "bytes"
   },
+  "fts_boot_timestamp_seconds": {
+    "added": "7.5.0",
+    "help": "The time the service booted in fractional seconds since Unix epoch.",
+    "notes": "This is a metric specific to serverless.",
+    "type": "gauge",
+    "unit": "seconds"
+  },
+  "fts_counter_cu_total": {
+    "added": "7.5.0",
+    "help": "The number of distinct operations recording Compute Units (CUs) with Regulator.",
+    "labels": [
+      "bucket",
+      "for",
+      "unbilled",
+      "variant"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
+  "fts_counter_ru_total": {
+    "added": "7.5.0",
+    "help": "The number of distinct operations recording Read Units (RUs) with Regulator.",
+    "labels": [
+      "bucket",
+      "for",
+      "unbilled",
+      "variant"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
+  "fts_counter_wu_total": {
+    "added": "7.5.0",
+    "help": "The number of distinct operations recording Write Units (WUs) with Regulator.",
+    "labels": [
+      "bucket",
+      "for",
+      "unbilled",
+      "variant"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
+  "fts_credit_cu_total": {
+    "added": "7.5.0",
+    "help": "The number of Compute Units (CUs) refunded.",
+    "labels": [
+      "bucket",
+      "for",
+      "variant"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
+  "fts_credit_ru_total": {
+    "added": "7.5.0",
+    "help": "The number of Read Units (RUs) refunded.",
+    "labels": [
+      "bucket",
+      "for",
+      "variant"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
+  "fts_credit_wu_total": {
+    "added": "7.5.0",
+    "help": "The number of Write Units (WUs) refunded.",
+    "labels": [
+      "bucket",
+      "for",
+      "variant"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
   "fts_curr_batches_blocked_by_herder": {
+    "added": "7.2.0",
     "help": "The difference between the number of batches that have been indexed and the number of batches yet to be indexed",
     "notes": "The app herder blocks indexing of batches till there is sufficient memory i.e. the memory used is below the memory quota",
     "type": "gauge",
     "uiName": "DCP Batches Blocked"
   },
   "fts_doc_count": {
+    "added": "7.2.0",
     "help": "Number of documents in the index",
     "labels": [
       "bucket",
@@ -61,7 +150,157 @@
     "type": "counter",
     "uiName": "Search Docs"
   },
+  "fts_global_query_timer_count": {
+    "added": "8.0.0",
+    "help": "The number of query timer events received at the global query endpoint",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index"
+    ],
+    "type": "counter"
+  },
+  "fts_global_query_timer_mean_ns": {
+    "added": "8.0.0",
+    "help": "Mean runtime for queries received at the global query endpoint",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index"
+    ],
+    "type": "gauge"
+  },
+  "fts_global_query_timer_median_ns": {
+    "added": "8.0.0",
+    "help": "Median runtime for queries received at the global query endpoint",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index"
+    ],
+    "type": "gauge"
+  },
+  "fts_global_query_timer_p80_ns": {
+    "added": "8.0.0",
+    "help": "80th percentile runtime for queries received at the global query endpoint",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index"
+    ],
+    "type": "gauge"
+  },
+  "fts_global_query_timer_p99_ns": {
+    "added": "8.0.0",
+    "help": "99th percentile runtime for queries received at the global query endpoint",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index"
+    ],
+    "type": "gauge"
+  },
+  "fts_grpc_query_timer_count": {
+    "added": "8.0.0",
+    "help": "The number of query timer events received at the gRPC endpoint",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index"
+    ],
+    "type": "counter"
+  },
+  "fts_grpc_query_timer_mean_ns": {
+    "added": "8.0.0",
+    "help": "Mean runtime for queries received at the gRPC endpoint",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index"
+    ],
+    "type": "gauge"
+  },
+  "fts_grpc_query_timer_median_ns": {
+    "added": "8.0.0",
+    "help": "Median runtime for queries received at the gRPC endpoint",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index"
+    ],
+    "type": "gauge"
+  },
+  "fts_grpc_query_timer_p80_ns": {
+    "added": "8.0.0",
+    "help": "80th percentile runtime for queries received at the gRPC endpoint",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index"
+    ],
+    "type": "gauge"
+  },
+  "fts_grpc_query_timer_p99_ns": {
+    "added": "8.0.0",
+    "help": "99th percentile runtime for queries received at the gRPC endpoint",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index"
+    ],
+    "type": "gauge"
+  },
+  "fts_meter_cu_total": {
+    "added": "7.5.0",
+    "help": "The number of Compute Units (CUs) recorded.",
+    "labels": [
+      "bucket",
+      "for",
+      "unbilled",
+      "variant"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
+  "fts_meter_ru_total": {
+    "added": "7.5.0",
+    "help": "The number of Read Units (RUs) recorded.",
+    "labels": [
+      "bucket",
+      "for",
+      "unbilled",
+      "variant"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
+  "fts_meter_wu_total": {
+    "added": "7.5.0",
+    "help": "The number of Write Units (WUs) recorded.",
+    "labels": [
+      "bucket",
+      "for",
+      "unbilled",
+      "variant"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
   "fts_num_batches_introduced": {
+    "added": "7.2.0",
     "help": "Total number of batches introduced as part of indexing.",
     "type": "counter"
   },
@@ -74,6 +313,7 @@
     "unit": "bytes"
   },
   "fts_num_bytes_used_disk": {
+    "added": "7.2.0",
     "help": "The number of bytes used on disk by the index",
     "labels": [
       "bucket",
@@ -86,6 +326,7 @@
     "unit": "bytes"
   },
   "fts_num_bytes_used_disk_by_root": {
+    "added": "7.2.0",
     "help": "The number of bytes used on disk by the root segment",
     "labels": [
       "bucket",
@@ -97,6 +338,7 @@
     "unit": "bytes"
   },
   "fts_num_bytes_used_ram": {
+    "added": "7.2.0",
     "help": "The number of bytes used in memory",
     "notes": "Process level statistic from the Go runtime",
     "type": "gauge",
@@ -104,6 +346,7 @@
     "unit": "bytes"
   },
   "fts_num_files_on_disk": {
+    "added": "7.2.0",
     "help": "The number of files on disk for an index",
     "labels": [
       "bucket",
@@ -114,12 +357,18 @@
     "type": "gauge",
     "uiName": "Search Disk Files"
   },
+  "fts_num_indexes": {
+    "added": "8.0.0",
+    "help": "Number of search indexes in the cluster",
+    "type": "gauge"
+  },
   "fts_num_knn_search_requests": {
     "added": "7.6.0",
     "help": "Total number of search requests with KNN",
     "type": "counter"
   },
   "fts_num_mutations_to_index": {
+    "added": "7.2.0",
     "help": "DCP sequence numbers yet to be indexed for an index",
     "labels": [
       "bucket",
@@ -131,6 +380,7 @@
     "uiName": "Search Mutations Remaining"
   },
   "fts_num_pindexes_actual": {
+    "added": "7.2.0",
     "help": "Total number of pindexes currently",
     "labels": [
       "bucket",
@@ -142,6 +392,7 @@
     "uiName": "Search Partitions"
   },
   "fts_num_pindexes_target": {
+    "added": "7.2.0",
     "help": "Planned/expected number of pindexes",
     "labels": [
       "bucket",
@@ -153,6 +404,7 @@
     "uiName": "Search Partitions Expected"
   },
   "fts_num_recs_to_persist": {
+    "added": "7.2.0",
     "help": "The number of entries (terms, records, dictionary rows, etc) by Bleve not yet persisted to storage",
     "labels": [
       "bucket",
@@ -164,6 +416,7 @@
     "uiName": "Search Records to Persist"
   },
   "fts_num_root_filesegments": {
+    "added": "7.2.0",
     "help": "The number of file segments in the root segment",
     "labels": [
       "bucket",
@@ -175,6 +428,7 @@
     "uiName": "Search Disk Segments"
   },
   "fts_num_root_memorysegments": {
+    "added": "7.2.0",
     "help": "The number of memory segments in the root segment",
     "labels": [
       "bucket",
@@ -185,7 +439,24 @@
     "type": "gauge",
     "uiName": "Search Memory Segments"
   },
+  "fts_num_vector_indexes": {
+    "added": "8.0.0",
+    "help": "Number of search indexes in the cluster that have vector/vector_base64 fields",
+    "type": "gauge"
+  },
+  "fts_op_count_total": {
+    "added": "7.5.0",
+    "help": "The number of distinct operations recorded with Regulator.",
+    "labels": [
+      "bucket",
+      "for"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
   "fts_pct_cpu_gc": {
+    "added": "7.2.0",
     "help": "The percentage of CPU time spent by an index in garbage collection",
     "notes": "Process level statistic from the Go runtime",
     "type": "gauge",
@@ -199,64 +470,167 @@
     "uiName": "Pct RAM Used by Search",
     "unit": "percent"
   },
+  "fts_reject_count_total": {
+    "added": "7.5.0",
+    "help": "The number of times Regulator instructed an operation to be rejected.",
+    "labels": [
+      "bucket",
+      "for"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
+  "fts_scoped_query_timer_count": {
+    "added": "8.0.0",
+    "help": "The number of query timer events received at the scoped query endpoint",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index"
+    ],
+    "type": "counter"
+  },
+  "fts_scoped_query_timer_mean_ns": {
+    "added": "8.0.0",
+    "help": "Mean runtime for queries received at the scoped query endpoint",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index"
+    ],
+    "type": "gauge"
+  },
+  "fts_scoped_query_timer_median_ns": {
+    "added": "8.0.0",
+    "help": "Median runtime for queries received at the scoped query endpoint",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index"
+    ],
+    "type": "gauge"
+  },
+  "fts_scoped_query_timer_p80_ns": {
+    "added": "8.0.0",
+    "help": "80th percentile runtime for queries received at the scoped query endpoint",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index"
+    ],
+    "type": "gauge"
+  },
+  "fts_scoped_query_timer_p99_ns": {
+    "added": "8.0.0",
+    "help": "99th percentile runtime for queries received at the scoped query endpoint",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index"
+    ],
+    "type": "gauge"
+  },
+  "fts_throttle_count_total": {
+    "added": "7.5.0",
+    "help": "The number of times Regulator instructed an operation to throttle.",
+    "labels": [
+      "bucket",
+      "for"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
+  "fts_throttle_seconds_total": {
+    "added": "7.5.0",
+    "help": "The total time spent throttling (in seconds).",
+    "labels": [
+      "bucket",
+      "for"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
   "fts_tot_batches_flushed_on_maxops": {
+    "added": "7.2.0",
     "help": "Total number of batches executed due to the batch size being greater than the maximum number of operations per batch",
     "type": "counter"
   },
   "fts_tot_batches_flushed_on_timer": {
+    "added": "7.2.0",
     "help": "Total number of batches executed at regular intervals",
     "type": "counter"
   },
   "fts_tot_bleve_dest_closed": {
+    "added": "7.2.0",
     "help": "Total number of times Bleve destinations closed",
     "type": "counter"
   },
   "fts_tot_bleve_dest_opened": {
+    "added": "7.2.0",
     "help": "The number of times Bleve destinations opened",
     "notes": "Each Bleve destination corresponds to a Bleve index.",
     "type": "counter"
   },
   "fts_tot_grpc_listeners_closed": {
+    "added": "7.2.0",
     "help": "Total number of gRPC listeners closed",
     "type": "counter"
   },
   "fts_tot_grpc_listeners_opened": {
+    "added": "7.2.0",
     "help": "Total number of gRPC listeners opened",
     "type": "counter"
   },
   "fts_tot_grpc_queryreject_on_memquota": {
+    "added": "7.2.0",
     "help": "Total number of gRPC queries rejected due to the memory quota being lesser than the estimated memory required for merging search results from all partitions from the query",
     "type": "counter"
   },
   "fts_tot_grpcs_listeners_closed": {
+    "added": "7.2.0",
     "help": "Total number of gRPC SSL listeners closed",
     "type": "counter"
   },
   "fts_tot_grpcs_listeners_opened": {
+    "added": "7.2.0",
     "help": "Total number of gRPC SSL listeners opened",
     "type": "counter"
   },
   "fts_tot_http_limitlisteners_closed": {
+    "added": "7.2.0",
     "help": "Total number of HTTP limit listeners closed",
     "type": "counter"
   },
   "fts_tot_http_limitlisteners_opened": {
+    "added": "7.2.0",
     "help": "Total number of HTTP limit listeners opened",
     "type": "counter"
   },
   "fts_tot_https_limitlisteners_closed": {
+    "added": "7.2.0",
     "help": "Total number of HTTPS limit listeners closed",
     "type": "counter"
   },
   "fts_tot_https_limitlisteners_opened": {
+    "added": "7.2.0",
     "help": "Total number of HTTPS limit listeners opened",
     "type": "counter"
   },
   "fts_tot_queryreject_on_memquota": {
+    "added": "7.2.0",
     "help": "Total number of queries rejected due to the memory quota being lesser than the estimated memory required for merging search results from all partitions from the query",
     "type": "counter"
   },
   "fts_tot_remote_grpc": {
+    "added": "7.2.0",
     "help": "Total number of remote(i.e. different node) gRPC requests",
     "type": "counter"
   },
@@ -266,14 +640,17 @@
     "type": "counter"
   },
   "fts_tot_remote_grpc_tls": {
+    "added": "7.2.0",
     "help": "Total number of remote(i.e. different node) gRPC SSL requests when adding clients.",
     "type": "counter"
   },
   "fts_tot_remote_http": {
+    "added": "7.2.0",
     "help": "Total number of remote(i.e. different node) HTTP requests",
     "type": "counter"
   },
   "fts_tot_remote_http2": {
+    "added": "7.2.0",
     "help": "Total number of remote(i.e. different node) HTTP SSL requests",
     "type": "counter"
   },
@@ -283,6 +660,7 @@
     "type": "counter"
   },
   "fts_total_bytes_indexed": {
+    "added": "7.2.0",
     "help": "Rate of bytes indexed for an index",
     "labels": [
       "bucket",
@@ -294,6 +672,7 @@
     "uiName": "Search Index Rate"
   },
   "fts_total_bytes_query_results": {
+    "added": "7.2.0",
     "help": "Size of results coming back from full text queries for search results, including the entire size of the JSON sent",
     "labels": [
       "bucket",
@@ -306,6 +685,7 @@
     "unit": "bytes"
   },
   "fts_total_compaction_written_bytes": {
+    "added": "7.2.0",
     "help": "Number of bytes written to disk as a result of compaction",
     "labels": [
       "bucket",
@@ -318,11 +698,13 @@
     "unit": "bytes"
   },
   "fts_total_gc": {
+    "added": "7.2.0",
     "help": "The number of garbage collection events triggered",
     "notes": "Process level statistic from the Go runtime",
     "type": "counter"
   },
   "fts_total_grpc_internal_queries": {
+    "added": "7.2.0",
     "help": "The number of internal gRPC requests from the co-ordinating node for the query to other nodes, for an index",
     "labels": [
       "bucket",
@@ -333,6 +715,7 @@
     "type": "counter"
   },
   "fts_total_grpc_queries": {
+    "added": "7.2.0",
     "help": "The total number of queries, using gRPC for streaming, for an index",
     "labels": [
       "bucket",
@@ -343,6 +726,7 @@
     "type": "counter"
   },
   "fts_total_grpc_queries_error": {
+    "added": "7.2.0",
     "help": "The number of queries that resulted in an error, using gRPC for streaming, for an index",
     "labels": [
       "bucket",
@@ -353,6 +737,7 @@
     "type": "counter"
   },
   "fts_total_grpc_queries_slow": {
+    "added": "7.2.0",
     "help": "The number of queries in the slow query log, using gRPC for streaming, for an index",
     "labels": [
       "bucket",
@@ -363,6 +748,7 @@
     "type": "counter"
   },
   "fts_total_grpc_queries_timeout": {
+    "added": "7.2.0",
     "help": "The number of queries that exceeded the timeout, using gRPC for streaming, for an index",
     "labels": [
       "bucket",
@@ -373,6 +759,7 @@
     "type": "counter"
   },
   "fts_total_internal_queries": {
+    "added": "7.2.0",
     "help": "The number of internal queries from the co-ordinating node to other nodes, per unit time for an index",
     "labels": [
       "bucket",
@@ -393,7 +780,19 @@
     ],
     "type": "counter"
   },
+  "fts_total_mutations_filtered": {
+    "added": "8.0.0",
+    "help": "Total number of mutations that qualify for any document filter in an index (in-memory only stat)",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index"
+    ],
+    "type": "counter"
+  },
   "fts_total_queries": {
+    "added": "7.2.0",
     "help": "The number of full text queries per second for an index",
     "labels": [
       "bucket",
@@ -417,6 +816,7 @@
     "uiName": "Search Query Error DissatisfiedConsistency"
   },
   "fts_total_queries_error": {
+    "added": "7.2.0",
     "help": "The number of FTS queries for an index that resulted in an error",
     "labels": [
       "bucket",
@@ -440,6 +840,7 @@
     "uiName": "Search Query Error PartialResults"
   },
   "fts_total_queries_rejected_by_herder": {
+    "added": "7.2.0",
     "help": "The number of queries rejected by the app herder when the memory used exceeds the application's query quota",
     "type": "counter",
     "uiName": "Rejected Queries"
@@ -451,6 +852,7 @@
     "uiName": "Search Query Error SearchInContext"
   },
   "fts_total_queries_slow": {
+    "added": "7.2.0",
     "help": "The number of FTS queries in the slow query log",
     "labels": [
       "bucket",
@@ -462,6 +864,7 @@
     "uiName": "Search Slow Queries"
   },
   "fts_total_queries_timeout": {
+    "added": "7.2.0",
     "help": "The number of FTS queries for an index that exceeded the timeout",
     "labels": [
       "bucket",
@@ -472,7 +875,30 @@
     "type": "counter",
     "uiName": "Search Query Timeout Rate"
   },
+  "fts_total_queries_to_actives": {
+    "added": "8.0.0",
+    "help": "Total number of searches served by the active partitions of an index on a node",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index"
+    ],
+    "type": "counter"
+  },
+  "fts_total_queries_to_replicas": {
+    "added": "8.0.0",
+    "help": "Total number of searches served by the replica partitions of an index on a node",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index"
+    ],
+    "type": "counter"
+  },
   "fts_total_request_time": {
+    "added": "7.2.0",
     "help": "Total time spent processing query requests for an index",
     "labels": [
       "bucket",
@@ -483,7 +909,19 @@
     "type": "counter",
     "unit": "nanoseconds"
   },
+  "fts_total_synonym_searches": {
+    "added": "8.0.0",
+    "help": "Total bleve synonym search operations",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index"
+    ],
+    "type": "counter"
+  },
   "fts_total_term_searchers": {
+    "added": "7.2.0",
     "help": "Number of bleve term searchers",
     "labels": [
       "bucket",
@@ -496,6 +934,7 @@
     "uiName": "Term Searchers Start Rate"
   },
   "fts_total_term_searchers_finished": {
+    "added": "7.2.0",
     "help": "Total term searchers that have finished serving a query",
     "labels": [
       "bucket",
@@ -509,5 +948,10 @@
     "added": "7.6.1",
     "help": "The total number of vectors indexed",
     "type": "gauge"
+  },
+  "total_knn_queries_rejected_by_throttler": {
+    "added": "7.6.4",
+    "help": "Total number of http query requests with KNN rejected by the throttler",
+    "type": "counter"
   }
 }

--- a/modules/metrics-reference/attachments/goxdcr_metrics_metadata.json
+++ b/modules/metrics-reference/attachments/goxdcr_metrics_metadata.json
@@ -49,7 +49,7 @@
     "type": "counter"
   },
   "xdcr_binary_filtered_total": {
-    "added": "7.2.1",
+    "added": "7.6.0",
     "help": "Number of documents filtered that were binary documents",
     "labels": [
       "sourceBucketName",
@@ -77,6 +77,259 @@
   "xdcr_client_txn_docs_filtered_total": {
     "added": "7.6.0",
     "help": "Total number of documents filtered and not replicated because the documents were transaction client records",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_clog_crd_docs_written_total": {
+    "added": "8.0.0",
+    "help": "Number of CRDs written to the conflict bucket.",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_clog_docs_filtered_total": {
+    "added": "8.0.0",
+    "help": "Number of conflict records filtered.",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_clog_docs_written_total": {
+    "added": "8.0.0",
+    "help": "Total number of conflict docs written. This counter includes all three types of conflict doc - source doc, target doc and CRD for the conflict detected.",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_clog_eaccesses_total": {
+    "added": "8.0.0",
+    "help": "Number of EACCESS errors encountered while writing the conflict records to the conflict bucket. It is likely that something has gone wrong with the previliges of the user used for conflict writing",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_clog_fatal_resps_total": {
+    "added": "8.0.0",
+    "help": "Number of fatal errors encountered while writing the conflict records to the conflict bucket. It includes EINVAL and XATTR_EINVAL.",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_clog_guardrail_hits_total": {
+    "added": "8.0.0",
+    "help": "Number of guardrail hit errors encountered while writing the conflict records to the conflict bucket. It includes resident ratio, data size and disk space guardrail errors.",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_clog_hibernated_count_total": {
+    "added": "8.0.0",
+    "help": "Number of docs which were identified as conflicts, but could not be logged because the conflict logger was hibernated.",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_clog_impossible_resps_total": {
+    "added": "8.0.0",
+    "help": "Number of errors which by design should not have been returned, encountered while writing the conflict records to the conflict bucket. It includes EEXISTS, ENOENT and LOCKED errors.",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_clog_not_my_vbs_total": {
+    "added": "8.0.0",
+    "help": "Number of NOT_MY_VBUCKET errors encountered while writing the conflict records to the conflict bucket. It mostly is an indicator of topology changes.",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_clog_nw_errors_total": {
+    "added": "8.0.0",
+    "help": "Number of network errors encountered while writing the conflict records to the conflict bucket.",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_clog_other_errors_total": {
+    "added": "8.0.0",
+    "help": "Number of unidentified errors encountered while writing the conflict records to the conflict bucket. One should turn on debug logging for the replication to catch the unknown response.",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_clog_pool_get_timedout_total": {
+    "added": "8.0.0",
+    "help": "Number of conflict records for which the conflict logger had trouble getting a connection to the conflict bucket.",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_clog_queue_full_total": {
+    "added": "8.0.0",
+    "help": "Number of docs which were identified as conflicts, but could not be logged because the logging queue was full.",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_clog_src_docs_written_total": {
+    "added": "8.0.0",
+    "help": "Number of source conflict docs written to the conflict bucket.",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_clog_status": {
+    "added": "8.0.0",
+    "help": "Indicates if the conflict logger of the replication is running or hibernated or if it does not exist.",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType",
+      "status"
+    ],
+    "stability": "committed",
+    "type": "gauge"
+  },
+  "xdcr_clog_tgt_docs_written_total": {
+    "added": "8.0.0",
+    "help": "Number of target conflict docs written to the conflict bucket.",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_clog_throttled_total": {
+    "added": "8.0.0",
+    "help": "Number of conflict records which were throttled due to resource management and hence not written to conflict bucket.",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_clog_tmpfails_total": {
+    "added": "8.0.0",
+    "help": "Number of TMPFAIL errors encountered while writing the conflict records to the conflict bucket. It indicates that the data service was temporarily busy and could not process the incoming write.",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_clog_unknown_collections_total": {
+    "added": "8.0.0",
+    "help": "Number of UNKNOWN_COLLECTION errors encountered while writing the conflict records to the conflict bucket. It indicates that where was a change to the collections setup which affected the conflict writes.",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_clog_unknown_resps_total": {
+    "added": "8.0.0",
+    "help": "Number of unknown responses returned by the source KV while writing the conflict records to the conflict bucket. One should turn on debug logging for the replication to catch the unknown response.",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_clog_write_timedout_total": {
+    "added": "8.0.0",
+    "help": "Number of conflict records for which the write to conflict bucket was timed out.",
     "labels": [
       "sourceBucketName",
       "targetClusterUUID",
@@ -127,7 +380,7 @@
     "unit": "bytes"
   },
   "xdcr_data_replicated_uncompress_bytes": {
-    "added": "7.6.0",
+    "added": "7.0.0",
     "help": "Theoretical amount of data replicated for a Replication if compression were not used",
     "labels": [
       "sourceBucketName",
@@ -275,6 +528,18 @@
     "stability": "internal",
     "type": "counter"
   },
+  "xdcr_docs_cas_poisoned_total": {
+    "added": "8.0.0",
+    "help": "Total number of documents not replicated because cas is beyond acceptable drift threshold",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
   "xdcr_docs_checked_total": {
     "added": "7.0.0",
     "help": "Across vBuckets for this node, the sum of all sequence numbers that have been considered to be checkpointed",
@@ -299,6 +564,18 @@
       "pipelineType"
     ],
     "notes": "This usually means that one source mutation is now going to exist in two or more target collections, leading to mismatching doc counts between buckets. This can happen when migration mode is turned on, and the migration filtering expression is not specific enough, leading to a single doc matching multiple migration filtering expressions. To prevent this, ensure that the filtering expr are more specific such that each doc is migrated to only one target collection.",
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_docs_compression_skipped_total": {
+    "added": "8.0.0",
+    "help": "Total number of documents whose compression was skipped before replication, due to a larger snappy-compressed size",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
     "stability": "committed",
     "type": "counter"
   },
@@ -443,6 +720,54 @@
     "type": "counter",
     "uiName": "xdcr_docs_received_from_dcp_total"
   },
+  "xdcr_docs_sent_with_poisonedCas_errorMode_total": {
+    "added": "8.0.0",
+    "help": "The total number of documents that failed the set_with_meta operation due to the set CAS exceeding the acceptable threshold on the target data service.",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_docs_sent_with_poisonedCas_replaceMode_total": {
+    "added": "8.0.0",
+    "help": "The total number of documents replicated to the target, where the target data service regenerated CAS values because the set CAS exceeded the acceptable threshold on the target's data service.",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_docs_sent_with_subdoc_delete_total": {
+    "added": "7.6.6",
+    "help": "The number of deletes issued using subdoc command instead of delete_with_meta to avoid cas rollback on target",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_docs_sent_with_subdoc_set_total": {
+    "added": "7.6.6",
+    "help": "The number of sets issued using subdoc command instead of set_with_meta to avoid cas rollback on target",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
   "xdcr_docs_unable_to_filter_total": {
     "added": "7.0.0",
     "help": "Number of Document Mutations that couldn't be filtered due to inability to parse the document through Advanced Filtering engine and were not replicated",
@@ -579,13 +904,26 @@
   },
   "xdcr_expiry_target_docs_skipped_total": {
     "added": "7.0.0",
-    "help": "Subset of the number of Document Mutations that originated from the Target that specifically had Expiry flag set",
+    "help": "Subset of the number of mutations (with Expiry flag set) and deletions/expirations that originated from the Target",
     "labels": [
       "sourceBucketName",
       "targetClusterUUID",
       "targetBucketName",
       "pipelineType"
     ],
+    "stability": "internal",
+    "type": "counter"
+  },
+  "xdcr_get_docs_cas_changed_total": {
+    "added": "8.0.0",
+    "help": "Number of get operations that were retried because the CAS on the target changed",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "notes": "Represents the number of docs which were in conflict, but it's target CAS changed before fetching target body for further processing for conflict logging or merging of the conflicting source and target docs.",
     "stability": "internal",
     "type": "counter"
   },
@@ -628,6 +966,66 @@
     "stability": "committed",
     "type": "counter"
   },
+  "xdcr_hlv_pruned_at_merge_total": {
+    "added": "7.6.6",
+    "help": "Number of mutations with HLV pruned when it is merged with target document",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_hlv_pruned_total": {
+    "added": "7.6.6",
+    "help": "Number of mutations with HLV pruned",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_hlv_updated_total": {
+    "added": "7.6.6",
+    "help": "Number of mutations with HLV updated",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_import_docs_failed_cr_source_total": {
+    "added": "7.6.6",
+    "help": "Number of mobile import mutations failed Source side Conflict Resolution. This is only counted in LWW buckets when enableCrossClusterVersioning is true",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_import_docs_written_total": {
+    "added": "7.6.6",
+    "help": "Number of import mutations sent",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
   "xdcr_mobile_docs_filtered_total": {
     "added": "7.6.0",
     "help": "Total number of documents filtered and not replicated because the documents were mobile records",
@@ -664,8 +1062,38 @@
     "stability": "committed",
     "type": "counter"
   },
+  "xdcr_number_of_replications_total": {
+    "added": "8.0.0",
+    "help": "The total number of replications that exists to replicate to a particular target cluster",
+    "labels": [
+      "targetClusterUUID"
+    ],
+    "stability": "committed",
+    "type": "gauge"
+  },
+  "xdcr_number_of_source_nodes_total": {
+    "added": "8.0",
+    "help": "For a given source cluster, the number of data service nodes that it contains",
+    "labels": [
+      "sourceClusterUUID",
+      "sourceClusterName"
+    ],
+    "stability": "committed",
+    "type": "gauge"
+  },
+  "xdcr_number_of_source_replications_total": {
+    "added": "8.0",
+    "help": "For a given source cluster, the total number of outbound replications to this cluster",
+    "labels": [
+      "sourceClusterUUID",
+      "sourceClusterName",
+      "status"
+    ],
+    "stability": "committed",
+    "type": "gauge"
+  },
   "xdcr_pipeline_errors": {
-    "added": "7.2.1",
+    "added": "7.6.0",
     "help": "The number of currently present errors for a specific Replication Pipeline",
     "labels": [
       "sourceBucketName",
@@ -678,7 +1106,7 @@
     "type": "gauge"
   },
   "xdcr_pipeline_status": {
-    "added": "7.2.1",
+    "added": "7.6.0",
     "help": "The pipeline status for a specific pipeline, where it could be paused, running or, error",
     "labels": [
       "sourceBucketName",
@@ -816,6 +1244,42 @@
     "type": "gauge",
     "unit": "bytes"
   },
+  "xdcr_source_sync_xattr_removed_total": {
+    "added": "7.6.6",
+    "help": "Number of mutations with source mobile extended attributes removed",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_subdoc_cmd_docs_cas_changed_total": {
+    "added": "7.6.6",
+    "help": "Number of Subdoc sets and delete operations that failed because the CAS on the Target changed",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "internal",
+    "type": "counter"
+  },
+  "xdcr_subdoc_cmd_docs_skipped_total": {
+    "added": "7.6.6",
+    "help": "Number of document mutations that were not replicated to the target because they resulted in subdoc commands breaching the maximum paths limit.",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "internal",
+    "type": "counter"
+  },
   "xdcr_system_events_received_from_dcp_total": {
     "added": "7.6.0",
     "help": "The number of system events received from source data service",
@@ -842,7 +1306,7 @@
     "type": "counter"
   },
   "xdcr_target_eaccess_total": {
-    "added": "7.2.1",
+    "added": "7.6.0",
     "help": "The total number of EACCESS errors returned from the target node.",
     "labels": [
       "sourceBucketName",
@@ -853,8 +1317,20 @@
     "stability": "committed",
     "type": "counter"
   },
+  "xdcr_target_sync_xattr_preserved_total": {
+    "added": "7.6.6",
+    "help": "Number of mutations with target mobile extended attributes preserved",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
   "xdcr_target_tmpfail_total": {
-    "added": "7.2.1",
+    "added": "7.6.0",
     "help": "The total number of TMPFAIL errors returned from the target node.",
     "labels": [
       "sourceBucketName",
@@ -916,6 +1392,18 @@
     "stability": "committed",
     "type": "gauge",
     "unit": "seconds"
+  },
+  "xdcr_true_conflicts_detected_total": {
+    "added": "8.0.0",
+    "help": "Number of true conflicts detected when the conflict logging feature is turned on. Logging of all these conflicts to a conflict bucket is best-effort, based on the system's state.",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
   },
   "xdcr_wtavg_docs_latency_seconds": {
     "added": "7.0.0",

--- a/modules/metrics-reference/attachments/index_metrics_metadata.json
+++ b/modules/metrics-reference/attachments/index_metrics_metadata.json
@@ -54,7 +54,7 @@
     "unit": "Nanoseconds"
   },
   "index_cache_hits": {
-    "help": "Number of times the required index page is found in memory, for this index",
+    "help": "The number of times the required index page for both scan and mutations is found in memory, for this index",
     "labels": [
       "bucket",
       "scope",
@@ -65,7 +65,7 @@
     "type": "counter"
   },
   "index_cache_misses": {
-    "help": "Number of times the required index page is NOT found in memory, for this index",
+    "help": "The number of times the required index page for both scan and mutations is NOT found in memory, for this index",
     "labels": [
       "bucket",
       "scope",
@@ -74,6 +74,30 @@
     ],
     "notes": "This metric is valid only for standard GSI indexes.",
     "type": "counter"
+  },
+  "index_codebook_mem_usage": {
+    "added": "7.7",
+    "help": "Amount of memory used by codebook for this index, includes memory used for coarse codebook and quantization codebook",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index"
+    ],
+    "type": "counter",
+    "unit": "bytes"
+  },
+  "index_codebook_train_duration": {
+    "added": "7.7",
+    "help": "Amount of time spent in training the codebook, for this index",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index"
+    ],
+    "type": "counter",
+    "unit": "Nanoseconds"
   },
   "index_data_size": {
     "help": "The approximate size of the valid uncompressed index data, for this index",
@@ -97,6 +121,18 @@
     ],
     "notes": "This metric is valid only for standard GSI indexes.",
     "type": "gauge",
+    "unit": "bytes"
+  },
+  "index_disk_bytes": {
+    "added": "7.6.4",
+    "help": "Number of bytes read from and written to disk, including insert, get, and delete operations",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index"
+    ],
+    "type": "counter",
     "unit": "bytes"
   },
   "index_disk_size": {
@@ -124,7 +160,6 @@
     "uiName": "Index Fragmentation"
   },
   "index_heap_in_use": {
-    "added": "7.6.0",
     "help": "Total heap memory in use by indexer process in the node",
     "notes": "This does not include the actual index pages, but it includes the Golang memory overheads required for index maintenance",
     "type": "gauge",
@@ -197,8 +232,13 @@
     "unit": "bytes"
   },
   "index_net_avg_scan_rate": {
-    "added": "7.6.0",
     "help": "Average index scan rate across all indexes, for this node",
+    "type": "gauge"
+  },
+  "index_num_diverging_replica_indexes": {
+    "added": "8.0.0",
+    "help": "Number of index partitions with diverging replica item counts.",
+    "notes": "Valid only for memory optimised, plasma storage modes.",
     "type": "gauge"
   },
   "index_num_docs_indexed": {
@@ -240,6 +280,17 @@
     "help": "Total number of indexes, located on this node",
     "type": "gauge"
   },
+  "index_num_items_flushed": {
+    "added": "7.6.4",
+    "help": "Number of documents written from memory to index storage",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index"
+    ],
+    "type": "counter"
+  },
   "index_num_requests": {
     "help": "Number of scan requests received by the index service, for this index",
     "labels": [
@@ -279,6 +330,32 @@
     "added": "7.2.0",
     "help": "Total number of storage instances, located on this node",
     "notes": "For partitioned indexes with replicas, for an index, more than one instance can reside on a single node.",
+    "type": "gauge"
+  },
+  "index_partn_is_diverging_replica": {
+    "added": "8.0.0",
+    "help": "Set to '1' if the index partition has diverging replica item counts",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index",
+      "partition"
+    ],
+    "notes": "Valid only for memory optimized, plasma indexes",
+    "type": "gauge"
+  },
+  "index_partn_items_count": {
+    "added": "7.6.6",
+    "help": "The actual number of items present in the latest index snapshot, for this partition",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index",
+      "partition"
+    ],
+    "notes": "This metric is valid only for partitioned indexes.",
     "type": "gauge"
   },
   "index_raw_data_size": {
@@ -340,6 +417,41 @@
     "uiName": "Index Scan Bytes",
     "unit": "bytes"
   },
+  "index_scan_cache_hits": {
+    "added": "8.0",
+    "help": "Number of times the required index page for serving scan request is found in memory, for this index",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index"
+    ],
+    "notes": "This metric is valid only for standard GSI indexes.",
+    "type": "counter"
+  },
+  "index_scan_cache_misses": {
+    "added": "8.0",
+    "help": "Number of times the required index page for serving scan request is NOT found in memory, for this index",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index"
+    ],
+    "notes": "This metric is valid only for standard GSI indexes.",
+    "type": "counter"
+  },
+  "index_state": {
+    "added": "7.6.6",
+    "help": "The current state of this index; CREATED: 0, READY: 1, INITIAL: 2, CATCHUP: 3, ACTIVE: 4, DELETED: 5, ERROR: 6, NIL: 7, SCHEDULED: 8, RECOVERED: 9. Index is usable only in ACTIVE state",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index"
+    ],
+    "type": "gauge"
+  },
   "index_storage_avg_item_size": {
     "added": "7.6.0",
     "help": "Ratio of total item size and total records",
@@ -394,6 +506,102 @@
     "notes": "Valid only for standard GSI indexes.",
     "type": "gauge",
     "unit": "bytes"
+  },
+  "index_storage_hvi_blk_read_bs": {
+    "added": "8.0.0",
+    "help": "Total number of bytes that were read from disk into memory",
+    "notes": "Valid only for HVI standard GSI indexes.",
+    "type": "gauge"
+  },
+  "index_storage_hvi_blk_reads_bs_get": {
+    "added": "8.0.0",
+    "help": "Total number of bytes that were read from disk into memory for index scans",
+    "notes": "Valid only for HVI standard GSI indexes.",
+    "type": "gauge"
+  },
+  "index_storage_hvi_blk_reads_bs_lookup": {
+    "added": "8.0.0",
+    "help": "Total number of bytes that were read from disk into memory for lookups",
+    "notes": "Valid only for HVI standard GSI indexes.",
+    "type": "gauge"
+  },
+  "index_storage_hvi_buf_memused": {
+    "added": "8.0.0",
+    "help": "Total Memory used by various reusable buffers",
+    "notes": "Valid only for HVI standard GSI indexes.",
+    "type": "gauge"
+  },
+  "index_storage_hvi_bytes_incoming": {
+    "added": "8.0.0",
+    "help": "Total number of bytes that were added to the stores and intended to be written to disk",
+    "notes": "Valid only for HVI standard GSI indexes.",
+    "type": "gauge"
+  },
+  "index_storage_hvi_bytes_written": {
+    "added": "8.0.0",
+    "help": "Total number of bytes that were written to disk",
+    "notes": "Valid only for HVI standard GSI indexes.",
+    "type": "gauge"
+  },
+  "index_storage_hvi_compacts": {
+    "added": "8.0.0",
+    "help": "Total count of compaction operations performed",
+    "notes": "Valid only for HVI standard GSI indexes.",
+    "type": "gauge"
+  },
+  "index_storage_hvi_compression_ratio_avg": {
+    "added": "8.0.0",
+    "help": "Ratio of data bytes to be compressed and data bytes after compression",
+    "notes": "Valid only for HVI standard GSI indexes.",
+    "type": "gauge"
+  },
+  "index_storage_hvi_fragmentation": {
+    "added": "8.0.0",
+    "help": "The fraction of garbage data present on disk",
+    "notes": "Valid only for HVI standard GSI indexes.",
+    "type": "gauge"
+  },
+  "index_storage_hvi_memory_used": {
+    "added": "8.0.0",
+    "help": "Total memory used by HVI indexes",
+    "notes": "Valid only for HVI standard GSI indexes.",
+    "type": "gauge"
+  },
+  "index_storage_hvi_num_reads": {
+    "added": "8.0.0",
+    "help": "Total number of times a disk block is read into memory",
+    "notes": "Valid only for HVI standard GSI indexes.",
+    "type": "gauge"
+  },
+  "index_storage_hvi_num_reads_get": {
+    "added": "8.0.0",
+    "help": "Total number of times a disk block was read into memory due to index scans",
+    "notes": "Valid only for HVI standard GSI indexes.",
+    "type": "gauge"
+  },
+  "index_storage_hvi_num_reads_lookup": {
+    "added": "8.0.0",
+    "help": "Total number of times a disk block was read into memory due to lookups",
+    "notes": "Valid only for HVI standard GSI indexes.",
+    "type": "gauge"
+  },
+  "index_storage_hvi_resident_ratio": {
+    "added": "8.0.0",
+    "help": "Ratio of cache mem used and cacheable size",
+    "notes": "Valid only for HVI standard GSI indexes.",
+    "type": "gauge"
+  },
+  "index_storage_hvi_total_disk_size": {
+    "added": "8.0.0",
+    "help": "Total disk usage in bytes",
+    "notes": "Valid only for HVI standard GSI indexes.",
+    "type": "gauge"
+  },
+  "index_storage_hvi_total_used_size": {
+    "added": "8.0.0",
+    "help": "Total number of disk bytes used. This size is eligible for cleanups in subsequent compactions.",
+    "notes": "Valid only for HVI standard GSI indexes.",
+    "type": "gauge"
   },
   "index_storage_items_count": {
     "added": "7.6.0",
@@ -527,17 +735,14 @@
     "type": "gauge"
   },
   "index_total_mutation_queue_size": {
-    "added": "7.6.0",
     "help": "Total number of index updates queued in the mutation queues, on this node",
     "type": "gauge"
   },
   "index_total_pending_scans": {
-    "added": "7.6.0",
     "help": "Sum of number of pending scans across all indexes, located on this node",
     "type": "gauge"
   },
   "index_total_raw_data_size": {
-    "added": "7.6.0",
     "help": "Sum of encoded, uncompressed size of the index data across all indexes, located on this node",
     "type": "gauge",
     "unit": "bytes"

--- a/modules/metrics-reference/attachments/kv_metrics_metadata.json
+++ b/modules/metrics-reference/attachments/kv_metrics_metadata.json
@@ -23,6 +23,32 @@
     "stability": "committed",
     "type": "gauge"
   },
+  "kv_auth_external_authentication_duration_seconds": {
+    "added": "8.0.0",
+    "help": "Timing histogram for external authentication execution times",
+    "stability": "committed",
+    "type": "histogram",
+    "unit": "seconds"
+  },
+  "kv_auth_external_authorization_duration_seconds": {
+    "added": "8.0.0",
+    "help": "Timing histogram for external authorization execution times",
+    "stability": "committed",
+    "type": "histogram",
+    "unit": "seconds"
+  },
+  "kv_auth_external_received": {
+    "added": "8.0.0",
+    "help": "The number of received external authentication responses",
+    "stability": "committed",
+    "type": "gauge"
+  },
+  "kv_auth_external_sent": {
+    "added": "8.0.0",
+    "help": "The total number of requests sent to the external authentication provider",
+    "stability": "committed",
+    "type": "gauge"
+  },
   "kv_bg_batch_size": {
     "added": "7.0.0",
     "help": "Batch size for background fetches",
@@ -65,66 +91,54 @@
   },
   "kv_cmd_lookup": {
     "added": "7.0.0",
-    "help": "The number of lookup operations",
+    "help": "The number of lookup operations. This includes operations such as Get, Gat, Getk, Getq, GetLocked, GetRandomKey, GetReplica, SubdocMultiLookup, SubdocGet and SubdocExists",
     "stability": "committed",
     "type": "counter"
   },
   "kv_cmd_lookup_10s_count": {
     "added": "7.0.0",
-    "help": "The number of lookup operations performed within the last 10 seconds",
+    "help": "The number of lookup operations performed within the last 10 seconds. This aggregates operations like Get, Gat, Getk, Getq, and various Sub-Document lookups",
     "stability": "committed",
     "type": "gauge"
   },
   "kv_cmd_lookup_10s_duration_seconds": {
     "added": "7.0.0",
-    "help": "The total duration of lookup operations performed over the last 10 seconds",
+    "help": "The total duration of lookup operations performed over the last 10 seconds. This aggregates the time for operations like Get, Gat, Getk, Getq, and various Sub-Document lookups",
     "stability": "committed",
     "type": "gauge",
     "unit": "seconds"
   },
   "kv_cmd_mutation": {
     "added": "7.0.0",
-    "help": "The number of mutation operations",
+    "help": "The number of mutation operations. This includes operations such as Add, Append, Decrement, Delete, Gat, Increment, Prepend, Replace, Set, Touch, and various Sub-Document mutations (e.g., SubdocArrayAddUnique, SubdocCounter, SubdocDelete, etc.)",
     "stability": "committed",
     "type": "counter"
   },
   "kv_cmd_mutation_10s_count": {
     "added": "7.0.0",
-    "help": "The number of mutation operations performed within the last 10 seconds",
+    "help": "The number of mutation operations performed within the last 10 seconds. This includes operations like Add, Append, Delete, Replace, and various Sub-Document mutations",
     "stability": "committed",
     "type": "gauge"
   },
   "kv_cmd_mutation_10s_duration_seconds": {
     "added": "7.0.0",
-    "help": "The total duration of mutation operations performed over the last 10 seconds",
+    "help": "The total duration of mutation operations performed over the last 10 seconds. This includes time spent on operations like Add, Append, Delete, Replace, and various Sub-Document mutations",
     "stability": "committed",
     "type": "gauge",
     "unit": "seconds"
   },
-  "kv_cmd_total_gets": {
-    "added": "7.0.0",
-    "help": "The total number of data retrieval operations (all buckets)",
-    "stability": "committed",
-    "type": "counter"
-  },
-  "kv_cmd_total_ops": {
-    "added": "7.0.0",
-    "help": "The sum of cmd_total_sets and cmd_total_gets (all buckets)",
-    "stability": "committed",
-    "type": "counter"
-  },
-  "kv_cmd_total_sets": {
-    "added": "7.0.0",
-    "help": "The total number of mutation operations (all buckets)",
-    "stability": "committed",
-    "type": "counter"
-  },
   "kv_collection_data_size_bytes": {
     "added": "7.0.0",
-    "help": "Per-collection data size on disk",
+    "help": "Per-collection data size on disk for active vbuckets only",
     "stability": "committed",
     "type": "gauge",
     "unit": "bytes"
+  },
+  "kv_collection_flush_uid": {
+    "added": "8.0.0",
+    "help": "The last manifest-uid triggering a flush",
+    "stability": "internal",
+    "type": "gauge"
   },
   "kv_collection_history": {
     "added": "7.2.0",
@@ -134,7 +148,7 @@
   },
   "kv_collection_item_count": {
     "added": "7.0.0",
-    "help": "Per-collection item count",
+    "help": "Per-collection item count for active vbuckets only",
     "stability": "committed",
     "type": "gauge"
   },
@@ -147,14 +161,14 @@
   },
   "kv_collection_mem_used_bytes": {
     "added": "7.0.0",
-    "help": "Per-collection memory usage",
+    "help": "Per-collection memory usage for active vbuckets only",
     "stability": "committed",
     "type": "gauge",
     "unit": "bytes"
   },
   "kv_collection_ops": {
     "added": "7.0.0",
-    "help": "Per-collection counters of sets/gets/deletes",
+    "help": "Per-collection counters of operations that perform store/get(read)/delete type operations against active vbuckets",
     "labels": [
       "op"
     ],
@@ -185,9 +199,33 @@
     "stability": "committed",
     "type": "gauge"
   },
+  "kv_credit_cu_total": {
+    "added": "7.6.0",
+    "help": "Total Compute Units refunded for a bucket (CU was charged, but operation failed) since reset",
+    "stability": "internal",
+    "type": "counter"
+  },
+  "kv_credit_ru_total": {
+    "added": "7.6.0",
+    "help": "Total Read Units refunded for a bucket (RU was charged, but operation failed) since reset",
+    "stability": "internal",
+    "type": "counter"
+  },
+  "kv_credit_wu_total": {
+    "added": "7.6.0",
+    "help": "Total Write Units refunded for a bucket (WU was charged, but operation failed) since reset",
+    "stability": "internal",
+    "type": "counter"
+  },
   "kv_curr_connections": {
     "added": "7.0.0",
     "help": "The current number of connections. This includes user, system and daemon connections",
+    "stability": "committed",
+    "type": "gauge"
+  },
+  "kv_curr_connections_closing": {
+    "added": "8.0.0",
+    "help": "The current number of connections currently closing down",
     "stability": "committed",
     "type": "gauge"
   },
@@ -206,6 +244,12 @@
   "kv_curr_temp_items": {
     "added": "7.0.0",
     "help": "Number of temporary items in memory",
+    "stability": "committed",
+    "type": "gauge"
+  },
+  "kv_current_external_client_connections": {
+    "added": "7.6.5",
+    "help": "The current number of authenticated connections using the labelled SDK",
     "stability": "committed",
     "type": "gauge"
   },
@@ -370,12 +414,6 @@
     "stability": "committed",
     "type": "gauge"
   },
-  "kv_ep_access_scanner_task_time": {
-    "added": "7.0.0",
-    "help": "Time of the next access scanner task (GMT), NOT_SCHEDULED if access scanner has been disabled",
-    "stability": "committed",
-    "type": "gauge"
-  },
   "kv_ep_ahead_exceptions": {
     "added": "7.0.0",
     "help": "Total number of times a vbucket saw an item with a HLC CAS from too far in the future (indicating the clock is behind)",
@@ -396,13 +434,13 @@
   },
   "kv_ep_alog_max_stored_items": {
     "added": "7.0.0",
-    "help": "",
+    "help": "The maximum number of items the Access Scanner will hold in memory before commiting them to disk",
     "stability": "volatile",
     "type": "gauge"
   },
   "kv_ep_alog_resident_ratio_threshold": {
     "added": "7.0.0",
-    "help": "",
+    "help": "Resident ratio percentage above which we do not generate access log",
     "stability": "volatile",
     "type": "gauge"
   },
@@ -434,7 +472,7 @@
   },
   "kv_ep_backfill_mem_threshold": {
     "added": "7.0.0",
-    "help": "",
+    "help": "Memory usage threshold (percentage of bucket quota) after which backfill will be snoozed.",
     "stability": "volatile",
     "type": "gauge"
   },
@@ -446,25 +484,25 @@
   },
   "kv_ep_bfilter_enabled": {
     "added": "7.0.0",
-    "help": "",
+    "help": "Enable or disable the bloom filter",
     "stability": "volatile",
     "type": "gauge"
   },
   "kv_ep_bfilter_fp_prob": {
     "added": "7.0.0",
-    "help": "",
+    "help": "Bloomfilter: Allowed probability for false positives",
     "stability": "volatile",
     "type": "gauge"
   },
   "kv_ep_bfilter_key_count": {
     "added": "7.0.0",
-    "help": "",
+    "help": "Bloomfilter: Estimated key count per vbucket",
     "stability": "volatile",
     "type": "gauge"
   },
   "kv_ep_bfilter_residency_threshold": {
     "added": "7.0.0",
-    "help": "",
+    "help": "If resident ratio (during full eviction) were found less than this threshold, compaction will include all items into bloomfilter",
     "stability": "volatile",
     "type": "gauge"
   },
@@ -604,6 +642,13 @@
     "type": "gauge",
     "unit": "bytes"
   },
+  "kv_ep_checkpoint_consumer_limit_bytes": {
+    "added": "7.6.2",
+    "help": "Max allocation allowed in all checkpoints (including the dcp consumer buffer quota)",
+    "stability": "committed",
+    "type": "gauge",
+    "unit": "bytes"
+  },
   "kv_ep_checkpoint_destruction_tasks": {
     "added": "7.0.0",
     "help": "Number of tasks responsible for destroying closed unreferenced checkpoints.",
@@ -685,12 +730,6 @@
     "stability": "committed",
     "type": "gauge"
   },
-  "kv_ep_chk_remover_stime": {
-    "added": "7.0.0",
-    "help": "",
-    "stability": "volatile",
-    "type": "gauge"
-  },
   "kv_ep_clock_cas_drift_threshold_exceeded": {
     "added": "7.0.0",
     "help": "ep_active_ahead_exceptions + ep_replica_ahead_exceptions",
@@ -755,7 +794,7 @@
   },
   "kv_ep_compaction_max_concurrent_ratio": {
     "added": "7.0.0",
-    "help": "",
+    "help": "Maximum number of CompactVBucketTask tasks which can run concurrently, as a fraction of the possible Writer task concurrency. Note that a minimum of 1, and a maximum of N-1 CompactVBucketTasks will be run (where N is the possible Writer task concurrency), to ensure both forward progress for Compaction and Flushing.",
     "stability": "volatile",
     "type": "gauge"
   },
@@ -774,6 +813,31 @@
   "kv_ep_connection_manager_interval": {
     "added": "7.0.0",
     "help": "How often connection manager task should be run (in seconds).",
+    "stability": "volatile",
+    "type": "gauge"
+  },
+  "kv_ep_continuous_backup_callback_count": {
+    "added": "8.0.0",
+    "help": "Number of times the continuous backup metadata callback was run.",
+    "stability": "committed",
+    "type": "gauge"
+  },
+  "kv_ep_continuous_backup_callback_time_seconds": {
+    "added": "8.0.0",
+    "help": "Time spent in KV in the continuous backup metadata callback.",
+    "stability": "committed",
+    "type": "gauge",
+    "unit": "seconds"
+  },
+  "kv_ep_continuous_backup_enabled": {
+    "added": "7.0.0",
+    "help": "True if continouous backup is enabled.",
+    "stability": "volatile",
+    "type": "gauge"
+  },
+  "kv_ep_continuous_backup_interval": {
+    "added": "7.0.0",
+    "help": "The continouous backup interval (in seconds).",
     "stability": "volatile",
     "type": "gauge"
   },
@@ -872,15 +936,51 @@
     "type": "gauge",
     "unit": "bytes"
   },
+  "kv_ep_dcp_backfill_byte_drain_ratio": {
+    "added": "7.0.0",
+    "help": "What ratio of the dcp_backfill_byte_limit must be drained for un-pausing a paused backfill",
+    "stability": "volatile",
+    "type": "gauge"
+  },
   "kv_ep_dcp_backfill_byte_limit": {
     "added": "7.0.0",
     "help": "Max bytes a connection can backfill into memory before backfill is paused",
     "stability": "volatile",
     "type": "gauge"
   },
+  "kv_ep_dcp_backfill_idle_disk_threshold": {
+    "added": "7.0.0",
+    "help": "The percentage of disk usage at which DCP backfills would be ended when no progress is made for dcp_backfill_idle_limit_seconds",
+    "stability": "volatile",
+    "type": "gauge"
+  },
+  "kv_ep_dcp_backfill_idle_limit_seconds": {
+    "added": "7.0.0",
+    "help": "How long (in seconds) a DCP Backfill can be held open with no progress being made. When this limit is exceeded the stream is force ended (reason Slow) releasing the resources being held by the stream. The default value is 2x of dcp_idle_timeout",
+    "stability": "volatile",
+    "type": "gauge"
+  },
+  "kv_ep_dcp_backfill_idle_protection_enabled": {
+    "added": "7.0.0",
+    "help": "When true, DCP backfills will be checked for progress. Any backfill which makes no progress for dcp_backfill_idle_limit_seconds will be subject to further checks. If the directory referenced by dbname is over dcp_backfill_idle_disk_threshold percent used and cancelling the backfill will free disk space, the scan cancels and the associated DCP stream will end with reason slow.",
+    "stability": "volatile",
+    "type": "gauge"
+  },
   "kv_ep_dcp_backfill_in_progress_per_connection_limit": {
     "added": "7.0.0",
     "help": "The maximum number of backfills each connection can have in-progress (i.e. KVStore snapshot open and reading data from)",
+    "stability": "volatile",
+    "type": "gauge"
+  },
+  "kv_ep_dcp_backfill_run_duration_limit": {
+    "added": "7.0.0",
+    "help": "Maximum time (in ms) backfill task will run before yielding.",
+    "stability": "volatile",
+    "type": "gauge"
+  },
+  "kv_ep_dcp_checkpoint_dequeue_limit": {
+    "added": "7.0.0",
+    "help": "The limit given to CheckpointManager::getNextItemsForDcp by ActiveStream",
     "stability": "volatile",
     "type": "gauge"
   },
@@ -908,12 +1008,6 @@
     "stability": "volatile",
     "type": "gauge"
   },
-  "kv_ep_dcp_consumer_process_unacked_bytes_yield_limit": {
-    "added": "7.0.0",
-    "help": "The number of DcpConsumerTask iterations before forcing the task to yield.",
-    "stability": "volatile",
-    "type": "gauge"
-  },
   "kv_ep_dcp_enable_noop": {
     "added": "7.0.0",
     "help": "Whether DCP Consumer connections should attempt to negotiate no-ops with the Producer",
@@ -928,7 +1022,7 @@
   },
   "kv_ep_dcp_min_compression_ratio": {
     "added": "7.0.0",
-    "help": "",
+    "help": "Compression ratio to be achieved above which producer will ship documents as is",
     "stability": "volatile",
     "type": "gauge"
   },
@@ -946,31 +1040,43 @@
   },
   "kv_ep_dcp_oso_backfill_large_value_ratio": {
     "added": "7.0.0",
-    "help": "",
+    "help": "When considering out-of-seqno order (OSO) DCP backfill for a collection with 'large' mean value size, OSO will only be selected if the backfilling collection item count is less than this fraction of the vBucket item count. Whether the collection has 'small' or 'large' items depends on the value of 'dcp_oso_backfill_mean_item_size_threshold'.",
     "stability": "volatile",
     "type": "gauge"
   },
   "kv_ep_dcp_oso_backfill_small_item_size_threshold": {
     "added": "7.0.0",
-    "help": "",
+    "help": "When considering out-of-seqno order (OSO) DCP backfill for a collection, should the items in the collection be considered 'small' or 'large' and subsequently should backfill use 'dcp_oso_backfill_small_value_collection_ratio' or 'dcp_oso_backfill_large_value_collection_ratio' when deciding ot use OSO or not? Collections whoss mean on-disk value size is less than this parameter are considered 'small', otherwise they are considered 'large'",
     "stability": "volatile",
     "type": "gauge"
   },
   "kv_ep_dcp_oso_backfill_small_value_ratio": {
     "added": "7.0.0",
-    "help": "",
+    "help": "When considering out-of-seqno order (OSO) DCP backfill for a collection with 'small' mean value size, OSO will only be selected if the backfilling collection item count is less than this fraction of the vBucket item count. Whether the collection has 'small' or 'large' items depends on the value of 'dcp_oso_backfill_mean_item_size_threshold'.",
     "stability": "volatile",
     "type": "gauge"
   },
   "kv_ep_dcp_oso_max_collections_per_backfill": {
     "added": "7.0.0",
-    "help": "",
+    "help": "This is the maximum number of collections that a DCP stream can be filtering to be eligible for OSO",
+    "stability": "volatile",
+    "type": "gauge"
+  },
+  "kv_ep_dcp_producer_catch_exceptions": {
+    "added": "7.0.0",
+    "help": "If true, ActiveStream will catch exceptions during item processing and close the stream's related connection (and thus all streams for that connection). If false, exception will be re-thrown.",
+    "stability": "volatile",
+    "type": "gauge"
+  },
+  "kv_ep_dcp_producer_processor_run_duration_us": {
+    "added": "7.0.0",
+    "help": "The approximate maximum runtime in microseconds for ActiveStreamCheckpointProcessorTask",
     "stability": "volatile",
     "type": "gauge"
   },
   "kv_ep_dcp_producer_snapshot_marker_yield_limit": {
     "added": "7.0.0",
-    "help": "The number of snapshots before ActiveStreamCheckpointProcessorTask::run yields.",
+    "help": "Not in use - replaced by dcp_producer_processor_run_duration_us",
     "stability": "volatile",
     "type": "gauge"
   },
@@ -1132,6 +1238,18 @@
     "stability": "committed",
     "type": "gauge"
   },
+  "kv_ep_ephemeral_mem_recovery_enabled": {
+    "added": "7.0.0",
+    "help": "Whether ephemeral memory recovery task is enabled. If disabled, ItemPager will carry out memory recovery for AutoDelete buckets.",
+    "stability": "volatile",
+    "type": "gauge"
+  },
+  "kv_ep_ephemeral_mem_recovery_sleep_time": {
+    "added": "7.0.0",
+    "help": "Duration in milliseconds the EphemeralMemRecovery task will sleep between periodic executions.",
+    "stability": "volatile",
+    "type": "gauge"
+  },
   "kv_ep_ephemeral_metadata_mark_stale_chunk_duration": {
     "added": "7.0.0",
     "help": "Maximum time (in ms) ephemeral hash table cleaner task will run for before being paused (and resumed at the next ephemeral_metadata_purge_interval).",
@@ -1198,15 +1316,27 @@
     "stability": "volatile",
     "type": "gauge"
   },
-  "kv_ep_expiry_pager_task_time": {
+  "kv_ep_expiry_visitor_expire_after_visit_duration_ms": {
     "added": "7.0.0",
-    "help": "Time of the next expiry pager task (GMT), NOT_SCHEDULED if expiry pager has been disabled",
-    "stability": "committed",
+    "help": "The time limit in milliseconds for processing expired items after visiting hash tables. After finding expired items during hash table traversal, the expiry pager will process them until this duration is reached before yielding.",
+    "stability": "volatile",
+    "type": "gauge"
+  },
+  "kv_ep_expiry_visitor_items_only_duration_ms": {
+    "added": "7.0.0",
+    "help": "The time limit in milliseconds for processing items from the expired items list at the start of an expiry pager run. If the expired items list is not empty when the pager starts, it will only process items from this list for up to this duration before yielding.",
+    "stability": "volatile",
     "type": "gauge"
   },
   "kv_ep_failpartialwarmup": {
     "added": "7.0.0",
     "help": "If true then do not allow traffic to be enabled to the bucket if warmup didn't complete successfully",
+    "stability": "volatile",
+    "type": "gauge"
+  },
+  "kv_ep_flush_batch_max_bytes": {
+    "added": "7.0.0",
+    "help": "Max size (in bytes) of a single flush-batch passed to the KVStore for persistence.",
     "stability": "volatile",
     "type": "gauge"
   },
@@ -1240,6 +1370,209 @@
     "help": "Perform a file sync() operation after every N bytes written. Disabled if set to 0.",
     "stability": "volatile",
     "type": "gauge"
+  },
+  "kv_ep_fusion_bytes_migrated_bytes": {
+    "added": "8.0.0",
+    "help": "Total number of bytes migrated over from the mounted source to the host volume.",
+    "stability": "committed",
+    "type": "counter",
+    "unit": "bytes"
+  },
+  "kv_ep_fusion_bytes_synced_bytes": {
+    "added": "8.0.0",
+    "help": "Total number of bytes synced to FusionLogStore.",
+    "stability": "committed",
+    "type": "counter",
+    "unit": "bytes"
+  },
+  "kv_ep_fusion_extent_merger_bytes_read_bytes": {
+    "added": "8.0.0",
+    "help": "Total number of bytes read in order to merge extents.",
+    "stability": "committed",
+    "type": "counter",
+    "unit": "bytes"
+  },
+  "kv_ep_fusion_extent_merger_reads": {
+    "added": "8.0.0",
+    "help": "Total number of read IOs issued in order to merge extents.",
+    "stability": "committed",
+    "type": "counter",
+    "unit": "count"
+  },
+  "kv_ep_fusion_file_map_mem_used_bytes": {
+    "added": "8.0.0",
+    "help": "Total amount of memory consumed by file map.",
+    "stability": "committed",
+    "type": "gauge",
+    "unit": "bytes"
+  },
+  "kv_ep_fusion_log_clean_bytes_read_bytes": {
+    "added": "8.0.0",
+    "help": "Total number of bytes read in order to clean the logs.",
+    "stability": "committed",
+    "type": "counter",
+    "unit": "bytes"
+  },
+  "kv_ep_fusion_log_clean_reads": {
+    "added": "8.0.0",
+    "help": "Total number of read IOs issued in order to clean the logs.",
+    "stability": "committed",
+    "type": "counter",
+    "unit": "count"
+  },
+  "kv_ep_fusion_log_store_garbage_size_bytes": {
+    "added": "8.0.0",
+    "help": "Total size of the garbage data present on FusionLogStore.",
+    "stability": "committed",
+    "type": "gauge",
+    "unit": "bytes"
+  },
+  "kv_ep_fusion_log_store_pending_delete_size_bytes": {
+    "added": "8.0.0",
+    "help": "Total number of bytes not yet deleted from FusionLogStore.",
+    "stability": "committed",
+    "type": "gauge",
+    "unit": "bytes"
+  },
+  "kv_ep_fusion_log_store_reads": {
+    "added": "8.0.0",
+    "help": "Total Number of read operations issued to FusionLogStore. The read maybe answered locally if there's a cache hit. This stats also includes ep_fusion_log_store_remote_gets.",
+    "stability": "committed",
+    "type": "counter",
+    "unit": "count"
+  },
+  "kv_ep_fusion_log_store_remote_deletes": {
+    "added": "8.0.0",
+    "help": "Total number of DELETE operations issued to FusionLogStore.",
+    "stability": "committed",
+    "type": "counter",
+    "unit": "count"
+  },
+  "kv_ep_fusion_log_store_remote_gets": {
+    "added": "8.0.0",
+    "help": "Total number of GET operations issued to FusionLogStore.",
+    "stability": "committed",
+    "type": "counter",
+    "unit": "count"
+  },
+  "kv_ep_fusion_log_store_remote_lists": {
+    "added": "8.0.0",
+    "help": "Total number of LIST operations issued to FusionLogStore.",
+    "stability": "committed",
+    "type": "counter",
+    "unit": "count"
+  },
+  "kv_ep_fusion_log_store_remote_puts": {
+    "added": "8.0.0",
+    "help": "Total number of PUT operations issued to FusionLogStore.",
+    "stability": "committed",
+    "type": "counter",
+    "unit": "count"
+  },
+  "kv_ep_fusion_log_store_size_bytes": {
+    "added": "8.0.0",
+    "help": "Total size of all the logs on FusionLogStore.",
+    "stability": "committed",
+    "type": "gauge",
+    "unit": "bytes"
+  },
+  "kv_ep_fusion_logs_cleaned": {
+    "added": "8.0.0",
+    "help": "Total number of logs cleaned because their garbage size crossed the fragmentation threshold.",
+    "stability": "committed",
+    "type": "counter",
+    "unit": "count"
+  },
+  "kv_ep_fusion_logs_migrated": {
+    "added": "8.0.0",
+    "help": "Total number of logs migrated over from the mounted source to the host volume.",
+    "stability": "committed",
+    "type": "counter",
+    "unit": "count"
+  },
+  "kv_ep_fusion_migration_completed_bytes_bytes": {
+    "added": "8.0.0",
+    "help": "Total number of bytes completed in the migration.",
+    "stability": "committed",
+    "type": "gauge",
+    "unit": "bytes"
+  },
+  "kv_ep_fusion_migration_failures": {
+    "added": "8.0.0",
+    "help": "Total number of times migrating logs failed.",
+    "stability": "committed",
+    "type": "counter",
+    "unit": "count"
+  },
+  "kv_ep_fusion_migration_total_bytes_bytes": {
+    "added": "8.0.0",
+    "help": "Total number of bytes in the migration.",
+    "stability": "committed",
+    "type": "gauge",
+    "unit": "bytes"
+  },
+  "kv_ep_fusion_num_file_extents": {
+    "added": "8.0.0",
+    "help": "Number of file extents on Fusion.",
+    "stability": "committed",
+    "type": "gauge",
+    "unit": "count"
+  },
+  "kv_ep_fusion_num_files": {
+    "added": "8.0.0",
+    "help": "Number of files on Fusion.",
+    "stability": "committed",
+    "type": "gauge",
+    "unit": "count"
+  },
+  "kv_ep_fusion_num_log_segments": {
+    "added": "8.0.0",
+    "help": "Number of log segments on Fusion.",
+    "stability": "committed",
+    "type": "gauge",
+    "unit": "count"
+  },
+  "kv_ep_fusion_num_logs_mounted": {
+    "added": "8.0.0",
+    "help": "Number of logs mounted on Fusion for the purpose of extent migration.",
+    "stability": "committed",
+    "type": "counter",
+    "unit": "count"
+  },
+  "kv_ep_fusion_sync_failures": {
+    "added": "8.0.0",
+    "help": "Total number of times syncing data to Fusion failed.",
+    "stability": "committed",
+    "type": "counter",
+    "unit": "count"
+  },
+  "kv_ep_fusion_sync_session_completed_bytes_bytes": {
+    "added": "8.0.0",
+    "help": "Total number of bytes completed in the sync session.",
+    "stability": "committed",
+    "type": "gauge",
+    "unit": "bytes"
+  },
+  "kv_ep_fusion_sync_session_total_bytes_bytes": {
+    "added": "8.0.0",
+    "help": "Total number of bytes in the sync session.",
+    "stability": "committed",
+    "type": "gauge",
+    "unit": "bytes"
+  },
+  "kv_ep_fusion_syncs": {
+    "added": "8.0.0",
+    "help": "Total number of times data was synced to Fusion.",
+    "stability": "committed",
+    "type": "counter",
+    "unit": "count"
+  },
+  "kv_ep_fusion_total_file_size_bytes": {
+    "added": "8.0.0",
+    "help": "Total size of all files on Fusion.",
+    "stability": "committed",
+    "type": "gauge",
+    "unit": "bytes"
   },
   "kv_ep_getl_default_timeout": {
     "added": "7.0.0",
@@ -1290,6 +1623,12 @@
     "type": "gauge",
     "unit": "seconds"
   },
+  "kv_ep_hlc_max_future_threshold_us": {
+    "added": "7.0.0",
+    "help": "The acceptable μs threshold of drift at which we accept a new cas value.",
+    "stability": "volatile",
+    "type": "gauge"
+  },
   "kv_ep_ht_item_memory_bytes": {
     "added": "7.1.0",
     "help": "The total byte size of all items, no matter the vbucket's state, no matter if an item's value is ejected. Tracks the same value as ep_total_cache_size",
@@ -1311,7 +1650,19 @@
   },
   "kv_ep_ht_size": {
     "added": "7.0.0",
-    "help": "Initial number of slots in HashTable objects.",
+    "help": "The initial and minimum number of slots in HashTable objects.",
+    "stability": "volatile",
+    "type": "gauge"
+  },
+  "kv_ep_ht_size_decrease_delay": {
+    "added": "7.0.0",
+    "help": "Delay in seconds before decreasing the size of a HashTable following a previous resize.",
+    "stability": "volatile",
+    "type": "gauge"
+  },
+  "kv_ep_ht_temp_items_allowed_percent": {
+    "added": "7.0.0",
+    "help": "",
     "stability": "volatile",
     "type": "gauge"
   },
@@ -1505,13 +1856,13 @@
   },
   "kv_ep_magma_bloom_filter_accuracy": {
     "added": "7.0.0",
-    "help": "",
+    "help": "Magma maintains a bloom filter per sstable in the LSMTree. The bloom filters are used to reduce IO in case of non-existent  This config sets the accuracy of the bloom filters ie. (1 - accuracy) = false positive rate",
     "stability": "volatile",
     "type": "gauge"
   },
   "kv_ep_magma_bloom_filter_accuracy_for_bottom_level": {
     "added": "7.0.0",
-    "help": "",
+    "help": "The bloom filters at the bottom level are used to avoid IO in case of non-existent keys. Also most of the data resides in the bottom level. This config allows for lowering of bloom filter accuracy of sstables residing in the lowermost level of the LSMTree.",
     "stability": "volatile",
     "type": "gauge"
   },
@@ -1613,6 +1964,12 @@
     "stability": "volatile",
     "type": "gauge"
   },
+  "kv_ep_magma_drop_encryption_keys_compactions": {
+    "added": "8.0.0",
+    "help": "Count of Magma compactions issued to drop older encryption keys.",
+    "stability": "committed",
+    "type": "gauge"
+  },
   "kv_ep_magma_enable_block_cache": {
     "added": "7.0.0",
     "help": "The block cache is an LRU policy driven cache that is used to maintain index blocks for the sstable's btrees.",
@@ -1627,7 +1984,7 @@
   },
   "kv_ep_magma_enable_group_commit": {
     "added": "7.0.0",
-    "help": "",
+    "help": "Group Commit allows transactions in magma to be grouped together to reduce the number of WAL fsyncs. When a transaction is ready to fsync, if there are new transactions waiting to start, we stall the transaction waiting to fsync until there are no more transactions waiting to start for a given magma instance.",
     "stability": "volatile",
     "type": "gauge"
   },
@@ -1692,6 +2049,24 @@
     "type": "gauge",
     "unit": "ratio"
   },
+  "kv_ep_magma_fusion_log_checkpoint_interval": {
+    "added": "7.0.0",
+    "help": "The interval at which FusionFS should create a log checkpoint on the FusionMetadataStore and delete eligible logs from the FusionLogStore, in seconds.",
+    "stability": "volatile",
+    "type": "gauge"
+  },
+  "kv_ep_magma_fusion_logstore_fragmentation_threshold": {
+    "added": "7.0.0",
+    "help": "The threshold at which the fusion log store will perform garbage collection. This is a ratio between 0.0 and 1.0.",
+    "stability": "volatile",
+    "type": "gauge"
+  },
+  "kv_ep_magma_fusion_upload_interval": {
+    "added": "7.0.0",
+    "help": "The interval between kvstore syncs to fusion, in seconds.",
+    "stability": "volatile",
+    "type": "gauge"
+  },
   "kv_ep_magma_gets": {
     "added": "7.1.0",
     "help": "Number of get operations",
@@ -1700,13 +2075,13 @@
   },
   "kv_ep_magma_group_commit_max_sync_wait_duration_ms": {
     "added": "7.0.0",
-    "help": "",
+    "help": "When a transaction is about to stall because there are pending transactions waiting to start, if there already are transactions waiting and the oldest transaction has been waiting for magma_group_commit_max_sync_wait_duration ms or more, the current transaction will perform the fsync. When group commit is enabled and both magma_group_commit_max_sync_wait_duration and magma_group_commit_max_transaction_count are set to 0, transactions will stall until there are no more transactions waiting to start. Unit is milliseconds.",
     "stability": "volatile",
     "type": "gauge"
   },
   "kv_ep_magma_group_commit_max_transaction_count": {
     "added": "7.0.0",
-    "help": "",
+    "help": "When a transaction is about to stall because there are pending transactions waiting to start, if there already are magma_group_commit_max_transaction_count including the current transaction waiting, the current transaction will perform the fsync. When group commit is enabled and both magma_group_commit_max_sync_wait_duration and magma_group_commit_max_transaction_count are set to 0, transactions will stall until there are no more transactions waiting to start.",
     "stability": "volatile",
     "type": "gauge"
   },
@@ -1823,7 +2198,7 @@
   },
   "kv_ep_magma_max_default_storage_threads": {
     "added": "7.0.0",
-    "help": "If the number of storage threads = 0, then we set the number of storage threads based on the number of writer threads up to a maximum of 20 threads and use magma_flusher_thread_percentage to determine the ratio of flusher and compactor threads.",
+    "help": "If the number of storage threads = 0, then we set the number of storage threads to this value and use magma_flusher_thread_percentage to determine the ratio of flusher and compactor threads.",
     "stability": "volatile",
     "type": "gauge"
   },
@@ -1865,7 +2240,7 @@
   },
   "kv_ep_magma_min_value_block_size_threshold": {
     "added": "7.0.0",
-    "help": "Magma creates value blocks for values larger than this size. Value blocks only contain a single KV item and their reads/writes are optimised for memory as it avoids many value copies. Right now compression is turned off for value blocks to reduce memory consumption while building them. This setting should be at least as large as the SeqIndex block size.",
+    "help": "Magma creates value blocks for values larger than this size. Value blocks only contain a single KV item and their reads/writes are optimised for lesser memory consumption as it avoids many value copies. For example, magma block compression is turned off for them as compression requires an output buffer as large as the input buffer. This is fine since for such large docs, per document Snappy compression already should give good enough space savings. This setting should be >= SeqIndex data block size or else it won't take effect.",
     "stability": "volatile",
     "type": "gauge"
   },
@@ -1932,7 +2307,7 @@
   },
   "kv_ep_magma_seq_tree_data_block_size": {
     "added": "7.0.0",
-    "help": "Magma uses SSTables for storage. SSTables are made up of different types of blocks. Data blocks contain the bulk of the data and contain the key, metadata and value for each of the items in the block. Larger block sizes can decrease storage space by better block compression but they require more memory, cpu and io bandwidth to read and write them.",
+    "help": "Magma uses SSTables for storage. SSTables are made up of different types of blocks. Data blocks contain the bulk of the data and contain the key, metadata and value for each of the items in the block. Larger block sizes can decrease storage space by better block compression but they require more memory, cpu and io bandwidth to read and write them. If this is less than magma_min_value_block_size_threshold, Magma will internally auto configure the value block size to be as large as this.",
     "stability": "volatile",
     "type": "gauge"
   },
@@ -2124,7 +2499,7 @@
   },
   "kv_ep_max_num_bgfetchers": {
     "added": "7.0.0",
-    "help": "Maximum number of bg fetcher objects (the number of concurrent bg fetch tasks we can run). 0 = auto-configure which means we use the same number as the number of shards (max_num_shards - for historic reasons). See also num_reader_threads.",
+    "help": "Maximum number of bg fetcher objects (the number of concurrent bg fetch tasks we can run). 0 = auto-configure which means we use the same number as the number of reader threads (num_reader_threads).",
     "stability": "volatile",
     "type": "gauge"
   },
@@ -2186,29 +2561,27 @@
   },
   "kv_ep_mem_high_wat": {
     "added": "7.0.0",
-    "help": "",
-    "stability": "volatile",
+    "help": "The bucket's memory used high watermark.",
+    "stability": "committed",
     "type": "gauge"
   },
-  "kv_ep_mem_high_wat_percent_ratio": {
+  "kv_ep_mem_high_wat_percent": {
     "added": "7.0.0",
-    "help": "High water mark (as a percentage)",
-    "stability": "committed",
-    "type": "gauge",
-    "unit": "ratio"
+    "help": "Ratio of the Bucket Quota at which to place the high watermark. This is the maximum desired memory usage. This value should be lower than mutation_mem_ratio to avoid no memory errors.",
+    "stability": "volatile",
+    "type": "gauge"
   },
   "kv_ep_mem_low_wat": {
     "added": "7.0.0",
-    "help": "",
-    "stability": "volatile",
+    "help": "The bucket's memory used low watermark.",
+    "stability": "committed",
     "type": "gauge"
   },
-  "kv_ep_mem_low_wat_percent_ratio": {
+  "kv_ep_mem_low_wat_percent": {
     "added": "7.0.0",
-    "help": "Low water mark (as a percentage)",
-    "stability": "committed",
-    "type": "gauge",
-    "unit": "ratio"
+    "help": "Ratio of the Bucket Quota at which to place the low watermark. This is the point to which to reduce the memory usage of the bucket after hitting the high watermark.",
+    "stability": "volatile",
+    "type": "gauge"
   },
   "kv_ep_mem_tracker_enabled": {
     "added": "7.0.0",
@@ -2244,7 +2617,7 @@
   },
   "kv_ep_mutation_mem_ratio": {
     "added": "7.0.0",
-    "help": "",
+    "help": "Ratio of the Bucket Quota that can be used before mutations return tmpOOMs",
     "stability": "volatile",
     "type": "gauge"
   },
@@ -2260,6 +2633,12 @@
     "stability": "internal",
     "type": "gauge"
   },
+  "kv_ep_not_locked_returns_tmpfail": {
+    "added": "7.0.0",
+    "help": "Controls which error code should be returned when attempting to unlock an item that is not locked. When value is true, the legacy temporary_failure is used instead of not_locked.",
+    "stability": "volatile",
+    "type": "gauge"
+  },
   "kv_ep_num_access_scanner_runs": {
     "added": "7.0.0",
     "help": "Number of times we ran accesss scanner to snapshot working set",
@@ -2271,6 +2650,12 @@
     "help": "Number of times accesss scanner task decided not to generate access log",
     "stability": "committed",
     "type": "gauge"
+  },
+  "kv_ep_num_cas_regenerated": {
+    "added": "8.0.0",
+    "help": "The total number of CAS value regenerated",
+    "stability": "committed",
+    "type": "counter"
   },
   "kv_ep_num_checkpoints": {
     "added": "7.1.0",
@@ -2311,6 +2696,12 @@
   "kv_ep_num_freq_decayer_runs": {
     "added": "7.0.0",
     "help": "Number of times we ran the freq decayer task because a frequency counter has become saturated",
+    "stability": "committed",
+    "type": "counter"
+  },
+  "kv_ep_num_invalid_cas": {
+    "added": "8.0.0",
+    "help": "The total number of invalid CAS values.",
     "stability": "committed",
     "type": "counter"
   },
@@ -2356,11 +2747,24 @@
     "stability": "volatile",
     "type": "gauge"
   },
+  "kv_ep_paging_visitor_pause_check_count": {
+    "added": "7.0.0",
+    "help": "Expected number of times the PagingVisitor will check the pause condition per vBucket",
+    "stability": "volatile",
+    "type": "gauge"
+  },
   "kv_ep_pending_compactions": {
     "added": "7.0.0",
     "help": "For persistent buckets, the count of compaction tasks.",
     "stability": "committed",
     "type": "gauge"
+  },
+  "kv_ep_pending_disk_ops_max_time_seconds": {
+    "added": "8.0.0",
+    "help": "The longest time spent in a disk operation that is currently executing",
+    "stability": "committed",
+    "type": "gauge",
+    "unit": "seconds"
   },
   "kv_ep_pending_ops": {
     "added": "7.0.0",
@@ -2399,21 +2803,15 @@
     "stability": "volatile",
     "type": "gauge"
   },
-  "kv_ep_pitr_enabled": {
+  "kv_ep_primary_warmup_min_items_threshold": {
     "added": "7.0.0",
-    "help": "Is PiTR enabled or not",
+    "help": "Mark primary warm-up as complete when the number of values loaded by warm-up reaches this percentage of the available values. This is checked after evaluating primry_warmup_min_memory_threshold.",
     "stability": "volatile",
     "type": "gauge"
   },
-  "kv_ep_pitr_granularity": {
+  "kv_ep_primary_warmup_min_memory_threshold": {
     "added": "7.0.0",
-    "help": "The granularity (interval between each rollback point) in seconds (up to 5 hours)",
-    "stability": "volatile",
-    "type": "gauge"
-  },
-  "kv_ep_pitr_max_history_age": {
-    "added": "7.0.0",
-    "help": "The number of seconds of the oldest entry to keep as part of compaction (up to 48 hours)",
+    "help": "Mark primary warm-up as complete when bucket memory usage reaches this percentage of max_data_size. This is checked before evaluating primry_warmup_min_items_threshold.",
     "stability": "volatile",
     "type": "gauge"
   },
@@ -2459,11 +2857,36 @@
     "stability": "committed",
     "type": "gauge"
   },
+  "kv_ep_secondary_warmup_estimated_value_count": {
+    "added": "8.0.0",
+    "help": "To facilitate warm-up progress tracking this value represents how many values need to be loaded to reach 100% of values loaded. This counter is only initialised when warm-up reaches the \"loading access log\", \"loading k/v pairs\" or \"loading data\" state and the ratio of ep_warmup_value_count and this provides insight into progress.",
+    "stability": "committed",
+    "type": "counter"
+  },
+  "kv_ep_secondary_warmup_min_items_threshold": {
+    "added": "7.0.0",
+    "help": "Stop secondary warm-up when the number of values loaded by warm-up reaches this percentage of the available values. This is checked after evaluating secondary_warmup_min_memory_threshold.",
+    "stability": "volatile",
+    "type": "gauge"
+  },
+  "kv_ep_secondary_warmup_min_memory_threshold": {
+    "added": "7.0.0",
+    "help": "Stop secondary warm-up when bucket memory usage reaches this percentage of max_data_size. This is checked before evaluating secondary_warmup_min_items_threshold.",
+    "stability": "volatile",
+    "type": "gauge"
+  },
   "kv_ep_seqno_persistence_timeout": {
     "added": "7.0.0",
     "help": "Timeout in seconds after which a pending SeqnoPersistence operation is temp-failed",
     "stability": "volatile",
     "type": "gauge"
+  },
+  "kv_ep_snapshot_read_bytes": {
+    "added": "8.0.0",
+    "help": "The number of bytes read when copying/downloading snapshots",
+    "stability": "committed",
+    "type": "gauge",
+    "unit": "bytes"
   },
   "kv_ep_startup_time_seconds": {
     "added": "7.0.0",
@@ -2623,10 +3046,16 @@
     "stability": "volatile",
     "type": "gauge"
   },
-  "kv_ep_warmup_access_log": {
-    "added": "7.1.0",
-    "help": "Number of keys present in access log",
-    "stability": "committed",
+  "kv_ep_warmup_accesslog_load_batch_size": {
+    "added": "7.0.0",
+    "help": "AccessLog loading operates in batches of this size (dictates the max number of keys issued to the KVStore::getMulti function)",
+    "stability": "volatile",
+    "type": "gauge"
+  },
+  "kv_ep_warmup_accesslog_load_duration": {
+    "added": "7.0.0",
+    "help": "The duration (in ms) after which warmup's LoadAccessLog phase will yield and re-schedule; allowing other tasks on the same thread pool to run.",
+    "stability": "volatile",
     "type": "gauge"
   },
   "kv_ep_warmup_backfill_scan_chunk_duration": {
@@ -2635,9 +3064,9 @@
     "stability": "volatile",
     "type": "gauge"
   },
-  "kv_ep_warmup_batch_size": {
+  "kv_ep_warmup_backfill_task_shard_ratio": {
     "added": "7.0.0",
-    "help": "The size of each batch loaded during warmup.",
+    "help": "Ratio controlling how many tasks that will be created in the KeyDump, LoadingKVPairs and LoadingData phases. This is a ratio using the number of shards as the denominator and least 1 task will be created per phase. A value of 0.0 will create tasks equal to the lower of #shards or #reader-threads, a value of 1.0 restores the orginal behaviour, 1 task per shard.",
     "stability": "volatile",
     "type": "gauge"
   },
@@ -2647,55 +3076,23 @@
     "stability": "committed",
     "type": "gauge"
   },
-  "kv_ep_warmup_estimate_time_seconds": {
-    "added": "7.1.0",
-    "help": "Total time spent in the estimate item count phase of warmup",
-    "stability": "committed",
-    "type": "gauge",
-    "unit": "seconds"
-  },
   "kv_ep_warmup_estimated_key_count": {
     "added": "7.1.0",
-    "help": "Estimated number of keys in database",
+    "help": "To facilitate warm-up progress tracking this value represents how many keys need to be loaded to reach 100% keys loaded. This count is useful for progress tracking for Value Eviction buckets during the \"loading keys\" state and the ratio of ep_warmup_key_count and this provides insight into progress. This value is the same for the estimated number of keys required to be loaded for secondary warmup, if secondary warmup is enabled.",
     "stability": "committed",
-    "type": "gauge"
+    "type": "counter"
   },
   "kv_ep_warmup_estimated_value_count": {
     "added": "7.1.0",
-    "help": "Estimated number of values in database",
+    "help": "To facilitate warm-up progress tracking this value represents how many values need to be loaded to reach 100% of values loaded. This counter is only initialised when warm-up reaches the \"loading access log\", \"loading k/v pairs\" or \"loading data\" state and the ratio of ep_warmup_value_count and this provides insight into progress.",
     "stability": "committed",
-    "type": "gauge"
+    "type": "counter"
   },
   "kv_ep_warmup_key_count": {
     "added": "7.1.0",
     "help": "Number of keys warmed up",
     "stability": "committed",
-    "type": "gauge"
-  },
-  "kv_ep_warmup_keys_time_seconds": {
-    "added": "7.1.0",
-    "help": "Time (µs) spent by warming keys",
-    "stability": "committed",
-    "type": "gauge",
-    "unit": "seconds"
-  },
-  "kv_ep_warmup_min_item_threshold": {
-    "added": "7.1.0",
-    "help": "The minimum number of items that needs to be warmed up before external data mutations is allowed. This is in % of the number of items.",
-    "stability": "committed",
-    "type": "gauge"
-  },
-  "kv_ep_warmup_min_items_threshold": {
-    "added": "7.0.0",
-    "help": "Percentage of total items warmed up before we enable traffic.",
-    "stability": "volatile",
-    "type": "gauge"
-  },
-  "kv_ep_warmup_min_memory_threshold": {
-    "added": "7.0.0",
-    "help": "Percentage of max mem warmed up before we enable traffic.",
-    "stability": "volatile",
-    "type": "gauge"
+    "type": "counter"
   },
   "kv_ep_warmup_oom": {
     "added": "7.0.0",
@@ -2709,15 +3106,9 @@
     "stability": "committed",
     "type": "gauge"
   },
-  "kv_ep_warmup_thread": {
-    "added": "7.0.0",
-    "help": "Warmup thread status",
-    "stability": "committed",
-    "type": "gauge"
-  },
   "kv_ep_warmup_time_seconds": {
     "added": "7.0.0",
-    "help": "Time (µs) spent by warming data",
+    "help": "Time (µs) spent by warming data during Primary warm-up",
     "stability": "committed",
     "type": "gauge",
     "unit": "seconds"
@@ -2726,6 +3117,12 @@
     "added": "7.1.0",
     "help": "Number of values warmed up",
     "stability": "committed",
+    "type": "counter"
+  },
+  "kv_ep_workload_monitor_enabled": {
+    "added": "7.0.0",
+    "help": "",
+    "stability": "volatile",
     "type": "gauge"
   },
   "kv_ep_xattr_enabled": {
@@ -2748,9 +3145,23 @@
     "type": "gauge",
     "unit": "bytes"
   },
+  "kv_fusion_migration_rate_limit_bytes": {
+    "added": "8.0.0",
+    "help": "The rate limit for fusion extent migration, in bytes per second.",
+    "stability": "committed",
+    "type": "gauge",
+    "unit": "bytes"
+  },
+  "kv_fusion_sync_rate_limit_bytes": {
+    "added": "8.0.0",
+    "help": "The rate limit for fusion sync uploads, in bytes per second.",
+    "stability": "committed",
+    "type": "gauge",
+    "unit": "bytes"
+  },
   "kv_item_alloc_sizes_bytes": {
     "added": "7.0.0",
-    "help": "Item allocation size counters (in bytes)",
+    "help": "Item allocation size counters for front-end mutations (in bytes)",
     "stability": "committed",
     "type": "histogram",
     "unit": "bytes"
@@ -2823,12 +3234,6 @@
     "type": "gauge",
     "unit": "bytes"
   },
-  "kv_manifest_force": {
-    "added": "7.0.0",
-    "help": "Whether the manifest was set by ns_server with the force flag",
-    "stability": "internal",
-    "type": "gauge"
-  },
   "kv_max_system_connections": {
     "added": "7.6.0",
     "help": "Maximum number of connections to the interfaces marked as system only",
@@ -2855,43 +3260,6 @@
     "type": "gauge",
     "unit": "bytes"
   },
-  "kv_memcache_curr_items": {
-    "added": "7.0.0",
-    "help": "Number of active items in memory",
-    "stability": "committed",
-    "type": "gauge"
-  },
-  "kv_memcache_engine_maxbytes": {
-    "added": "7.0.0",
-    "help": "The max size of the bucket",
-    "stability": "committed",
-    "type": "gauge"
-  },
-  "kv_memcache_evictions": {
-    "added": "7.0.0",
-    "help": "Number of items evicted from the bucket",
-    "stability": "committed",
-    "type": "gauge"
-  },
-  "kv_memcache_mem_size_bytes": {
-    "added": "7.0.0",
-    "help": "Engine's total memory usage",
-    "stability": "committed",
-    "type": "gauge",
-    "unit": "bytes"
-  },
-  "kv_memcache_reclaimed": {
-    "added": "7.0.0",
-    "help": "Number of items allocated by reusing expired objects",
-    "stability": "committed",
-    "type": "gauge"
-  },
-  "kv_memcache_total_items": {
-    "added": "7.0.0",
-    "help": "Total number of items in the bucket",
-    "stability": "committed",
-    "type": "gauge"
-  },
   "kv_memory_overhead_bytes": {
     "added": "7.0.0",
     "help": "The \"unused\" memory caused by the allocator returning bigger chunks than requested",
@@ -2911,6 +3279,24 @@
     "stability": "committed",
     "type": "gauge",
     "unit": "bytes"
+  },
+  "kv_meter_cu_total": {
+    "added": "7.6.0",
+    "help": "Total Compute Units used by a bucket since reset",
+    "stability": "internal",
+    "type": "counter"
+  },
+  "kv_meter_ru_total": {
+    "added": "7.6.0",
+    "help": "Total Read Units used by a bucket since reset",
+    "stability": "internal",
+    "type": "counter"
+  },
+  "kv_meter_wu_total": {
+    "added": "7.6.0",
+    "help": "Total Write Units used by a bucket since reset",
+    "stability": "internal",
+    "type": "counter"
   },
   "kv_num_high_pri_requests": {
     "added": "7.0.0",
@@ -2937,7 +3323,7 @@
       "op"
     ],
     "stability": "committed",
-    "type": "gauge"
+    "type": "counter"
   },
   "kv_ops_failed": {
     "added": "7.0.0",
@@ -2946,7 +3332,7 @@
       "op"
     ],
     "stability": "committed",
-    "type": "gauge"
+    "type": "counter"
   },
   "kv_read_bytes": {
     "added": "7.0.0",
@@ -2961,33 +3347,15 @@
     "stability": "internal",
     "type": "counter"
   },
-  "kv_rejected_conns": {
-    "added": "7.0.0",
+  "kv_rejected_connections": {
+    "added": "8.0.0",
     "help": "The number of connections rejected due to hitting the maximum number of connections",
     "stability": "committed",
-    "type": "gauge"
+    "type": "counter"
   },
   "kv_rollback_item_count": {
     "added": "7.0.0",
     "help": "Num of items rolled back",
-    "stability": "committed",
-    "type": "gauge"
-  },
-  "kv_scope_collection_count": {
-    "added": "7.0.0",
-    "help": "Number of collections in the scope",
-    "stability": "committed",
-    "type": "gauge"
-  },
-  "kv_scope_data_limit": {
-    "added": "7.1.0",
-    "help": "The configured data limit for the scope (not used)",
-    "stability": "internal",
-    "type": "gauge"
-  },
-  "kv_stat_reset": {
-    "added": "7.0.0",
-    "help": "Timestamp when the stats was reset",
     "stability": "committed",
     "type": "gauge"
   },
@@ -3040,7 +3408,7 @@
       "op"
     ],
     "stability": "committed",
-    "type": "gauge"
+    "type": "counter"
   },
   "kv_subdoc_update_races": {
     "added": "7.6.0",
@@ -3064,18 +3432,19 @@
     "stability": "committed",
     "type": "gauge"
   },
+  "kv_task_duration_seconds": {
+    "added": "7.6.2",
+    "help": "Per-task histogram of time taken to run a task",
+    "stability": "committed",
+    "type": "histogram",
+    "unit": "seconds"
+  },
   "kv_thread_cpu_usage_seconds": {
     "added": "7.6.0",
     "help": "Number of seconds the given thread has spent running according to the OS",
     "stability": "committed",
     "type": "gauge",
     "unit": "seconds"
-  },
-  "kv_threads": {
-    "added": "7.0.0",
-    "help": "The number of threads used to serve clients",
-    "stability": "committed",
-    "type": "gauge"
   },
   "kv_throttle_count_total": {
     "added": "7.6.0",
@@ -3208,15 +3577,15 @@
     "stability": "committed",
     "type": "gauge"
   },
-  "kv_vb_evictable_mfu": {
-    "added": "7.6.0",
-    "help": "Histogram of the per-VBucket tracking MFU values of items which are currently evictable",
-    "stability": "committed",
-    "type": "gauge"
-  },
   "kv_vb_expired": {
     "added": "7.0.0",
     "help": "Cumulative count of the number of items which have been expired for this vBucket",
+    "stability": "committed",
+    "type": "gauge"
+  },
+  "kv_vb_ht_avg_size": {
+    "added": "7.2.5",
+    "help": "The average size (number of slots) of the HashTable across all vbuckets",
     "stability": "committed",
     "type": "gauge"
   },
@@ -3234,8 +3603,23 @@
     "type": "gauge",
     "unit": "bytes"
   },
+  "kv_vb_ht_max_size": {
+    "added": "7.2.5",
+    "help": "The maximum HashTable size (number of slots) across all vbuckets",
+    "stability": "committed",
+    "type": "gauge"
+  },
   "kv_vb_ht_memory_bytes": {
     "added": "7.0.0",
+    "deprecated": "8.0.0",
+    "help": "Memory overhead of the HashTable",
+    "notes": "Renamed as kv_vb_ht_memory_overhead_bytes, as it describes the metric more accurately",
+    "stability": "committed",
+    "type": "gauge",
+    "unit": "bytes"
+  },
+  "kv_vb_ht_memory_overhead_bytes": {
+    "added": "8.0.0",
     "help": "Memory overhead of the HashTable",
     "stability": "committed",
     "type": "gauge",
@@ -3428,7 +3812,13 @@
   },
   "kv_vb_sync_write_committed_count": {
     "added": "7.0.0",
-    "help": "Total number of comitted SyncWrites",
+    "help": "Total number of all committed SyncWrites (includes vb_sync_write_committed_not_durable_count)",
+    "stability": "committed",
+    "type": "gauge"
+  },
+  "kv_vb_sync_write_committed_not_durable_count": {
+    "added": "8.0.0",
+    "help": "Total number of SyncWrites which could not be written durably, but were committed because the fallback was enabled (see durability_impossible_fallback)",
     "stability": "committed",
     "type": "gauge"
   },

--- a/modules/metrics-reference/attachments/n1ql_metrics_metadata.json
+++ b/modules/metrics-reference/attachments/n1ql_metrics_metadata.json
@@ -10,6 +10,11 @@
     "help": "The total number of values allocated in the query engine.",
     "type": "counter"
   },
+  "n1ql_approx_vector_distance_func": {
+    "added": "8.0.0",
+    "help": "The number of APPROX_VECTOR_DISTANCE() calls made by statements.",
+    "type": "counter"
+  },
   "n1ql_at_plus": {
     "added": "7.0.0",
     "help": "Total number of N1QL requests with at_plus index consistency.",
@@ -35,6 +40,40 @@
     "help": "The total number of potentially auditable requests sent to the query engine.",
     "type": "counter"
   },
+  "n1ql_boot_timestamp_seconds": {
+    "added": "7.6.0",
+    "help": "The time the service booted in fractional seconds since Unix epoch.",
+    "notes": "This is a metric specific to serverless.",
+    "type": "gauge",
+    "unit": "seconds"
+  },
+  "n1ql_bucket_reads": {
+    "added": "7.6.0",
+    "help": "The total number of reads on the bucket.",
+    "labels": [
+      "bucket"
+    ],
+    "notes": "This is a metric specific to provisioned mode.",
+    "type": "gauge"
+  },
+  "n1ql_bucket_retries": {
+    "added": "7.6.0",
+    "help": "The total number of retries on the bucket.",
+    "labels": [
+      "bucket"
+    ],
+    "notes": "This is a metric specific to provisioned mode.",
+    "type": "gauge"
+  },
+  "n1ql_bucket_writes": {
+    "added": "7.6.0",
+    "help": "The total number of writes on the bucket.",
+    "labels": [
+      "bucket"
+    ],
+    "notes": "This is a metric specific to provisioned mode.",
+    "type": "gauge"
+  },
   "n1ql_bulk_get_errors": {
     "added": "7.2.4",
     "help": "Count of errors due to bulk get operations",
@@ -50,9 +89,143 @@
     "help": "Count of CAS mismatch errors",
     "type": "counter"
   },
+  "n1ql_counter_cu_total": {
+    "added": "7.6.0",
+    "help": "The number of distinct operations recording Compute Units (CUs) with Regulator.",
+    "labels": [
+      "bucket",
+      "for",
+      "unbilled",
+      "variant"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
+  "n1ql_credit_cu_total": {
+    "added": "7.6.0",
+    "help": "The number of Compute Units (CUs) refunded.",
+    "labels": [
+      "bucket",
+      "for",
+      "variant"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
+  "n1ql_credit_ru_total": {
+    "added": "7.6.0",
+    "help": "The number of Read Units (RUs) refunded.",
+    "labels": [
+      "bucket",
+      "for",
+      "variant"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
+  "n1ql_credit_wu_total": {
+    "added": "7.6.0",
+    "help": "The number of Write Units (WUs) refunded.",
+    "labels": [
+      "bucket",
+      "for",
+      "variant"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
+  "n1ql_curl_call_errors": {
+    "added": "7.6.2",
+    "help": "The number of CURL() calls made by statements that failed (returned an error).",
+    "type": "counter"
+  },
+  "n1ql_curl_calls": {
+    "added": "7.6.2",
+    "help": "The number of CURL() calls made by statements.",
+    "type": "counter"
+  },
+  "n1ql_cvi_request_timer_15m_rate": {
+    "added": "8.0.0",
+    "help": "The 15m.rate latency of SQL++ Composite VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_cvi_request_timer_1m_rate": {
+    "added": "8.0.0",
+    "help": "The 1m.rate latency of SQL++ Composite VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_cvi_request_timer_5m_rate": {
+    "added": "8.0.0",
+    "help": "The 5m.rate latency of SQL++ Composite VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_cvi_request_timer_count": {
+    "added": "8.0.0",
+    "help": "The number of SQL++ Composite VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_cvi_request_timer_max": {
+    "added": "8.0.0",
+    "help": "The MAX latency of SQL++ Composite VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_cvi_request_timer_mean": {
+    "added": "8.0.0",
+    "help": "The MEAN latency of SQL++ Composite VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_cvi_request_timer_mean_rate": {
+    "added": "8.0.0",
+    "help": "The mean.rate latency of SQL++ Composite VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_cvi_request_timer_median": {
+    "added": "8.0.0",
+    "help": "The MEDIAN latency of SQL++ Composite VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_cvi_request_timer_min": {
+    "added": "8.0.0",
+    "help": "The MIN latency of SQL++ Composite VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_cvi_request_timer_p75": {
+    "added": "8.0.0",
+    "help": "The 75% latency of SQL++ Composite VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_cvi_request_timer_p95": {
+    "added": "8.0.0",
+    "help": "The 95% latency of SQL++ Composite VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_cvi_request_timer_p99": {
+    "added": "8.0.0",
+    "help": "The 99% latency of SQL++ Composite VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_cvi_request_timer_p99point9": {
+    "added": "8.0.0",
+    "help": "The 99.9% latency of SQL++ Composite VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_cvi_request_timer_stddev": {
+    "added": "8.0.0",
+    "help": "The STDDEV latency of SQL++ Composite VECTOR requests.",
+    "type": "gauge"
+  },
   "n1ql_deletes": {
     "added": "7.0.0",
     "help": "Total number of DELETE operations.",
+    "type": "counter"
+  },
+  "n1ql_engine_error_count": {
+    "added": "8.0.0",
+    "help": "Total number of system-caused errors.",
     "type": "counter"
   },
   "n1ql_errors": {
@@ -62,9 +235,145 @@
     "type": "counter",
     "uiName": "N1QL Error Rate"
   },
+  "n1ql_ffdc_manual": {
+    "added": "7.6.6",
+    "help": "The total number of ffdc captures triggered due to manual invocation of ffdc admin api",
+    "type": "counter"
+  },
+  "n1ql_ffdc_memory_limit": {
+    "added": "7.6.6",
+    "help": "The total number of ffdc captures triggered due to free memory dropping below 10%",
+    "type": "counter"
+  },
+  "n1ql_ffdc_memory_rate": {
+    "added": "7.6.6",
+    "help": "The total number of ffdc captures triggered due to memory usage rate increasing by 20% of the average memory usage over the past 2 hours",
+    "type": "counter"
+  },
+  "n1ql_ffdc_memory_threshold": {
+    "added": "7.6.6",
+    "help": "The total number of ffdc captures triggered due to memory usage exceeding the 80% threshold",
+    "type": "counter"
+  },
+  "n1ql_ffdc_plus_queue_full": {
+    "added": "7.6.6",
+    "help": "The total number of ffdc captures triggered due to the plus-request queue being full",
+    "type": "counter"
+  },
+  "n1ql_ffdc_request_queue_full": {
+    "added": "7.6.6",
+    "help": "The total number of ffdc captures triggered due to the unbounded-request queue being full",
+    "type": "counter"
+  },
+  "n1ql_ffdc_shutdown": {
+    "added": "7.6.6",
+    "help": "The total number of ffdc captures triggered due to shutdown processing exceeding 30 minutes",
+    "type": "counter"
+  },
+  "n1ql_ffdc_sigterm": {
+    "added": "7.6.6",
+    "help": "The total number of ffdc captures triggered by a SIGTERM signal",
+    "notes": "This metric is included for completeness, as a SIGTERM resets all accounting metrics to zero, rendering this metric redundant.",
+    "type": "counter"
+  },
+  "n1ql_ffdc_stalled_queue": {
+    "added": "7.6.6",
+    "help": "The total number of ffdc captures triggered due to no requests being processed when the queued requests exceed three times the number of servicers within the last 30 seconds",
+    "type": "counter"
+  },
+  "n1ql_ffdc_total": {
+    "added": "7.6.6",
+    "help": "The total number of ffdc occurrences",
+    "type": "counter"
+  },
+  "n1ql_fts_searches": {
+    "added": "8.0.0",
+    "help": "Total number of SQL++ FTS Searches.",
+    "type": "counter"
+  },
+  "n1ql_fts_searches_svi": {
+    "added": "8.0.0",
+    "help": "Total number of SQL++ FTS Vetcor Searches.",
+    "type": "counter"
+  },
+  "n1ql_hvi_request_timer_15m_rate": {
+    "added": "8.0.0",
+    "help": "The 15m.rate latency of SQL++ Hyperscale VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_hvi_request_timer_1m_rate": {
+    "added": "8.0.0",
+    "help": "The 1m.rate latency of SQL++ Hyperscale VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_hvi_request_timer_5m_rate": {
+    "added": "8.0.0",
+    "help": "The 5m.rate latency of SQL++ Hyperscale VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_hvi_request_timer_count": {
+    "added": "8.0.0",
+    "help": "The number of SQL++ Hyperscale VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_hvi_request_timer_max": {
+    "added": "8.0.0",
+    "help": "The MAX latency of SQL++ Hyperscale VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_hvi_request_timer_mean": {
+    "added": "8.0.0",
+    "help": "The MEAN latency of SQL++ Hyperscale VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_hvi_request_timer_mean_rate": {
+    "added": "8.0.0",
+    "help": "The mean.rate latency of SQL++ Hyperscale VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_hvi_request_timer_median": {
+    "added": "8.0.0",
+    "help": "The MEDIAN latency of SQL++ Hyperscale VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_hvi_request_timer_min": {
+    "added": "8.0.0",
+    "help": "The MIN latency of SQL++ Hyperscale VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_hvi_request_timer_p75": {
+    "added": "8.0.0",
+    "help": "The 75% latency of SQL++ Hyperscale VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_hvi_request_timer_p95": {
+    "added": "8.0.0",
+    "help": "The 95% latency of SQL++ Hyperscale VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_hvi_request_timer_p99": {
+    "added": "8.0.0",
+    "help": "The 99% latency of SQL++ Hyperscale VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_hvi_request_timer_p99point9": {
+    "added": "8.0.0",
+    "help": "The 99.9% latency of SQL++ Hyperscale VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_hvi_request_timer_stddev": {
+    "added": "8.0.0",
+    "help": "The STDDEV latency of SQL++ Hyperscale VECTOR requests.",
+    "type": "gauge"
+  },
   "n1ql_index_scans": {
     "added": "7.0.0",
     "help": "Total number of secondary index scans.",
+    "type": "counter"
+  },
+  "n1ql_index_scans_cvi": {
+    "added": "8.0.0",
+    "help": "Total number of Composite VECTOR index scans.",
     "type": "counter"
   },
   "n1ql_index_scans_fts": {
@@ -77,6 +386,11 @@
     "added": "7.2.4",
     "help": "Total number of index scans performed by GSI.",
     "notes": "This is a sub-division of n1ql_index_scans.",
+    "type": "counter"
+  },
+  "n1ql_index_scans_hvi": {
+    "added": "8.0.0",
+    "help": "Total number of Hyperscale VECTOR index scans.",
     "type": "counter"
   },
   "n1ql_index_scans_seq": {
@@ -111,8 +425,21 @@
   },
   "n1ql_mem_quota_exceeded_errors": {
     "added": "7.2.4",
-    "help": "Count of memory quota exceeded errors",
+    "help": "Count of memory quota exceeded errrors",
     "type": "counter"
+  },
+  "n1ql_meter_cu_total": {
+    "added": "7.6.0",
+    "help": "The number of Compute Units (CUs) recorded.",
+    "labels": [
+      "bucket",
+      "for",
+      "unbilled",
+      "variant"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
   },
   "n1ql_mutations": {
     "added": "7.0.0",
@@ -121,9 +448,26 @@
   },
   "n1ql_node_memory": {
     "added": "7.6.0",
-    "help": "The total size of in use memory in the query node.",
+    "help": "The total size of document memory in use, allocated from the node-wide document memory quota. This quota is defined only when node-quota and node-quota-val-percent settings are set.",
     "type": "gauge",
     "unit": "bytes"
+  },
+  "n1ql_node_rss": {
+    "added": "7.6.1",
+    "help": "The resident set size (RSS) of the query node process.",
+    "type": "gauge",
+    "unit": "bytes"
+  },
+  "n1ql_op_count_total": {
+    "added": "7.6.0",
+    "help": "The number of distinct operations recorded with Regulator.",
+    "labels": [
+      "bucket",
+      "for"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
   },
   "n1ql_prepared": {
     "added": "7.0.0",
@@ -159,6 +503,17 @@
     "notes": "This metric was named query_queued_requests in versions before 7.0.0.",
     "type": "gauge"
   },
+  "n1ql_reject_count_total": {
+    "added": "7.6.0",
+    "help": "The number of times Regulator instructed an operation to be rejected.",
+    "labels": [
+      "bucket",
+      "for"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
   "n1ql_request_time": {
     "added": "7.0.0",
     "help": "Total end-to-end time to process all queries.",
@@ -166,6 +521,76 @@
     "type": "counter",
     "uiName": "Query Request Time",
     "unit": "nanoseconds"
+  },
+  "n1ql_request_timer_15m_rate": {
+    "added": "8.0.0",
+    "help": "The 15m.rate latency of SQL++ requests.",
+    "type": "gauge"
+  },
+  "n1ql_request_timer_1m_rate": {
+    "added": "8.0.0",
+    "help": "The 1m.rate latency of SQL++ requests.",
+    "type": "gauge"
+  },
+  "n1ql_request_timer_5m_rate": {
+    "added": "8.0.0",
+    "help": "The 5m.rate latency of SQL++ requests.",
+    "type": "gauge"
+  },
+  "n1ql_request_timer_count": {
+    "added": "8.0.0",
+    "help": "The number of SQL++ requests.",
+    "type": "gauge"
+  },
+  "n1ql_request_timer_max": {
+    "added": "8.0.0",
+    "help": "The MAX latency of SQL++ requests.",
+    "type": "gauge"
+  },
+  "n1ql_request_timer_mean": {
+    "added": "8.0.0",
+    "help": "The MEAN latency of SQL++ requests.",
+    "type": "gauge"
+  },
+  "n1ql_request_timer_mean_rate": {
+    "added": "8.0.0",
+    "help": "The mean.rate latency of SQL++ requests.",
+    "type": "gauge"
+  },
+  "n1ql_request_timer_median": {
+    "added": "8.0.0",
+    "help": "The MEDIAN latency of SQL++ requests.",
+    "type": "gauge"
+  },
+  "n1ql_request_timer_min": {
+    "added": "8.0.0",
+    "help": "The MIN latency of SQL++ requests.",
+    "type": "gauge"
+  },
+  "n1ql_request_timer_p75": {
+    "added": "8.0.0",
+    "help": "The 75% latency of SQL++ requests.",
+    "type": "gauge"
+  },
+  "n1ql_request_timer_p95": {
+    "added": "8.0.0",
+    "help": "The 95% latency of SQL++ requests.",
+    "type": "gauge"
+  },
+  "n1ql_request_timer_p99": {
+    "added": "8.0.0",
+    "help": "The 99% latency of SQL++ requests.",
+    "type": "gauge"
+  },
+  "n1ql_request_timer_p99point9": {
+    "added": "8.0.0",
+    "help": "The 99.9% latency of SQL++ requests.",
+    "type": "gauge"
+  },
+  "n1ql_request_timer_stddev": {
+    "added": "8.0.0",
+    "help": "The STDDEV latency of SQL++ requests.",
+    "type": "gauge"
   },
   "n1ql_requests": {
     "added": "7.0.0",
@@ -202,6 +627,56 @@
     "type": "counter",
     "uiName": "Queries > 500ms"
   },
+  "n1ql_requests_cvi": {
+    "added": "8.0.0",
+    "help": "Total number of SQL++ GSI Composite VECTOR requests.",
+    "type": "counter"
+  },
+  "n1ql_requests_gsi": {
+    "added": "8.0.0",
+    "help": "Total number of SQL++ GSI requests.",
+    "type": "counter"
+  },
+  "n1ql_requests_hvi": {
+    "added": "8.0.0",
+    "help": "Total number of SQL++ GSI Hyperscale VECTOR requests.",
+    "type": "counter"
+  },
+  "n1ql_requests_natural_ftssql": {
+    "added": "8.0.0",
+    "help": "Total number of SQL++ Natural Language FTSSQL requests.",
+    "type": "counter"
+  },
+  "n1ql_requests_natural_jsudf": {
+    "added": "8.0.0",
+    "help": "Total number of SQL++ Natural Language JSUDF requests.",
+    "type": "counter"
+  },
+  "n1ql_requests_natural_sql": {
+    "added": "8.0.0",
+    "help": "Total number of SQL++ Natural Language SQL requests.",
+    "type": "counter"
+  },
+  "n1ql_requests_natural_total": {
+    "added": "8.0.0",
+    "help": "Total number of SQL++ Natural Language requests.",
+    "type": "counter"
+  },
+  "n1ql_requests_search": {
+    "added": "8.0.0",
+    "help": "Total number of SQL++ FTS requests.",
+    "type": "counter"
+  },
+  "n1ql_requests_svi": {
+    "added": "8.0.0",
+    "help": "Total number of SQL++ FTS VECTOR requests.",
+    "type": "counter"
+  },
+  "n1ql_requests_vector": {
+    "added": "8.0.0",
+    "help": "Total number of SQL++ VECTOR requests.",
+    "type": "counter"
+  },
   "n1ql_result_count": {
     "added": "7.0.0",
     "help": "Total number of results (documents) returned by the query engine.",
@@ -237,10 +712,173 @@
     "uiName": "Query Execution Time",
     "unit": "nanoseconds"
   },
+  "n1ql_spills_order": {
+    "added": "8.0.0",
+    "help": "Number of order by operations that have spilled to disk.",
+    "type": "counter"
+  },
+  "n1ql_svi_request_timer_15m_rate": {
+    "added": "8.0.0",
+    "help": "The 15m.rate latency of SQL++ FTS VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_svi_request_timer_1m_rate": {
+    "added": "8.0.0",
+    "help": "The 1m.rate latency of SQL++ FTS VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_svi_request_timer_5m_rate": {
+    "added": "8.0.0",
+    "help": "The 5m.rate latency of SQL++ FTS VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_svi_request_timer_count": {
+    "added": "8.0.0",
+    "help": "The number of SQL++ FTS VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_svi_request_timer_max": {
+    "added": "8.0.0",
+    "help": "The MAX latency of SQL++ FTS VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_svi_request_timer_mean": {
+    "added": "8.0.0",
+    "help": "The MEAN latency of SQL++ FTS VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_svi_request_timer_mean_rate": {
+    "added": "8.0.0",
+    "help": "The mean.rate latency of SQL++ FTS VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_svi_request_timer_median": {
+    "added": "8.0.0",
+    "help": "The MEDIAN latency of SQL++ FTS VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_svi_request_timer_min": {
+    "added": "8.0.0",
+    "help": "The MIN latency of SQL++ FTS VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_svi_request_timer_p75": {
+    "added": "8.0.0",
+    "help": "The 75% latency of SQL++ FTS VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_svi_request_timer_p95": {
+    "added": "8.0.0",
+    "help": "The 95% latency of SQL++ FTS VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_svi_request_timer_p99": {
+    "added": "8.0.0",
+    "help": "The 99% latency of SQL++ FTS VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_svi_request_timer_p99point9": {
+    "added": "8.0.0",
+    "help": "The 99.9% latency of SQL++ FTS VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_svi_request_timer_stddev": {
+    "added": "8.0.0",
+    "help": "The STDDEV latency of SQL++ FTS VECTOR requests.",
+    "type": "gauge"
+  },
+  "n1ql_temp_hwm": {
+    "added": "8.0.0",
+    "help": "High water mark for temp space use.",
+    "type": "counter"
+  },
   "n1ql_temp_space_errors": {
     "added": "7.6.0",
     "help": "Count of temp space related errors",
     "type": "counter"
+  },
+  "n1ql_temp_usage": {
+    "added": "8.0.0",
+    "help": "Current temp space use.",
+    "type": "gauge"
+  },
+  "n1ql_tenant_kv_throttle_count": {
+    "added": "7.6.0",
+    "help": "The total number of times KV has been throttled for queries on this tenant.",
+    "labels": [
+      "bucket"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "gauge"
+  },
+  "n1ql_tenant_kv_throttle_seconds_total": {
+    "added": "7.6.0",
+    "help": "The total amount of time KV has been throttled for queries on this tenant.",
+    "labels": [
+      "bucket"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "gauge",
+    "unit": "seconds"
+  },
+  "n1ql_tenant_memory": {
+    "added": "7.6.0",
+    "help": "The total size of document memory in use, allocated from the tenant-wide document memory quota.",
+    "labels": [
+      "bucket"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "gauge",
+    "unit": "bytes"
+  },
+  "n1ql_tenant_reads": {
+    "added": "7.6.0",
+    "help": "The total number of reads on the tenant.",
+    "labels": [
+      "bucket"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "gauge"
+  },
+  "n1ql_tenant_retries": {
+    "added": "7.6.0",
+    "help": "The total number of retries on the tenant.",
+    "labels": [
+      "bucket"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "gauge"
+  },
+  "n1ql_tenant_writes": {
+    "added": "7.6.0",
+    "help": "The total number of writes on the tenant.",
+    "labels": [
+      "bucket"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "gauge"
+  },
+  "n1ql_throttle_count_total": {
+    "added": "7.6.0",
+    "help": "The number of times Regulator instructed an operation to throttle.",
+    "labels": [
+      "bucket",
+      "for"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
+  "n1ql_throttle_seconds_total": {
+    "added": "7.6.0",
+    "help": "The total time spent throttling (in seconds).",
+    "labels": [
+      "bucket",
+      "for"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
   },
   "n1ql_timeouts": {
     "added": "7.2.4",
@@ -271,6 +909,16 @@
   "n1ql_updates": {
     "added": "7.0.0",
     "help": "Total number of UPDATE requests.",
+    "type": "counter"
+  },
+  "n1ql_user_error_count": {
+    "added": "8.0.0",
+    "help": "Total number of user-caused errors.",
+    "type": "counter"
+  },
+  "n1ql_vector_distance_func": {
+    "added": "8.0.0",
+    "help": "The number of VECTOR_DISTANCE() calls made by statements.",
     "type": "counter"
   },
   "n1ql_warnings": {


### PR DESCRIPTION
I noticed while trying to fix another issues that the metrifcs in the re;ease/8.0 branch are lacking many metrics marked as 8.0. So, I updated the metrics based on the JSON files from build #3773. 

Preview URL:
https://preview.docs-test.couchbase.com/docs-server-Update_Metrics_8.0

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.

Link to the preview metrics page: https://preview.docs-test.couchbase.com/docs-server-Update_Metrics_8.0/server/current/metrics-reference/metrics-reference.html