### PR TITLE
Add missing bucket API param and fix formatting errors

### DIFF
--- a/modules/rest-api/pages/rest-bucket-create.adoc
+++ b/modules/rest-api/pages/rest-bucket-create.adoc
@@ -108,41 +108,42 @@ Parameters that support the creation and editing of buckets can be broken into t
 
 This section lists the general parameters for creating a bucket. 
 
-You must supply a value for the following parameters:
+* You must supply a value for the following parameters:
 
-* xref:rest-api:rest-bucket-create.adoc#ramQuota[ramQuota]
-* xref:rest-api:rest-bucket-create.adoc#name[name]
-
+** xref:rest-api:rest-bucket-create.adoc#ramQuota[ramQuota]
+** xref:rest-api:rest-bucket-create.adoc#name[name]
++
 All other parameters are optional and have a default value.
 
-The following parameters can be edited after bucket creation:
+* You can edit the following parameters after bucket creation:
 
-* <<evictionpolicy,evictionPolicy>>
-* <<durabilityminlevel,durabilityMinLevel>>
-* <<rank,rank>>
-* <<replicanumber,replicaNumber>>
-* <<compressionmode,compressionMode>>
-* <<maxttl,maxTTL>>
-* <<flushenabled,flushEnabled>>
-* <<magmaseqtreedatablocksize,magmaSeqTreeDataBlockSize>>
-* <<historyretentioncollectiondefault,historyRetentionCollectionDefault>>
-* <<historyretentionbytes,historyRetentionBytes>>
-* <<storagebackend,storageBackend>>
-* <<historyretentionseconds,historyRetentionSeconds>>
-* <<encryptionAtRestKeyId>>
-* <<encryptionAtRestDekRotationInterval>>
-* <<encryptionAtRestDekLifetime>>
+** <<evictionpolicy,evictionPolicy>>
+** <<durabilityminlevel,durabilityMinLevel>>
+** <<durabilityimpossiblefallback,durabilityImpossibleFallback>>
+** <<rank,rank>>
+** <<replicanumber,replicaNumber>>
+** <<compressionmode,compressionMode>>
+** <<maxttl,maxTTL>>
+** <<flushenabled,flushEnabled>>
+** <<magmaseqtreedatablocksize,magmaSeqTreeDataBlockSize>>
+** <<historyretentioncollectiondefault,historyRetentionCollectionDefault>>
+** <<historyretentionbytes,historyRetentionBytes>>
+** <<storagebackend,storageBackend>>
+** <<historyretentionseconds,historyRetentionSeconds>>
+** <<encryptionAtRestKeyId>>
+** <<encryptionAtRestDekRotationInterval>>
+** <<encryptionAtRestDekLifetime>>
+** <<accessscannerenabled,accessScannerEnabled>>
+** <<expirypagersleeptime,expiryPagerSleepTime>>
+** <<warmupbehavior,warmupBehavior>>
+** <<memorylowwatermark,memoryLowWatermark>>
+** <<memoryhighwatermark,memoryHighWatermark>>
 
-** Parameters that _can_ be edited after bucket creation; these being xref:rest-api:rest-bucket-create.adoc#evictionpolicy[evictionPolicy], xref:rest-api:rest-bucket-create.adoc#durabilityminlevel[durabilityMinLevel], xref:rest-api:rest-bucket-create.adoc#rank[rank], xref:rest-api:rest-bucket-create.adoc#replicanumber[replicaNumber], xref:rest-api:rest-bucket-create.adoc#compressionmode[compressionMode], xref:rest-api:rest-bucket-create.adoc#maxttl[maxTTL], xref:rest-api:rest-bucket-create.adoc#flushenabled[flushEnabled], xref:rest-api:rest-bucket-create.adoc#magmaseqtreedatablocksize[magmaSeqTreeDataBlockSize],
-xref:rest-api:rest-bucket-create.adoc#historyretentioncollectiondefault[historyRetentionCollectionDefault],
-xref:rest-api:rest-bucket-create.adoc#historyretentionbytes[historyRetentionBytes], xref:rest-api:rest-bucket-create.adoc#storagebackend[storageBackend],
-xref:rest-api:rest-bucket-create.adoc#historyretentionseconds[historyRetentionSeconds], xref:rest-api:rest-bucket-create.adoc#accessscannerenabled[accessScannerEnabled], xref:rest-api:rest-bucket-create.adoc#expirypagersleeptime[expiryPagerSleepTime], xref:rest-api:rest-bucket-create.adoc#warmupbehavior[warmupBehavior], xref:rest-api:rest-bucket-create.adoc#memorylowwatermark[memoryLowWatermark], and xref:rest-api:rest-bucket-create.adoc#memoryhighwatermark[memoryHighWatermark].
+* You cannot edit these parameters after bucket creation:
 
-You cannot edit these parameters after bucket creation:
-
-* xref:rest-api:rest-bucket-create.adoc#buckettype[bucketType]
-* xref:rest-api:rest-bucket-create.adoc#replicaindex[replicaIndex]
-* xref:rest-api:rest-bucket-create.adoc#conflictresolutiontype[conflictResolutionType]
+** xref:rest-api:rest-bucket-create.adoc#buckettype[bucketType]
+** xref:rest-api:rest-bucket-create.adoc#replicaindex[replicaIndex]
+** xref:rest-api:rest-bucket-create.adoc#conflictresolutiontype[conflictResolutionType]
 
 For full details and examples, see xref:rest-api:rest-bucket-create.adoc#general-parameters[General Parameters].
 

--- a/modules/rest-api/pages/rest-bucket-create.adoc
+++ b/modules/rest-api/pages/rest-bucket-create.adoc
@@ -139,7 +139,7 @@ All other parameters are optional and have a default value.
 ** <<memorylowwatermark,memoryLowWatermark>>
 ** <<memoryhighwatermark,memoryHighWatermark>>
 
-* You cannot edit these parameters after bucket creation:
+* You cannot edit the following parameters after bucket creation:
 
 ** xref:rest-api:rest-bucket-create.adoc#buckettype[bucketType]
 ** xref:rest-api:rest-bucket-create.adoc#replicaindex[replicaIndex]


### PR DESCRIPTION
DOC-13629

- Listed `durabilityImpossibleFallbackand` and added a link to its section.
- `durabilityMinLevel` is already present.

Git preview of the PR:
https://github.com/couchbase/docs-server/blob/c0854eb6378c41584d5fd1fa172a807d098f5510/modules/rest-api/pages/rest-bucket-create.adoc#general