### PR TITLE
DOC-13673 update process list for 7.6

### DIFF
--- a/modules/install/pages/server-processes.adoc
+++ b/modules/install/pages/server-processes.adoc
@@ -22,7 +22,7 @@ Depending on your security environment, you may need to explicitly approve these
 Otherwise, Couchbase Server cannot not function properly.
 
 NOTE: The minor version numbers of the Erlang/OTP subcomponents (which are under the `erlang` directory in the paths listed in the tables) can change between Couchbase Server maintenance releases. 
-When possible, add the parent directories of these components to any allowlists in security systems installed on your nodes. 
+When possible, add the parent directories of these components to any allow lists in security systems installed on your nodes. 
 For example, on Linux-based nodes, add the pattern `/opt/couchbase/lib/erlang/**` to allow lists.
 Adding these patterns means you do not need to update your security policies for every Couchbase Server maintenance release.
 

--- a/modules/install/pages/server-processes.adoc
+++ b/modules/install/pages/server-processes.adoc
@@ -124,7 +124,7 @@ The following table lists the Couchbase processes that run on Linux platforms.
 | `js-evaluator` 
 | JavaScript UDF evaluator for Query 
 | Query
-| `/opt/couchbase/bin/js-evaluator``
+| `/opt/couchbase/bin/js-evaluator`
 
 | `memcached`
 | Data service responsible for storing user data
@@ -157,7 +157,7 @@ The following table lists the Couchbase processes that run on Linux platforms.
 | `/opt/couchbase/bin/`
 
 | `sh -s disksup` (2 copies)
-| Two Erlang-specific processes that supervises the available disk space,  1 for `ns_server` VM and 1 for `ns_couchdb` VM
+| Two Erlang-specific processes that supervise the available disk space,  1 for `ns_server` VM and 1 for `ns_couchdb` VM
 | Data
 | `/opt/couchbase/lib/erlang/lib/{osmon-version}/ebin/`
 

--- a/modules/install/pages/server-processes.adoc
+++ b/modules/install/pages/server-processes.adoc
@@ -19,7 +19,7 @@ If a particular Couchbase service is not running on a node, then the processes a
 
 Configure any security environment to allow the Couchbase service processes to run and access files on your nodes.
 Depending on your security environment, you may need to explicitly approve these processes and their binary directories in your security policy.
-Otherwise, Couchbase Server cannot not function properly.
+Otherwise, Couchbase Server cannot function properly.
 
 NOTE: The minor version numbers of the Erlang/OTP subcomponents (which are under the `erlang` directory in the paths listed in the tables) can change between Couchbase Server maintenance releases. 
 When possible, add the parent directories of these components to any allow lists in security systems installed on your nodes. 
@@ -44,7 +44,7 @@ The following table lists the Couchbase processes that run on Linux platforms.
 | `beam.smp` (3 copies)
 | Couchbase Cluster Manager run as Erlang virtual machines - `babysitter`, `ns_server`, and `ns_couchdb`
 | Data
-| `/opt/couchbase/lib/erlang/{erts-version}/bin/`
+| `/opt/couchbase/lib/erlang/{erts-version}/bin/beam.smp`
 
 | `cbas`
 | Go-wrapper that communicates with `ns_server` and manages the lifecycle of the Analytics Driver
@@ -69,7 +69,7 @@ The following table lists the Couchbase processes that run on Linux platforms.
 | `cpu_sup` (2 copies)
 | Erlang-specific process used to collect CPU: 1 for `ns_server` VM and 1 for `ns_couchdb` VM
 | Data
-| `/opt/couchbase/lib/erlang/lib/{osmon-version}/priv/bin/`
+| `/opt/couchbase/lib/erlang/lib/{osmon-version}/priv/bin/cpu_sup`
 
 | `eventing-consumer` (n copies)
 | Eventing worker (multiple instances per node which you configure in Couchbase Server Web Control Panel)
@@ -86,12 +86,12 @@ The following table lists the Couchbase processes that run on Linux platforms.
 | Data
 | `/opt/couchbase/bin/`
 
-| `godu` (2 copies)
+| `godu` 
 | Go utility that gets disk usage stats
 | Data
-| `/opt/couchbase/bin/priv/`
+| `/opt/couchbase/bin/priv/godu`
 
-| `goport` (5 copies)
+| `goport` (number of copies varies)
 | Process that acts as a bridge between `ns_server` (Erlang) and the other server components (`cbq- engine`, `cbft`, and so on) which are written in Go
 | Query
 | `/opt/couchbase/bin/`
@@ -114,7 +114,7 @@ The following table lists the Couchbase processes that run on Linux platforms.
 | `inet_gethost` (2 copies)
 | Built-in Erlang port process that performs name service lookups
 | Data
-| `/opt/couchbase/lib/erlang/{erts-version}/bin/`
+| `/opt/couchbase/lib/erlang/{erts-version}/bin/inet_gethost`
 
 | `java` (Analytics Driver)
 | JVM running the Analytics NC and CC
@@ -134,7 +134,7 @@ The following table lists the Couchbase processes that run on Linux platforms.
 | `memsup` (2 copies)
 | Two Erlang-specific processes used to collect memory usage: 1 for `ns_server` VM and 1 for `ns_couchdb` VM
 | Data
-| `/opt/couchbase/lib/erlang/lib/{osmon-version}/priv/bin/`
+| `/opt/couchbase/lib/erlang/lib/{osmon-version}/priv/bin/memsup`
 
 | `portsigar`
 | Sigar is an open source tool that collects system information

--- a/modules/install/pages/server-processes.adoc
+++ b/modules/install/pages/server-processes.adoc
@@ -24,7 +24,7 @@ Otherwise, Couchbase Server cannot not function properly.
 NOTE: The minor version numbers of the Erlang/OTP subcomponents (which are under the `erlang` directory in the paths listed in the tables) can change between Couchbase Server maintenance releases. 
 When possible, add the parent directories of these components to any allow lists in security systems installed on your nodes. 
 For example, on Linux-based nodes, add the pattern `/opt/couchbase/lib/erlang/**` to allow lists.
-Adding these patterns means you do not need to update your security policies for every Couchbase Server maintenance release.
+Adding these patterns limits the updates you may need to make to your security policies for Couchbase Server maintenance releases.
 
 == Linux
 

--- a/modules/install/pages/server-processes.adoc
+++ b/modules/install/pages/server-processes.adoc
@@ -1,20 +1,30 @@
 = Couchbase Server Processes
 :description: Couchbase Server spawns a number of different processes on each node.
+:erts-version: erts-13.2.2.3
+:osmon-version: os_mon-2.8.2
+// Needed because AsciiDoc treats backslash as an escape character even when you escape it.
+:backslash: \
 
 [abstract]
 {description}
 These processes vary in type and number depending on which Couchbase services are running on a particular node.
 
-Couchbase Server spawns processes from a set of binaries that get installed by the Couchbase installer.
+Couchbase Server spawns processes from a set of binaries installed by the Couchbase installer.
 Some of these processes support the basic functions of Couchbase Server, and run on every node in the Couchbase cluster (Data).
-Other processes, however, support the various Couchbase services, and only run on the nodes that happen to run a particular Couchbase service (Data, Query, Index, Search, Analytics, and Eventing).
+Other processes, however, support the various Couchbase services.
+They only run on the nodes that happen to run a particular Couchbase service (Data, Query, Index, Search, Analytics, and Eventing).
 
-The tables on this page list out all of the Couchbase processes, along with the specific Couchbase services that will invoke them.
-If a particular Couchbase service is not running on a node, then the processes associated with that service will not run.
+The tables on this page list out all of the Couchbase processes, along with the specific Couchbase services that invoke them.
+If a particular Couchbase service is not running on a node, then the processes associated with that service cannot run.
 
-It's important that each of these processes is allowed to run and access files on the nodes that are enabled for the Couchbase services that they support.
-Otherwise, Couchbase Server will not function properly.
+Configure any security environment to allow the Couchbase service processes to run and access files on your nodes.
 Depending on your security environment, you may need to explicitly approve these processes and their binary directories in your security policy.
+Otherwise, Couchbase Server cannot not function properly.
+
+NOTE: The minor version numbers of the Erlang/OTP subcomponents (which are under the `erlang` directory in the paths listed in the tables) can change between Couchbase Server maintenance releases. 
+When possible, add the parent directories of these components to any allowlists in security systems installed on your nodes. 
+For example, on Linux-based nodes, add the pattern `/opt/couchbase/lib/erlang/**` to allow lists.
+Adding these patterns means you do not need to update your security policies for every Couchbase Server maintenance release.
 
 == Linux
 
@@ -26,121 +36,135 @@ The following table lists the Couchbase processes that run on Linux platforms.
 
 | Process | Description | Service | Path
 
-| `cbft`
-| Couchbase Full-Text Search (FTS) service
-| Search
-| _/opt/couchbase/bin/_
-
-| `cbq-engine`
-| Couchbase Query service
-| Query
-| _/opt/couchbase/bin/_
-
-| `goport` (5 copies)
-| Process that acts as a bridge between `ns_server` (Erlang) and the other server components (`cbq- engine`, `cbft`, etc.) which are written in Go
-| Query
-| _/opt/couchbase/bin/_
-
-| `gosecrets`
-| Service that is used to encrypt the cluster configuration stored on disk
-| Data
-| _/opt/couchbase/bin/_
-
-| `goxdcr`
-| Cross Data Center Replication (XDCR) - replicates data from one cluster to another
-| Data
-| _/opt/couchbase/bin/_
-
-| `indexer`
-| Index service
-| Index
-| _/opt/couchbase/bin/_
-
-| `memcached`
-| Data service responsible for storing user data
-| Data
-| _/opt/couchbase/bin/_
-
-| `godu` (2 copies)
-| Utility in Go to get disk usage stats
-| Data
-| _/opt/couchbase/bin/priv/_
-
-| `projector`
-| Extracts secondary key from documents
-| Data
-| _/opt/couchbase/bin/_
-
-| `saslauthd-port`
-| Erlang port process (wrapper) used to talk to the `saslauthd` daemon for authentication purposes
-| Data
-| _/opt/couchbase/bin/_
+| `backup`
+| Backup command-line application for Couchbase data
+| Backup
+| `/opt/couchbase/bin/backup`
 
 | `beam.smp` (3 copies)
-| Couchbase cluster manager run as Erlang virtual machines - `babysitter`, `ns_server`, and `ns_couchdb`
+| Couchbase Cluster Manager run as Erlang virtual machines - `babysitter`, `ns_server`, and `ns_couchdb`
 | Data
-| _/opt/couchbase/lib/erlang/erts-9.3.3.9/bin/_
-
-| `epmd`
-| Erlang-specific process which acts as a name server for Erlang distribution
-| Data
-| _/opt/couchbase/bin/_
-
-| `cpu_sup` (2 copies)
-| Erlang-specific process used to collect CPU: 1 for `ns_server` VM and 1 for `ns_couchdb` VM
-| Data
-| _/opt/couchbase/lib/erlang/lib/os_mon-2.2.14/priv/bin/_
-
-| `memsup` (2 copies)
-| Erlang-specific process used to collect memory usage: 1 for `ns_server` VM and 1 for `ns_couchdb` VM
-| Data
-| _/opt/couchbase/lib/erlang/lib/os_mon-2.2.14/priv/bin/_
-
-| `inet_gethost` (2 copies)
-| Built-in Erlang port process that is used to perform name service lookup
-| Data
-| _/opt/couchbase/lib/erlang/erts-5.10.4.0.0.1/bin/_
-
-| `portsigar`
-| Open source tool sigar that is used to collect system information
-| Data
-| _/opt/couchbase/bin/_
-
-| `sh -s disksup` (2 copies)
-| Erlang-specific process that is used to supervise the available disk space: 1 for `ns_server` VM and 1 for `ns_couchdb` VM
-| Data
-| _/opt/couchbase/lib/erlang/lib/os_mon-2.2.14/ebin/_
-
-| `sh -s ns_disksup`
-| Wrapper for `disksup` which also collects information about mounted drives
-| Data
-| _/opt/couchbase/lib/ns_server/erlang/lib/ns_server/ebin/_
-
-| `cbcollect_info`
-| Utility used to collect Couchbase server logs (will be seen only during log collection)
-| Data
-| _/opt/couchbase/bin/_
-
-| `eventing-producer` (1 copy)
-| Eventing supervisor service (one instance per node)
-| Eventing
-| _/opt/couchbase/bin/_
-
-| `eventing-consumer` (n copies)
-| Eventing worker (multiple instances per node).
-Instance count is configured in UI.
-| Eventing
-| _/opt/couchbase/bin/_
-
-| `java` (Analytics Driver)
-| JVM running the Analytics NC and CC
-| Analytics
-| _/opt/couchbase/lib/cbas/runtime/bin_
+| `/opt/couchbase/lib/erlang/{erts-version}/bin/`
 
 | `cbas`
 | Go-wrapper that communicates with `ns_server` and manages the lifecycle of the Analytics Driver
 | Analytics
-| _/opt/couchbase/bin/_
+| `/opt/couchbase/bin/`
+
+| `cbcollect_info`
+| Utility that collects Couchbase Server logs (only seen during log collection)
+| Data
+| `/opt/couchbase/bin/`
+
+| `cbft`
+| Couchbase Full-Text Search (FTS) service
+| Search
+| `/opt/couchbase/bin/`
+
+| `cbq-engine`
+| Couchbase Query Service
+| Query
+| `/opt/couchbase/bin/`
+
+| `cpu_sup` (2 copies)
+| Erlang-specific process used to collect CPU: 1 for `ns_server` VM and 1 for `ns_couchdb` VM
+| Data
+| `/opt/couchbase/lib/erlang/lib/{osmon-version}/priv/bin/`
+
+| `eventing-consumer` (n copies)
+| Eventing worker (multiple instances per node which you configure in Couchbase Server Web Control Panel)
+| Eventing
+| `/opt/couchbase/bin/`
+
+| `eventing-producer` (1 copy)
+| Eventing supervisor service (1 instance per node)
+| Eventing
+| `/opt/couchbase/bin/`
+
+| `epmd`
+| Erlang-specific name server process for Erlang distribution
+| Data
+| `/opt/couchbase/bin/`
+
+| `godu` (2 copies)
+| Go utility that gets disk usage stats
+| Data
+| `/opt/couchbase/bin/priv/`
+
+| `goport` (5 copies)
+| Process that acts as a bridge between `ns_server` (Erlang) and the other server components (`cbq- engine`, `cbft`, and so on) which are written in Go
+| Query
+| `/opt/couchbase/bin/`
+
+| `gosecrets`
+| Service that's used to encrypt the cluster configuration stored on disk
+| Data
+| `/opt/couchbase/bin/`
+
+| `goxdcr`
+| Cross datacenter replication (XDCR) - replicates data from 1 cluster to another
+| Data
+| `/opt/couchbase/bin/`
+
+| `indexer`
+| Index Service
+| Index
+| `/opt/couchbase/bin/`
+
+| `inet_gethost` (2 copies)
+| Built-in Erlang port process that performs name service lookups
+| Data
+| `/opt/couchbase/lib/erlang/{erts-version}/bin/`
+
+| `java` (Analytics Driver)
+| JVM running the Analytics NC and CC
+| Analytics
+| `/opt/couchbase/lib/cbas/runtime/bin`
+
+| `js-evaluator` 
+| JavaScript UDF evaluator for Query 
+| Query
+| `/opt/couchbase/bin/js-evaluator``
+
+| `memcached`
+| Data service responsible for storing user data
+| Data
+| `/opt/couchbase/bin/`
+
+| `memsup` (2 copies)
+| Two Erlang-specific processes used to collect memory usage: 1 for `ns_server` VM and 1 for `ns_couchdb` VM
+| Data
+| `/opt/couchbase/lib/erlang/lib/{osmon-version}/priv/bin/`
+
+| `portsigar`
+| Sigar is an open source tool that collects system information
+| Data
+| `/opt/couchbase/bin/`
+
+| `projector`
+| Extracts secondary key from documents
+| Data
+| `/opt/couchbase/bin/`
+
+| `prometheus`
+| Embedded Prometheus exporter
+| Core
+| `/opt/couchbase/bin/prometheus`
+
+| `saslauthd-port`
+| Erlang port process (wrapper) that talks to the `saslauthd` daemon for authentication
+| Data
+| `/opt/couchbase/bin/`
+
+| `sh -s disksup` (2 copies)
+| Two Erlang-specific processes that supervises the available disk space,  1 for `ns_server` VM and 1 for `ns_couchdb` VM
+| Data
+| `/opt/couchbase/lib/erlang/lib/{osmon-version}/ebin/`
+
+| `sh -s ns_disksup`
+| Wrapper for `disksup` which also collects information about mounted drives
+| Data
+| `/opt/couchbase/lib/ns_server/erlang/lib/ns_server/ebin/`
 |===
 
 == Windows
@@ -156,112 +180,111 @@ The following table lists the Couchbase processes that run on the Windows platfo
 | `backup.exe`
 | Backup application for Couchbase data
 | Backup
-| _C:\Program Files\Couchbase\Server\bin_
+| `C:\Program Files\Couchbase\Server\bin`
 
 | `cbas.exe`
 | Go-wrapper that communicates with `ns_server` and manages the lifecycle of the Analytics Driver
 | Analytics
-| _C:\Program Files\Couchbase\Server\bin_
+| `C:\Program Files\Couchbase\Server\bin`
 
 | `cbcollect_info.exe`
-| Utility used to collect Couchbase server logs (will be seen only during log collection)
+| Utility that collects Couchbase Server logs (only seen during log collection)
 | Data
-| _C:\Program Files\Couchbase\Server\bin_
+| `C:\Program Files\Couchbase\Server\bin`
 
 | `cbft.exe`
 | Couchbase Full-Text Search (FTS) service
 | Search
-| _C:\Program Files\Couchbase\Server\bin_
+| `C:\Program Files\Couchbase\Server\bin`
 
 | `cbq-engine.exe`
-| Couchbase Query service
+| Couchbase Query Service
 | Query
-| _C:\Program Files\Couchbase\Server\bin_
+| `C:\Program Files\Couchbase\Server\bin`
 
 | `epmd.exe`
 | Erlang-specific process which acts as a name server for Erlang distribution
 | Data
-| _C:\Program Files\Couchbase\Server\erts-x.x.x.x\bin_
+| `C:\Program Files\Couchbase\Server{backslash}{erts-version}\bin`
 
 | `erl.exe`
 | Erlang process used by the name server.
 | Data
-| _C:\Program Files\Couchbase\Server\erts-x.x.x.x\bin_
+| `C:\Program Files\Couchbase\Server{backslash}{erts-version}\bin`
 
 | `erlsrv.exe`
-| Used to start the Erlang emulator as a Windows process.
+| Used to start the Erlang emulator as a Windows process
 | Data
-| _C:\Program Files\Couchbase\Server\erts-x.x.x.x\bin_
+| `C:\Program Files\Couchbase\Server{backslash}{erts-version}\bin`
 
 | `eventing-consumer.exe` 
 | Eventing worker (multiple instances per node).
-Instance count is configured in UI.
+You set the number of instances via the Couchbase Server Web Console
 | Eventing
-| _C:\Program Files\Couchbase\Server\bin_
+| `C:\Program Files\Couchbase\Server\bin`
 
 | `eventing-producer.exe` 
-| Eventing supervisor service (one instance per node)
+| Eventing supervisor service (1 instance per node)
 | Eventing
-| _C:\Program Files\Couchbase\Server\bin_
-
-| `goport.exe` 
-| Process that acts as a bridge between `ns_server` (Erlang) and the other server components (`cbq- engine.exe`, `cbft.exe`, etc.)
-| Query
-| _C:\Program Files\Couchbase\Server\bin_
-
-| `gosecrets.exe`
-| Service that is used to encrypt the cluster configuration stored on disk
-| Data
-| _C:\Program Files\Couchbase\Server\bin_
-
-| `goxdcr.exe`
-| Cross Data Center Replication (XDCR) - replicates data from one cluster to another
-| Data
-| _C:\Program Files\Couchbase\Server\bin_
-
-| `indexer.exe`
-| Index service
-| Index
-| _C:\Program Files\Couchbase\Server\bin_
+| `C:\Program Files\Couchbase\Server\bin`
 
 | `godu.exe` 
-| Utility in Go to get disk usage stats
+| Go utility to get disk usage stats
 | Data
-| _C:\Program Files\Couchbase\Server\bin\priv_
+| `C:\Program Files\Couchbase\Server\bin\priv`
+
+| `goport.exe` 
+| Process that acts as a bridge between `ns_server` (Erlang) and the other server components (`cbq- engine.exe`, `cbft.exe`, and so on)
+| Query
+| `C:\Program Files\Couchbase\Server\bin`
+
+| `gosecrets.exe`
+| Service that's used to encrypt the cluster configuration stored on disk
+| Data
+| `C:\Program Files\Couchbase\Server\bin`
+
+| `goxdcr.exe`
+| Cross datacenter replication (XDCR) - replicates data from 1 cluster to another
+| Data
+| `C:\Program Files\Couchbase\Server\bin`
+
+| `indexer.exe`
+| Index Service
+| Index
+| `C:\Program Files\Couchbase\Server\bin`
 
 | `inet_gethost.exe`
-| Built-in Erlang port process that is used to perform name service lookup
+| Built-in Erlang port process that performs name service lookups
 | Data
-| _C:\Program Files\Couchbase\Server\erts-x.x.x.x\bin_
-
+| `C:\Program Files\Couchbase\Server{backslash}{erts-version}\bin`
 
 | `java.exe` (Analytics Driver)
 | JVM running the Analytics NC and CC
 | Analytics
-| _C:\Program Files\Couchbase\Server\bin_
+| `C:\Program Files\Couchbase\Server\bin`
 
 | `memcached.exe`
 | Data service responsible for storing user data
 | Data
-| _C:\Program Files\Couchbase\Server\bin_
+| `C:\Program Files\Couchbase\Server\bin`
 
 | `projector.exe`
 | Extracts secondary key from documents
 | Data
-| _C:\Program Files\Couchbase\Server\bin_
+| `C:\Program Files\Couchbase\Server\bin`
 
 | `prometheus.exe`
-| Engine used Couchbase for creating metrics.
+| Engine used Couchbase for creating metrics
 | Data
-| _C:\Program Files\Couchbase\Server\bin_
+| `C:\Program Files\Couchbase\Server\bin`
 
 | `saslauthd-port.exe`
-| Erlang port process (wrapper) used to talk to the `saslauthd` daemon for authentication purposes
+| Erlang port process (wrapper) that talks to the `saslauthd` daemon for authentication
 | Data
-| _C:\Program Files\Couchbase\Server\bin_
+| `C:\Program Files\Couchbase\Server\bin`
 
 | `sigar_port.exe`
-| Open source tool sigar that is used to collect system information
+| Sigar is an open source tool that collects system information
 | Data
-| _C:\Program Files\Couchbase\Server\bin_
+| `C:\Program Files\Couchbase\Server\bin`
 |===

--- a/preview/HEAD.yml
+++ b/preview/HEAD.yml
@@ -1,6 +1,4 @@
 sources:
-  docs-server:
-    branches: [DOC-13396-Create-release-note-for-7.6.7-Release,DOC-13372-Create-release-note-for-docs-server-7.2.8]
   docs-devex:
     branches: release/7.6
   cb-swagger:


### PR DESCRIPTION
Updated the process list for 7.6:

- Added page attributes for the Erlang components so we only have change them in the future, as opposed to search/replacing them each time.
- Edited content to bring it up to current documentation standards.
- Sorted the table content to make finding particular entries easier. Due to the sorting, it's probably easier to review the preview than the diff.

Preview URL:
https://preview.docs-test.couchbase.com/docs-server-DOC-13673_update_process_list_7.6/server/current/install/server-processes.html

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.