### PR TITLE
[DOC-13414]: Change alog_sleep_time example value

### DIFF
--- a/modules/cli/pages/cbepctl/set-flush_param.adoc
+++ b/modules/cli/pages/cbepctl/set-flush_param.adoc
@@ -160,18 +160,18 @@ cbepctl 10.5.2.117:11210 -b foo-bucket -u Administrator -p password \
 set flush_param alog_sleep_time 2880
 ----
 
+This response shows the time interval changed to 2 days.
+
+----
+setting param: alog_sleep_time 2880
+set alog_sleep_time to 2880
+----
+
 To change the initial time that the access scanner process runs from the 2:00 AM UTC default to 11:00 PM UTC.
 
 ----
 cbepctl 10.5.2.117:11210 -b foo-bucket -u Administrator -p password \
 set flush_param alog_task_time 23
-----
-
-This response shows the time interval changed to 20 minutes.
-
-----
-setting param: alog_sleep_time 20
-set alog_sleep_time to 20
 ----
 
 This response shows the initial access scanner run time changed to 11:00 PM UTC.


### PR DESCRIPTION
Corrected erroneous example.

----
Preview URL:
https://preview.docs-test.couchbase.com/docs-server-DOC-13414/release/8.0/Change-alog-sleep-time-example-value/server/current/cli/cbepctl/set-flush_param.html

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.