### PR TITLE
[DOC-13127]: Docs currently incorrectly state that the backup plan task array can be empty

### DIFF
--- a/modules/rest-api/pages/backup-create-and-edit-plans.adoc
+++ b/modules/rest-api/pages/backup-create-and-edit-plans.adoc
@@ -55,8 +55,7 @@ The `plan-description` contains the following:
 
 * An array containing the Couchbase Services whose data is to be backed up.
 
-* An array.
-This may be empty, or may contain one or more tasks.
+* An array containing one or more backup tasks.
 Each specified task contains the following:
 
 ** A task-name that is unique across the plan.


### PR DESCRIPTION

The text now makes it clear that the plan must have at least one task when it's created.