### PR TITLE
[DOC-12324]: Configure Client Certificates page | Java Client Access

### DIFF
--- a/modules/manage/pages/manage-security/configure-client-certificates.adoc
+++ b/modules/manage/pages/manage-security/configure-client-certificates.adoc
@@ -349,6 +349,11 @@ keytool -certreq -alias selfsigned -keyalg RSA -file my.csr \
 ----
 +
 This creates the signing-request file, `my.csr`.
++
+Note that in this example, although only the `Common Name` is being used to establish the identity of the user seeking authorization, one or more `Subject Alternative Names` could also be added.
+For example, by adding `-ext "san=email:john.smith@mail.com"` to the certificate signing-request used in the current step, the email-address `john.smith@mail.com` could be established as the basis for an alternative username to be submitted for authentication.
+See xref:learn:security/certificates.adoc#identity-encoding-in-client-certificates[Specifying Usernames for Client-Certificate Authentication], for more information.
+
 
 . Create an  extensions file.
 (`extendedKeyUsage = clientAuth` means that the certificate will be used for client authentication):
@@ -361,10 +366,6 @@ keyUsage = digitalSignature,keyEncipherment
 EOF
 ----
 +
-Note that in this example, although only the `Common Name` is being used to establish the identity of the user seeking authorization, one or more `Subject Alternative Names` could also be added.
-For example, by adding `-ext "san=email:john.smith@mail.com"` to the certificate signing-request used in the current step, the email-address `john.smith@mail.com` could be established as the basis for an alternative username to be submitted for authentication.
-See xref:learn:security/certificates.adoc#identity-encoding-in-client-certificates[Specifying Usernames for Client-Certificate Authentication], for more information.
-
 . Generate the client certificate, signing it with the root private key, and thereby establishing the root certificate's authority:
 +
 [source,bash]

--- a/modules/manage/pages/manage-security/configure-client-certificates.adoc
+++ b/modules/manage/pages/manage-security/configure-client-certificates.adoc
@@ -349,6 +349,17 @@ keytool -certreq -alias selfsigned -keyalg RSA -file my.csr \
 ----
 +
 This creates the signing-request file, `my.csr`.
+
+. Create an  extensions file.
+(`extendedKeyUsage = clientAuth` means that the certificate will be used for client authentication):
++
+[source,bash]
+----
+cat > client.ext <<EOF
+extendedKeyUsage = clientAuth
+keyUsage = digitalSignature,keyEncipherment
+EOF
+----
 +
 Note that in this example, although only the `Common Name` is being used to establish the identity of the user seeking authorization, one or more `Subject Alternative Names` could also be added.
 For example, by adding `-ext "san=email:john.smith@mail.com"` to the certificate signing-request used in the current step, the email-address `john.smith@mail.com` could be established as the basis for an alternative username to be submitted for authentication.


### PR DESCRIPTION
Added missing section: create the `client.ext` file.