### PR TITLE
[DOC-13487]: Clarify that alternate addresses documentation applies only to non-CAO-managed environments

### DIFF
--- a/modules/xdcr-reference/pages/xdcr-security-and-networking.adoc
+++ b/modules/xdcr-reference/pages/xdcr-security-and-networking.adoc
@@ -86,6 +86,8 @@ It also involves, on the source, specification of the external network interface
 
 When a cluster has been configured in this way for external networking, and status on the cluster is returned by means of Couchbase Web Console, the CLI, or the REST API, both the internal and the external addresses are represented.
 
+IMPORTANT: Please note that the use of alternate addresses only applies to non-CAO managed environments.
+
 The REST API reference page xref:rest-api:rest-set-up-alternate-address.adoc[Managing Alternate Addresses] explains how alternate addresses can be established for and removed from nodes.
 The REST API reference page xref:rest-api:rest-list-node-services.adoc[Listing Node Services] explains how to retrieve all internal and external address settings.
 


### PR DESCRIPTION

Added note stating that alternate addresses only apply to non-CAO managed environments.