### PR TITLE
DOC-8634: numatrs should not be a request level parameter

### DIFF
--- a/modules/settings/pages/query-settings.adoc
+++ b/modules/settings/pages/query-settings.adoc
@@ -383,7 +383,7 @@ a| <<max_parallelism_req,max_parallelism>>
 
 <<memory_quota_req,memory_quota>>
 
-<<numatrs_req,numatrs>>
+<<numatrs_req,numatrs>> (for future use)
 
 <<pipeline_batch_req,pipeline_batch>>
 

--- a/preview/DOC-8634-numatrs-req.yml
+++ b/preview/DOC-8634-numatrs-req.yml
@@ -1,5 +1,5 @@
 sources:
   docs-devex:
-    branches: release/7.2
+    branches: DOC-8634-numatrs-req
   cb-swagger:
     branches: DOC-8634-numatrs-req

--- a/preview/DOC-8634-numatrs-req.yml
+++ b/preview/DOC-8634-numatrs-req.yml
@@ -1,0 +1,5 @@
+sources:
+  docs-devex:
+    branches: release/7.2
+  cb-swagger:
+    branches: DOC-8634-numatrs-req

--- a/preview/DOC-8634-numatrs-req.yml
+++ b/preview/DOC-8634-numatrs-req.yml
@@ -1,5 +1,0 @@
-sources:
-  docs-devex:
-    branches: DOC-8634-numatrs-req
-  cb-swagger:
-    branches: DOC-8634-numatrs-req


### PR DESCRIPTION
Jira issue: DOC-8634

This PR marks the `numatrs` request-level parameter for future use on the Query Settings page.

Docs preview: [Settings and Parameters](https://preview.docs-test.couchbase.com/docs-server-DOC-8634-numatrs-req/server/current/settings/query-settings.html)
You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.

This PR must be merged at the same time as the following:

- https://github.com/couchbaselabs/cb-swagger/pull/203
- https://github.com/couchbaselabs/docs-devex/pull/517

Backport to the following branches:

- [x] `release/7.0` (unsupported)
- [x] `release/7.1` (unsupported)

In 7.6, the query-settings page was migrated to the `docs-devex` repo. Merge to the following branches:

- [x] `release/7.6`
- [x] `release/8.0`
- [x] `capella` (for Data API passthrough)