### PR TITLE
Doc 13590 mention FLE on encryption page

### DIFF
--- a/modules/learn/pages/security/encryption-overview.adoc
+++ b/modules/learn/pages/security/encryption-overview.adoc
@@ -73,19 +73,21 @@ Use OS-level disk encryption::
 You can use disk encryption such as the LUKS encrypted filesystem which is available on Linux.
 See xref:manage:manage-security/manage-connections-and-disks.adoc#securing-on-disk-data[Securing On-Disk Data].
 
+[#encryption-in-applications]
+Use field-level encryption in applications::
+Applications can use the SDK to encrypt specific fields.
+Depending on your application's requirements, field-level encryption may be more appropriate than encrypting the entire bucket or disk.
+See the SDK documentation for your development language for more information.
+For example:
+
++
+* Go SDK: xref:go-sdk:howtos:encrypting-using-sdk.adoc[]
+* Java SDK: xref:java-sdk:howtos:encrypting-using-sdk.adoc[]
+* Python SDK: xref:python-sdk:howtos:encrypting-using-sdk.adoc[]
 
 == System Secrets
 
 Couchbase Server can write passwords, certificates, and other sensitive information to disk in encrypted format.
 See xref:manage:manage-security/manage-system-secrets.adoc[Manage System Secrets].
 
-[#encryption-in-applications]
-== Encryption in Applications
 
-Applications can use the SDK to store fields in encrypted format.
-See the SDK documentation for your development language for more information.
-For example:
-
-* Go SDK: xref:go-sdk:howtos:encrypting-using-sdk.adoc[]
-* Java SDK: xref:java-sdk:howtos:encrypting-using-sdk.adoc[]
-* Python SDK: xref:python-sdk:howtos:encrypting-using-sdk.adoc[]

--- a/modules/learn/pages/security/native-encryption-at-rest-overview.adoc
+++ b/modules/learn/pages/security/native-encryption-at-rest-overview.adoc
@@ -9,6 +9,19 @@ This feature is transparent to the database's users.
 Couchbase Server automatically decrypts data when reading it from disk and encrypts it when writing it to disk.
 For steps to take when managing this feature, see xref:manage:manage-security/manage-native-encryption-at-rest.adoc[].
 
+[NOTE]
+====
+Applications can use the SDK to encrypt specific fields.
+Depending on your application's requirements, field-level encryption may be more appropriate than encrypting the entire bucket.
+See the SDK documentation for your development language for more information.
+For example:
+
+* Go SDK: xref:go-sdk:howtos:encrypting-using-sdk.adoc[]
+* Java SDK: xref:java-sdk:howtos:encrypting-using-sdk.adoc[]
+* Python SDK: xref:python-sdk:howtos:encrypting-using-sdk.adoc[]
+====
+
+
 [#keys]
 == Encryption-at-Rest Keys 
 

--- a/modules/learn/pages/security/native-encryption-at-rest-overview.adoc
+++ b/modules/learn/pages/security/native-encryption-at-rest-overview.adoc
@@ -10,6 +10,7 @@ Couchbase Server automatically decrypts data when reading it from disk and encry
 For steps to take when managing this feature, see xref:manage:manage-security/manage-native-encryption-at-rest.adoc[].
 
 [NOTE]
+.Field-Level Encryption in Applications
 ====
 Applications can use the SDK to encrypt specific fields.
 Depending on your application's requirements, field-level encryption may be more appropriate than encrypting the entire bucket.


### PR DESCRIPTION
Adds references to the SDK's field-level encryption to the encryption at rest docs.

- In the [Encryption](https://preview.docs-test.couchbase.com/docs-server-DOC-13590_mention_FLE_on_encryption_page/server/current/learn/security/encryption-overview.html) page, moved the standalone section of field-level encryption to the encryption at rest discussion.
- In the [Native Encryption at Rest](https://preview.docs-test.couchbase.com/docs-server-DOC-13590_mention_FLE_on_encryption_page/server/current/learn/security/native-encryption-at-rest-overview.html) page, added note about field-level encryption as a possible alternative.

Note: couldn't manage to use a partial for both of these, even though the text is almost identical. Antora's fussy formatting strikes again. 
