### PR TITLE
DOC-13439 added note about bucket memory

### DIFF
--- a/modules/learn/pages/buckets-memory-and-storage/storage-engines.adoc
+++ b/modules/learn/pages/buckets-memory-and-storage/storage-engines.adoc
@@ -72,7 +72,7 @@ The following table summarizes the differences between Couchstore and Magma stor
 | 100{nbsp}MiB 
 | 1{nbsp}GiB 
 
-| Minimum memory to data ratio
+| Minimum memory to data ratio<<quota-note, ^[1]^>>
 | 10%
 | 1%
 | 1%
@@ -83,6 +83,11 @@ The following table summarizes the differences between Couchstore and Magma stor
 | 10{nbsp}TB
 
 |===
+[horizontal]
+[[memory-note]]<<quota-ref, ^1^>>:: Memory refers to the memory allocated to the bucket.
+Disk space of the bucket refers to the data size of the bucket on the disk, including all of its replicas.
+This can be estimated by: (number of documents * average document size * number of replicas * expected compression ratio).
+On a running system, the metric `kv_logical_data_size_bytes` reflects the bucket's size on the disk.
 
 == Which Storage Engine Should You Use?
 


### PR DESCRIPTION
DOC-13439

Added a note to clear up some confusion about what memory actually means within the context of storing data in a bucket.

This is for 8.0, which differs slightly to the 7.6 version.