### PR TITLE
[DOC-12554]: Document how to check if a cluster has buckets with flushing enabled

### DIFF
--- a/modules/rest-api/pages/rest-bucket-create.adoc
+++ b/modules/rest-api/pages/rest-bucket-create.adoc
@@ -809,6 +809,38 @@ Flushing deletes every document in the bucket, and therefore should not be enabl
 
 This parameter can be modified, following bucket-creation.
 
+[#example-flush-check]
+==== Example: Check whether flushing is enabled
+You can check the `flush` status of all your buckets by using the following command:
+
+[source, bash]
+----
+curl -s -X GET -u Administrator:password http://127.0.0.1:8091/pools/default/buckets| jq . | egrep '"name"|flush'
+----
+
+If flushing is enabled for a bucket, then the result will include a `doFlush` statement for that bucket:
+
+[source,text]
+----
+ "name": "bucket1",
+ "flush": "/pools/default/buckets/bucket1/controller/doFlush"
+ "name": "bucket2",
+ "flush": "/pools/default/buckets/bucket2/controller/doFlush"
+ "name": "travel-sample",
+ "flush": "/pools/default/buckets/travel-sample/controller/doFlush"
+----
+
+The `doflush` statement is excluded for buckets that don't have flushing enabled.
+
+[source,text]
+----
+ "name": "bucket1",
+ "name": "bucket2",
+ "flush": "/pools/default/buckets/bucket2/controller/doFlush"
+ "name": "travel-sample",
+ "flush": "/pools/default/buckets/travel-sample/controller/doFlush"
+----
+
 [#example-create]
 ==== Example: Enable Flushing, when Creating
 

--- a/modules/rest-api/pages/rest-bucket-flush.adoc
+++ b/modules/rest-api/pages/rest-bucket-flush.adoc
@@ -61,7 +61,7 @@ This will list the buckets in your cluster along with an additional `doFlush` st
  "name": "bucket1",
  "name": "bucket2",
  "name": "beer-sample",
- "flush": "/pools/default/buckets/travel-sample/controller/doFlush"
+ "flush": "/pools/default/buckets/beer-sample/controller/doFlush"
 ----
 
 == See Also

--- a/modules/rest-api/pages/rest-bucket-flush.adoc
+++ b/modules/rest-api/pages/rest-bucket-flush.adoc
@@ -49,6 +49,21 @@ http://10.144.220.101:8091/pools/default/buckets/beer-sample/controller/doFlush 
 -u Administrator:password
 ----
 
+You can check whether `flush` is enabled for buckets in your cluster using the following command:
+
+----
+ curl -s -X GET -u Administrator:password http://10.144.220.101:8091/pools/default/buckets| jq . | egrep '"name"|flush'
+----
+
+This will list the buckets in your cluster along with an additional `doFlush` statement for buckets with `flush` enabled:
+
+----
+ "name": "bucket1",
+ "name": "bucket2",
+ "name": "beer-sample",
+ "flush": "/pools/default/buckets/travel-sample/controller/doFlush"
+----
+
 == See Also
 
 For information on enabling flushing with the REST API, see xref:rest-api:rest-bucket-create.adoc[Creating and Editing Buckets].


### PR DESCRIPTION
Added instructions on how to get hold of the buckets' `flush` status.

----

https://preview.docs-test.couchbase.com/docs-server-DOC-12554-Document-how-to-check-if-a-cluster-has-buckets-with-flushing-enabled/server/current/rest-api/rest-bucket-create.html

https://preview.docs-test.couchbase.com/docs-server-DOC-12554-Document-how-to-check-if-a-cluster-has-buckets-with-flushing-enabled/server/current/rest-api/rest-bucket-flush.html



