### PR TITLE
DOC-13126-Incorrect-list-of-values-for-"operator"-in-Getting-Multiple-Statistics

### DIFF
--- a/modules/rest-api/pages/rest-statistics-multiple.adoc
+++ b/modules/rest-api/pages/rest-statistics-multiple.adoc
@@ -62,7 +62,7 @@ Each object takes the following form:
 
 The value of the key `label`, `label_name`, must be a string that specifies how the metric is identified: for example, `name`, or `proc`.
 The value of the key `value`, `label_val`, must be a string that is the actual name used to identify the metric: for example, `sys_cpu_utilization_rate`.
-The value of the key `"operator"` must be `=` | `!=` | `=~` | `!~` | `any` | `not_any`
+The value of the key `"operator"` must be `=` | `!=` | `=~` | `!~` | `any` | `not_any`.
 
 * `applyFunctions.`
 Can be any of the functions described in the section xref:rest-api:rest-statistics-single.adoc#function[function], on the page xref:rest-api:rest-statistics-single.adoc[Getting a Single Statistic].

--- a/modules/rest-api/pages/rest-statistics-multiple.adoc
+++ b/modules/rest-api/pages/rest-statistics-multiple.adoc
@@ -56,13 +56,13 @@ Each object takes the following form:
 {
   "label": <label_name>,
   "value": <label_val>,
-  "operator": "=" | "!=" | "=~" | "~="
+  "operator": "=" | "!=" | "=~" | "!~" | "any" | "not_any"
 }
 ----
 
 The value of the key `label`, `label_name`, must be a string that specifies how the metric is identified: for example, `name`, or `proc`.
 The value of the key `value`, `label_val`, must be a string that is the actual name used to identify the metric: for example, `sys_cpu_utilization_rate`.
-The value of the key `"operator"` must be `=`, `!=`, `=~`, or `~=`.
+The value of the key `"operator"` must be `=` | `!=` | `=~` | `!~` | `any` | `not_any`
 
 * `applyFunctions.`
 Can be any of the functions described in the section xref:rest-api:rest-statistics-single.adoc#function[function], on the page xref:rest-api:rest-statistics-single.adoc[Getting a Single Statistic].


### PR DESCRIPTION
https://jira.issues.couchbase.com/browse/DOC-13126

Updated "=" | "!=" | "=~" | "~=" / “=, !=, =~, or ~="

to  =, !=, =~, !~, any, or not_any.