### PR TITLE
[DOC-13414]: Change alog_sleep_time example value

### DIFF
--- a/modules/cli/pages/cbepctl/set-flush_param.adoc
+++ b/modules/cli/pages/cbepctl/set-flush_param.adoc
@@ -196,18 +196,19 @@ cbepctl 10.5.2.117:11210 -b foo-bucket -u Administrator -p password \
 set flush_param alog_sleep_time 2880
 ----
 
+
+This response shows the time interval changed to 2 days.
+
+----
+setting param: alog_sleep_time 2880
+set alog_sleep_time to 2880
+----
+
 To change the initial time that the access scanner process runs from the 2:00 AM UTC default to 11:00 PM UTC.
 
 ----
 cbepctl 10.5.2.117:11210 -b foo-bucket -u Administrator -p password \
 set flush_param alog_task_time 23
-----
-
-This response shows the time interval changed to 20 minutes.
-
-----
-setting param: alog_sleep_time 20
-set alog_sleep_time to 20
 ----
 
 This response shows the initial access scanner run time changed to 11:00 PM UTC.
@@ -262,9 +263,16 @@ cbepctl 10.5.2.117:11210 -b foo-bucket -u Administrator -p password \
 set flush_param mem_low_wat 70%
 ----
 
+The following example response shows the low water mark set to 70%.
+
+----
+setting param: mem_low_wat 70
+set mem_low_wat to 70
+----
+
 *Example for setting the high water mark*
 
-The high water mark set the amount of RAM consumed by items that must be breached before infrequently used active and replica items are ejected.
+The high water mark sets the amount of RAM consumed by items that must be breached before infrequently used active and replica items are ejected.
 
 The following example sets the high water mark percentage to 80% of RAM for a specific bucket on a node.
 This means that items in RAM on this node can consume up to 80% of RAM before the item pager begins ejecting items.
@@ -274,14 +282,9 @@ cbepctl 10.5.2.117:11210 -b foo-bucket -u Administrator -p password \
 set flush_param mem_high_wat 80%
 ----
 
-
-
-The following example response shows the low water mark and high water mark of ejected items being set.
+The following example response shows the high water mark of ejected items being set to 80%.
 
 ----
-setting param: mem_low_wat 70
-set mem_low_wat to 70
-
 setting param: mem_high_wat 80
 set mem_high_wat to 80
 ----


### PR DESCRIPTION
Corrected erroneous example.

----

Preview URL:

https://preview.docs-test.couchbase.com/docs-server-DOC-13414/release/7.6/Change-alog-sleep-time-example-value/server/current/cli/cbepctl/set-flush_param.html

