### PR TITLE
Added delete notes to the query system catalog role

### DIFF
--- a/modules/learn/pages/security/roles.adoc
+++ b/modules/learn/pages/security/roles.adoc
@@ -1117,9 +1117,9 @@ Cannot use the Query Workbench in Couchbase Server Web Console.
 [#query-system-catalog]
 === Query System Catalog
 
-The Query System Catalog role lets the user query the system catalog using {sqlpp}.
-This access include querying `system:indexes`, `system:prepareds`, and tables listing current and past queries.
-Assign this role to developers who need to query these tables when troubleshooting and debugging queries.
+The Query System Catalog role lets the user query the system catalog using {sqlpp}. Importantly, this role also grants permissions to **delete** from certain in-memory system tables, which is useful for clearing caches and historical query logs without restarting a server.
+
+This access includes querying `system:indexes` and `system:prepareds`, as well as tables listing current and past queries. Assign this role to developers who need to query these tables when troubleshooting and debugging.
 
 The role grants Couchbase Server Web Console access.
 
@@ -1142,11 +1142,29 @@ Cannot add, failover, remove, modify services, or rebalance servers.
 | Cannot list scopes or collections, create, drop, edit settings, read or write data
 
 | *Query*
-| Can query system tables
-| Cannot perform any other query actions.
-Cannot use the Query Workbench in Couchbase Server Web Console.
+|
+*SELECT* from all system catalog tables.
+
+
+Querying certain keyspaces like `system:indexes`, `system:keyspaces`, and `system:scopes` is subject to row-based filtering. The user must also have the appropriate `SELECT` privilege on the underlying keyspace or collection to see the corresponding entries.
+
+*DELETE* from the following in-memory system tables to clear caches and logs:
+`system:active_requests`
+`system:completed_requests`
+`system:completed_requests_history`
+`system:prepareds`
+`system:functions_cache`
+`system:dictionary_cache`
+`system:tasks_cache`
+`system:aus_settings`
+
+|
+* Cannot perform any other query actions.
+* Cannot use the Query Workbench in Couchbase Server Web Console.
+* Cannot `INSERT` or `UPDATE` system catalog tables. For this functionality (available from 8.0+), see the `manage_system_catalog` role.
 
 |===
+
 
 [#manage-global-functions]
 === Manage Global Functions

--- a/modules/learn/pages/security/roles.adoc
+++ b/modules/learn/pages/security/roles.adoc
@@ -1117,9 +1117,11 @@ Cannot use the Query Workbench in Couchbase Server Web Console.
 [#query-system-catalog]
 === Query System Catalog
 
-The Query System Catalog role lets the user query the system catalog using {sqlpp}. Importantly, this role also grants permissions to **delete** from certain in-memory system tables, which is useful for clearing caches and historical query logs without restarting a server.
+The Query System Catalog role lets the user query the system catalog using {sqlpp}.
+This role also grants permissions to delete from certain in-memory system tables, which is useful for clearing caches and historical query logs without restarting a server.
 
-This access includes querying `system:indexes` and `system:prepareds`, as well as tables listing current and past queries. Assign this role to developers who need to query these tables when troubleshooting and debugging.
+This access includes querying `system:indexes` and `system:prepareds`, as well as tables listing current and past queries.
+Assign this role to developers who need to query these tables when troubleshooting and debugging.
 
 The role grants Couchbase Server Web Console access.
 
@@ -1146,7 +1148,8 @@ Cannot add, failover, remove, modify services, or rebalance servers.
 *SELECT* from all system catalog tables.
 
 
-Querying certain keyspaces like `system:indexes`, `system:keyspaces`, and `system:scopes` is subject to row-based filtering. The user must also have the appropriate `SELECT` privilege on the underlying keyspace or collection to see the corresponding entries.
+Querying certain keyspaces like `system:indexes`, `system:keyspaces`, and `system:scopes` is subject to row-based filtering.
+The user must also have the appropriate `SELECT` privilege on the underlying keyspace or collection to see the corresponding entries.
 
 *DELETE* from the following in-memory system tables to clear caches and logs:
 `system:active_requests`
@@ -1161,7 +1164,8 @@ Querying certain keyspaces like `system:indexes`, `system:keyspaces`, and `syste
 |
 * Cannot perform any other query actions.
 * Cannot use the Query Workbench in Couchbase Server Web Console.
-* Cannot `INSERT` or `UPDATE` system catalog tables. For this functionality (available from 8.0+), see the `manage_system_catalog` role.
+* Cannot `INSERT` or `UPDATE` system catalog tables.
+For this functionality (available from 8.0+), see the `query_manage_system_catalog` role.
 
 |===
 


### PR DESCRIPTION
DOC-13138

Bit of a tricky one. I apologise but I didn't see a very elegant way to doc this while maintaining the accuracy the behaviour requires.

Essentially you get DELETE access on various system tables... but only ones that are in-memory as a quirk of in-memory not having specific write access in roles.

Added Istvan as a reviewer as I'm happy to be corrected, here.
