### PR TITLE
DOC-13735-Feedback on Couchbase Server Ports-7.6

### DIFF
--- a/modules/install/pages/install-ports.adoc
+++ b/modules/install/pages/install-ports.adoc
@@ -35,7 +35,7 @@ These paths are defined as:
 
 * _Node-local_: A Couchbase service running on a node connects to the port on localhost, and communication happens entirely within the node itself.
 
-* _Node-to-node_: A Couchbase service connects to the port on other nodes in the cluster.
+* __: A Couchbase service connects to the port on other nodes in the cluster.
 
 * _Client-to-node_: A Couchbase client, such as an application using the Couchbase SDK, connects to the port on the node that it requires access to.
 
@@ -77,7 +77,7 @@ The following table lists all port numbers, grouped by category of communication
 | _Node-to-node_
 | *Unencrypted*: 4369, 8091-8094, 9100-9105, 9110-9118, 9120-9122, 9130, 9999, 11209-11210, 21100
 
-*Encrypted*: 9999, 11206, 11207, 18091-18094, 19102, 19130, 21150
+*Encrypted*: 9999, 9124, 11206, 11207, 18091-18094, 19102, 19130, 21150
 
 | _Client-to-node_
 | *Unencrypted*: 8091-8097, 9123, 9140 {fn-eventing-debug-port}, 11210, 11280


### PR DESCRIPTION
Added port 9124 to encrypted ports under "node-to-node" at https://docs.couchbase.com/server/current/install/install-ports.html#ports-listed-by-communication-path.
https://jira.issues.couchbase.com/browse/DOC-13735