### PR TITLE
[DOC-12894]: Feedback on set flush_param | Couchbase Docs

### DIFF
--- a/modules/cli/pages/cbepctl/set-flush_param.adoc
+++ b/modules/cli/pages/cbepctl/set-flush_param.adoc
@@ -36,9 +36,8 @@ Parameters used for changing ejection thresholds:
 
 * `mem_low_wat`
 * `mem_high_wat`
-* `pager_active_vb_pcnt`
 
-The syntax to set the out of memory threshold is:
+The syntax to set the out-of-memory threshold is:
 
 ----
 cbepctl [host]:11210 -b [bucket-name] -u [administrator-name] -p [administrator-password] set flush_param mutation_mem_threshold [value]
@@ -77,12 +76,12 @@ By default, this maintenance process runs every 10 minutes, but it can be config
 +
 NOTE: The compaction process will also remove expired items.
 
-mem_low_wat, mem_high_wat, pager_active_vb_pcnt::
+mem_low_wat, mem_high_wat::
 xref:learn:buckets-memory-and-storage/memory.adoc#ejection[Ejection] means that documents are removed from RAM but the key and metadata remain.
 If the amount of RAM used by items reaches the high water mark (upper threshold), both active and replica data are ejected until the memory usage (amount of RAM consumed) reaches the low water mark (lower threshold).
 The server determines that items are not recently used based on a not-recently-used (NRU) value.
 +
-Use the `mem_low_wat`, `mem_high_wat`, and `pager_active_vb_pcnt` settings to change the server thresholds for ejection.
+Use the `mem_low_wat` and `mem_high_wat` settings to change the server thresholds for ejection.
 +
 WARNING: Do not change the ejection defaults unless required by Couchbase Support.
 
@@ -124,9 +123,6 @@ Setting this value to `0` will disable the Expiry Pager from running.
 | `flushall_enabled`
 | Deprecated.
 Enable flush operation.
-
-| `pager_active_vb_pcnt`
-| Percentage of active vBuckets items among all ejected items by item pager.
 
 | `max_size`
 | Maximum memory used by the server.
@@ -275,25 +271,9 @@ cbepctl 10.5.2.117:11210 -b foo-bucket -u Administrator -p password \
 set flush_param mem_high_wat 80%
 ----
 
-*Examples for setting percentage of ejected items*
 
-Based on the NRU algorithm, the server ejects active and replica data from a node.
-By default, the server is configured to 60% active items and 40% replica data from a node.
 
-The following example increases the percentage of active items that can be ejected from a node to 50%.
-
-----
-cbepctl 10.5.2.117:11210 -b foo-bucket -u Administrator -p password \
-set flush_param pager_active_vb_pcnt 50
-----
-
-Be aware of potential performance implications when changing the percentage of ejected items.
-It may be more desirable to eject as many replica items as possible and limit the amount of active data that can be ejected.
-By doing so, active data from a source node is maximized while maintaining incoming requests to that node.
-However, if the server is ejecting a very large percentage of replica data and a node fails, the replica data is not immediately available.
-In this case, the items are retrieved from disk and put back into RAM before the request is fulfilled.
-
-The following example response shows the low water mark, high water mark, and percentage of ejected items being set.
+The following example response shows the low water mark and high water mark of ejected items being set.
 
 ----
 setting param: mem_low_wat 70
@@ -301,7 +281,4 @@ set mem_low_wat to 70
 
 setting param: mem_high_wat 80
 set mem_high_wat to 80
-
-setting param: pager_active_vb_pcnt 50
-set pager_active_vb_pcnt to 50
 ----


### PR DESCRIPTION

Removing references to `pager_active_vb_pcnt`

Preview URL:
https://preview.docs-test.couchbase.com/docs-server-DOC-12894/release/7.6/Feedback-on-set-flush_param--Couchbase-Docs/server/current/cli/cbepctl-intro.html

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.
