### PR TITLE
[DOC-12771]: Feedback on Filter a Replication | Couchbase Docs

### DIFF
--- a/modules/manage/pages/manage-xdcr/filter-xdcr-replication.adoc
+++ b/modules/manage/pages/manage-xdcr/filter-xdcr-replication.adoc
@@ -182,8 +182,8 @@ Note that the replication of deletions, expirations, and/or TTLs is _not_ preven
 === Filtering Binary Documents
 
 The *Binary Documents* option is used to specify whether binary documents should be replicated.
-If the option is selected, binary documents are _not_ replicated, regardless of whether a filter expression is applied.
-If the option is _not_ selected:
+If the option is selected, binary documents are replicated, regardless of whether a filter expression is applied.
+If the option is selected:
 
 * The behavior is identical to that of Couchbase-Server versions prior to 7.1.5, where the option did not exist.
 


### PR DESCRIPTION

Clarifying that the `Binary Documents` option is checked for binary documents to be replicated.

Please check to make sure that the other options in this section still hold. If they don't, I'll fix 'em.