### PR TITLE
DOC-12531-Feedback on set flush_param

### DIFF
--- a/modules/cli/pages/cbepctl/set-flush_param.adoc
+++ b/modules/cli/pages/cbepctl/set-flush_param.adoc
@@ -70,7 +70,7 @@ Note also that if the scanner runs at the same time that index updates are being
 The scanner should be configured to minimize the likelihood of this problem.
 
 exp_pager_stime::
-The `cbepctl flush_param exp_pager_stime` command sets the time interval to scan for expired items, and erase them from memory and disk.
+The `cbepctl flush_param exp_pager_stime` command sets the time interval to scan for expired items and erase them from memory and disk.
 Couchbase Server does lazy xref:learn:buckets-memory-and-storage/memory.adoc#expiry-pager[expiration], that is, expired items are flagged as deleted rather than being immediately erased.
 Couchbase Server has a maintenance process that periodically looks through all information and erases expired items.
 By default, this maintenance process runs every 10 minutes, but it can be configured to run at a different interval.

--- a/modules/cli/pages/cbepctl/set-flush_param.adoc
+++ b/modules/cli/pages/cbepctl/set-flush_param.adoc
@@ -20,7 +20,7 @@ cbepctl [hostname]:11210 -b [bucket-name] -u [administrator-name] -p [administra
 cbepctl [hostname]:11210 -b [bucket-name] -u [administrator-name] -p [administrator-password] set flush_param alog_task_time [value]
 ----
 
-The syntax for disk cleanup is:
+The syntax for asynchronous expiry is:
 
 ----
 cbepctl [host]:11210 -b [bucket-name] -u [administrator-name] -p [administrator-password] set flush_param exp_pager_stime [value]

--- a/modules/cli/pages/cbepctl/set-flush_param.adoc
+++ b/modules/cli/pages/cbepctl/set-flush_param.adoc
@@ -70,7 +70,7 @@ Note also that if the scanner runs at the same time that index updates are being
 The scanner should be configured to minimize the likelihood of this problem.
 
 exp_pager_stime::
-The `cbepctl flush_param exp_pager_stime` command sets the time interval for disk cleanup.
+The `cbepctl flush_param exp_pager_stime` command sets the time interval to scan for expired items, and erase them from memory and disk.
 Couchbase Server does lazy xref:learn:buckets-memory-and-storage/memory.adoc#expiry-pager[expiration], that is, expired items are flagged as deleted rather than being immediately erased.
 Couchbase Server has a maintenance process that periodically looks through all information and erases expired items.
 By default, this maintenance process runs every 10 minutes, but it can be configured to run at a different interval.


### PR DESCRIPTION
Changed "The cbepctl flush_param exp_pager_stime command sets the time interval for disk cleanup " to 

"The `cbepctl flush_param exp_pager_stime` command sets the time interval to scan for expired items, and erase them from memory and disk."

https://jira.issues.couchbase.com/browse/DOC-12531