### PR TITLE
[DOC-13127-7.6]: Docs incorrectly state that backup plan can be empty

### DIFF
--- a/modules/rest-api/pages/backup-create-and-edit-plans.adoc
+++ b/modules/rest-api/pages/backup-create-and-edit-plans.adoc
@@ -53,8 +53,7 @@ The `plan-description` contains the following:
 
 * An array containing the Couchbase Services whose data is to be backed up.
 
-* An array.
-This may be empty, or may contain one or more tasks.
+* An array containing one or more backup tasks.
 Each specified task contains the following:
 
 ** A task-name that is unique across the plan.


### PR DESCRIPTION

Corrected statement.