### PR TITLE
Automatic resolution of name conflicts during a backup restore

### DIFF
--- a/modules/introduction/partials/new-features-80.adoc
+++ b/modules/introduction/partials/new-features-80.adoc
@@ -323,7 +323,10 @@ Incremental backups now keep track of which backups they depend on.
 You cannot delete a backup if another incremental backup needs it, however, you can choose to override this protection from the UI and REST API.
 For more information, see xref:manage:manage-backup-and-restore/manage-backup-and-restore.adoc#delete-backups[Delete Backups].
 
-
+https://jira.issues.couchbase.com/browse/MB-66173[MB-66173]: Automatically resolve name conflicts during a backup restore::
+Automated the process of resolving name conflicts between collections or scopes in the backup and those in the target cluster, during a restore.
+For this purpose, added a new flag, `--auto-resolve-conflicts` to the `cbbackupmgr restore` parameter.
+For more information, see xref:backup-restore:cbbackupmgr-restore.adoc[cbbackupmgr restore].
 
 
 [#section-new-feature-800-XDCR]

--- a/modules/introduction/partials/new-features-80.adoc
+++ b/modules/introduction/partials/new-features-80.adoc
@@ -325,7 +325,7 @@ For more information, see xref:manage:manage-backup-and-restore/manage-backup-an
 
 https://jira.issues.couchbase.com/browse/MB-66173[MB-66173]: Automatically resolve name conflicts during a backup restore::
 Automated the process of resolving name conflicts between collections or scopes in the backup and those in the target cluster, during a restore.
-For this purpose, added a new flag, `--auto-resolve-conflicts` to the `cbbackupmgr restore` parameter.
+For this purpose, we have added a new flag, `--auto-resolve-conflicts` to the `cbbackupmgr restore` parameter.
 For more information, see xref:backup-restore:cbbackupmgr-restore.adoc[cbbackupmgr restore].
 
 


### PR DESCRIPTION
DOC-13618

Preview docs [login password](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords).

Added the [What's New entry](https://preview.docs-test.couchbase.com/DOC-13618/server/current/introduction/whats-new.html#section-new-feature-800-backup-service):
- Search for "MB-66173" or "Automatically resolve name conflicts during a backup restore".