### PR TITLE
Update upgrade concerns

### DIFF
--- a/modules/install/pages/upgrade.adoc
+++ b/modules/install/pages/upgrade.adoc
@@ -51,6 +51,23 @@ To replicate from a bucket on an earlier version of Couchbase Server, explicitly
 
 For more information about storage backends, see xref:buckets-memory-and-storage/storage-engines.adoc#storage-engines[].
 
+=== x86 AVX2 Requirement for Couchbase Server Version 8.0 and Later
+
+When running on x86-64 processors, Couchbase Server 8.0 and later requires that the CPU support the AVX2 instruction set.
+Most Intel processors manufactured since 2013 and AMD processors manufactured since 2015 support AVX2.
+If you attempt to run Couchbase Server 8.0 or later on a CPU that does not support AVX2, the server exits with an error.
+See xref:install:pre-install.adoc#avx2-requirement-for-x86-processors[Instruction Set Requirements for x86 Processors] for more information.
+
+
+=== Memcached Buckets Have Been Removed in Couchbase Server Version 8.0 and Later
+
+Memcached buckets have been removed in Couchbase Server 8.0 and later.
+The upgrade process exits with an error if you attempt to upgrade a cluster with Memcached buckets.
+If your cluster has Memcached buckets, you must replace them with ephemeral buckets before upgrading.
+See https://docs-archive.couchbase.com/server/6.6/learn/buckets-memory-and-storage/buckets.html#bucket-capabilities[Bucket Capabilities in the Version 6.6 documentation] for a summary of the differences between Memcached and ephemeral buckets.
+
+[#dotnet-sdk-upgrade-note]
+
 // So long as upgrading from 6.x is supported, this notice will need to stay in some form in each new release.
 === Upgrading to Version 7.x With Earlier Versions of .NET SDK
 

--- a/modules/install/pages/upgrade.adoc
+++ b/modules/install/pages/upgrade.adoc
@@ -38,7 +38,7 @@ Magma buckets with 128 vBuckets is a new feature in Couchbase Server 8.0 and lat
 These behavior changes could cause issues if you rely on the prior behavior, especially if you use deployment scripts.
 If you have deployment scripts that create buckets, review them to determine if you need to make changes.
 
-For example, suppose your deployment script does not specify the storage backend when it creates a bucket that you intend to use with the xref:views/views-mapreduce-intro.adoc[] feature.
+For example, suppose your deployment script does not specify the storage backend when it creates a bucket that you intend to use with the xref:learn:views/views-intro.adoc[views] feature.
 On versions prior to Couchbase Server 8.0, your script created a Couchstore bucket with 1024 vBuckets,
 In version 8.0, due to change in the default backend, your script creates a bucket with the Magma storage backend with 128 vBuckets.
 Attempting to use MapReduce Views with this bucket results in errors, because Magma buckets do not support this feature.

--- a/modules/install/pages/upgrade.adoc
+++ b/modules/install/pages/upgrade.adoc
@@ -132,7 +132,7 @@ TIP: As far as is possible, you should aim to keep your cluster up to date with 
 | Any 6.0.x / 6.5.x → 6.6 → 7.2.3 → 8.0
 
 | 7.x
-| Any 7.0.x / 7.1.x → 7.2.3→ 8.0{empty}xref:#erlang-7-2-4-footnote1[^+[1]+^] 
+| Any 7.0.x / 7.1.x → 7.2.3 → 8.0{empty}xref:#erlang-7-2-4-footnote1[^+[1]+^] 
 
 Any 7.2.x / 7.6.x → 8.0
 

--- a/modules/install/pages/upgrade.adoc
+++ b/modules/install/pages/upgrade.adoc
@@ -49,7 +49,7 @@ Another concern is that versions of Couchbase Server earlier than 8.0 do not sup
 Therefore, you cannot replicate to a bucket you create with the new default backend setting from buckets on an earlier server version. 
 To replicate from a bucket on an earlier version of Couchbase Server, explicitly set the new bucket's storage backend to Couchstore or to Magma with 1024 vBuckets during creation.
 
-For more information about storage backends, see xref:buckets-memory-and-storage/storage-engines.adoc#storage-engines[].
+For more information about storage backends, see xref:learn:buckets-memory-and-storage/storage-engines.adoc[].
 
 === x86 AVX2 Requirement for Couchbase Server Version 8.0 and Later
 


### PR DESCRIPTION
This PR adds some additional version 8.0 items to the "Before You Upgrade" section of the Upgrade page.:

- Removal of memcached buckets
- AVX2 requirement on x86.

Also fixed a broken link.

[Preview of changes.](https://preview.docs-test.couchbase.com/docs-server-Update_upgrade_concerns/server/current/install/upgrade.html#before-you-upgrade)

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.