### PR TITLE
[DOC-13414]: Change alog_sleep_time example value

### DIFF
--- a/modules/cli/pages/cbepctl/set-flush_param.adoc
+++ b/modules/cli/pages/cbepctl/set-flush_param.adoc
@@ -67,6 +67,9 @@ By default, the access scanner runs once every 24 hours at 10:00 AM GMT.
 The scanner is highly CPU-intensive: therefore, to reduce the cluster-wide impact of running this task, its start time should be staggered to a different value on each node in the cluster.
 Note also that if the scanner runs at the same time that index updates are being made (either on the current node, or on one or more other nodes) by the Index Service, the performance of the index updates may be adversely affected.
 The scanner should be configured to minimize the likelihood of this problem.
++
+NOTE: The access scanner always scans the entire key table,
+so increasing the frequency of the scans will not decrease the amount of work the scanner is doing.
 
 exp_pager_stime::
 The `cbepctl flush_param exp_pager_stime` command sets the time interval to scan for expired items and erase them from memory.
@@ -186,11 +189,11 @@ NOTE: *%* You must use the percentage sign in order to set the value by percenta
 
 *Examples for setting the access scanner process*
 
-To change the time interval when the access scanner process runs to every 20 minutes.
+To change the time interval when the access scanner process runs to every 2880 minutes (2 days).
 
 ----
 cbepctl 10.5.2.117:11210 -b foo-bucket -u Administrator -p password \
-set flush_param alog_sleep_time 20
+set flush_param alog_sleep_time 2880
 ----
 
 To change the initial time that the access scanner process runs from the 2:00 AM UTC default to 11:00 PM UTC.


### PR DESCRIPTION

Added note explaining the scanner always scans the entire key table, so increasing the frequency of the scan will not decrease the amount of work it is doing.

Changed example `alog_sleep_time` to 2880 minutes, which is a more realistic example.