### PR TITLE
DOC-12785 Add a note for the vector index restoration process

### DIFF
--- a/modules/manage/pages/manage-backup-and-restore/manage-backup-and-restore.adoc
+++ b/modules/manage/pages/manage-backup-and-restore/manage-backup-and-restore.adoc
@@ -853,11 +853,11 @@ You can also restore a Magma-backed bucket backup to a Couchstore bucket.
 When restoring Vector Indexes, you must run the BUILD command only after the Key-Value Data restoration is complete.
 The sequence of stages in the restoration process is same as that of the xref:backup-restore:cbbackupmgr-backup.adoc#DISCUSSION[backup] process.
 
-Starting the build before all the data is restored can result in incomplete codebook training or an inaccurate codebook.
-This can cause training failures or unreliable query results.
-Also, the re-training of codebook after the build has started is not yet supported.
+Starting the build before all the data is restored can result in the training failure or inaccurate codebook.
+This can cause the build to either error-out or produce unreliable query results.
+Also, the re-training of codebook after the build has started is not supported.
 
-Couchbase recommends waiting for the full dataset restoration.
+Couchbase recommends waiting for the restoration of the full dataset.
 Only after the restoration is complete, run a build to make sure that the codebook generated out of build accurately represents the completely restored dataset.
 ====
 

--- a/modules/manage/pages/manage-backup-and-restore/manage-backup-and-restore.adoc
+++ b/modules/manage/pages/manage-backup-and-restore/manage-backup-and-restore.adoc
@@ -851,13 +851,14 @@ You can also restore a Magma-backed bucket backup to a Couchstore bucket.
 [NOTE]
 ====
 When restoring Vector Indexes, you must run the BUILD command only after the Key-Value Data restoration is complete.
-During a restoration process, KV Data is restored first and then the sequence is same as that of the xref:backup-restore:cbbackupmgr-backup.adoc#DISCUSSION[backup] process.
+The sequence of stages in the restoration process is same as that of the xref:backup-restore:cbbackupmgr-backup.adoc#DISCUSSION[backup] process.
 
 Starting the build before all the data is restored can result in incomplete codebook training or an inaccurate codebook.
 This can cause training failures or unreliable query results.
-Also, re-training the codebook after the build has started is not yet supported.
+Also, the re-training of codebook after the build has started is not yet supported.
 
-Couchbase recommends waiting for the full dataset restoration and only after that, run a build to make sure that the build generated codebook accurately represents the completely restored dataset.
+Couchbase recommends waiting for the full dataset restoration.
+Only after the restoration is complete, run a build to make sure that the codebook generated out of build accurately represents the completely restored dataset.
 ====
 
 To restore a backup:

--- a/modules/manage/pages/manage-backup-and-restore/manage-backup-and-restore.adoc
+++ b/modules/manage/pages/manage-backup-and-restore/manage-backup-and-restore.adoc
@@ -848,6 +848,18 @@ The buckets you restore data to do not have to use the same xref:learn:buckets-m
 You can restore a backup of data from a bucket using the Couchstore storage engine to one using Magma.
 You can also restore a Magma-backed bucket backup to a Couchstore bucket.
 
+[NOTE]
+====
+When restoring Vector Indexes, you must run the BUILD command only after the Key-Value Data restoration is complete.
+During a restoration process, KV Data is restored first and then the sequence is same as that of the xref:backup-restore:cbbackupmgr-backup.adoc#DISCUSSION[backup] process.
+
+Starting the build before all the data is restored can result in incomplete codebook training or an inaccurate codebook.
+This can cause training failures or unreliable query results.
+Also, re-training the codebook after the build has started is not yet supported.
+
+Couchbase recommends waiting for the full dataset restoration and only after that, run a build to make sure that the build generated codebook accurately represents the completely restored dataset.
+====
+
 To restore a backup:
 
 . Select menu:Backup[Repositories] then expand the repository containing the data you want to restore.

--- a/modules/manage/pages/manage-backup-and-restore/manage-backup-and-restore.adoc
+++ b/modules/manage/pages/manage-backup-and-restore/manage-backup-and-restore.adoc
@@ -850,12 +850,12 @@ You can also restore a Magma-backed bucket backup to a Couchstore bucket.
 
 [NOTE]
 ====
-When restoring Vector Indexes, you must run the BUILD command only after the Key-Value Data restoration is complete.
-The sequence of stages in the restoration process is same as that of the xref:backup-restore:cbbackupmgr-backup.adoc#DISCUSSION[backup] process.
+When restoring Vector Indexes, you must run the BUILD INDEX command only after the Key-Value Data restoration is complete.
+The sequence of stages in the restoration process is the same as that of the xref:backup-restore:cbbackupmgr-backup.adoc#DISCUSSION[backup] process.
 
-Starting the build before all the data is restored can result in the training failure or inaccurate codebook.
+Starting the build before all the data is restored can result in training failure or an inaccurate codebook.
 This can cause the build to either error-out or produce unreliable query results.
-Also, the re-training of codebook after the build has started is not supported.
+Also, re-training the codebook after the build has started is not supported.
 
 Couchbase recommends waiting for the restoration of the full dataset.
 Only after the restoration is complete, run a build to make sure that the codebook generated out of build accurately represents the completely restored dataset.

--- a/modules/rest-api/pages/backup-restore-data.adoc
+++ b/modules/rest-api/pages/backup-restore-data.adoc
@@ -21,13 +21,14 @@ Details of the restoration must be specified as a JSON payload.
 [NOTE]
 ====
 When restoring Vector Indexes, you must run the BUILD command only after the Key-Value Data restoration is complete.
-During a restoration process, KV Data is restored first and then the sequence is same as that of the xref:backup-restore:cbbackupmgr-backup.adoc#DISCUSSION[backup] process.
+The sequence of stages in the restoration process is same as that of the xref:backup-restore:cbbackupmgr-backup.adoc#DISCUSSION[backup] process.
 
 Starting the build before all the data is restored can result in incomplete codebook training or an inaccurate codebook.
 This can cause training failures or unreliable query results.
-Also, re-training the codebook after the build has started is not yet supported.
+Also, the re-training of codebook after the build has started is not yet supported.
 
-Couchbase recommends waiting for the full dataset restoration and only after that, run a build to make sure that the build generated codebook accurately represents the completely restored dataset.
+Couchbase recommends waiting for the full dataset restoration.
+Only after the restoration is complete, run a build to make sure that the codebook generated out of build accurately represents the completely restored dataset.
 ====
 
 [#curl-syntax]

--- a/modules/rest-api/pages/backup-restore-data.adoc
+++ b/modules/rest-api/pages/backup-restore-data.adoc
@@ -18,6 +18,18 @@ Documents from a specified repository are restored from that repository to the c
 The repository can be active, imported, or archived.
 Details of the restoration must be specified as a JSON payload.
 
+[NOTE]
+====
+When restoring Vector Indexes, you must run the BUILD command only after the Key-Value Data restoration is complete.
+During a restoration process, KV Data is restored first and then the sequence is same as that of the xref:backup-restore:cbbackupmgr-backup.adoc#DISCUSSION[backup] process.
+
+Starting the build before all the data is restored can result in incomplete codebook training or an inaccurate codebook.
+This can cause training failures or unreliable query results.
+Also, re-training the codebook after the build has started is not yet supported.
+
+Couchbase recommends waiting for the full dataset restoration and only after that, run a build to make sure that the build generated codebook accurately represents the completely restored dataset.
+====
+
 [#curl-syntax]
 == Curl Syntax
 

--- a/modules/rest-api/pages/backup-restore-data.adoc
+++ b/modules/rest-api/pages/backup-restore-data.adoc
@@ -20,12 +20,12 @@ Details of the restoration must be specified as a JSON payload.
 
 [NOTE]
 ====
-When restoring Vector Indexes, you must run the BUILD command only after the Key-Value Data restoration is complete.
-The sequence of stages in the restoration process is same as that of the xref:backup-restore:cbbackupmgr-backup.adoc#DISCUSSION[backup] process.
+When restoring Vector Indexes, you must run the BUILD INDEX command only after the Key-Value Data restoration is complete.
+The sequence of stages in the restoration process is the same as that of the xref:backup-restore:cbbackupmgr-backup.adoc#DISCUSSION[backup] process.
 
-Starting the build before all the data is restored can result in the training failure or inaccurate codebook.
+Starting the build before all the data is restored can result in training failure or an inaccurate codebook.
 This can cause the build to either error-out or produce unreliable query results.
-Also, the re-training of codebook after the build has started is not supported.
+Also, re-training the codebook after the build has started is not supported.
 
 Couchbase recommends waiting for the restoration of the full dataset.
 Only after the restoration is complete, run a build to make sure that the codebook generated out of build accurately represents the completely restored dataset.

--- a/modules/rest-api/pages/backup-restore-data.adoc
+++ b/modules/rest-api/pages/backup-restore-data.adoc
@@ -23,11 +23,11 @@ Details of the restoration must be specified as a JSON payload.
 When restoring Vector Indexes, you must run the BUILD command only after the Key-Value Data restoration is complete.
 The sequence of stages in the restoration process is same as that of the xref:backup-restore:cbbackupmgr-backup.adoc#DISCUSSION[backup] process.
 
-Starting the build before all the data is restored can result in incomplete codebook training or an inaccurate codebook.
-This can cause training failures or unreliable query results.
-Also, the re-training of codebook after the build has started is not yet supported.
+Starting the build before all the data is restored can result in the training failure or inaccurate codebook.
+This can cause the build to either error-out or produce unreliable query results.
+Also, the re-training of codebook after the build has started is not supported.
 
-Couchbase recommends waiting for the full dataset restoration.
+Couchbase recommends waiting for the restoration of the full dataset.
 Only after the restoration is complete, run a build to make sure that the codebook generated out of build accurately represents the completely restored dataset.
 ====
 

--- a/preview/DOC_12785_note_for_restoring_vector_index.yml
+++ b/preview/DOC_12785_note_for_restoring_vector_index.yml
@@ -1,0 +1,28 @@
+sources:
+    docs-server:
+      branches: DOC_12785_note_for_restoring_vector_index
+    docs-analytics:
+      branches: release/8.0
+    docs-devex:
+      url: https://github.com/couchbaselabs/docs-devex.git
+      branches: master
+      startPaths: docs/
+    couchbase-cli:
+      # url: ../../docs-includes/couchbase-cli
+      url: https://github.com/couchbaselabs/couchbase-cli-doc
+      # branches: HEAD
+      branches: master
+      startPaths: docs/
+    backup:
+      # url: ../../docs-includes/backup
+      url: https://github.com/couchbaselabs/backup-docs.git
+      #branches: HEAD
+      branches: master
+      startPaths: docs/    
+    #analytics:
+    #  url: ../../docs-includes/docs-analytics
+    #  branches: HEAD
+    #cb-swagger:
+    #  rl: https://github.com/couchbaselabs/cb-swagger
+    #  branches: release/8.0
+    #  start_path: docs


### PR DESCRIPTION
DOC-12785

This PR's preview docs [login credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords).

Added a Note for Vector Indexes' restoration process in the following sections/pages:
- [Restore Backups](https://preview.docs-test.couchbase.com/docs-server-DOC_12785_note_for_restoring_vector_index/server/current/manage/manage-backup-and-restore/manage-backup-and-restore.html#restore-backups) in the "Manage Backup and Restore" page.
- [Restore Data](https://preview.docs-test.couchbase.com/docs-server-DOC_12785_note_for_restoring_vector_index/server/current/rest-api/backup-restore-data.html#description) page.

Ignore the preview yml file.