### PR TITLE
DOC-12563 fixed mcstat info for 7.2

### DIFF
--- a/modules/cli/pages/mcstat.adoc
+++ b/modules/cli/pages/mcstat.adoc
@@ -1,14 +1,10 @@
 = mcstat
-:description: pass:q[The `mcstat` tool provides memory-related information for a specified bucket, or for all buckets on a cluster.]
+:description: pass:q[The mcstat tool provides detailed information for a node, specified bucket, or for all buckets on a cluster.]
 :page-topic-type: reference
 :page-aliases: cli:cbstats/cbstats-allocator
 
 [abstract]
 {description}
-
-== Description
-
-The `mcstat` tool provides memory-related information for a specified bucket, or for all buckets on a cluster.
 
 The tool is located as follows:
 
@@ -40,9 +36,7 @@ The `options` are as follows:
 | Options | Description
 
 | `-h[=statkey]`or `--help[=statkey]`
-| Show the help message and exit.
-If `=statkey` is not specified, the common options for the command are listed.
-If `=statkey` _is_ specified, the available _statkeys_ for the command are listed instead.
+| Outputs possible `statkey` values with descriptions and indications of the stat's scope and required privileges.
 
 | `-h` or `--hostname`, with the parameter `<hostname[:port]>` (for IPv4), or `[address]:port` (for IPv6)
 | The name of the host (and optionally, the port number) to connect to.


### PR DESCRIPTION
DOC-12563

The doc was a bit malformed, stating the description twice. The description needed an update as well as info on the help command, which was pretty much just wrong. I've reworded the dev's advice.

This is for 7.2