### PR TITLE
DOC-13744: Remove 8092, 18092 ports association with XDCR

### DIFF
--- a/modules/manage/pages/manage-xdcr/prepare-for-xdcr.adoc
+++ b/modules/manage/pages/manage-xdcr/prepare-for-xdcr.adoc
@@ -31,7 +31,7 @@ For example, XDCR needs 1-2 additional CPU cores per stream; and in some cases, 
 If a cluster is not sized to handle _both_ the existing workload _and_ the new XDCR streams, the performance of both XDCR and the cluster overall may be negatively impacted.
 
 * Couchbase Server uses TCP/IP port `8091` to exchange cluster configuration information.
-If you are communicating with a destination cluster over a dedicated connection, or over the Internet, ensure that all nodes in the destination and source clusters can communicate with each other over ports `8091` and `8092`.
+If you are communicating with a destination cluster over a dedicated connection, or over the Internet, ensure that all nodes in the destination and source clusters can communicate with each other over port `8091`.
 
 [#next-xdcr-steps-after-preparation]
 == Next Steps


### PR DESCRIPTION
DOC-13744: Remove 8092, 18092 ports association with XDCR update prepare-for-xdcr.adoc, 7.6