### PR TITLE
Align description entry lines using the open block

### DIFF
--- a/modules/release-notes/partials/docs-server-8.0.0-breaking-changes.adoc
+++ b/modules/release-notes/partials/docs-server-8.0.0-breaking-changes.adoc
@@ -47,11 +47,13 @@ For more details, see the xref:introduction:whats-new.adoc#whats-new-magma-vbuck
 
 Configurable Warmup Behavior (Background Warmup):
 The new `warmup_behavior` setting, configured using `warmupBehavior` in the REST API, controls when a persistent bucket becomes fully available for read and write operations after a bucket restart. This setting replaces multiple warmup threshold parameters with a single configuration point:
-
++
+--
 * *background* (default): The bucket becomes fully available as soon as required metadata is loaded from storage. The bucket’s cache is then filled in the background until memory usage reaches the low watermark (`memoryLowWatermark`).
 * *blocking*: This is the original behaviour. The bucket becomes read-available as soon as required metadata is loaded from storage, then continues filling the cache until memory usage reaches the low watermark (`memoryLowWatermark`). The bucket becomes fully available only after this point.
 * *none*: Disables warmup. The bucket becomes fully available as soon as required metadata is loaded from storage. The cache remains empty.
-
++
+--
 API Changes: The REST API now includes the per-bucket setting `warmupBehavior`. The previous advanced tuning settings `warmup_min_items_threshold` and `warmup_min_memory_threshold` have been removed from the `cbepctl` interface.
 
 *https://jira.issues.couchbase.com/browse/MB-63938/[MB-63938]*::


### PR DESCRIPTION
Adjust the open block to properly align the description entry with corresponding elements for consistency.