### PR TITLE
8-0 docs preview - Fix typo in the create a bucket page

### DIFF
--- a/modules/manage/pages/manage-buckets/create-bucket.adoc
+++ b/modules/manage/pages/manage-buckets/create-bucket.adoc
@@ -278,7 +278,7 @@ For example:
 --enable-flush 0
 ----
 
-The preceding example creates a `Couchbase` bucket named `testBucket`, with a RAM size of `1024` with the default storage backed (Magma with 128 vBucket).
+The preceding example creates a `Couchbase` bucket named `testBucket`, with a RAM size of `1024` with the default storage backend (Magma with 128 vBucket).
  It sets a Maximum Time-to-Live and disables Flush.
  It also sets a Minimum Durability Level of `persistToMajority`.
 


### PR DESCRIPTION
DOC-13631

Changed "backed" to "backend" in the line 281.

(antora builds are failing, so couldn't create a docs preview build for this PR)