### PR TITLE
[DOC-12342]: Feedback on set flush_param | Couchbase Docs

### DIFF
--- a/modules/cli/pages/cbepctl/set-flush_param.adoc
+++ b/modules/cli/pages/cbepctl/set-flush_param.adoc
@@ -69,7 +69,7 @@ Note also that if the scanner runs at the same time that index updates are being
 The scanner should be configured to minimize the likelihood of this problem.
 
 exp_pager_stime::
-The `cbepctl flush_param exp_pager_stime` command sets the time interval to scan for expired items and erase them from memory and disk.
+The `cbepctl flush_param exp_pager_stime` command sets the time interval to scan for expired items and erase them from memory.
 Couchbase Server does lazy xref:learn:buckets-memory-and-storage/memory.adoc#expiry-pager[expiration], that is, expired items are flagged as deleted rather than being immediately erased.
 Couchbase Server has a maintenance process that periodically looks through all information and erases expired items.
 By default, this maintenance process runs every 10 minutes, but it can be configured to run at a different interval.
@@ -117,7 +117,7 @@ The following are the command options:
 
 | `exp_pager_stime`
 | Expiry Pager interval.
-Time interval that Couchbase Server waits before it performs cleanup and removal of expired items from disk.
+Time interval that Couchbase Server waits before it performs cleanup and removal of expired items from memory.
 Setting this value to `0` will disable the Expiry Pager from running.
 
 | `flushall_enabled`
@@ -214,10 +214,10 @@ setting param: alog_task_time 23
 set alog_task_time to 23
 ----
 
-*Examples for setting the disk cleanup*
+*Examples for setting the memory cleanup*
 
 The following example sets the cleanup process to run every 600 seconds (10 minutes).
-This is the interval that Couchbase Server waits before it tries to remove expired items from disk.
+This is the interval that Couchbase Server waits before it tries to remove expired items from memory.
 
 ----
 cbepctl 10.5.2.117:11210 -b foo-bucket -u Administrator -p password \


### PR DESCRIPTION

Clarified that `exp_pager_stime` affects memory rather than disk.

Preview URL:
https://preview.docs-test.couchbase.com/docs-server-DOC-12342/release/7.6/Feedback-on-set-flush_param--Couchbase-Docs/server/current/cli/cbepctl/set-flush_param.html

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.