### PR TITLE
DOC-13756: Minor doc fixes

### DIFF
--- a/modules/install/pages/upgrade.adoc
+++ b/modules/install/pages/upgrade.adoc
@@ -1,4 +1,5 @@
 = Upgrade
+:page-aliases: n1ql:n1ql_application_continuity
 :description: To upgrade a Couchbase-Server cluster means to upgrade the version of Couchbase Server that is running on every node.
 
 :erlang-upgrade-note: The upgrade to Erlang support in Couchbase server 7.2.4 requires that you first upgrade Couchbase to version 7.1.0 or later before upgrading to version 7.6.x


### PR DESCRIPTION
Jira issue: DOC-13756

Following https://github.com/couchbaselabs/docs-devex/pull/484, this PR adds an alias for the deleted N1QL Application Continuity page.