### PR TITLE
Remove tools-ver parameter from install pages

### DIFF
--- a/modules/install/pages/install-package-windows.adoc
+++ b/modules/install/pages/install-package-windows.adoc
@@ -1,6 +1,5 @@
 = Install Couchbase Server on Windows
 :description: Couchbase Server can be installed on Windows Server for production use-cases, and Windows Desktop for development use-cases.
-:tools-ver: 8.0.0
 :tabs:
 
 [abstract]
@@ -75,7 +74,7 @@ The following is only an example:
 +
 [source,shell]
 ----
-call couchbase-server-enterprise_{tools-ver}-3777-windows_amd64.msi
+call couchbase-server-enterprise_8.0.0-3777-windows_amd64.msi
 ----
 +
 The install wizard now appears:

--- a/modules/install/pages/non-root.adoc
+++ b/modules/install/pages/non-root.adoc
@@ -1,6 +1,5 @@
 = Non-Root Install and Upgrade
 :description: pass:q[Couchbase Server can be installed on any supported Linux distribution by users who do not have _root_ or _sudo_ privileges.]
-:tools-ver: 8.0.0
 
 :x86-install-location: https://packages.couchbase.com/cb-non-package-installer/cb-non-package-installer-x86_64
 :aarch64-install-location: https://packages.couchbase.com/cb-non-package-installer/cb-non-package-installer-aarch64
@@ -157,7 +156,7 @@ For example:
 [source, console, subs=+quotes]
 ----
  ./cb-non-package-installer-#<platform-suffix># --install --install-location ./cb-install \
- --package ./couchbase-server-enterprise-{tools-ver}-linux.#<platform-suffix>#.rpm
+ --package ./couchbase-server-enterprise-8.0.0-linux.#<platform-suffix>#.rpm
 ----
 +
 NOTE: the program performs dependency checking, prior to installation.
@@ -264,7 +263,7 @@ For example:
 [source, console, subs=+quotes]
 ----
 ./cb-non-package-installer-#<platform-suffix># --upgrade --install-location ./cb-install \
---package ./couchbase-server-enterprise-{tools-ver}-linux.#<platform-suffix>#.rpm
+--package ./couchbase-server-enterprise-8.0.0-linux.#<platform-suffix>#.rpm
 ----
 
 During upgrade, the following message may appear:

--- a/modules/install/pages/rhel-suse-install-intro.adoc
+++ b/modules/install/pages/rhel-suse-install-intro.adoc
@@ -1,7 +1,6 @@
 = Install Couchbase Server on Red Hat Enterprise Linux, Oracle Linux, or Amazon Linux 2023
 :description: Couchbase Server can be installed on Red Hat Enterprise Linux, Oracle Linux, or Amazon Linux 2023 for production and development use cases.
 :tabs:
-:tools-ver: 8.0.0
 
 [abstract]
 {description}
@@ -109,7 +108,7 @@ The following is an example of the listing:
 +
 [subs=+quotes]
 ----
-couchbase-server.x86_64 *{tools-ver}-3777*
+couchbase-server.x86_64 *8.0.0-3777*
 ----
 
 . Specify a release to install it.
@@ -123,7 +122,7 @@ The following is an example of the installation command:
 +
 [subs=+quotes]
 ----
-sudo dnf install couchbase-server-*{tools-ver}-3777*
+sudo dnf install couchbase-server-*8.0.0-3777*
 ----
 +
 You'll be prompted to start the download of Couchbase Server and its dependencies, and import several GPG keys.
@@ -164,7 +163,7 @@ The following is an example of the listing:
 +
 [subs=+quotes]
 ----
-couchbase-server-community.x86_64 *{tools-ver}-3777*
+couchbase-server-community.x86_64 *8.0.0-3777*
 ----
 
 . Specify a release to install it.
@@ -178,7 +177,7 @@ The following is an example of the installation command:
 +
 [subs=+quotes]
 ----
-sudo dnf install couchbase-server-community-*{tools-ver}-3777*
+sudo dnf install couchbase-server-community-*8.0.0-3777*
 ----
 +
 You'll be prompted to start the download of Couchbase Server and its dependencies, and import several GPG keys.

--- a/modules/install/pages/ubuntu-debian-install.adoc
+++ b/modules/install/pages/ubuntu-debian-install.adoc
@@ -2,7 +2,6 @@
 :description: Couchbase Server can be installed on Ubuntu Linux and Debian Linux for production and development use-cases. \
 Root and non-root installations are supported.
 :tabs:
-:tools-ver: 8.0.0
 
 [abstract]
 {description}
@@ -87,7 +86,7 @@ The following is an example of the listing:
 +
 [subs=+quotes]
 ----
-couchbase-server/xenial *{tools-ver}-3777* amd64
+couchbase-server/xenial *8.0.0-3777* amd64
 ----
 +
 . Specify a release to install it.
@@ -101,7 +100,7 @@ The following is an example of the installation command:
 +
 [subs=+quotes]
 ----
-sudo apt-get install couchbase-server=*{tools-ver}-3777*
+sudo apt-get install couchbase-server=*8.0.0-3777*
 ----
 --
 
@@ -132,7 +131,7 @@ The following is an example of the listing:
 +
 [subs=+quotes]
 ----
-couchbase-server-community/xenial *{tools-ver}-3777* amd64
+couchbase-server-community/xenial *8.0.0-3777* amd64
 ----
 +
 . Specify a release to install it.
@@ -146,7 +145,7 @@ The following is an example of the installation command:
 +
 [subs=+quotes]
 ----
-sudo apt-get install couchbase-server-community=*{tools-ver}-3777*
+sudo apt-get install couchbase-server-community=*8.0.0-3777*
 ----
 --
 ====


### PR DESCRIPTION
DOC-13681

`:{tools-ver}: 8.0.0` was added in the pages' head matter.

`{tools-ver}` was added in the body to call the parameter for `8.0.0` version number automatically. But in the output docs, instead of `8.0.0`, the content was displayed as `{tools-ver}`.