### PR TITLE
[DOC-13414]: Change alog_sleep_time example value

### DIFF
--- a/modules/cli/pages/cbepctl/set-flush_param.adoc
+++ b/modules/cli/pages/cbepctl/set-flush_param.adoc
@@ -200,6 +200,13 @@ cbepctl 10.5.2.117:11210 -b foo-bucket -u Administrator -p password \
 set flush_param alog_sleep_time 2880
 ----
 
+This response shows the time interval changed to 2 days.
+
+----
+setting param: alog_sleep_time 2880
+set alog_sleep_time to 2880
+----
+
 To change the initial time that the access scanner process runs from the 2:00 AM UTC default to 11:00 PM UTC.
 
 ----
@@ -207,19 +214,12 @@ cbepctl 10.5.2.117:11210 -b foo-bucket -u Administrator -p password \
 set flush_param alog_task_time 23
 ----
 
-This response shows the time interval changed to 20 minutes.
-
-----
-setting param: alog_sleep_time 20
-set alog_sleep_time to 20
-----
-
 This response shows the initial access scanner run time changed to 11:00 PM UTC.
-
 ----
 setting param: alog_task_time 23
 set alog_task_time to 23
 ----
+
 
 *Examples for setting the memory cleanup*
 
@@ -266,6 +266,13 @@ cbepctl 10.5.2.117:11210 -b foo-bucket -u Administrator -p password \
 set flush_param mem_low_wat 70%
 ----
 
+The following example response shows the low water mark set to 70%
+
+----
+setting param: mem_low_wat 70
+set mem_low_wat to 70
+----
+
 *Example for setting the high water mark*
 
 The high water mark set the amount of RAM consumed by items that must be breached before infrequently used active and replica items are ejected.
@@ -277,6 +284,14 @@ This means that items in RAM on this node can consume up to 80% of RAM before th
 cbepctl 10.5.2.117:11210 -b foo-bucket -u Administrator -p password \
 set flush_param mem_high_wat 80%
 ----
+
+The following response example shows the high water mark set to 80%
+
+----
+setting param: mem_high_wat 80
+set mem_high_wat to 80
+----
+
 
 *Examples for setting percentage of ejected items*
 
@@ -296,14 +311,9 @@ By doing so, active data from a source node is maximized while maintaining incom
 However, if the server is ejecting a very large percentage of replica data and a node fails, the replica data is not immediately available.
 In this case, the items are retrieved from disk and put back into RAM before the request is fulfilled.
 
-The following example response shows the low water mark, high water mark, and percentage of ejected items being set.
+The following example response shows the percentage of ejected items being set.
 
 ----
-setting param: mem_low_wat 70
-set mem_low_wat to 70
-
-setting param: mem_high_wat 80
-set mem_high_wat to 80
 
 setting param: pager_active_vb_pcnt 50
 set pager_active_vb_pcnt to 50


### PR DESCRIPTION
Corrected erroneous example.

----

Preview URL

https://preview.docs-test.couchbase.com/docs-server-DOC-13414/release/7.2/Change-alog-sleep-time-example-value/server/current/cli/cbepctl/set-flush_param.html

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.
