### PR TITLE
Mention 8-0 version cluster and remove memcached ref from manage section

### DIFF
--- a/modules/manage/pages/manage-buckets/create-bucket.adoc
+++ b/modules/manage/pages/manage-buckets/create-bucket.adoc
@@ -197,18 +197,6 @@ NOTE: Enable Cross Cluster Versioning can be enabled only in the xref:manage:man
 Enabling Cross Cluster Versioning is a prerequisite for features like XDCR Conflict Logging and XDCR Active-Active with Sync Gateway 4.0+.
 For more information, see xref:learn:clusters-and-availability/xdcr-enable-crossclusterversioning.adoc[XDCR enableCrossClusterVersioning].
 
-[#memcached-bucket-settings]
-==== Memcached Bucket Settings
-
-CAUTION: Memcached buckets are deprecated. Use a *Couchbase* or *Ephemeral* bucket, instead.
-
-To configure advanced settings for a Memcached bucket:
-
-. To enable xref:learn:security/native-encryption-at-rest-overview.adoc[native encryption at rest], select the *Enable Encryption at Rest*, then select a key from the *Encryption Key* list.
-For more details about enabling encryption at rest, see xref:manage:manage-security/manage-native-encryption-at-rest.adoc[].
-
-
-
 [#ephemeral-bucket-settings]
 ==== Ephemeral Bucket Settings
 

--- a/modules/manage/pages/manage-nodes/modify-services-and-rebalance.adoc
+++ b/modules/manage/pages/manage-nodes/modify-services-and-rebalance.adoc
@@ -24,8 +24,9 @@ For more information about adding or removing the Data Service on an existing no
 
 == Prerequisites
 
-Before modifying non-data services on nodes, ensure you have the following:
+Before modifying non-data services on nodes, make sure you have the following:
 
+* The Couchbase Server cluster must be running the 8.0 or a later version.
 * Full Administrator access.
 For more information, see xref:learn:security/roles.adoc#full-admin[Full Admin].
 * A clear understanding of the current service distribution across the nodes.


### PR DESCRIPTION
DOC-13627

Preview docs [password](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords).

- Removed the section "Memcached Bucket Settings" from the [Create a Bucket](https://preview.docs-test.couchbase.com/DOC-13627/server/current/manage/manage-buckets/create-bucket.html) page.
- In the [Prerequisites](https://preview.docs-test.couchbase.com/DOC-13627/server/current/manage/manage-nodes/modify-services-and-rebalance.html#prerequisites) section, listed the required minimum Couchbase Server cluster version as 8.0.