### PR TITLE
Fix the whats new page related content issues

### DIFF
--- a/modules/introduction/partials/new-features-80.adoc
+++ b/modules/introduction/partials/new-features-80.adoc
@@ -12,6 +12,7 @@ Couchbase Server 8.0 adds support for the following operating systems:
 * Windows Server 2025
 
 Couchbase Server 8.0 no longer supports the following operating systems:
+
 * Amazon Linux 2
 * macOS 12 "Monterey"
 * SUSE Linux Enterprise Server (SLES) 12

--- a/modules/introduction/partials/new-features-80.adoc
+++ b/modules/introduction/partials/new-features-80.adoc
@@ -10,6 +10,7 @@ Couchbase Server 8.0 adds support for the following operating systems:
 * RHEL 10
 * Rocky Linux 10
 * Windows Server 2025
+
 Couchbase Server 8.0 no longer supports the following operating systems:
 * Amazon Linux 2
 * macOS 12 "Monterey"
@@ -57,12 +58,13 @@ See xref:install:upgrade.adoc#before-you-upgrade[Before You Upgrade] for potenti
 
 ==== Native Encryption at Rest
 
-Couchbase Server Enterprise Edition can now natively encrypt bucket, log, audit, and some configuration data when writing it to disk.
+Couchbase Server Enterprise Edition can now natively encrypt bucket, log, audit, and configuration data when writing it to disk.
 
 This feature:
 
 * Can help reduce the chances of or severity of data breaches. 
-* Is transparent to the database's users--Couchbase Server automati cally decrypts data when reading it from disk and encrypts it when writing it to disk. 
+* Is transparent to the database users.
+Couchbase Server automatically decrypts data when reading it from disk and encrypts it when writing to disk. 
 * Supports using third-party key management services such as Amazon's Key Management Service and those compliant with Key Management Interoperability Protocol. 
 
 For more information about native encryption at rest, see xref:learn:security/native-encryption-at-rest-overview.adoc[Native Encryption at Rest].
@@ -95,7 +97,8 @@ See xref:learn:clusters-and-availability/automatic-failover.adoc#auto-failover-a
 
 ==== Configurable Warmup Behavior (Background Warmup)
 
-The new `warmup_behavior` setting, configured using `warmupBehavior` in the REST API, controls when a persistent bucket becomes fully available for `read` and `write` operations after a bucket restart. 
+The new Warmup behavior setting, configured using `warmupBehavior` in the REST API,
+controls when a persistent bucket becomes fully available for `read` and `write` operations after a bucket restart. 
 
 This setting replaces multiple warmup threshold parameters with a single configuration point:
 
@@ -103,7 +106,8 @@ This setting replaces multiple warmup threshold parameters with a single configu
 The bucket's cache is then filled in the background until memory usage reaches the low watermark (`memoryLowWatermark`).
 
 * *blocking:* This is the original behavior. 
-The bucket becomes read-available as soon as required metadata is loaded from storage, then continues filling the cache until memory usage reaches the low watermark (`memoryLowWatermark`).
+The bucket becomes read-available as soon as required metadata is loaded from storage,
+then continues filling the cache until memory usage reaches the low watermark (`memoryLowWatermark`).
 The bucket becomes fully available only after this point.
 
 * *none:* Disables warmup.
@@ -367,7 +371,7 @@ For more information, see xref:n1ql:n1ql-language-reference/metafun.adoc#evaluat
 For more information, see xref:n1ql:n1ql-language-reference/stringfun.adoc#fn-str-compress[COMPRESS].
 
 * `UNCOMPRESS()`: Takes a base64 encoded, compressed string as input and returns the original uncompressed string.
-For more information, see xref:n1ql:n1ql-language-reference/stringfun.adocl#fn-str-uncompress[UNCOMRESS].
+For more information, see xref:n1ql:n1ql-language-reference/stringfun.adocl#fn-str-uncompress[UNCOMPRESS].
 
 
 ==== Automatic Workload Repository
@@ -464,7 +468,7 @@ For more information about how to configure type identifiers or create a custom 
 
 ==== New Search Index Algorithm
 
-Couchbase Server version 8.0 now supports the bm25 algorithm for scoring search results.
+Couchbase Server version 8.0 now supports the BM25 algorithm for scoring search results.
 The `bm25` algorithm supports better hybrid searches and richer result rankings, as well as more stable result ordering across Search index partitions. 
 
 You can now choose to use tf-idf or bm25 from your xref:search:set-advanced-settings.adoc#scoring_model[Search index settings].

--- a/modules/introduction/partials/new-features-80.adoc
+++ b/modules/introduction/partials/new-features-80.adoc
@@ -470,7 +470,7 @@ For more information about how to configure type identifiers or create a custom 
 ==== New Search Index Algorithm
 
 Couchbase Server version 8.0 now supports the BM25 algorithm for scoring search results.
-The `bm25` algorithm supports better hybrid searches and richer result rankings, as well as more stable result ordering across Search index partitions. 
+The `BM25` algorithm supports better hybrid searches and richer result rankings, as well as more stable result ordering across Search index partitions. 
 
 You can now choose to use tf-idf or bm25 from your xref:search:set-advanced-settings.adoc#scoring_model[Search index settings].
 

--- a/preview/DOC_13641_preview_docs_whats_new.yml
+++ b/preview/DOC_13641_preview_docs_whats_new.yml
@@ -1,0 +1,28 @@
+sources:
+    docs-server:
+      branches: DOC_13641_preview_docs_whats_new
+    docs-analytics:
+      branches: release/8.0
+    docs-devex:
+      url: https://github.com/couchbaselabs/docs-devex.git
+      branches: master
+      startPaths: docs/
+    couchbase-cli:
+      # url: ../../docs-includes/couchbase-cli
+      url: https://github.com/couchbaselabs/couchbase-cli-doc
+      # branches: HEAD
+      branches: master
+      startPaths: docs/
+    backup:
+      # url: ../../docs-includes/backup
+      url: https://github.com/couchbaselabs/backup-docs.git
+      #branches: HEAD
+      branches: master
+      startPaths: docs/    
+    #analytics:
+    #  url: ../../docs-includes/docs-analytics
+    #  branches: HEAD
+    #cb-swagger:
+    #  rl: https://github.com/couchbaselabs/cb-swagger
+    #  branches: release/8.0
+    #  start_path: docs


### PR DESCRIPTION
DOC-13641

PR's preview docs page [login credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords).

[What's New](https://preview.docs-test.couchbase.com/docs-server-DOC_13641_preview_docs_whats_new/server/current/introduction/whats-new.html) page.

Ignore the preview yml file.