### PR TITLE
DOC-11021  starter kits

### DIFF
--- a/modules/getting-started/pages/starter-kits.adoc
+++ b/modules/getting-started/pages/starter-kits.adoc
@@ -1,7 +1,8 @@
 // Starter Kits for Couchbase Developers
 = Starter Kits
+:page-layout: landing-page-top-level-sdk
 :page-role: tiles
-:url-guides-org: https://github.com/couchbase-guides
+// :page-rank: 70
 :!sectids:
 :description: Starter kits are repositories containing example code to get you started with various development projects.
 
@@ -21,8 +22,415 @@ ifdef::basebackend-html[]
 ++++
 endif::[]
 
-{description}
+= Starter Kits
 
+Couchbase's https://www.couchbase.com/developers/[Developer Site] contains several useful https://developer.couchbase.com/tutorials/[Quickstart Guides].
+These tutorials cover developing for Couchbase, using Couchbase SDKs, within the context of a wider software ecosystem -- such as developing with the Java SDK, using Spring Data.
+
+Go to the https://developer.couchbase.com/tutorials/[Developer Quickstart Guides] or the 
+https://github.com/couchbase-examples[GitHub repo] for a full listing.
+Here we list some of the more popular tutorials.
+
+
+
+{empty} +
+
+
+== Server SDKs
+
+
+++++
+<div class="card-row three-column-row">
+++++
+
+[.column]
+====== {empty}
+.ASP.NET & EFCore
+
+[.content]
+A sample ASP.NET app using Couchbase and EF Core to demonstrate CRUD operations and basic queries with sample data models.
+[]
+https://github.com/couchbase-examples/aspnet-efcore-quickstart[ASP.NET & EFCore]
+
+
+
+[.column]
+====== {empty}
+.{cpp} Quickstart
+
+[.content]
+Entry level Couchbase demo/tutorial with {cpp}.
+[]
+https://github.com/couchbase-examples/cxx-quickstart[{cpp} Quickstart]
+
+
+
+[.column]
+====== {empty}
+.Golang & Gin Gonic
+
+[.content]
+Entry level Couchbase Golang Gin Gonic tutorial/demo.
+This repo is designed to teach you how to connect to a Couchbase Capella cluster to create, read, update, and delete documents using Key Value operations
+and how to write simple parametrized SQL++ queries using the built-in travel-sample bucket. 
+[]
+https://github.com/couchbase-examples/golang-quickstart[Golang & Gin Gonic]
+
+
++++
+</div>
++++
+
+
+
+
+{empty} +
+
+
+{empty} +
+
+
+++++
+<div class="card-row three-column-row">
+++++
+
+
+[.column]
+====== {empty}
+.Java Transactions
+
+[.content]
+A Spring Boot application that illustrates using Couchbase transactions with the Java SDK.
+[]
+https://github.com/couchbase-examples/java-transactions-quickstart[Java Transactions]
+
+
+
+[.column]
+====== {empty}
+.Node.js & Ottoman
+
+[.content]
+Entry level Couchbase Ottoman and NodeJS tutorial/demo.
+Steps to build a REST API to manage user profile CRUD operations in Couchbase Server.
+[]
+https://github.com/couchbase-examples/ottomanjs-quickstart[Node.js & Ottoman]
+
+
+// https://github.com/couchbase-examples/couchbase-flask-realworld-example-app[]
+
+
+[.column]
+====== {empty}
+.PHP & Laravel
+
+[.content]
+Quickstart in Couchbase with PHP using Laravel.
+This repo is designed to teach you how to connect to a Couchbase Capella cluster to create, read, update, and delete documents using Key Value operations
+and how to write simple parametrized SQL++ queries using the built-in travel-sample bucket. 
+[]
+https://github.com/couchbase-examples/php-laravel-quickstart[PHP & Laravel]
+
+
++++
+</div>
++++
+
+
+
+
+{empty} +
+
+
+{empty} +
+
+
+++++
+<div class="card-row three-column-row">
+++++
+
+
+
+[.column]
+====== {empty}
+.Python & Jupyter Labs
+
+[.content]
+A series of labs created to start using Couchbase with the Python SDK.
+[]
+https://github.com/couchbase-examples/couchbase-jupyter-labs[Python & Jupyter Labs]
+
+
+
+[.column]
+====== {empty}
+.Build a REST API with Ruby Couchbase ORM
+
+[.content]
+A starter project in Ruby on Rails to generate a REST API performing Create, Read, Update, and Delete (CRUD) operations for the Couchbase database.
+[]
+https://github.com/couchbase-examples/ruby-couchbase-orm-quickstart[Ruby Couchbase ORM]
+
+
+
+[.column]
+====== {empty}
+.Scala Quickstart
+
+[.content]
+Entry level Couchbase Scala tutorial/demo.
+Steps to build REST APIs to manage user profile CRUD operations.
+[]
+https://github.com/couchbase-examples/scala-quickstart[Scala Quickstart]
+
+
++++
+</div>
++++
+
+
+
+
+{empty} +
+
+
+
+{empty} +
+
+
+
+
+== Mobile & Edge
+
+
+++++
+<div class="card-row three-column-row">
+++++
+
+
+
+[.column]
+====== {empty}
+.Android & Java
+
+[.content]
+Quickstart in Couchbase Lite using a standalone database with Android and Java.
+This tutorial will show you how to use Query Builder to do queries in the database and how to use a pre-built database in your applications.
+[]
+https://github.com/couchbase-examples/android-java-cblite-userprofile-query[Android & Java]
+
+
+
+
+
+
+
+[.column]
+====== {empty}
+.Android & Kotlin
+
+[.content]
+Learn Couchbase Lite SDK with Kotlin and `JetPack Compose` for Android Developers.
+[]
+https://github.com/couchbase-examples/android-kotlin-cbl-learning-path[Android & Kotlin]
+
+
+
+
+
+
+[.column]
+====== {empty}
+.Dart & Flutter
+
+[.content]
+An Android and iOS Application that uses the community-supported Couchbase Lite SDK for Dart and Flutter. 
+You will learn how to get and insert documents using the key-value engine, and query the database using the `QueryBuilder` engine or {sqlpp}.
+Learn how to sync information between your mobile app and a Couchbase Server using Sync Gateway -- or using peer-to-peer technology.
+[]
+https://github.com/couchbase-examples/flutter_cbl_learning_path[Dart and Flutter]
+
+
+
+
+
++++
+</div>
++++
+
+
+
+
+{empty} +
+
+
+{empty} +
+
+
+++++
+<div class="card-row three-column-row">
+++++
+
+
+
+
+
+[.column]
+====== {empty}
+.Edge Server & TypeScript
+
+[.content]
+The sample React-based web application simulates an airline seat back application, that allows users in business and economy class to place their in-flight meal orders.
+The sample app leverages Couchbase Edge Server for data storage and processing at the edge, simulating a disconnected offline experience within an aircraft.
+The seatback web app accesses Edge Server via a RESTful interface.
+When there is Internet connectivity, the Edge Server syncs data with remote Capella App Services.
+
+https://github.com/couchbase-examples/edge-server-meal-order-sample-app[Edge Server & TypeScript]
+
+
+
+
+[.column]
+====== {empty}
+.iOS Swift P2P Quickstart
+
+[.content]
+This quick-start app demonstrates how to use Couchbase Lite Swift to load a prebuilt database, create and update documents, and query documents.
+It also shows how to set up peer-to-peer replication using the Multipeer Replicator, which leverages DNS-SD (Bonjour) for automatic peer discovery over Wi-Fi, enabling synchronization between nearby devices without requiring a centralized server.
+[]
+https://github.com/couchbase-examples/ios-swift-quickstart-p2p[iOS Swift P2P Quickstart]
+
+
+[.column]
+====== {empty}
+.React Native
+
+[.content]
+Expo-based React Native app that uses `cbl-reactnative` and the Travel Sample bucket dataset with the hotels and landmark collections.
+
+https://github.com/couchbase-examples/expo-cbl-travel[]
+
+
++++
+</div>
++++
+
+{empty} +
+
+{empty} +
+
+
+
+
+
+== Agentic Apps, LLM, & RAG
+
+++++
+<div class="card-row four-column-row">
+++++
+
+
+[.column]
+====== {empty}
+.Agent Catalog Quickstart
+
+[.content]
+This repository provides a quickstart guide for using the Agent Catalog with Capella Model Services and Couchbase.
+[]
+https://github.com/couchbase-examples/agent-catalog-quickstart[Agent Catalog Quickstart]
+
+
+
+[.column]
+====== {empty}
+.Chatbot Demo
+
+[.content]
+Q&A Chatbot Demo using Couchbase, `LangChain`, `OpenAI`, and `Streamlit`.
+[]
+https://github.com/couchbase-examples/qa-bot-demo[Chatbot Demo]
+
+
+
+[.column]
+====== {empty}
+.Llamaindex RAG Demo
+
+[.content]
+A RAG demo using `LlamaIndex` that allows you to chat with your uploaded PDF documents.
+[]
+https://github.com/couchbase-examples/rag-demo-llama-index[Llamaindex RAG Demo]
+
+
+
+[.column]
+====== {empty}
+.Spring AI & COuchbase Victor Store
+
+[.content]
+A simple Spring Boot application to demonstrate the usage of Couchbase Vector Store with Spring AI.
+[]
+https://github.com/couchbase-examples/couchbase-spring-ai-demo[Spring AI & COuchbase Victor Store]
+
+
++++
+</div>
++++
+
+{empty} +
+
+{empty} +
+
+
+
+
+
+////
+
+== Other
+
+
+
+++++
+<div class="card-row three-column-row">
+++++
+
+
+Demo to search hotels by city using an AWS AppSync GraphQL API backed by Couchbase Data API, with a Streamlit frontend for visualization.
+
+https://github.com/couchbase-examples/couchbase-data-api-serverless-cookbook[]
+
+
+
+
++++
+</div>
++++
+
+{empty} +
+
+////
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+////
 == Couchbase Server in Docker
 
 Start a Couchbase Server Docker Container and connect to the server using the Couchbase CLI.
@@ -88,3 +496,4 @@ Learn how to restore backups to Couchbase Server.
 Use these guidelines to build your own guide using AsciiDoc and push it to the couchbase-guides Github repository.
 
 {url-guides-org}/how-to-write-a-guide[Learn more]
+////

--- a/modules/getting-started/pages/starter-kits.adoc
+++ b/modules/getting-started/pages/starter-kits.adoc
@@ -32,8 +32,8 @@ https://github.com/couchbase-examples[GitHub repo] for a full listing.
 Here we list some of the more popular tutorials.
 
 
-
-{empty} +
+[.column]
+====== {empty}
 
 
 == Server SDKs
@@ -52,7 +52,6 @@ A sample ASP.NET app using Couchbase and EF Core to demonstrate CRUD operations 
 []
 https://github.com/couchbase-examples/aspnet-efcore-quickstart[ASP.NET & EFCore]
 
-{empty} +
 
 
 [.column]
@@ -64,7 +63,6 @@ Entry level Couchbase demo/tutorial with {cpp}.
 []
 https://github.com/couchbase-examples/cxx-quickstart[{cpp} Quickstart]
 
-{empty} +
 
 
 [.column]
@@ -78,14 +76,10 @@ and how to write simple parametrized SQL++ queries using the built-in travel-sam
 []
 https://github.com/couchbase-examples/golang-quickstart[Golang & Gin Gonic]
 
-{empty} +
 
 +++
 </div>
 +++
-
-{empty} +
-
 
 ++++
 <div class="card-row three-column-row">
@@ -102,8 +96,6 @@ A Spring Boot application that illustrates using Couchbase transactions with the
 https://github.com/couchbase-examples/java-transactions-quickstart[Java Transactions]
 
 
-{empty} +
-
 [.column]
 ====== {empty}
 .Node.js & Ottoman
@@ -114,8 +106,6 @@ Steps to build a REST API to manage user profile CRUD operations in Couchbase Se
 []
 https://github.com/couchbase-examples/ottomanjs-quickstart[Node.js & Ottoman]
 
-
-{empty} +
 
 // https://github.com/couchbase-examples/couchbase-flask-realworld-example-app[]
 
@@ -131,14 +121,10 @@ and how to write simple parametrized SQL++ queries using the built-in travel-sam
 []
 https://github.com/couchbase-examples/php-laravel-quickstart[PHP & Laravel]
 
-{empty} +
 
 +++
 </div>
 +++
-
-
-{empty} +
 
 
 ++++
@@ -157,8 +143,6 @@ A series of labs created to start using Couchbase with the Python SDK.
 https://github.com/couchbase-examples/couchbase-jupyter-labs[Python & Jupyter Labs]
 
 
-{empty} +
-
 [.column]
 ====== {empty}
 .Build a REST API with Ruby Couchbase ORM
@@ -168,9 +152,6 @@ A starter project in Ruby on Rails to generate a REST API performing Create, Rea
 []
 https://github.com/couchbase-examples/ruby-couchbase-orm-quickstart[Ruby Couchbase ORM]
 
-
-
-{empty} +
 
 [.column]
 ====== {empty}
@@ -182,27 +163,20 @@ Steps to build REST APIs to manage user profile CRUD operations.
 []
 https://github.com/couchbase-examples/scala-quickstart[Scala Quickstart]
 
-
-{empty} +
-
-
 +++
 </div>
 +++
 
-
-{empty} +
-
+[.column]
+====== {empty}
 
 
 
 == Mobile & Edge
 
-
 ++++
 <div class="card-row three-column-row">
 ++++
-
 
 
 [.column]
@@ -217,12 +191,6 @@ https://github.com/couchbase-examples/android-java-cblite-userprofile-query[Andr
 
 
 
-{empty} +
-
-
-
-
-
 [.column]
 ====== {empty}
 .Android & Kotlin
@@ -231,11 +199,6 @@ https://github.com/couchbase-examples/android-java-cblite-userprofile-query[Andr
 Learn Couchbase Lite SDK with Kotlin and `JetPack Compose` for Android Developers.
 []
 https://github.com/couchbase-examples/android-kotlin-cbl-learning-path[Android & Kotlin]
-
-
-{empty} +
-
-
 
 
 
@@ -251,24 +214,13 @@ Learn how to sync information between your mobile app and a Couchbase Server usi
 https://github.com/couchbase-examples/flutter_cbl_learning_path[Dart and Flutter]
 
 
-
-{empty} +
-
-
-
 +++
 </div>
 +++
 
-{empty} +
-
-
 ++++
 <div class="card-row three-column-row">
 ++++
-
-
-
 
 
 [.column]
@@ -283,7 +235,6 @@ When there is Internet connectivity, the Edge Server syncs data with remote Cape
 
 https://github.com/couchbase-examples/edge-server-meal-order-sample-app[Edge Server & TypeScript]
 
-{empty} +
 
 [.column]
 ====== {empty}
@@ -295,7 +246,6 @@ It also shows how to set up peer-to-peer replication using the Multipeer Replica
 []
 https://github.com/couchbase-examples/ios-swift-quickstart-p2p[iOS Swift P2P Quickstart]
 
-{empty} +
 
 [.column]
 ====== {empty}
@@ -306,17 +256,13 @@ Expo-based React Native app that uses `cbl-reactnative` and the Travel Sample bu
 
 https://github.com/couchbase-examples/expo-cbl-travel[]
 
-{empty} +
-
 
 +++
 </div>
 +++
 
-{empty} +
-
-
-
+[.column]
+====== {empty}
 
 
 
@@ -336,7 +282,6 @@ This repository provides a quickstart guide for using the Agent Catalog with Cap
 []
 https://github.com/couchbase-examples/agent-catalog-quickstart[Agent Catalog Quickstart]
 
-{empty} +
 
 
 [.column]
@@ -348,13 +293,11 @@ Q&A Chatbot Demo using Couchbase, `LangChain`, `OpenAI`, and `Streamlit`.
 []
 https://github.com/couchbase-examples/qa-bot-demo[Chatbot Demo]
 
-{empty} +
 
 +++
 </div>
 +++
 
-{empty} +
 
 ++++
 <div class="card-row two-column-row">
@@ -370,7 +313,6 @@ A RAG demo using `LlamaIndex` that allows you to chat with your uploaded PDF doc
 []
 https://github.com/couchbase-examples/rag-demo-llama-index[Llamaindex RAG Demo]
 
-{empty} +
 
 
 [.column]
@@ -382,13 +324,11 @@ A simple Spring Boot application to demonstrate the usage of Couchbase Vector St
 []
 https://github.com/couchbase-examples/couchbase-spring-ai-demo[Spring AI & Couchbase Victor Store]
 
-{empty} +
 
 +++
 </div>
 +++
 
-{empty} +
 
 
 
@@ -415,7 +355,6 @@ https://github.com/couchbase-examples/couchbase-data-api-serverless-cookbook[]
 </div>
 +++
 
-{empty} +
 
 ////
 

--- a/modules/getting-started/pages/starter-kits.adoc
+++ b/modules/getting-started/pages/starter-kits.adoc
@@ -52,6 +52,7 @@ A sample ASP.NET app using Couchbase and EF Core to demonstrate CRUD operations 
 []
 https://github.com/couchbase-examples/aspnet-efcore-quickstart[ASP.NET & EFCore]
 
+{empty} +
 
 
 [.column]
@@ -63,6 +64,7 @@ Entry level Couchbase demo/tutorial with {cpp}.
 []
 https://github.com/couchbase-examples/cxx-quickstart[{cpp} Quickstart]
 
+{empty} +
 
 
 [.column]
@@ -76,16 +78,11 @@ and how to write simple parametrized SQL++ queries using the built-in travel-sam
 []
 https://github.com/couchbase-examples/golang-quickstart[Golang & Gin Gonic]
 
+{empty} +
 
 +++
 </div>
 +++
-
-
-
-
-{empty} +
-
 
 {empty} +
 
@@ -105,6 +102,7 @@ A Spring Boot application that illustrates using Couchbase transactions with the
 https://github.com/couchbase-examples/java-transactions-quickstart[Java Transactions]
 
 
+{empty} +
 
 [.column]
 ====== {empty}
@@ -116,6 +114,8 @@ Steps to build a REST API to manage user profile CRUD operations in Couchbase Se
 []
 https://github.com/couchbase-examples/ottomanjs-quickstart[Node.js & Ottoman]
 
+
+{empty} +
 
 // https://github.com/couchbase-examples/couchbase-flask-realworld-example-app[]
 
@@ -131,15 +131,11 @@ and how to write simple parametrized SQL++ queries using the built-in travel-sam
 []
 https://github.com/couchbase-examples/php-laravel-quickstart[PHP & Laravel]
 
+{empty} +
 
 +++
 </div>
 +++
-
-
-
-
-{empty} +
 
 
 {empty} +
@@ -161,6 +157,7 @@ A series of labs created to start using Couchbase with the Python SDK.
 https://github.com/couchbase-examples/couchbase-jupyter-labs[Python & Jupyter Labs]
 
 
+{empty} +
 
 [.column]
 ====== {empty}
@@ -173,6 +170,8 @@ https://github.com/couchbase-examples/ruby-couchbase-orm-quickstart[Ruby Couchba
 
 
 
+{empty} +
+
 [.column]
 ====== {empty}
 .Scala Quickstart
@@ -184,15 +183,12 @@ Steps to build REST APIs to manage user profile CRUD operations.
 https://github.com/couchbase-examples/scala-quickstart[Scala Quickstart]
 
 
+{empty} +
+
+
 +++
 </div>
 +++
-
-
-
-
-{empty} +
-
 
 
 {empty} +
@@ -221,6 +217,8 @@ https://github.com/couchbase-examples/android-java-cblite-userprofile-query[Andr
 
 
 
+{empty} +
+
 
 
 
@@ -234,6 +232,8 @@ Learn Couchbase Lite SDK with Kotlin and `JetPack Compose` for Android Developer
 []
 https://github.com/couchbase-examples/android-kotlin-cbl-learning-path[Android & Kotlin]
 
+
+{empty} +
 
 
 
@@ -252,17 +252,13 @@ https://github.com/couchbase-examples/flutter_cbl_learning_path[Dart and Flutter
 
 
 
+{empty} +
+
 
 
 +++
 </div>
 +++
-
-
-
-
-{empty} +
-
 
 {empty} +
 
@@ -287,8 +283,7 @@ When there is Internet connectivity, the Edge Server syncs data with remote Cape
 
 https://github.com/couchbase-examples/edge-server-meal-order-sample-app[Edge Server & TypeScript]
 
-
-
+{empty} +
 
 [.column]
 ====== {empty}
@@ -300,6 +295,7 @@ It also shows how to set up peer-to-peer replication using the Multipeer Replica
 []
 https://github.com/couchbase-examples/ios-swift-quickstart-p2p[iOS Swift P2P Quickstart]
 
+{empty} +
 
 [.column]
 ====== {empty}
@@ -310,6 +306,8 @@ Expo-based React Native app that uses `cbl-reactnative` and the Travel Sample bu
 
 https://github.com/couchbase-examples/expo-cbl-travel[]
 
+{empty} +
+
 
 +++
 </div>
@@ -317,7 +315,6 @@ https://github.com/couchbase-examples/expo-cbl-travel[]
 
 {empty} +
 
-{empty} +
 
 
 
@@ -326,7 +323,7 @@ https://github.com/couchbase-examples/expo-cbl-travel[]
 == Agentic Apps, LLM, & RAG
 
 ++++
-<div class="card-row four-column-row">
+<div class="card-row two-column-row">
 ++++
 
 
@@ -339,6 +336,7 @@ This repository provides a quickstart guide for using the Agent Catalog with Cap
 []
 https://github.com/couchbase-examples/agent-catalog-quickstart[Agent Catalog Quickstart]
 
+{empty} +
 
 
 [.column]
@@ -350,6 +348,17 @@ Q&A Chatbot Demo using Couchbase, `LangChain`, `OpenAI`, and `Streamlit`.
 []
 https://github.com/couchbase-examples/qa-bot-demo[Chatbot Demo]
 
+{empty} +
+
++++
+</div>
++++
+
+{empty} +
+
+++++
+<div class="card-row two-column-row">
+++++
 
 
 [.column]
@@ -361,6 +370,7 @@ A RAG demo using `LlamaIndex` that allows you to chat with your uploaded PDF doc
 []
 https://github.com/couchbase-examples/rag-demo-llama-index[Llamaindex RAG Demo]
 
+{empty} +
 
 
 [.column]
@@ -372,15 +382,13 @@ A simple Spring Boot application to demonstrate the usage of Couchbase Vector St
 []
 https://github.com/couchbase-examples/couchbase-spring-ai-demo[Spring AI & Couchbase Victor Store]
 
+{empty} +
 
 +++
 </div>
 +++
 
 {empty} +
-
-{empty} +
-
 
 
 
@@ -412,88 +420,3 @@ https://github.com/couchbase-examples/couchbase-data-api-serverless-cookbook[]
 ////
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-////
-== Couchbase Server in Docker
-
-Start a Couchbase Server Docker Container and connect to the server using the Couchbase CLI.
-
-{url-guides-org}/couchbase-docker[Learn more]
-
-== Couchbase Server on Amazon EC2
-
-Start an EC2 instance and connect to the server using the Couchbase CLI.
-
-{url-guides-org}/couchbase-amazon-cli[Learn more]
-
-== Couchbase Server with ASP.NET Core
-
-Create a "`hello world`" ASP.NET Core web application that uses Couchbase Server as the backend database.
-
-{url-guides-org}/asp-net-core-mvc[Learn more]
-
-== Couchbase with Java SDK
-
-Create a Java application that uses Couchbase Server as the backend to store a JSON document.
-
-{url-guides-org}/java-sdk[Learn more]
-
-== Couchbase with Node.js using Express Framework
-
-Create a "`hello world`" Node.js web application that uses Couchbase Server as the backend database.
-
-{url-guides-org}/nodejs-express[Learn more]
-
-== Couchbase with NativeScript using Angular
-
-Create a "`hello world`" NativeScript mobile application that uses Couchbase Server, NativeScript, and Angular.
-
-{url-guides-org}/nativescript-angular[Learn more]
-
-== Couchbase with Python SDK
-
-Create a simple Python application to store and retrieve a JSON document in Couchbase Server.
-
-{url-guides-org}/python-sdk[Learn more]
-
-== Couchbase Lite (CBL) on Android
-
-Build an Android application consisting of a single activity that performs CRUD operations and uses Couchbase Lite to store documents locally on the device.
-
-{url-guides-org}/java-android[Learn more]
-
-== Couchbase Backup
-
-Learn how to create backups from Couchbase Server.
-
-{url-guides-org}/couchbase-backup[Learn more]
-
-== Couchbase Restore
-
-Learn how to restore backups to Couchbase Server.
-
-{url-guides-org}/couchbase-restore[Learn more]
-
-== Write Your Own Starter Kit
-
-Use these guidelines to build your own guide using AsciiDoc and push it to the couchbase-guides Github repository.
-
-{url-guides-org}/how-to-write-a-guide[Learn more]
-////

--- a/modules/getting-started/pages/starter-kits.adoc
+++ b/modules/getting-started/pages/starter-kits.adoc
@@ -81,6 +81,8 @@ https://github.com/couchbase-examples/golang-quickstart[Golang & Gin Gonic]
 </div>
 +++
 
+== {empty}
+
 ++++
 <div class="card-row three-column-row">
 ++++
@@ -126,6 +128,7 @@ https://github.com/couchbase-examples/php-laravel-quickstart[PHP & Laravel]
 </div>
 +++
 
+== {empty}
 
 ++++
 <div class="card-row three-column-row">
@@ -218,6 +221,8 @@ https://github.com/couchbase-examples/flutter_cbl_learning_path[Dart and Flutter
 </div>
 +++
 
+== {empty}
+
 ++++
 <div class="card-row three-column-row">
 ++++
@@ -298,6 +303,7 @@ https://github.com/couchbase-examples/qa-bot-demo[Chatbot Demo]
 </div>
 +++
 
+== {empty}
 
 ++++
 <div class="card-row two-column-row">

--- a/modules/getting-started/pages/starter-kits.adoc
+++ b/modules/getting-started/pages/starter-kits.adoc
@@ -365,12 +365,12 @@ https://github.com/couchbase-examples/rag-demo-llama-index[Llamaindex RAG Demo]
 
 [.column]
 ====== {empty}
-.Spring AI & COuchbase Victor Store
+.Spring AI & Couchbase Victor Store
 
 [.content]
 A simple Spring Boot application to demonstrate the usage of Couchbase Vector Store with Spring AI.
 []
-https://github.com/couchbase-examples/couchbase-spring-ai-demo[Spring AI & COuchbase Victor Store]
+https://github.com/couchbase-examples/couchbase-spring-ai-demo[Spring AI & Couchbase Victor Store]
 
 
 +++

--- a/modules/getting-started/pages/starter-kits.adoc
+++ b/modules/getting-started/pages/starter-kits.adoc
@@ -259,7 +259,7 @@ https://github.com/couchbase-examples/ios-swift-quickstart-p2p[iOS Swift P2P Qui
 [.content]
 Expo-based React Native app that uses `cbl-reactnative` and the Travel Sample bucket dataset with the hotels and landmark collections.
 
-https://github.com/couchbase-examples/expo-cbl-travel[]
+https://github.com/couchbase-examples/expo-cbl-travel[React Native Expo Travel Sample App]
 
 
 +++

--- a/modules/getting-started/pages/starter-kits.adoc
+++ b/modules/getting-started/pages/starter-kits.adoc
@@ -27,7 +27,7 @@ endif::[]
 Couchbase's https://www.couchbase.com/developers/[Developer Site] contains several useful https://developer.couchbase.com/tutorials/[Quickstart Guides].
 These tutorials cover developing for Couchbase, using Couchbase SDKs, within the context of a wider software ecosystem -- such as developing with the Java SDK, using Spring Data.
 
-Go to the https://developer.couchbase.com/tutorials/[Developer Quickstart Guides] or the 
+Go to the https://developer.couchbase.com/tutorials/#cb-tutorials-container-header[Developer Tutorials] or the 
 https://github.com/couchbase-examples[GitHub repo] for a full listing.
 Here we list some of the more popular tutorials.
 

--- a/modules/getting-started/pages/starter-kits.adoc
+++ b/modules/getting-started/pages/starter-kits.adoc
@@ -24,7 +24,7 @@ endif::[]
 
 = Starter Kits
 
-Couchbase's https://www.couchbase.com/developers/[Developer Site] contains several useful https://developer.couchbase.com/tutorials/[Quickstart Guides].
+Couchbase's https://www.couchbase.com/developers/[Developer Site] contains several useful https://developer.couchbase.com/tutorials/[Tutorials].
 These tutorials cover developing for Couchbase, using Couchbase SDKs, within the context of a wider software ecosystem -- such as developing with the Java SDK, using Spring Data.
 
 Go to the https://developer.couchbase.com/tutorials/#cb-tutorials-container-header[Developer Tutorials] or the 

--- a/modules/getting-started/pages/starter-kits.adoc
+++ b/modules/getting-started/pages/starter-kits.adoc
@@ -32,6 +32,79 @@ https://github.com/couchbase-examples[GitHub repo] for a full listing.
 Here we list some of the more popular tutorials.
 
 
+
+
+[.column]
+====== {empty}
+
+
+
+== Agentic Apps, LLM, & RAG
+
+++++
+<div class="card-row two-column-row">
+++++
+
+
+[.column]
+====== {empty}
+.Agent Catalog Quickstart
+
+[.content]
+This repository provides a quickstart guide for using the Agent Catalog with Capella Model Services and Couchbase.
+[]
+https://github.com/couchbase-examples/agent-catalog-quickstart[Agent Catalog Quickstart]
+
+
+
+[.column]
+====== {empty}
+.Chatbot Demo
+
+[.content]
+Q&A Chatbot Demo using Couchbase, `LangChain`, `OpenAI`, and `Streamlit`.
+[]
+https://github.com/couchbase-examples/qa-bot-demo[Chatbot Demo]
+
+
++++
+</div>
++++
+
+== {empty}
+
+++++
+<div class="card-row two-column-row">
+++++
+
+
+[.column]
+====== {empty}
+.Llamaindex RAG Demo
+
+[.content]
+A RAG demo using `LlamaIndex` that allows you to chat with your uploaded PDF documents.
+[]
+https://github.com/couchbase-examples/rag-demo-llama-index[Llamaindex RAG Demo]
+
+
+
+[.column]
+====== {empty}
+.Spring AI & Couchbase Victor Store
+
+[.content]
+A simple Spring Boot application to demonstrate the usage of Couchbase Vector Store with Spring AI.
+[]
+https://github.com/couchbase-examples/couchbase-spring-ai-demo[Spring AI & Couchbase Victor Store]
+
+
++++
+</div>
++++
+
+
+
 [.column]
 ====== {empty}
 
@@ -265,76 +338,6 @@ https://github.com/couchbase-examples/expo-cbl-travel[React Native Expo Travel S
 +++
 </div>
 +++
-
-[.column]
-====== {empty}
-
-
-
-== Agentic Apps, LLM, & RAG
-
-++++
-<div class="card-row two-column-row">
-++++
-
-
-[.column]
-====== {empty}
-.Agent Catalog Quickstart
-
-[.content]
-This repository provides a quickstart guide for using the Agent Catalog with Capella Model Services and Couchbase.
-[]
-https://github.com/couchbase-examples/agent-catalog-quickstart[Agent Catalog Quickstart]
-
-
-
-[.column]
-====== {empty}
-.Chatbot Demo
-
-[.content]
-Q&A Chatbot Demo using Couchbase, `LangChain`, `OpenAI`, and `Streamlit`.
-[]
-https://github.com/couchbase-examples/qa-bot-demo[Chatbot Demo]
-
-
-+++
-</div>
-+++
-
-== {empty}
-
-++++
-<div class="card-row two-column-row">
-++++
-
-
-[.column]
-====== {empty}
-.Llamaindex RAG Demo
-
-[.content]
-A RAG demo using `LlamaIndex` that allows you to chat with your uploaded PDF documents.
-[]
-https://github.com/couchbase-examples/rag-demo-llama-index[Llamaindex RAG Demo]
-
-
-
-[.column]
-====== {empty}
-.Spring AI & Couchbase Victor Store
-
-[.content]
-A simple Spring Boot application to demonstrate the usage of Couchbase Vector Store with Spring AI.
-[]
-https://github.com/couchbase-examples/couchbase-spring-ai-demo[Spring AI & Couchbase Victor Store]
-
-
-+++
-</div>
-+++
-
 
 
 


### PR DESCRIPTION
Jira ticket: DOC-11021

https://github.com/couchbase-guides has not been updated in several years - all of the current DEE quickstart guides are now at https://github.com/couchbase-examples

This PR picks a reasonable selection from the many available, and points customers to developer.couchbase.com and to https://github.com/couchbase-examples for the remainder.

You can see the page built at https://preview.docs-test.couchbase.com/ia-dev/server/current/getting-started/starter-kits.html