### PR TITLE
[DOC-12894]: Feedback on set flush_param | Couchbase Docs

### DIFF
--- a/modules/cli/pages/cbepctl/set-flush_param.adoc
+++ b/modules/cli/pages/cbepctl/set-flush_param.adoc
@@ -26,11 +26,8 @@ The syntax for ejection is:
 cbepctl [host]:11210 -b [bucket-name] -u [administrator-name] -p [administrator-password] set flush_param [parameter] [value]
 ----
 
-Parameter used for changing ejection thresholds:
 
-* `pager_active_vb_pcnt`
-
-The syntax to set the out of memory threshold is:
+The syntax to set the out-of-memory threshold is:
 
 ----
 cbepctl [host]:11210 -b [bucket-name] -u [administrator-name] -p [administrator-password] set flush_param mutation_mem_threshold [value]
@@ -69,13 +66,6 @@ The scanner is highly CPU-intensive: therefore, to reduce the cluster-wide impac
 Note also that if the scanner runs at the same time that index updates are being made (either on the current node, or on one or more other nodes) by the Index Service, the performance of the index updates may be adversely affected.
 The scanner should be configured to minimize the likelihood of this problem.
 
-pager_active_vb_pcnt::
-xref:learn:buckets-memory-and-storage/memory.adoc#ejection[Ejection] means that documents are removed from RAM but the key and metadata remain.
-+
-Use `pager_active_vb_pcnt` settings to change the server thresholds for ejection.
-+
-WARNING: Do not change the ejection defaults unless required by Couchbase Support.
-
 mutation_mem_threshold::
 By default, Couchbase Server sends clients a temporary out-of-memory error message if RAM is 95% consumed and only 5% RAM remains for overhead.
 Use the `cbepctl set flush_param mutation_mem-threshold` command parameter to change this threshold value.
@@ -109,9 +99,6 @@ The following are the command options:
 | `flushall_enabled`
 | Deprecated.
 Enable flush operation.
-
-| `pager_active_vb_pcnt`
-| Percentage of active vBuckets items among all ejected items by item pager.
 
 | `max_size`
 | Maximum memory used by the server.
@@ -205,29 +192,4 @@ The following example response shows the RAM threshold set to 65%.
 ----
 setting param: mutation_mem_threshold 65
 set mutation_mem_threshold to 65
-----
-
-*Examples for setting percentage of ejected items*
-
-Based on the NRU algorithm, the server ejects active and replica data from a node.
-By default, the server is configured to 60% active items and 40% replica data from a node.
-
-The following example increases the percentage of active items that can be ejected from a node to 50%.
-
-----
-cbepctl 10.5.2.117:11210 -b foo-bucket -u Administrator -p password \
-set flush_param pager_active_vb_pcnt 50
-----
-
-Be aware of potential performance implications when changing the percentage of ejected items.
-It may be more desirable to eject as many replica items as possible and limit the amount of active data that can be ejected.
-By doing so, active data from a source node is maximized while maintaining incoming requests to that node.
-However, if the server is ejecting a very large percentage of replica data and a node fails, the replica data is not immediately available.
-In this case, the items are retrieved from disk and put back into RAM before the request is fulfilled.
-
-The following example response shows the percentage of ejected items being set.
-
-----
-setting param: pager_active_vb_pcnt 50
-set pager_active_vb_pcnt to 50
 ----


### PR DESCRIPTION
Removed reference to `pager_active_vb_pcnt`

Preview URL:
https://preview.docs-test.couchbase.com/docs-server-DOC-12894/release/8.0/Feedback-on-set-flush_param--Couchbase-Docs/server/current/cli/cbepctl/set-flush_param.html


You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.

