### PR TITLE
[DOC-13670]: Fix the link on the release note page.

### DIFF
--- a/modules/release-notes/partials/docs-server-8.0.0-breaking-changes.adoc
+++ b/modules/release-notes/partials/docs-server-8.0.0-breaking-changes.adoc
@@ -86,7 +86,8 @@ Users can use a pipe in conjunction with an external formatting tool such as jq 
 
 Couchbase Server 8.0 has removed support for Memcached buckets. They were deprecated in version 6.5.1.
 +
-Before upgrading to Couchbase Server 8.0, you must remove any Memcached buckets from your cluster. You can replace them with ephemeral buckets which are similar to Memcached buckets but support features such as rebalance, backup, query, and eventing. See the https://docs-archive.couchbase.com/server/6.6/learn/buckets-memory-and-storage/buckets.html#bucket-capabilities[https://docs-archive.couchbase.com/server/6.6/learn/buckets-memory-and-storage/buckets.html#bucket-capabilities]   for a summary of the differences between Memcached and ephemeral buckets.
+Before upgrading to Couchbase Server 8.0, you must remove any Memcached buckets from your cluster. You can replace them with ephemeral buckets which are similar to Memcached buckets but support features such as rebalance, backup, query, and eventing.
+See link:https://docs-archive.couchbase.com/server/6.6/learn/buckets-memory-and-storage/buckets.html#bucket-capabilities[Bucket capabilities]   for a summary of the differences between Memcached and ephemeral buckets.
 +
 If you do not remove your Memcached buckets, the upgrade process reports an error message telling you to remove the Memcached buckets before proceeding.
 

--- a/modules/release-notes/partials/docs-server-8.0.0-fixes-and-improvements.adoc
+++ b/modules/release-notes/partials/docs-server-8.0.0-fixes-and-improvements.adoc
@@ -261,7 +261,7 @@ Added a plan version to prepared statements and logic to trigger  reprepare when
 
 *https://jira.issues.couchbase.com/browse/MB-67849/[MB-67849]*::
 
-The recent builds of Couchbase Server versions 7.2.7 through 8.1.0 and Enterprise Analytics 2.1.0 include updates from the go_json library to address int64 overflow issues reported under MB-67849. The updates involve implementing proper checks for int64 overflow  to properly represent large numbers (greater than stem:[2^63] or less than stem:[-2^63]).
+The recent builds of Couchbase Server versions 7.2.7 through 8.1.0 and Enterprise Analytics 2.1.0 include updates from the go_json library to address int64 overflow issues reported under MB-67849. The updates involve implementing proper checks for int64 overflow  to properly represent large numbers (greater than 2^63^ or less than -2^63^).
 
 
 


### PR DESCRIPTION
Updated release notes for Couchbase Server 8.0.0 with the following changes:
- Fixed the link for the "Bucket capabilities" page.
- Corrected formatting for int64 overflow representation ([MB-67849]).


These changes improve documentation clarity and accuracy.

[MB-67849]: https://couchbasecloud.atlassian.net/browse/MB-67849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ