### PR TITLE
DOC-5016 Add Enterprise Edition label to the Security pages

### DIFF
--- a/modules/install/pages/install-security-bp.adoc
+++ b/modules/install/pages/install-security-bp.adoc
@@ -1,6 +1,7 @@
 = Security Considerations
 :description: Ensure that you follow security best best practices throughout the deployment lifecycle.
 :page-topic-type: concept
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/learn/pages/security/auditing.adoc
+++ b/modules/learn/pages/security/auditing.adoc
@@ -1,6 +1,7 @@
 = Auditing
 :description: Couchbase Server provides event-auditing, sending output to a log-file.
 :page-aliases: security:security-auditing
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/learn/pages/security/authentication-domains.adoc
+++ b/modules/learn/pages/security/authentication-domains.adoc
@@ -1,5 +1,6 @@
 = Authentication Domains
 :description: pass:q[To access Couchbase Server, users must be authenticated: this can occur in either the _local_ or the _external_ authentication domain.]
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/learn/pages/security/authentication-overview.adoc
+++ b/modules/learn/pages/security/authentication-overview.adoc
@@ -1,6 +1,7 @@
 = Understanding Authentication
 :description: pass:q[To access Couchbase Server, users must be authenticated. \
 _Authentication_ is a process for identifying who is attempting to access a system.]
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/learn/pages/security/authentication.adoc
+++ b/modules/learn/pages/security/authentication.adoc
@@ -2,6 +2,7 @@
 :description: pass:q[To access Couchbase Server, users must be authenticated. \
 _Authentication_ is a process for identifying who is attempting to access a system.]
 :page-aliases: security:security-authentication,security:security-ldap-new
+:page-edition: Enterprise Edition
 
 {description}
 Subsequent to successful authentication, _authorization_ can be performed, whereby the user's appropriate access-level is determined.

--- a/modules/learn/pages/security/authorization-overview.adoc
+++ b/modules/learn/pages/security/authorization-overview.adoc
@@ -1,6 +1,7 @@
 = Authorization
 :description: pass:q[For authorizing users, Couchbase Server provides _Role-Based Access Control_.]
 :page-aliases: security:security-authorization,security:security-bucket-protection
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/learn/pages/security/certificates.adoc
+++ b/modules/learn/pages/security/certificates.adoc
@@ -3,6 +3,7 @@
 :page-aliases: security:security-certs-auth,security:security-encryption
 :page-toclevels: 3
 [abstract]
+:page-edition: Enterprise Edition
 
 {description}
 

--- a/modules/learn/pages/security/encryption-overview.adoc
+++ b/modules/learn/pages/security/encryption-overview.adoc
@@ -1,5 +1,7 @@
 = Encryption
-:description: pass:q[Couchbase Server uses _encryption_, to protect data.]
+:description: pass:q[Couchbase Server lets you use encryption to protect data.]
+:page-toclevels: 2
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/learn/pages/security/on-the-wire-security.adoc
+++ b/modules/learn/pages/security/on-the-wire-security.adoc
@@ -1,5 +1,6 @@
 = On-the-Wire Security
 :description: To support secure communications between nodes, clusters, and clients, Couchbase Server provides interfaces for the configuration of on-the-wire security.
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/learn/pages/security/roles.adoc
+++ b/modules/learn/pages/security/roles.adoc
@@ -1,6 +1,8 @@
 = Roles
 :description: pass:q[A Couchbase role permits one or more resources to be accessed according to defined privileges.]
 :page-aliases: security:security-roles,security:concepts-rba,security:concepts-rba-for-apps,security:rbac-ro-user,learn:security/resources-under-access-control,security:security-resources-under-access-control
+:page-toclevels: 3
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/learn/pages/security/security-overview.adoc
+++ b/modules/learn/pages/security/security-overview.adoc
@@ -1,6 +1,7 @@
 = Security
 :description: Couchbase Server can be rendered highly secure.
 :page-aliases: security:security-intro,concepts:security
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/learn/pages/security/upgrading-to-rbac.adoc
+++ b/modules/learn/pages/security/upgrading-to-rbac.adoc
@@ -1,6 +1,7 @@
 = Upgrading to RBAC
 :description: Couchbase provides an upgrade path, whereby users can seamlessly transition their activities from Couchbase Server 4.6 and earlier (which are all pre-RBAC releases) to 5.0 and post-5.0 (which are RBAC-enabled releases).
 :page-aliases: security:security-rbac-upgrade
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/learn/pages/security/usernames-and-passwords.adoc
+++ b/modules/learn/pages/security/usernames-and-passwords.adoc
@@ -1,6 +1,7 @@
 = Usernames and Passwords
 :description: pass:q[Couchbase Server requires that administrators and applications _authenticate_, in order to gain access to data, settings, and statistics.]
 :page-aliases: security:security-pw-auth,security:security-passwords
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/learn/pages/security/using-multiple-cas.adoc
+++ b/modules/learn/pages/security/using-multiple-cas.adoc
@@ -1,5 +1,6 @@
 = Using Multiple Root Certificates
 :description: Couchbase Server supports use of multiple CA (or 'root') certificates, for a single cluster.
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/manage/pages/manage-security/configure-client-certificates.adoc
+++ b/modules/manage/pages/manage-security/configure-client-certificates.adoc
@@ -1,6 +1,7 @@
 = Configure Client Certificates
 :description: Couchbase Server supports client-authentication by means of X.509 \
 certificates.
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/manage/pages/manage-security/configure-ldap.adoc
+++ b/modules/manage/pages/manage-security/configure-ldap.adoc
@@ -1,5 +1,6 @@
 = Configure LDAP
 :description: pass:q[Couchbase Server can be configured to authenticate users by means of LDAP; and to map the LDAP _groups_ of which a user is a member to roles defined on Couchbase Server.]
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/manage/pages/manage-security/configure-pam.adoc
+++ b/modules/manage/pages/manage-security/configure-pam.adoc
@@ -1,6 +1,7 @@
 = Configure PAM
 :description: pass:q[_Pluggable Authentication Modules_ (PAM) provide an authentication framework that allows multiple, low-level authentication schemes to be used by a single API.]
 :page-aliases: security:security-pam-auth
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/manage/pages/manage-security/configure-saml.adoc
+++ b/modules/manage/pages/manage-security/configure-saml.adoc
@@ -1,4 +1,5 @@
 = Configure SAML
+:page-edition: Enterprise Edition
 
 You can enable _Structured Authentication Markup Language_ (SAML)  authentication that allows users to log into the Couchbase Server Web Console. This authentication methods offers features such as single sign on, two-factor authentication, and centralized authentication administration.
 

--- a/modules/manage/pages/manage-security/configure-saslauthd.adoc
+++ b/modules/manage/pages/manage-security/configure-saslauthd.adoc
@@ -2,6 +2,7 @@
 :description: pass:q[`saslauthd` is a daemon process that handles plaintext authentication \
 requests on behalf of the SASL library.]
 :page-aliases: security:security-saslauthd-new
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/manage/pages/manage-security/configure-server-certificates.adoc
+++ b/modules/manage/pages/manage-security/configure-server-certificates.adoc
@@ -1,5 +1,6 @@
 = Configure Server Certificates
 :description: Couchbase Server Enterprise Edition supports using X.509 and PKCS #12 certificates for authenticating and encrypting data between the nodes in the cluster.
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/manage/pages/manage-security/enable-client-certificate-handling.adoc
+++ b/modules/manage/pages/manage-security/enable-client-certificate-handling.adoc
@@ -1,5 +1,6 @@
 = Enable Client-Certificate Handling
 :description: Couchbase Server can be enabled to support certificate-based client authentication.
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/manage/pages/manage-security/handle-certificate-errors.adoc
+++ b/modules/manage/pages/manage-security/handle-certificate-errors.adoc
@@ -1,5 +1,6 @@
 = Certificate Error Handling
 :description: Specific errors can arise from use of X.509 certificates: these should be recognized and appropriately dealt with.
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/manage/pages/manage-security/manage-auditing.adoc
+++ b/modules/manage/pages/manage-security/manage-auditing.adoc
@@ -2,7 +2,8 @@
 :description: pass:q[Actions performed on Couchbase Server can be _audited_. \
 This allows administrators to ensure that system-management tasks are being appropriately performed.]
 :page-aliases: security:security-audit-events,security:security-audit-targets,security:security-json-fields-new
-:page-toclevels: 3
+:page-toclevels: 2
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/manage/pages/manage-security/manage-authentication.adoc
+++ b/modules/manage/pages/manage-security/manage-authentication.adoc
@@ -1,5 +1,6 @@
 = Manage Authentication
 :description: To access Couchbase Server, administrators and applications must be authenticated.
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/manage/pages/manage-security/manage-certificates.adoc
+++ b/modules/manage/pages/manage-security/manage-certificates.adoc
@@ -1,6 +1,7 @@
 = Manage Certificates
 :description: Couchbase Server supports the use of X.509 certificates.
 :page-aliases: security:security-x509certsintro
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/manage/pages/manage-security/manage-connections-and-disks.adoc
+++ b/modules/manage/pages/manage-security/manage-connections-and-disks.adoc
@@ -2,6 +2,7 @@
 :description: Couchbase-Server security can be enhanced by proper management of \
 connections and disks.
 :page-aliases: security:security-data-encryption,security:security-comm-encryption,security:security-best-practices,security:security-iptables,security:security-acls-new
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/manage/pages/manage-security/manage-console-access.adoc
+++ b/modules/manage/pages/manage-security/manage-console-access.adoc
@@ -1,6 +1,7 @@
 = Manage Console Access
 :description: Administrators can connect securely with Couchbase Web Console.
 :page-edition: Enterprise Edition
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/manage/pages/manage-security/manage-security-settings.adoc
+++ b/modules/manage/pages/manage-security/manage-security-settings.adoc
@@ -2,6 +2,7 @@
 :description: Couchbase Server security-settings can be managed from Couchbase Web \
 Console, and by means of the REST API.
 :page-aliases: security:security-session-timeouts,settings:configure-account-settings
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/manage/pages/manage-security/manage-sessions.adoc
+++ b/modules/manage/pages/manage-security/manage-sessions.adoc
@@ -1,6 +1,7 @@
 = Manage Sessions
 :description: User-sessions with Couchbase Web Console can be timed out, following \
 a specified period of user-inactivity.
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/manage/pages/manage-security/manage-system-secrets.adoc
+++ b/modules/manage/pages/manage-security/manage-system-secrets.adoc
@@ -1,6 +1,7 @@
 = Manage System Secrets
 :description: System secrets can be managed with a special degree of security.
 :page-aliases: security:secret-mgmt
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/manage/pages/manage-security/manage-tls.adoc
+++ b/modules/manage/pages/manage-security/manage-tls.adoc
@@ -1,5 +1,6 @@
 = Manage On-the-Wire Security
 :description: To support secure communications between nodes, clusters, and clients, Couchbase Server provides interfaces for the configuration of on-the-wire security settings.
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/manage/pages/manage-security/manage-users-and-roles.adoc
+++ b/modules/manage/pages/manage-security/manage-users-and-roles.adoc
@@ -1,6 +1,8 @@
 = Manage Users, Groups, and Roles
 :description: pass:q[Couchbase Server allows defined _users_ to be assigned roles, which permit access to resources.]
 :page-aliases: security:security-rbac-user-management,security:security-rbac-for-admins-and-apps
+:page-toclevels: 2
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/manage/pages/manage-security/rotate-server-certificates.adoc
+++ b/modules/manage/pages/manage-security/rotate-server-certificates.adoc
@@ -1,5 +1,6 @@
 = Certificate Rotation
 :description: Certificates should be rotated periodically, to ensure optimal security.
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/manage/pages/manage-security/security-management-overview.adoc
+++ b/modules/manage/pages/manage-security/security-management-overview.adoc
@@ -1,6 +1,7 @@
 = Security Management Overview
 :description: Couchbase Server can be rendered highly secure.
 :page-aliases: security:security-in-applications,security:security-user-input
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/rest-api/pages/change-master-password.adoc
+++ b/modules/rest-api/pages/change-master-password.adoc
@@ -1,5 +1,6 @@
 = Changing the Master Password
 :description: The master password can be changed, by means of the REST API.
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/rest-api/pages/delete-trusted-cas.adoc
+++ b/modules/rest-api/pages/delete-trusted-cas.adoc
@@ -1,6 +1,7 @@
 = Delete Root Certificates
 :description: Trusted CA (or 'root') certificates previously loaded into the Couchbase-Server cluster can be deleted.
 :page-topic-type: reference
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/rest-api/pages/get-trusted-cas.adoc
+++ b/modules/rest-api/pages/get-trusted-cas.adoc
@@ -1,6 +1,7 @@
 = Get Root Certificates
 :description: Trusted CA (or 'root') certificates previously loaded into the Couchbase-Server cluster can be retrieved and inspected.
 :page-topic-type: reference
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/rest-api/pages/load-trusted-cas.adoc
+++ b/modules/rest-api/pages/load-trusted-cas.adoc
@@ -1,6 +1,7 @@
 = Load Root Certificates
 :description: Trusted CA (or 'root') certificates can be loaded into the trust store of the Couchbase-Server cluster; in order to provide authority to the cluster's nodes, and to authenticate clients' access-attempts. Intermediate certificates can also be loaded into the trust store.
 :page-topic-type: reference
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/rest-api/pages/rbac.adoc
+++ b/modules/rest-api/pages/rbac.adoc
@@ -1,6 +1,7 @@
 = Role-Based Access Control (RBAC)
 :description: pass:q[Full  and Security Administrators can manage the Couchbase _Role-Based Access Control_ (RBAC) system, using the REST API.]
 :page-aliases: rest-bucket-auth,rest-user-create,rest-user-getname,rest-user-password-put,rest-user-delete
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/rest-api/pages/rest-auditing.adoc
+++ b/modules/rest-api/pages/rest-auditing.adoc
@@ -1,5 +1,6 @@
 = Configure Auditing
 :description: pass:q[Couchbase Server _event auditing_ can be configured, per node.]
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/rest-api/pages/rest-authentication.adoc
+++ b/modules/rest-api/pages/rest-authentication.adoc
@@ -1,5 +1,6 @@
 = Authentication API
 :description: Couchbase Server supports authentication via local and external domains.
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/rest-api/pages/rest-authorization.adoc
+++ b/modules/rest-api/pages/rest-authorization.adoc
@@ -1,5 +1,6 @@
 = Authorization API
 :description: pass:q[Authorization by means of Role-Based Access Control can be manage with the REST API.]
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/rest-api/pages/rest-certificate-management.adoc
+++ b/modules/rest-api/pages/rest-certificate-management.adoc
@@ -1,5 +1,6 @@
 = Certificate Management API
 :description: The REST API can be used to manage the root and node certificates of a cluster.
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/rest-api/pages/rest-configure-ldap.adoc
+++ b/modules/rest-api/pages/rest-configure-ldap.adoc
@@ -1,5 +1,6 @@
 = Configure LDAP
 :description: pass:q[Couchbase Server can be configured to authenticate the user by means of an LDAP server; and to recognize the LDAP _groups_ of which the user is a member.]
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/rest-api/pages/rest-configure-saml.adoc
+++ b/modules/rest-api/pages/rest-configure-saml.adoc
@@ -1,5 +1,6 @@
 = Configure SAML
 :description: pass:q[You can configure Couchbase Server to authenticate a Couchbase Server Web Console user via a SAML Identity Provider.]
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/rest-api/pages/rest-configure-saslauthd.adoc
+++ b/modules/rest-api/pages/rest-configure-saslauthd.adoc
@@ -1,6 +1,7 @@
 = Configuring saslauthd
 :description: pass:q[The Couchbase REST API supports enablement of _saslauthd_ and the establishment of saslauthd administrators for the cluster.]
 :page-topic-type: reference
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/rest-api/pages/rest-regenerate-all-certs.adoc
+++ b/modules/rest-api/pages/rest-regenerate-all-certs.adoc
@@ -1,6 +1,7 @@
 = Regenerate All Certificates
 :description: pass:q[The REST API can be used to _regenerate_ the cluster's root and node certificates.]
 :page-topic-type: reference
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/rest-api/pages/rest-rotate-internal-credentials.adoc
+++ b/modules/rest-api/pages/rest-rotate-internal-credentials.adoc
@@ -1,6 +1,7 @@
 = Rotate Internal Credentials
 :description: Credentials used for Couchbase-Server internal users can be rotated at any time, on a specified node, by means of the REST API.
 :page-topic-type: reference
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/rest-api/pages/rest-secret-mgmt.adoc
+++ b/modules/rest-api/pages/rest-secret-mgmt.adoc
@@ -1,6 +1,7 @@
 = System Secrets API
 :description: pass:q[System secrets can be managed with the REST API.]
 :page-topic-type: reference
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/rest-api/pages/rest-security.adoc
+++ b/modules/rest-api/pages/rest-security.adoc
@@ -1,6 +1,7 @@
 = Security API
 :description: The REST API supports all aspects of Couchbase-Server security
 :page-topic-type: reference
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/rest-api/pages/rest-set-password-policy.adoc
+++ b/modules/rest-api/pages/rest-set-password-policy.adoc
@@ -1,6 +1,7 @@
 = Set Password Policy
 :description: pass:q[The REST API allows the  _password policy_ for a cluster to be established and retrieved by means of the `POST` and `GET` methods respectively, using the `/settings/passwordPolicy` URI.]
 :page-topic-type: reference
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/rest-api/pages/rest-set-password.adoc
+++ b/modules/rest-api/pages/rest-set-password.adoc
@@ -1,5 +1,6 @@
 = Change Password
 :description: A local user of Couchbase Server can change their password.
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/rest-api/pages/rest-setting-hsts.adoc
+++ b/modules/rest-api/pages/rest-setting-hsts.adoc
@@ -1,6 +1,7 @@
 = Configure HSTS
 :description: Establish an HTTP Secure Transport Header (HSTS); so as to inform the Web-Console browser never to load a site using HTTP; and instead, to automatically convert all access-requests from HTTP to HTTPS. 
 :page-topic-type: reference
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/rest-api/pages/rest-setting-security.adoc
+++ b/modules/rest-api/pages/rest-setting-security.adoc
@@ -1,6 +1,7 @@
 = Configure On-the-Wire Security
 :description: Establish and retrieve cluster-wide settings for the use of encryption and cipher-suites.
 :page-topic-type: reference
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/rest-api/pages/rest-specify-node-addition-conventions.adoc
+++ b/modules/rest-api/pages/rest-specify-node-addition-conventions.adoc
@@ -1,5 +1,6 @@
 = Restrict Node-Addition
 :description: The REST API allows node-naming conventions to be configured such that only nodes whose names conform to those conventions can be added to the cluster.
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/rest-api/pages/rest-whoami.adoc
+++ b/modules/rest-api/pages/rest-whoami.adoc
@@ -1,6 +1,7 @@
 = Who Am I?
 :description: pass:q[A Couchbase-Server user can check their id (or _username_), domain, roles, and other details.]
 :page-topic-type: reference
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/rest-api/pages/retrieve-all-node-certs.adoc
+++ b/modules/rest-api/pages/retrieve-all-node-certs.adoc
@@ -1,6 +1,7 @@
 = Retrieve All Node Certificates
 :description: The REST API can be used to retrieve the node certificate for each node in the cluster.
 :page-topic-type: reference
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/rest-api/pages/rotate-data-key.adoc
+++ b/modules/rest-api/pages/rotate-data-key.adoc
@@ -1,5 +1,6 @@
 = Rotating the Data Key
 :description: The data key can be rotated, by means of the REST API.
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/rest-api/pages/system-secrets-configuration.adoc
+++ b/modules/rest-api/pages/system-secrets-configuration.adoc
@@ -1,5 +1,6 @@
 = Configuring System Secrets
 :description: By means of the REST API, System Secrets can be configured, and the current configuration can be retrieved.
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/modules/rest-api/pages/upload-retrieve-node-cert.adoc
+++ b/modules/rest-api/pages/upload-retrieve-node-cert.adoc
@@ -2,6 +2,7 @@
 :description: The REST API can be used to upload and retrieve a node certificate.
 :page-topic-type: reference
 :page-aliases: rest-api:rest-encryption
+:page-edition: Enterprise Edition
 
 [abstract]
 {description}

--- a/preview/DOC-5016-preview.yml
+++ b/preview/DOC-5016-preview.yml
@@ -1,8 +1,14 @@
 sources:
     docs-server:
+<<<<<<< HEAD
       branches: DOC-5016-security-pages-EE-7-6
     docs-analytics:
       branches: release/7.6
+=======
+      branches: DOC-5016-security-pages-EE-8-0
+    docs-analytics:
+      branches: release/8.0
+>>>>>>> 1515954b (Added Enterprise Edition label to Security pages)
     docs-devex:
       url: https://github.com/couchbaselabs/docs-devex.git
       branches: master

--- a/preview/DOC-5016-preview.yml
+++ b/preview/DOC-5016-preview.yml
@@ -1,14 +1,8 @@
 sources:
     docs-server:
-<<<<<<< HEAD
       branches: DOC-5016-security-pages-EE-7-6
     docs-analytics:
       branches: release/7.6
-=======
-      branches: DOC-5016-security-pages-EE-8-0
-    docs-analytics:
-      branches: release/8.0
->>>>>>> 1515954b (Added Enterprise Edition label to Security pages)
     docs-devex:
       url: https://github.com/couchbaselabs/docs-devex.git
       branches: master

--- a/preview/DOC-5016-preview.yml
+++ b/preview/DOC-5016-preview.yml
@@ -1,0 +1,28 @@
+sources:
+    docs-server:
+      branches: DOC-5016-security-pages-EE-7-6
+    docs-analytics:
+      branches: release/7.6
+    docs-devex:
+      url: https://github.com/couchbaselabs/docs-devex.git
+      branches: master
+      startPaths: docs/
+    couchbase-cli:
+      # url: ../../docs-includes/couchbase-cli
+      url: https://github.com/couchbaselabs/couchbase-cli-doc
+      # branches: HEAD
+      branches: master
+      startPaths: docs/
+    backup:
+      # url: ../../docs-includes/backup
+      url: https://github.com/couchbaselabs/backup-docs.git
+      #branches: HEAD
+      branches: master
+      startPaths: docs/    
+    #analytics:
+    #  url: ../../docs-includes/docs-analytics
+    #  branches: HEAD
+    #cb-swagger:
+    #  url: https://github.com/couchbaselabs/cb-swagger
+    #  branches: release/8.0
+    #  start_path: docs


### PR DESCRIPTION
DOC-5016

Tagged all security pages in the following sections with the `Enterprise Edition` label:
- [Learn](https://preview.docs-test.couchbase.com/docs-server-DOC-5016-security-pages-EE-7-6/server/current/learn/security/security-overview.html)
- [Manage](https://preview.docs-test.couchbase.com/docs-server-DOC-5016-security-pages-EE-7-6/server/current/manage/manage-security/security-management-overview.html)
- [REST APIs](https://preview.docs-test.couchbase.com/docs-server-DOC-5016-security-pages-EE-7-6/server/current/rest-api/rest-security.html)