### PR TITLE
[DOC-13831]: Increase port range on `docker run` command to cover the backup REST API

### DIFF
--- a/modules/install/pages/getting-started-docker.adoc
+++ b/modules/install/pages/getting-started-docker.adoc
@@ -38,7 +38,7 @@ To set up Docker on the host computer, refer to Docker's https://www.docker.com/
 --
 [source,console]
 ----
-$ docker run -d --name db -p 8091-8096:8091-8096 -p 11210-11211:11210-11211 couchbase
+$ docker run -d --name db -p 8091-8097:8091-8097 -p 11210-11211:11210-11211 couchbase/server
 ----
 
 .Multiple instances with Docker
@@ -143,7 +143,7 @@ $ docker run -d --name db2 couchbase
 
 [source,console]
 ----
-$ docker run -d --name db3 -p 8091-8096:8091-8096 -p 11210-11211:11210-11211 couchbase
+$ docker run -d --name db3 -p 8091-8097:8091-8097 -p 11210-11211:11210-11211 couchbase/server
 ----
 
 After running the above commands, three instances (`db1`, `db2`, `db3`) of the latest https://hub.docker.com/_/couchbase/[official Couchbase Server container image^] are downloaded and run on the host computer.
@@ -362,12 +362,12 @@ Make sure to run each of the following commands:
 +
 [source,console]
 ----
-$ docker run -d --name db1 -p 8091-8096:8091-8096 -p 11210-11211:11210-11211 couchbase
+$ docker run -d --name db1 -p 8091-8097:8091-8097 -p 11210-11211:11210-11211 couchbase/server
 ----
 +
 [source,console]
 ----
-$ docker run -d --name db2 -p 9091-9096:8091-8096 -p 21210-21211:11210-11211 couchbase
+$ docker run -d --name db2 -p 9091-9097:8091-8097 -p 21210-21211:11210-11211 couchbase/server
 ----
 +
 After running the above commands,


### PR DESCRIPTION

Changed the end port to 8097 to accommodate the backup REST API.