### PR TITLE
[DOC-13146]: Backup encryption using Backup Service

### DIFF
--- a/modules/manage/pages/manage-backup-and-restore/manage-backup-and-restore.adoc
+++ b/modules/manage/pages/manage-backup-and-restore/manage-backup-and-restore.adoc
@@ -68,17 +68,11 @@ On Linux, therefore, for a filesystem location, use the `chgrp` command to set t
 
 To access the Backup Service UI, proceed as follows:
 
-. On Couchbase Web Console, click the *Backup* tab, in the vertical navigation bar:
-+
-image::manage-backup-restore/accessBackupTab.png[,100,align=left]
-+
-This brings up the *Backup* screen.
-The initial appearance is as follows:
-+
-image::manage-backup-restore/backupScreenInitial.png[,720,align=left]
+. On Couchbase Web Console, click the *Backup* tab, in the vertical navigation bar to invoke the *Backup* screen.
+
 +
 The *Backup* screen features two tabs, located on the upper, horizontal navigation bar: these are *Repositories* and *Plans*.
-By default, the *Repositories* tab is selected: the corresponding, *Repositories* view features three panels, for *Active*, *Imported*, and *Archived* repositories respectively.
+By default, the *Repositories* tab is selected: the corresponding *Repositories* view features three panels, for *Active*, *Imported*, and *Archived* repositories respectively.
 Currently, all panels are blank.
 
 [#schedule-backups]
@@ -86,8 +80,8 @@ Currently, all panels are blank.
 
 The Backup Service allows backups (and merges) to be scheduled, as _tasks_.
 This section describes how task-definition and scheduling can be accomplished.
-For any given repository, the Backup Service performs one task at a time; with each task maintaining a lock on the repository.
-Therefore, the administrator-defined interval between tasks should always be sufficient to allow each task to run to completion.
+For any given repository, the Backup Service performs one task at a time, with each task maintaining a lock on the repository.
+Therefore, the administrator-defined interval between tasks should always be enough to allow each task to run to completion.
 If a new task is scheduled to start while a previously started task is still running, the new task cannot run.
 For information, see xref:learn:services-and-indexes/services/backup-service.adoc#avoiding-task-overlap[Avoiding Task Overlap].
 
@@ -97,13 +91,9 @@ To schedule one or more backups, proceed as follows:
 When fully defined, the repository will combine the definitions of one or more backup and related activities, scheduled for one or more buckets, targeted at a storage location accessible to all nodes on the cluster.
 Each repository must have a name unique among repositories on the cluster.
 +
-To add a repository, click the *ADD REPOSITORY* tab, at the upper right of the screen:
+To add a repository, click the *ADD REPOSITORY* tab, at the upper right of the screen.
+This opens the *Select Plan* dialog.
 +
-image::manage-backup-restore/addRepositoryTab.png[,140,align=left]
-+
-This opens the *Select Plan* dialog which initially appears as follows:
-+
-image::manage-backup-restore/selectPlanDialog.png[,420,align=left]
 
 . Specify whether to use a default or a custom plan.
 A _plan_ determines what kind of backup is to occur, affecting what data, and on what schedule.
@@ -113,43 +103,40 @@ The *&#95;hourly_backups* plan appears as the default selection.
 (For more information, see xref:manage:manage-backup-and-restore/manage-backup-and-restore.adoc#default-plans[Default Plans], below.)
 +
 Click the control that appears at the right-hand side of the *Select plan* dialog's interactive text-field.
-A pull-down menu appears, as follows:
+A pull-down menu appears with the following options:
 +
-image::manage-backup-restore/selectPlanDialogPullDownMenuInitial.png[,420,align=left]
+--
+* *&#95;daily_backups*
+* *&#95;hourly_backups*
+* *&#95;daily_full_backups_with_incrementals*
+* *&#95;weekly_full_backups_with_incrementals*
+--
 +
-The options are *&#95;daily_backups*, *&#95;hourly_backups*, *&#95;daily_full_backups_with_incrementals*, and *&#95;weekly_full_backups_with_incrementals*.
-Another option is *+ Create new plan*. In this illustration, select *+ Create new plan*.
+Along with an additional option to create a new plan.
 +
-image::manage-backup-restore/selectPlanDialogPullDownMenuSelection.png[,420,align=left]
+Select [.ui]*{plus}Create new plan.*
 +
-This establishes the string *+ Create new plan* within the interactive text field; and modifies the *Select Plan* dialog to appear as follows:
-+
-image::manage-backup-restore/selectPlanDialog2.png[,420,align=left]
+This establishes the string [.ui]*{plus} Create new plan* within the interactive text field; and modifies the *Select Plan* dialog to create a new plan.
+
 
 . Create a custom plan.
 In the *Name* field of the *Select Plan* dialog, enter a name for the plan that's to be created.
 The name must be unique across the cluster, can only use the characters `[`, `]`, `A` to `Z`, `a` to `z`, `&#95;` and `-`; and must not start with either `&#95;` or `-`.
 +
-Then, optionally, add a description for the plan in the *Description* field: the description can be up to 140 characters in length.
-For example, to specify a plan for hourly backups, the following might be entered:
-+
-image::manage-backup-restore/createPlanDialogWithInitialInput.png[,420,align=left]
+Then, optionally, add a description for the plan in the [.ui]*Description* field.
 +
 Next, specify the services for which data will be backed up.
 Click *Services* to display the list of Couchbase Services.
 +
-image::manage-backup-restore/createPlanServicesListInitial.png[,90,align=left]
-+
 To specify that only data for the Data and Index Services should be backed up, clear the boxes for all the other services.
 +
 Next, to specify precise details of what should occur when the backup is run, click the *Add Task* control.
-The dialog now expands, to reveal the following fields:
+The dialog now expands to reveal the task options.
 +
-image::manage-backup-restore/createPlanDialogAddTaskFields.png[,420,align=left]
-+
+
 The fields permit the input of data to specify the details of a particular task.
-The dialog permits multiple tasks to be added by click the *Add Task* control.
-It also allows you to remove tasks by click the *Remove Task* control.
+The dialog permits multiple tasks to be added by clicking the [.ui]*Add Task* control.
+It also allows you to remove tasks by clicking the [.ui]*Remove Task* control.
 +
 In the *Name* field, enter an appropriate name for the task: for example, *hourlyBackup*.
 +
@@ -172,8 +159,6 @@ To make sure that the hourly task is performed on the hour, leave these numbers 
 In the *Type* field, specify the task to be performed, by accessing the control at the right-hand side of the field.
 This displays the following pull-down menu:
 +
-image::manage-backup-restore/typePullDownMenu.png[,420,align=left]
-+
 Select *Backup*, from the pull-down menu.
 Then, in the *Frequency* field, specify the frequency with which the task should be performed.
 The field only accepts integers: these must be between 1 and 200 inclusive.
@@ -183,18 +168,12 @@ See xref:manage:manage-backup-and-restore/manage-backup-and-restore.adoc#review-
 +
 To complete specification of the task, determine whether the backup to be performed is *Full* or *Incremental*.
 If it's to be *Full*, select *Full Backup*.
-If it's to be *Incremental* (as should be the case in the current example), leave *Full Backup* cleared*.
+If it's to be *Incremental* (as should be the case in the current example), leave *Full Backup* cleared.
 +
-The dialog now appears as follows:
-+
-image::manage-backup-restore/taskPanelComplete.png[,420,align=left]
-+
-At this stage, if another task is to be specified, the *Add Task* control should be clicked on: this expands the dialog further, and provides another set of task-specification fields.
+At this stage, if another task is to be specified, the [ui.]*Add Task* control should be clicked on: this expands the dialog further, and provides another set of task-specification fields.
 If the task already added is to be removed, left-click on the *Cancel* button: this discards the data that has been added for the task, and closes the task-panel.
 If the specification of the plan is to be abandoned, left-click on the *Cancel* tab, at the lower right.
 If the specification for the task is to be retained and used, and no other task is to be specified (as is the case in the current example), left-click on the *Next* button:
-+
-image::manage-backup-restore/nextButton.png[,130,align=left]
 +
 This brings up the *Create Repository* dialog, which appears as follows:
 +
@@ -241,27 +220,20 @@ You can use *Encryption Options* to encrypt the backup data.
 +
 To encrypt the backup data, select *Encrypted*.
 +
+--
 ** *KM Key URL* is the URL path to the key in the external key manager.
 The prefix defines what key manager system to use from awskms, gcpkms, azurekeyvault, hashivault, or hashivaults.
 ** *KM Region* (optional) is the region of the key manager, which is required only for AWS KMS.
 ** *KM Endpoint* (optional) is the endpoint of the key manager to override the default endpoint for KMS.
 ** *KMS Authentication Type* (optional) is the authentication type for the key manager with the options Environmental Auth, File Auth, and Access Key Auth.
+--
 +
 For more information, see xref:backup-restore/ccbackupmgr-encryption.adoc[Encryption].
-
-. When complete, the dialog may look as follows:
-+
-image::manage-backup-restore/createRepositoryDialogComplete.png[,420,align=left]
 +
 To confirm, left-click on the *Add* button:
 +
-image::manage-backup-restore/addButton.png[,120,align=left]
-
 This concludes the process for creating repository and plan.
-The *Backup* screen now appears as follows:
-
-image::manage-backup-restore/newRepository.png[,820,align=left]
-
++
 The newly created repository, *hourlyBackupRepo*, is displayed with its associated plan, `HourlyBackupPlan`, with the affected bucket (`travel-sample`) and the next scheduled backup displayed.
 Data Service and Index Service data for `travel-sample` will now be backed up to the specified location on the specified schedule.
 
@@ -272,49 +244,37 @@ A repository whose plan is being executed (with data thereby backed up repeatedl
 
 By means of the Backup Service, an _immediate_ backup can be run: this eliminates the need to wait for a scheduled backup to run at an appointed time.
 To run an immediate backup, access the *Backup* screen, and left-click on the row for an already-defined, active repository.
-For example:
-
-image::manage-backup-restore/selectActiveRepository.png[,820,align=left]
 
 This causes the row to expand vertically, as follows:
 
 image::manage-backup-restore/activeRepositoryRowExpanded.png[,820,align=left]
 
 A number of buttons now appear, arranged horizontally across the bottom of the row, permitting a variety of actions.
-To perform an immediate backup, left-click on the *Run Backup* button:
+To perform an immediate backup, left-click on the *Run Backup* button
 
-image::manage-backup-restore/runBackupButton.png[,120,align=left]
-
-This displays the *Trigger Backup* dialog, which appears as follows:
-
-image::manage-backup-restore/triggerBackup.png[,420,align=left]
+This displays the *Trigger Backup* dialog.
 
 The immediate backup to be performed will be _incremental_ by default.
 To perform a _full_ backup, select *Perform a full backup*.
 
 Click the *Backup* button, at the lower right of the dialog.
-The dialog disappears, and a notification is displayed at the lower left of the console:
+The dialog disappears, and a notification is displayed,
+indicating that an immediate backup has been triggered.
 
-image::manage-backup-restore/immediateBackupNotification.png[,220,align=left]
-
-This duly indicates that an immediate backup has been triggered.
+This  indicates that an immediate backup has been triggered.
 
 [#inspect-backups]
 == Inspect Backups
 
 Using Couchbase Web Console, the history of backups to a specified repository can be reviewed.
-Left-click on the row of a repository, to expand it vertically.
-Then, left-click on the *Inspect Backups* button:
-
-image::manage-backup-restore/inspectBackupsButton.png[,240,align=left]
+Left-click on the row of a repository to expand it vertically.
+Then, left-click on the *Inspect Backups* button
 
 This displays the *Backup* facility's *Repository* screen, which appears as follows:
 
 image::manage-backup-restore/inspectBackupsScreen.png[,820,align=left]
 
-The screen provides two possible views, which are *Inspect Backups* and *Task History* : these can be selected by means of the buttons at the upper right:
-
-image::manage-backup-restore/tasksAndBackupsButtons.png[,130,align=left]
+The screen provides two possible views, which are *Inspect Backups* and *Task History* : these can be selected by means of the buttons at the upper right.
 
 The *Inspect Backups* view is selected by default.
 (Note the left-clicking the *Task History* button displays the *Tasks History* view: this is the same display as that accessed by means of the *Task History button, from the expanded row on the *Repositories* view of the *Backup* screen; and is described in xref:manage:manage-backup-and-restore/manage-backup-and-restore.adoc#inspect-tasks[Inspect Tasks], below.)
@@ -326,16 +286,14 @@ To inspect a particular backup in detail, click the control at the left-hand sid
 image::manage-backup-restore/examineBackupExpanded.png[,820,align=left]
 
 The displayed data includes the UUID for the source cluster.
-Also specified are the numbers of *Eventing Functions* written for the Eventing Service, and the number of *Full Text Search Aliases* for the Search Service (here, the numbers are both zero).
+Also specified are the numbers of *Eventing Functions* written for the Eventing Service, and the number of *Full Text Search Aliases* for the Search Service.
 
 Each backed-up bucket appears on a table showing its size and the number of items, mutations, and tombstones that have been included in the backup.
-The row also lists the numbers of backed up indexes for the Index, Search, and Analytics Services plus the number of backed up Views.
+The row also lists the numbers of backed-up indexes for the Index, Search, and Analytics Services plus the number of backed-up Views.
 A searchable sub-panel lists each scope that the bucket contains along with the number of mutations and tombstones they contain.
 
 To inspect the individual collections within a displayed scope, click the row for the scope.
-The row expands vertically, as follows:
 
-image::manage-backup-restore/examineBackupExpandedScope.png[,820,align=left]
 
 Clicking on the row for the `inventory` scope displays the individual collections within the scope with the mutations and tombstones for each collection.
 Collections can be searched for, based on strings entered into the *filter collections* field, which is located to the upper right of the collections panel.
@@ -343,9 +301,7 @@ Collections can be searched for, based on strings entered into the *filter colle
 The upper panel of the *Data* screen provides interactive fields labelled *Key* and *Search Path*.
 These can be used to search for a specific document within the repository.
 Optionally, the subset of backups within the repository can be specified, by means of the *Start* and *End* fields.
-For example, by accessing the control at the left-hand side of the *Start* field, a pull-down menu is displayed: this lists backups any one of which can be used as the starting point for the search:
-
-image::manage-backup-restore/specifyStartingBackupForSearch.png[,280,align=left]
+For example, by accessing the control at the left-hand side of the *Start* field, a pull-down menu is displayed: this lists backups any one of which can be used as the starting point for the search.
 
 For example, type a known document key into the *Key* field &#8212; such as `airline_10`.
 Then, enter the bucket name into the *Search Path* field. 
@@ -361,26 +317,22 @@ The *Examine* screen is now displayed:
 
 image::manage-backup-restore/examineScreen.png[,720,align=left]
 
-The controls adjacent to the *Diff* button, near the top of the screen, allow different backups to be selected, so that the differences between the document-versions they contain can be individually examined:
-
-image::manage-backup-restore/diffSelector.png[,420,align=left]
+The controls adjacent to the *Diff* button,
+near the top of the screen,
+allow different backups to be selected so that the differences between the document versions they contain can be individually examined.
 
 The specified document is thereby shown, in the left and right-hand panels of the main display, in versions that respectively correspond to the backups selected.
 When a field has changed, the earlier version appears shaded red, the later shaded green.
 
 By default, a *Side-by-Side Diff* view of the specified document is shown.
-To display an *Inline Diff* view, access the control at the upper right of the screen:
+To display an *Inline Diff* view, access the control at the upper right of the screen.
 
-image::manage-backup-restore/diffView.png[,120,align=left]
-
-The *Inline Diff* view is now provided:
-
-image::manage-backup-restore/inlineDiffView.png[,720,align=left]
+The *Inline Diff* view is now provided.
 
 [#delete-backups]
 == Delete Backups
 
-You can delete backups that are no longer needed, to free up space in the repository.
+You can free up space in your repository by deleting backups you no longer need.
 
 You can delete individual backups that:
 
@@ -403,8 +355,6 @@ For more information, see xref:manage:manage-backup-and-restore/manage-backup-an
 To delete a backup, with or without dependent incremental backups, follow these steps:
 
 . Go to the *Backup* screen and select the repository.
-+
-image::manage-backup-restore/delete-backup-screen.png[,820,align=left]
 
 . Click *Inspect Backups*.
 
@@ -420,9 +370,7 @@ image::manage-backup-restore/backups-listed-for-deletion.png[,820,align=left]
 
 . Click the delete icon associated with the backup.
 +
-*Delete Backup* dialog appears.
-+
-image::manage-backup-restore/delete-backup-dialog.png[,300,align=left]
+The *Delete Backup* dialog appears.
 
 . Enter the name of the backup you want to delete in the *Backup Name* field.
 
@@ -436,9 +384,8 @@ The backup is deleted.
 
 To set the Disable the Safe Remove Check or `disable_safe_remove_check` property in the API call, see xref:rest-api:backup-delete-backups.adoc[Delete a Backup].
 
-If you try to delete a backup that has dependent incremental backups, without enabling the *Disable Safe Remove Check* option, the following warning appears.
-
-image::manage-backup-restore/warning-cannot-delete-backup.png[,250,align=left]
+NOTE: If you try to delete a backup that has dependent incremental backups, without enabling the *Disable Safe Remove Check* option,
+you will see an alert telling you that the backup cannot be deleted.
 
 [#inspect-tasks]
 == Inspect Tasks
@@ -462,9 +409,6 @@ The list has an *Offset* figure displayed at its head: this indicates the positi
 The task list is presented as a table, which shows, for each task that has been executed, the *Task name*, *Task type* (such as *Backup* or *Merge*), status (such as *done* or *running*), the *Elapsed* time for the task, the number of *Items* and size of data that was *Transferred* by the task, and the *Start* and *End* times for the task.
 
 To inspect a particular task in detail, left-click on the row for the task.
-For example:
-
-image::manage-backup-restore/leftClickOnTaskRow.png[,240,align=left]
 
 The selected row is expanded vertically, as follows:
 
@@ -531,7 +475,6 @@ To manually schedule a Prune task, do the following:
 To delete such backups, use xref:manage:manage-backup-and-restore/manage-backup-and-restore.adoc#delete-backups[Delete Backups].
 ====
 +
-image::manage-backup-restore/prune-select-plan.png[,480,align=left]
 
 . To create a *Prune* task, click *Add Task*, and do the following:
 ** Enter a name for the pruning task in the *Task Name* field.
@@ -560,10 +503,6 @@ To prune backups on demand, follow these steps:
 
 . To examine the backups in the repository, click *Inspect Backups*.
 +
-The repository details and backups are displayed.
-+
-image::manage-backup-restore/prune-inspect-backups.png[,820,align=left]
-+
 Examine the expiry status of the backups in the repository.
 If the backups have reached their retention period, they're marked as _Expired_.
 +
@@ -571,11 +510,8 @@ NOTE: Only expired backups can be pruned.
 
 . Go back to the *Backup* screen with repositories, select the repository, and click *Prune*.
 +
-image::manage-backup-restore/prune-backup-page.png[,820,align=left]
+The *Prune Expired Backups* dialog appears, listing the backups that are eligible for pruning.
 +
-*Prune Expired Backups* dialog appears, listing the backups that are eligible for pruning.
-+
-image::manage-backup-restore/prune-expired-backups-dialog.png[,300,align=left]
 
 . Type *permanently delete* in the *Type 'permanently delete' to confirm* field.
 
@@ -592,9 +528,8 @@ The repository details and backups are displayed.
 
 . Select the *Task History* tab.
 +
-The Task History lists all the attempted pruning, removed backups, and the backups that were not removed due to a non-expired dependent backup.
-+
-image::manage-backup-restore/pruned-backup-list.png[,820,align=left]
+The Task History lists all the attempted pruning, removed backups,
+and the backups that were not removed due to a non-expired dependent backup.
 
 [#backup-retention]
 == Retain Backups
@@ -657,16 +592,13 @@ The default value is 0.
 . Click *Add* to save the changes.
 +
 The *Backup* screen lists the new repository with its default retention period.
-+
-image::manage-backup-restore/retention-on-backup-page.png[,820,align=left]
 
-* When you have set the retention period for the repository but haven't created a pruning task, the repository is listed with a warning icon.
-+
-image::manage-backup-restore/retention-period-with-warning.png[,820,align=left]
+[NOTE]
+====
+When you have set the retention period for the repository but haven't created a pruning task, the repository is listed with a warning icon.
+When you have not set the retention period for a repository, the repository indicates it.
+====
 
-* When you have not set the retention period for a repository, the repository indicates it.
-+
-image::manage-backup-restore/no-retention-set.png[,820,align=left]
 
 [#set-retention-period-after-repo-creation]
 === Set Retention Period after Creating a Repository
@@ -676,8 +608,6 @@ You can also set the retention period for a repository after it has been created
 To set the retention period for an existing repository, follow these steps:
 
 . On the Backup screen, in the *Repositories* list, click the repository for which you want to set the retention period.
-+
-image::manage-backup-restore/retention-on-backup-page.png[,820,align=left]
 
 . Click *Edit* associated with the label Default Retention Period.
 The *Edit Default Retention* dialog appears.
@@ -686,15 +616,17 @@ The *Edit Default Retention* dialog appears.
 
 . To apply the new retention value to the existing backups along with the repository, select *Retroactive*.
 +
+image::manage-backup-restore/edit-default-retention.png[,300,align=left]
+
+
+
+. Click *Edit Retention* to save the changes.
+
 [NOTE]
 ====
 * The new retention value applies to existing backups at the time of the backup creation.
 * If you set a retention value that's shorter than the original value, existing backups may be pruned according to the new retention period.
 ====
-+
-image::manage-backup-restore/edit-default-retention.png[,300,align=left]
-
-. Click *Edit Retention* to save the changes.
 
 [#set-retention-period-for-a-backup]
 === Set Retention Period for a Specific Backup
@@ -706,22 +638,17 @@ To set a new retention period or edit a default retention period for a specific 
 . Click *Inspect Backups*.
 The repository and its backups are displayed.
 Each backup has an associated *Edit* button, listed in the retention period column.
-+
-image::manage-backup-restore/for-retention-inspect-backups.png[,820,align=left]
+
 
 . Click *Edit* associated with the backup for which you want to set the retention period.
 +
-image::manage-backup-restore/edit-in-backup-list.png[,820,align=left]
-+
-*Edit Backup Retention* dialog appears.
+The *Edit Backup Retention* dialog appears.
 
 . Specify the new retention period, in days, for the backup in the *New Retention* field.
-+
-image::manage-backup-restore/edit-backup-retention.png[,250,align=left]
 
 . Click *Edit Retention* to save the changes.
 
-As a result, the backup's retention period overrides the repository's default retention period.
+The backup's retention period will now override the repository's default retention period.
 
 To set the retention period for a backup using the REST API, see xref:rest-api:backup-retention.adoc[Retain a Backup].
 
@@ -772,8 +699,7 @@ If backups were not made every day during the specified period, as many as can b
 A detailed, diagrammatic explanation of *Merge Offset Start* and *Merge Offset End* is provided in xref:learn:services-and-indexes/services/backup-service.adoc#specifying-merge-offsets[Specifying Merge Offsets].
 +
 Left-click on the *Next* button:
-+
-image::manage-backup-restore/nextButton.png[,140,align=left]
+
 
 . When the *Create Repository* dialog appears, enter the *ID* of the repository you're creating, the name of the *Bucket* that is being backed up, the appropriate value of *Storage Locations* (here, *Filesystem*), and the on-disk location of the repository-archive.
 (Note that this on-disk location must be accessible to _all_ Backup Service nodes in the cluster.)
@@ -783,11 +709,10 @@ image::manage-backup-restore/createRepositoryForMerge.png[,420,align=left]
 +
 Left-click on the *Add* button.
 The new repository now appears in the *Repositories* view of the *Backup* screen:
-+
-image::manage-backup-restore/newRepositoryConfirmed.png[,820,align=left]
+
 
 The defined backups and merges will now occur, on the specified schedule.
-This can eventally be seen by left-clicking on the row for the new repository, and then left-clicking on *Inspect Backups*.
+This can eventually be seen by left-clicking on the row for the new repository, and then left-clicking on *Inspect Backups*.
 
 [#perform-an-immediate-merge]
 == Perform an Immediate Merge
@@ -802,8 +727,6 @@ Proceed as follows:
 . In the *Repositories* view of the *Backup* screen, select a repository that contains multiple backups, by left-clicking on the row for the repository.
 When the row has expanded vertically, left-click on the *Merge* button:
 +
-image::manage-backup-restore/mergeButton.png[,90,align=left]
-+
 The *Merge Backups* dialog is now displayed:
 +
 image:manage-backup-restore/mergeDialog.png[,420,align=left]
@@ -812,18 +735,13 @@ The dialog allows determination of which backups should be merged, based on spec
 
 . To specify the first backup, access the interactive control at the right-hand side of the *Start* field.
 This produces a pull-down menu that displays all available backups for this repository:
-+
-image:manage-backup-restore/start-menu-backups-for-merge.png[,320,align=left]
+
 
 . Select a backup that will be the starting backup for the merge.
 Then, access the control at the right-hand side of the *End* field, and select, from its pull-down menu, a backup that will be the ending backup for the merge.
 
 . Left-click on the *Merge Backups* button, at the lower right of the dialog.
-The dialog now disappears, and the following notification appears, at the lower left of the console:
-+
-image:manage-backup-restore/mergeNotification.png[,220,align=left]
-+
-The specified merge has now been triggered.
+The dialog now disappears, and any you will receive a console notification stating that you have triggered a merge.
 
 . To check the results, in the *Repositories* view of the *Backup* screen, left-click on the *Inspect Backups* button, on the expanded row for the selected repository.
 This displays the history of backups and merges for the repository.
@@ -876,11 +794,8 @@ You can use either Plain (a username and password) or a client certificate and k
 After making your choice, supply the credentials for the target cluster.
 . In the *Start* and *End* fields, choose the start and end range of backups you want to restore. 
 . If you want to restore users and groups, expand *Users* and click *Restore users and User Groups*. 
-Also choose whether the backed-up users and groups overwrite any identically named existing ones. 
+You can also choose whether the backed-up users and groups overwrite any identically named existing ones.
 . If you want to select which service's data gets restored, expand the *Services* section and select or clear services you want.
-For example:
-+
-image:manage-backup-restore/restoreUncheckCheckboxes.png[,240,align=left]
 
 . Expand the *Advanced Restore Options* if you want to:
 +
@@ -1014,14 +929,11 @@ Then, when a _resume_ is subsequently executed by the administrator, the task-sc
 
 To pause a backup, access the *Repositories* view of the *Backup* screen, and left-click on the row for the repository to be paused.
 This expands the row vertically, and displays the *Pause* button.
-Left-click on this, to pause backups:
-
-image:manage-backup-restore/pauseButton.png[,420,align=left]
+Left-click on this, to pause backups.
 
 The button now changes into a *Resume* button.
 Left-click on this whenever backups are to be resumed:
 
-image:manage-backup-restore/resumeButton.png[,420,align=left]
 
 [#archive-repositories]
 == Archive Repositories
@@ -1033,13 +945,7 @@ To archive a repository, proceed as follows;
 . Access the repository that is to be archived in the *Repositories* view of the *Backup* screen, and expand the row for the repository by left-clicking on the repository's row.
 When the row has expanded, left-click on the *Archive* button:
 +
-image:manage-backup-restore/archiveButton.png[,90,align=left]
-+
-This brings up the *Archive Repository* dialog, which appears as follows:
-+
-image:manage-backup-restore/archiveRepositoryDialog.png[,420,align=left]
-+
-The dialog contains a notification, warning that no further backups or merges will be possible to the repository, once it has been archived.
+The displayed dialog contains a notification, warning that no further backups or merges will be possible to the repository, once it has been archived.
 
 . Confirm the repository to be archived.
 Enter its name into the *Confirm repository ID to archive* field.
@@ -1093,8 +999,7 @@ For example, a repository that was archived and subsequently deleted can be impo
 To import a repository, proceed as follows:
 
 . Left-click on the *IMPORT* tab, at the upper right of the *Repositories* view of the *Backup* screen:
-+
-image:manage-backup-restore/importTab.png[,180,align=left]
+
 +
 This brings up the *Import Repository* dialog, which appears as follows:
 +
@@ -1137,7 +1042,6 @@ image:manage-backup-restore/importedRepositoriesPanelExpanded.png[,720,align=lef
 
 All plans created for the Backup Service can be reviewed, by left-clicking on the *Plans* tab, on the upper, horizontal navigation bar of the *Backup* screen:
 
-image:manage-backup-restore/plansTab.png[,260,align=left]
 
 This displays the *Backup* screen's *Plans* view:
 


### PR DESCRIPTION

The changes for the backup encryption seem to have been added already.

So the PR aims to improve the page by removing some screenshots and reorganising the text.

----

Preview URL:
https://preview.docs-test.couchbase.com/docs-server-DOC-13146/release/8.0/Backup-encryption-using-Backup-Service/server/current/manage/manage-backup-and-restore/manage-backup-and-restore.html

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.