### PR TITLE
[DOC-13729]: Document the amount of stats collected by the server

### DIFF
--- a/modules/manage/pages/monitor/monitor-intro.adoc
+++ b/modules/manage/pages/monitor/monitor-intro.adoc
@@ -5,7 +5,7 @@
 [abstract]
 {description}
 
-This page summarizes the options available for monitoring Couchbase Server; and provides links to more detailed interface-descriptions.
+This page summarizes the options available for monitoring Couchbase Server and provides links to more detailed interface-descriptions.
 
 [#monitoring-with-the-ui]
 == Monitoring with the UI
@@ -14,6 +14,8 @@ Couchbase-Server statistics can be monitored by means of Couchbase Web Console.
 
 Users with the *Full Admin* or *Bucket Admin* role can assemble statistics as _groups_ of _charts_, on the *Dashboard* of Couchbase Web Console.
 This is visible by default after login; and can at any time be displayed by left-clicking on the *Dashboard* tab, in the left-hand navigation bar:
+
+Note that the UI will return the last 30 days of statistics.
 
 [#access-dashboard]
 image::manage-statistics/DBaccessDB.png[,100,align=left]
@@ -38,7 +40,7 @@ The complete interface for `cbstats` is documented in xref:cli:cbstats-intro.ado
 Couchbase Server provides a REST API for xref:rest-api:rest-statistics.adoc[Getting Cluster Statistics].
 Statistics are retrieved based on the specification of one or more _metrics_.
 Optionally, the statistics can be further defined through the specifying of a _function_; and/or _labels_ with values.
-An instance of _Prometheus_ runs on each node of the cluster; and the metrics for each node are duly stored in that node’s instance of Prometheus.
+An instance of _Prometheus_ runs on each node of the cluster, and the metrics for each node are duly stored in that node’s instance of Prometheus.
 
 For a complete list of metrics, see the xref:metrics-reference:metrics-reference.adoc[Metrics Reference].
 
@@ -49,7 +51,7 @@ Statistics for the Index Service can be managed by means of Couchbase Web Consol
 
 The monitoring of statistics related to the Query Service is described in xref:n1ql:n1ql-manage/monitoring-n1ql-query.adoc[].
 
-The progressive desynchronization of nodes whose clock have been previously synchronized can be monitored; as described in xref:manage:monitor/xdcr-monitor-timestamp-conflict-resolution.adoc[Monitor Clock Drift].
+The progressive desynchronization of nodes whose clock has been previously synchronized can be monitored, as described in xref:manage:monitor/xdcr-monitor-timestamp-conflict-resolution.adoc[Monitor Clock Drift].
 
 == Monitoring Couchbase Metrics with Prometheus
 

--- a/modules/manage/pages/monitor/monitor-intro.adoc
+++ b/modules/manage/pages/monitor/monitor-intro.adoc
@@ -15,7 +15,7 @@ Couchbase-Server statistics can be monitored by means of Couchbase Web Console.
 Users with the *Full Admin* or *Bucket Admin* role can assemble statistics as _groups_ of _charts_, on the *Dashboard* of Couchbase Web Console.
 This is visible by default after login; and can at any time be displayed by left-clicking on the *Dashboard* tab, in the left-hand navigation bar:
 
-Note that the UI will return the last 30 days of statistics.
+Note that the UI returns the last 30 days of statistics.
 
 [#access-dashboard]
 image::manage-statistics/DBaccessDB.png[,100,align=left]

--- a/modules/rest-api/pages/rest-statistics.adoc
+++ b/modules/rest-api/pages/rest-statistics.adoc
@@ -6,8 +6,10 @@
 
 == APIs in this Section
 
-Metrics are provided for all Couchbase Services, and also for the Cluster Manager and XDCR.
+Metrics are provided for all Couchbase Services, the Cluster Manager, and XDCR.
 All metrics can be queried by means of the REST API.
+
+Couchbase Server stores up to 365 days or 1GB of stats, whichever limit occurs first.
 
 For a complete list of available metrics that can be queried, see the xref:metrics-reference:metrics-reference.adoc[Metrics Reference].
 


### PR DESCRIPTION

Added details of stats collections.

Preview URLs:

https://preview.docs-test.couchbase.com/docs-server-DOC-13729/release/8.0/Document-amount-of-stats-collected-by-the-server/server/current/manage/monitor/monitor-intro.html

https://preview.docs-test.couchbase.com/docs-server-DOC-13729/release/8.0/Document-amount-of-stats-collected-by-the-server/server/current/rest-api/rest-statistics.html


You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.