### PR TITLE
DOC-13608 Added performance recommendations for Magma

### DIFF
--- a/modules/learn/pages/buckets-memory-and-storage/storage-engines.adoc
+++ b/modules/learn/pages/buckets-memory-and-storage/storage-engines.adoc
@@ -27,7 +27,7 @@ NOTE: Magma buckets with 128 vBuckets are only available in clusters that have f
 
 Magma using 1024 vBuckets has a minimum memory quota of 1{nbsp}GiB per node.
 
-If you can allocate at least 1{nbsp}GiB memory per node to your bucket, you should choose the 1024 vBucket option for Magma as you will get better performance at scale.
+If you can allocate at least 1{nbsp}GiB memory per node to your bucket, you should choose the 1024 vBucket option for Magma as you'll get better performance at scale.
 As your dataset grows, Magma has a minimum memory-to-data ratio of 1%.
 For example, a node with 5{nbsp}TiB data in a Magma bucket must allocate at least 51{nbsp}GiB of RAM for the bucket.
 
@@ -35,7 +35,7 @@ For example, a node with 5{nbsp}TiB data in a Magma bucket must allocate at leas
 
 When using Magma, consider the following performance optimizations:
 
-* Make sure your data storage path for the bucket is on a fast SSD or NVME disk. 
+* Make sure your data storage path for the bucket is on an SSD. 
 
 * When installing Couchbase Server on Linux, use the https://en.wikipedia.org/wiki/XFS[XFS file system^] for the data storage path. 
 Magma is a disk-optimized storage engine, and its performance depends on the speed of the underlying disk and its filesystem.
@@ -43,14 +43,13 @@ Magma is a disk-optimized storage engine, and its performance depends on the spe
 * Set the bucket's ejection policy to Full to minimize memory use.
 See xref:learn:buckets-memory-and-storage/memory.adoc#ejection[Ejection] for more information.
 
-
 ==== Magma Writer Thread Settings
 
 Couchbase Server lets you set the number of threads for reading and writing data to the disk.
-Under some circumstances, you may want to set the Writer Threads to `Disk i/o optimized` for Magma buckets. 
-This setting makes sure there are enough threads to sustain high write rates.
+For higher I/O concurrency, consider increasing the number of reader and writer threads by setting the bucket's *Reader Thread Settings* and *Writer Thread Settings* to *Disk i/o optimized* for Magma buckets. 
+This setting makes sure there are enough threads to sustain high read and write rates.
 
-To learn more about how you should configure the Writer Thread settings for your Magma bucket, see xref:manage:manage-settings/general-settings.adoc#data-settings[Data Settings]
+To learn more about configuring the Writer Thread settings for your Magma bucket, see xref:manage:manage-settings/general-settings.adoc#data-settings[Data Settings]
 
 [#couchstore]
 == Couchstore

--- a/modules/learn/pages/buckets-memory-and-storage/storage-engines.adoc
+++ b/modules/learn/pages/buckets-memory-and-storage/storage-engines.adoc
@@ -31,13 +31,26 @@ If you can allocate at least 1{nbsp}GiB memory per node to your bucket, you shou
 As your dataset grows, Magma has a minimum memory-to-data ratio of 1%.
 For example, a node with 5{nbsp}TiB data in a Magma bucket must allocate at least 51{nbsp}GiB of RAM for the bucket.
 
-=== Magma Writer Thread Settings
+=== Magma Performance Considerations
+
+When using Magma, consider the following performance optimizations:
+
+* Make sure your data storage path for the bucket is on a fast SSD or NVME disk. 
+
+* When installing Couchbase Server on Linux, use the https://en.wikipedia.org/wiki/XFS[XFS file system^] for the data storage path. 
+Magma is a disk-optimized storage engine, and its performance depends on the speed of the underlying disk and its filesystem.
+
+* Set the bucket's ejection policy to Full to minimize memory use.
+See xref:learn:buckets-memory-and-storage/memory.adoc#ejection[Ejection] for more information.
+
+
+==== Magma Writer Thread Settings
 
 Couchbase Server lets you set the number of threads for reading and writing data to the disk.
 Under some circumstances, you may want to set the Writer Threads to `Disk i/o optimized` for Magma buckets. 
 This setting makes sure there are enough threads to sustain high write rates.
 
-To learn more about how you should configure the  Writer Thread settings for your Magma bucket, see xref:manage:manage-settings/general-settings.adoc#data-settings[Data Settings]
+To learn more about how you should configure the Writer Thread settings for your Magma bucket, see xref:manage:manage-settings/general-settings.adoc#data-settings[Data Settings]
 
 [#couchstore]
 == Couchstore


### PR DESCRIPTION
Added "Magma Performance Considerations" to the Storage Engines page. 
Moved the existing Writer Thread Setting subsection under that.

Preview link for the update: 
https://preview.docs-test.couchbase.com/docs-server-DOC-13608_magma_recommendations/server/current/learn/buckets-memory-and-storage/storage-engines.html#magma-performance-considerations

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.