### PR TITLE
Doc 13623 b (What's New and Release Notes)

### DIFF
--- a/modules/introduction/pages/whats-new.adoc
+++ b/modules/introduction/pages/whats-new.adoc
@@ -7,7 +7,7 @@
 {description} +
 Couchbase Server 8.0 combines the strengths of relational databases with the flexibility, performance, and scale of Couchbase.
 
-For information about platform support changes, deprecation notifications, notable improvements, and fixed and known issues, refer to the xref:release-notes:relnotes.adoc[Release Notes].
+For information about platform support changes, deprecation notifications, and fixed and known issues, see the xref:release-notes:relnotes.adoc[Release Notes].
 
 [#new-features-80]
 == New Features and Enhancements in 8.0.0

--- a/modules/introduction/partials/new-features-80.adoc
+++ b/modules/introduction/partials/new-features-80.adoc
@@ -41,7 +41,6 @@ For more information, see xref:vector-index:vectors-and-indexes-overview.adoc[Us
 === Data Service Changes
 
 Couchbase Server 8.0 introduces several new features for the Data Service.
-For a full list of new features for the Data Service, see xref:release-notes:relnotes.adoc#dlist-fixed-issues-80-data-service[Data Service].
 
 ==== Magma with 128 vBuckets is the New Default Storage Engine
 
@@ -138,7 +137,6 @@ See xref:learn:clusters-and-availability/automatic-failover.adoc#auto-failover-a
 === Non-Data Services
 
 Couchbase Server 8.0 release has key non-Data Services enhancements. 
-For a full list of new features for the non-Data Services, see xref:release-notes:relnotes.adoc#dlist-fixed-issues-80-cluster-manager[Cluster Manager] and xref:release-notes:relnotes.adoc#dlist-fixed-issues-80-index-service[Index Service].
 
 ==== Dynamically Add or Remove Non-Data Services on Existing Nodes
 
@@ -230,7 +228,6 @@ For more information, see xref:rest-api:rest-bucket-create.adoc[Creating and Edi
 
 Couchbase Server 8.0 release has key cross datacenter replication (XDCR) enhancements and diagnostic capabilities. 
 These updates improve visibility and operational control in replication topologies.
-For a full list of new features for the cross datacenter replication, see xref:release-notes:relnotes.adoc#dlist-fixed-issues-80-xdcr[XDCR].
 
 ==== XDCR Conflict Logging Feature
 
@@ -268,7 +265,6 @@ For more information, see xref:rest-api:rest-xdcr-adv-settings.adoc[XDCR Advance
 === Security and Authentication
 
 Couchbase Server 8.0 release has key security and authentication enhancements.
-For a full list of new features for the security and authentication, see xref:release-notes:relnotes.adoc#dlist-fixed-issues-80-cluster-manager[Cluster Manager].
 
 ==== Hybrid Authentication Mode
 Couchbase Server now supports the Hybrid authentication mode in the certificate-based client authentication.
@@ -321,7 +317,6 @@ For more information, see xref:learn:security/auditing.adoc#audit-user-activity[
 === Query Service
 
 Couchbase Server 8.0 release has key Query Service features. 
-For a full list of Query Service related new features, see xref:release-notes:relnotes.adoc#dlist-fixed-issues-80-query-service[Query Service].
 
 ==== New {sqlpp} Statements for Vector Indexes
 
@@ -446,7 +441,7 @@ For more information, see xref:n1ql:n1ql-language-reference/infer.adoc[INFER].
 
 === Search Service
 
-Couchbase Server 8.0 introduces several new features for the Search Service. For a full list of new features for the Search Service, see xref:release-notes:relnotes.adoc#dlist-fixed-issues-80-search-service[Search Service].
+Couchbase Server 8.0 introduces several new features for the xref:search:search.adoc[Search Service].
 
 ==== Partition Selection for Queries
 

--- a/modules/introduction/partials/new-features-80.adoc
+++ b/modules/introduction/partials/new-features-80.adoc
@@ -143,7 +143,7 @@ Couchbase Server 8.0 release has key non-Data Services enhancements.
 Now you can add or remove non-Data Services dynamically on existing nodes in a cluster, without adding or removing nodes.
 After you add or remove non-Data Services, the rebalancing operation is automatically triggered to distribute service workloads and complete the modification.
 
-You can modify these services using the Couchbase xref:manage:manage-nodes/modify-services-on-nodes-and-rebalance.adoc#modify-mds-services-from-ui[UI], xref:rest-api:rest-set-up-services-existing-nodes.adoc[REST API], or xref:manage:manage-nodes/modify-services-on-nodes-and-rebalance.adoc#modify-mds-services-using-cli[CLI].
+You can modify these services using the Couchbase xref:manage:manage-nodes/modify-services-and-rebalance.adoc#modify-mds-services-from-ui[UI], xref:rest-api:rest-set-up-services-existing-nodes.adoc[REST API], or xref:manage:manage-nodes/modify-services-and-rebalance.adoc#modify-mds-services-using-cli[CLI].
 The following services can be modified:
 
 * `index` (Index Service)

--- a/modules/learn/pages/clusters-and-availability/nodes.adoc
+++ b/modules/learn/pages/clusters-and-availability/nodes.adoc
@@ -165,7 +165,7 @@ For information about the deployment of services on a new node using:
 
 You can add or remove non-Data Services on an existing node in a cluster using the following methods:
 
-* From the xref:manage:manage-nodes/modify-services-on-nodes-and-rebalance.adoc#modify-mds-services-from-ui[UI] or xref:manage:manage-nodes/modify-services-on-nodes-and-rebalance.adoc#modify-mds-services-using-cli[CLI].
+* From the xref:manage:manage-nodes/modify-services-and-rebalance.adoc#modify-mds-services-from-ui[UI] or xref:manage:manage-nodes/modify-services-and-rebalance.adoc#modify-mds-services-using-cli[CLI].
 For more information, see xref:manage:manage-nodes/modify-services-and-rebalance.adoc[Modify Services and Rebalance].
 * Using the REST API. For more information, see xref:rest-api:rest-set-up-services-existing-nodes.adoc[Assigning Services to an Existing Node].
 

--- a/modules/manage/pages/manage-nodes/modify-services-and-rebalance.adoc
+++ b/modules/manage/pages/manage-nodes/modify-services-and-rebalance.adoc
@@ -5,7 +5,7 @@
 [abstract]
 {description}
 
-You can dynamically add or remove the following Multi-Dimensional Scaling (MDS) services on existing nodes in a cluster from the Couchbase xref:manage:manage-nodes/modify-services-on-nodes-and-rebalance.adoc#modify-mds-services-from-ui[UI], xref:rest-api:rest-set-up-services-existing-nodes.adoc[REST API], or xref:manage:manage-nodes/modify-services-on-nodes-and-rebalance.adoc#modify-mds-services-using-cli[CLI]:
+You can dynamically add or remove the following Multi-Dimensional Scaling (MDS) services on existing nodes in a cluster from the Couchbase xref:manage:manage-nodes/modify-services-and-rebalance.adoc#modify-mds-services-from-ui[UI], xref:rest-api:rest-set-up-services-existing-nodes.adoc[REST API], or xref:manage:manage-nodes/modify-services-and-rebalance.adoc#modify-mds-services-using-cli[CLI]:
 
 * `index` (Index Service)
 * `n1ql` (Query Service)

--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -1,7 +1,13 @@
 = Release Notes for Couchbase Server 8.0
 :page-aliases: analytics:releasenote
-:description: Couchbase Server 8.0.0 introduces multiple new features and fixes, as well as some deprecations and removals.
+:description: Couchbase Server 8.0.0 introduces many fixes, as well as some deprecations and removals.
 :page-toclevels: 2
+
+== New Features
+
+These release notes are focused on bug fixes, behaviour changes and breaking changes.
+
+For information about new features and significant improvements made in Couchbase Server 8.0, see xref:introduction:whats-new.adoc[What's New].
 
 [#deprecated-80]
 == Deprecated Platforms

--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -5,9 +5,9 @@
 
 == New Features
 
-These release notes are focused on bug fixes, behaviour changes and breaking changes.
+These release notes are focused on bug fixes and breaking changes.
 
-For information about new features and significant improvements made in Couchbase Server 8.0, see xref:introduction:whats-new.adoc[What's New].
+For information about new features and major improvements made in Couchbase Server 8.0, see xref:introduction:whats-new.adoc[What's New].
 
 [#deprecated-80]
 == Deprecated Platforms

--- a/preview/DOC-13623-b.yml
+++ b/preview/DOC-13623-b.yml
@@ -1,0 +1,29 @@
+sources:
+    docs-server:
+      branches: DOC-13623-b
+    docs-analytics:
+      branches: release/8.0
+    docs-devex:
+      url: https://github.com/couchbaselabs/docs-devex.git
+      branches: master
+      startPaths: docs/
+    couchbase-cli:
+      # url: ../../docs-includes/couchbase-cli
+      url: https://github.com/couchbaselabs/couchbase-cli-doc
+      # branches: HEAD
+      branches: master
+      startPaths: docs/
+    backup:
+      # url: ../../docs-includes/backup
+      url: https://github.com/couchbaselabs/backup-docs.git
+      #branches: HEAD
+      branches: master
+      startPaths: docs/    
+    #analytics:
+    #  url: ../../docs-includes/docs-analytics
+    #  branches: HEAD
+    #cb-swagger:
+    #  rl: https://github.com/couchbaselabs/cb-swagger
+    #  branches: release/8.0
+    #  start_path: docs
+


### PR DESCRIPTION
Removed some of the "see the release notes for a full list" links, since release notes are just for bug fixes and breaking changes.

Changed some wording. Added links to and from the release notes / whats new so people know where to go for what.