### PR TITLE
DOC-12444 add vector indexes to index+overview

### DIFF
--- a/modules/learn/pages/services-and-indexes/indexes/indexes.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/indexes.adoc
@@ -4,45 +4,67 @@
 
 [abstract]
 {description}
+Indexes help services like Query, Analytics, and Search find data faster.
+Each index makes a specific subset of data available for searching.
 
-_Indexes_ are used by certain services, such as _Query_, _Analytics_, and _Search_, as targets for search-routines.
-Each index makes a predefined subset of data available for the search.
+The Query Service uses indexes from the xref:learn:services-and-indexes/services/index-service.adoc[].
+The xref:learn:services-and-indexes/services/search-service.adoc[Search] and xref:learn:services-and-indexes/services/analytics-service.adoc[Analytics Services] create and use their own indexes.
 
-The _Query_ service relies on indexes provided by the _Index_ service.
-The _Search_ and _Analytics_ services both provide their own indexes, internally.
+Couchbase Server supports two classes of indexes: <<#traditional-indexes>> and <<#vector-indexes>>.
 
-Indexes, when well-designed, provide significant enhancements to the performance of search-operations.
+[#traditional-indexes]
+== Traditional Indexes
 
-== Indexes
+You can use the following types of indexes for traditional scalar data:
 
-The following forms of index are available:
+Primary:: 
+The xref:services-and-indexes/services/index-service.adoc[Index Service] provides primary indexes based on the unique key of each item in a collection.
+Couchbase Server maintains every primary index asynchronously.
+Use a primary index for basic queries without filters or predicates.
+For more information about primary indexes, see xref:indexes:indexing-overview.adoc[].
 
-Primary:: Provided by the xref:services-and-indexes/services/index-service.adoc[Index Service], this is based on the unique key of every item in a specified collection.
-Every primary index is maintained asynchronously.
-A primary index is intended to be used for simple queries, which have no filters or predicates.
-For information on primary indexes, see xref:indexes:indexing-overview.adoc[].
+Secondary:: 
+The xref:services-and-indexes/services/index-service.adoc[Index Service] provides secondary indexes based on attributes in a document.
+The attribute value can be a scalar, object, or array.
 
-Secondary:: Provided by the xref:services-and-indexes/services/index-service.adoc[Index Service], this is based on an attribute _within_ a document.
-The value associated with the attribute can be of any type: scalar, object, or array.
 +
-A Secondary Index is frequently referred to as a _Global Secondary Index_, or _GSI_.
-This is the kind of index used most frequently in Couchbase Server, for queries performed with {sqlpp}.
-For information on Global Secondary Indexes, see xref:indexes:indexing-overview.adoc[].
+A secondary index is also called a Global Secondary Index (GSI).
+Most queries in Couchbase Server use GSIs with {sqlpp}.
+For more information about Global Secondary Indexes, see xref:indexes:indexing-overview.adoc[].
 
-Search:: Provided by the xref:services-and-indexes/services/search-service.adoc[Search Service], this is a specially purposed index, which contains targets derived from the contents of documents within one or more specified keyspaces.
-Search indexes support text matching, geospatial, date-time, numeric range searches, and more.
-For text matching, you can add filters to remove undesirable characters from input and target text values, such as punctuation marks or HTML tags.
-For information on how to create Search indexes, see xref:search:create-search-indexes.adoc[].
+Search:: 
+The xref:services-and-indexes/services/search-service.adoc[Search Service] provides Search indexes that support text matching, geospatial, date-time, and numeric range searches.
+For text matching, you can add filters to remove unwanted characters from input and target text, such as punctuation marks or HTML tags.
+For more information about creating Search indexes, see xref:search:create-search-indexes.adoc[].
 
-Vector Search:: Provided by the xref:services-and-indexes/services/search-service.adoc[Search Service], this is a type of Search index which supports vector embeddings.
-Use Vector Search indexes to run searches with the Search service using vector comparisons.
-You can use Vector Search indexes for Retrieval Augmented Generation (RAG) with an existing Large Language Model (LLM).
-To create Vector Search indexes, see xref:vector-search:create-vector-search-index-ui.adoc[] or xref:vector-search:create-vector-search-index-rest-api.adoc[].
+Analytics:: 
+The xref:services-and-indexes/services/analytics-service.adoc[Analytics Service] provides analytics indexes for shadow data in an Analytics collection.
+Analytics indexes speed up selection and join queries in Analytics.
+When operational data changes, Couchbase Server updates analytics indexes automatically.
+For more information about using analytics indexes, see xref:analytics:7_using_index.adoc[].
 
-Analytics:: Provided by the xref:services-and-indexes/services/analytics-service.adoc[Analytics Service], this is a materialized access path for the shadow data in an Analytics collection.
-Analytics indexes can be used to speed up Analytics selection queries and join queries.
-If changes in operational data result in corresponding modifications to shadow data, Analytics indexes are updated automatically.
-See the section on xref:analytics:7_using_index.adoc[Using Indexes] in Couchbase Analytics.
+Views:: 
+xref:learn:views/views-intro.adoc[Couchbase Views] extract fields and information from documents to create their own index.
 
-View:: Supports xref:learn:views/views-intro.adoc[Couchbase Views], with fields and information extracted from documents.
-Views are deprecated in Couchbase Server 7.0, and will be removed in a future release.
++
+IMPORTANT: Views were deprecated in Couchbase Server 7.0 and will be removed in a future release.
+
+[#vector-indexes]
+== Vector Indexes
+
+Couchbase Server also supports indexes for vector search.
+These indexes let you perform semantic similarity searches that form the basis of AI applications.
+See xref:vector-index/vectors-and-indexes-overview.adoc[] for more information about using vector indexes.
+
+Hyperscale Vector Indexes:: 
+The Index Service provides xref:vector-index/hyperscale-vector-index.adoc[Hyperscale Vector Indexes] which index a single vector column. 
+They offer the highest performance of any index when it comes to vector data. 
+They can scale up to a billion documents containing vectors with a large number of dimensions. 
+
+Composite Vector Indexes:: 
+The Index Service provides xref:vector-index/composite-vector-index.adoc[Composite Vector Indexes] which are Global Secondary Indexes (GSIs) with a single vector column. 
+The vector column lets your application perform queries using both the index’s scalar, array, and object index entries to pre-filter the dataset before performing a vector similarity search.
+
+Search Vector Indexes:: 
+The Search Service provides xref:vector-search/vector-search.adoc[Search Vector Indexes] that support vector embeddings.
+You can use Search Vector Indexes for Retrieval Augmented Generation (RAG) with a Large Language Model (LLM).

--- a/modules/learn/pages/services-and-indexes/indexes/indexes.adoc
+++ b/modules/learn/pages/services-and-indexes/indexes/indexes.adoc
@@ -1,10 +1,9 @@
 = Indexes
-:description: Couchbase Server indexes enhance the performance of query and search operations.
+:description: Couchbase Server uses indexes to improve the performance of queries and searches.
 :page-aliases: understanding-couchbase:services-and-indexes/indexes/indexes,concepts:indexing
 
 [abstract]
 {description}
-Indexes help services like Query, Analytics, and Search find data faster.
 Each index makes a specific subset of data available for searching.
 
 The Query Service uses indexes from the xref:learn:services-and-indexes/services/index-service.adoc[].
@@ -59,12 +58,12 @@ See xref:vector-index/vectors-and-indexes-overview.adoc[] for more information a
 Hyperscale Vector Indexes:: 
 The Index Service provides xref:vector-index/hyperscale-vector-index.adoc[Hyperscale Vector Indexes] which index a single vector column. 
 They offer the highest performance of any index when it comes to vector data. 
-They can scale up to a billion documents containing vectors with a large number of dimensions. 
+These indexes can scale up to a billion documents containing vectors with a large number of dimensions. 
 
 Composite Vector Indexes:: 
 The Index Service provides xref:vector-index/composite-vector-index.adoc[Composite Vector Indexes] which are Global Secondary Indexes (GSIs) with a single vector column. 
-The vector column lets your application perform queries using both the index’s scalar, array, and object index entries to pre-filter the dataset before performing a vector similarity search.
+These indexes let your application use searches for scalar, array, and object index entries to pre-filter the dataset before performing a vector similarity search.
 
 Search Vector Indexes:: 
-The Search Service provides xref:vector-search/vector-search.adoc[Search Vector Indexes] that support vector embeddings.
-You can use Search Vector Indexes for Retrieval Augmented Generation (RAG) with a Large Language Model (LLM).
+The Search Service provides xref:vector-search/vector-search.adoc[Search Vector Indexes] that support a single vector column.
+You can use Search Vector Indexes for tasks such as Retrieval Augmented Generation (RAG) with a Large Language Model (LLM).


### PR DESCRIPTION
Adds references to the vector indexes to the Server's Indexes topic. Topic was also brought up to doc standards.
[Here's the preview of the changes](https://preview.docs-test.couchbase.com/docs-server-DOC-12444_Add_vector_indexes_to_index+overview/server/current/learn/services-and-indexes/indexes/indexes.html).