### PR TITLE
[DOC-12408]: Feedback on Index Service Metrics | Couchbase Docs

### DIFF
--- a/modules/metrics-reference/attachments/index_metrics_metadata.json
+++ b/modules/metrics-reference/attachments/index_metrics_metadata.json
@@ -54,7 +54,7 @@
     "unit": "Nanoseconds"
   },
   "index_cache_hits": {
-    "help": "The number of times the required index page for both scan and mutations is found in memory, for this index. It is normal to see activity in `index_cache_hits` even when no index scans are occurring. This is because the metric track memory access for both scans and mutations. When an index is updated, the system checks if the relevant record is in memory; a successful find is recorded as a hit.",
+    "help": "The number of times an index page is found in the memory cache. It is normal to see activity in `index_cache_hits` even when no index scans are occurring. This is because the metric track memory access for both scans and mutations. When an index is updated, the system checks if the relevant record is in memory; a successful find is recorded as a hit.",
     "labels": [
       "bucket",
       "scope",
@@ -65,7 +65,7 @@
     "type": "counter"
   },
   "index_cache_misses": {
-    "help": "The number of times the required index page for both scan and mutations is NOT found in memory, for this index. It is normal to see activity in `index_cache_misses` even when no index scans are occurring. This is because the metric tracks memory access for both scans and mutations. When an index is updated, the system checks if the relevant record is in memory; if a disk fetch is required, it is recorded as a miss.",
+    "help": "The number of times an index page is found not in the memory cache. It is normal to see activity in `index_cache_misses` even when no index scans are occurring. This is because the metric tracks memory access for both scans and mutations. When an index is updated, the system checks if the relevant record is in memory; if a disk fetch is required, it is recorded as a miss.",
     "labels": [
       "bucket",
       "scope",

--- a/modules/metrics-reference/attachments/index_metrics_metadata.json
+++ b/modules/metrics-reference/attachments/index_metrics_metadata.json
@@ -54,7 +54,7 @@
     "unit": "Nanoseconds"
   },
   "index_cache_hits": {
-    "help": "The number of times the required index page for both scan and mutations is found in memory, for this index",
+    "help": "The number of times the required index page for both scan and mutations is found in memory, for this index. It is normal to see activity in `index_cache_hits` even when no index scans are occurring. This is because the metric track memory access for both scans and mutations. When an index is updated, the system checks if the relevant record is in memory; a successful find is recorded as a hit.",
     "labels": [
       "bucket",
       "scope",
@@ -65,7 +65,7 @@
     "type": "counter"
   },
   "index_cache_misses": {
-    "help": "The number of times the required index page for both scan and mutations is NOT found in memory, for this index",
+    "help": "The number of times the required index page for both scan and mutations is NOT found in memory, for this index. It is normal to see activity in `index_cache_misses` even when no index scans are occurring. This is because the metric tracks memory access for both scans and mutations. When an index is updated, the system checks if the relevant record is in memory; if a disk fetch is required, it is recorded as a miss.",
     "labels": [
       "bucket",
       "scope",

--- a/modules/metrics-reference/partials/metrics.hbs
+++ b/modules/metrics-reference/partials/metrics.hbs
@@ -12,7 +12,7 @@
 [TIP.key]
 ====
 * The [.edition]#x.y.z# badge shows the Couchbase Server version the metric was added in.
-* The [.status]#type / unit# badge shows shows the Prometheus
+* The [.status]#type / unit# badge shows the Prometheus
 https://prometheus.io/docs/tutorials/understanding_metric_types/[type] and 
 https://prometheus.io/docs/practices/naming/#base-units[unit] (if present).
 ====


### PR DESCRIPTION

Additional details for index cache hits and misses.

Minor fix for the template.

Preview URL:
https://preview.docs-test.couchbase.com/docs-server-DOC-12408/release/8.0/Feedback-on-Index-Service-Metrics-/server/current/metrics-reference/index-service-metrics.html

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.