### PR TITLE
Add missing link for encryption at rest

### DIFF
--- a/modules/manage/pages/manage-security/manage-native-encryption-at-rest.adoc
+++ b/modules/manage/pages/manage-security/manage-native-encryption-at-rest.adoc
@@ -54,7 +54,7 @@ See xref:learn:security/native-encryption-at-rest-overview.adoc#kms[Encryption K
 You must decide what data your encryption key can encrypt. 
 You can create an encryption key that can encrypt any type of data and other encryption keys.
 You can also choose to limit what types of data the key can encrypt, or configure it to only encrypt other encryption keys. 
-See learn:security/native-encryption-at-rest-overview.adoc#keys[Encryption-at-Rest Keys] for more information.
+See xref:learn:security/native-encryption-at-rest-overview.adoc#keys[Encryption-at-Rest Keys] for more information.
 
 You must have the proper privileges to create encryption keys.
 The role you need depends on what the key you're creating can encrypt:

--- a/preview/MB-68967_preview_doc_edit_8_0.yml
+++ b/preview/MB-68967_preview_doc_edit_8_0.yml
@@ -1,0 +1,28 @@
+sources:
+    docs-server:
+      branches: MB_68967_preview_doc_edit_8_0
+    docs-analytics:
+      branches: release/8.0
+    docs-devex:
+      url: https://github.com/couchbaselabs/docs-devex.git
+      branches: master
+      startPaths: docs/
+    couchbase-cli:
+      # url: ../../docs-includes/couchbase-cli
+      url: https://github.com/couchbaselabs/couchbase-cli-doc
+      # branches: HEAD
+      branches: master
+      startPaths: docs/
+    backup:
+      # url: ../../docs-includes/backup
+      url: https://github.com/couchbaselabs/backup-docs.git
+      #branches: HEAD
+      branches: master
+      startPaths: docs/    
+    #analytics:
+    #  url: ../../docs-includes/docs-analytics
+    #  branches: HEAD
+    #cb-swagger:
+    #  rl: https://github.com/couchbaselabs/cb-swagger
+    #  branches: release/8.0
+    #  start_path: docs


### PR DESCRIPTION
MB-68967

Preview doc [password](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords).

In the section [Requirements](https://preview.docs-test.couchbase.com/docs-server-MB_68967_preview_doc_edit_8_0/server/current/manage/manage-security/manage-native-encryption-at-rest.html#requirements), fixed the link for:

- See [Encryption-at-Rest Keys](https://preview.docs-test.couchbase.com/docs-server-MB_68967_preview_doc_edit_8_0/server/current/learn/security/native-encryption-at-rest-overview.html#keys) for more information

Ignore the "preview" file.
