### PR TITLE
[DOC-13988] What's New for 7.6.10 Query Service

### DIFF
--- a/modules/introduction/pages/whats-new.adoc
+++ b/modules/introduction/pages/whats-new.adoc
@@ -23,6 +23,7 @@ If you are performing a backup/restore operation on a Couchbase Server 7.6.x clu
 ensure that you use `cbbackupmgr` version 7.6.
 ====
 
+include::partial$new_features-76_10.adoc[]
 include::partial$new_features-76_6.adoc[]
 include::partial$new_features-76_4.adoc[]
 include::partial$new-features-76_2.adoc[]

--- a/modules/introduction/partials/new_features-76_10.adoc
+++ b/modules/introduction/partials/new_features-76_10.adoc
@@ -1,0 +1,15 @@
+[#new-features-7610]
+== New Features and Enhancements in 7.6.10
+
+The following new features are provided in this release.
+
+[#new-features-7610-query]
+== Query
+
+* *https://jira.issues.couchbase.com/browse/MB-69387[MB-69387]:*
+Couchbase Server 7.6.10 now includes an auto-reprepare feature for PREPARE statements. 
+When enabled, a prepared statement automatically updates its query plan whenever GSI metadata version changes, ensuring it always uses newer, more efficient indexes as they become available.
+For more information, see xref:n1ql:n1ql-language-reference/prepare.adoc[PREPARE].
+
+
+

--- a/modules/introduction/partials/new_features-76_10.adoc
+++ b/modules/introduction/partials/new_features-76_10.adoc
@@ -4,7 +4,7 @@
 The following new features are provided in this release.
 
 [#new-features-7610-query]
-== Query
+== Query Service
 
 * *https://jira.issues.couchbase.com/browse/MB-69387[MB-69387]:*
 Couchbase Server 7.6.10 now includes an auto-reprepare feature for PREPARE statements. 

--- a/modules/introduction/partials/new_features-76_10.adoc
+++ b/modules/introduction/partials/new_features-76_10.adoc
@@ -10,6 +10,3 @@ The following new features are provided in this release.
 Couchbase Server 7.6.10 now includes an auto-reprepare feature for PREPARE statements. 
 When enabled, a prepared statement automatically updates its query plan whenever GSI metadata version changes, ensuring it always uses newer, more efficient indexes as they become available.
 For more information, see xref:n1ql:n1ql-language-reference/prepare.adoc[PREPARE].
-
-
-

--- a/modules/introduction/partials/new_features-76_6.adoc
+++ b/modules/introduction/partials/new_features-76_6.adoc
@@ -1,6 +1,4 @@
 
-NOTE: *Sync Gateway 4.0.0 is a future release version.
-
 [#new-features-766]
 == New Features and Enhancements in 7.6.6
 
@@ -13,9 +11,9 @@ The following new features are provided in this release.
 == XDCR
 
 * *https://jira.issues.couchbase.com/browse/MB-57921[MB-57921]:*
-Created provision to set up XDCR bidirectional replication with Sync Gateway (SGW) 4.0* or a later version.
-In the versions earlier than Server 7.6.6 and Sync Gateway (SGW) 4.0.0*, only an active-passive setup was supported with both XDCR and SGW.
+Created provision to set up XDCR bidirectional replication with Sync Gateway (SGW) 4.0 or a later version.
+In the versions earlier than Server 7.6.6 and Sync Gateway (SGW) 4.0.0, only an active-passive setup was supported with both XDCR and SGW.
 XDCR active-active replication with Sync Gateway for XDCR-Mobile interoperability configuration is introduced in the Server 7.6.6 version, where you can configure an active-active XDCR setup with Sync Gateway and mobile applications both on the XDCR source and target clusters.
-You need to have at least a Server 7.6.6 version and SGW 4.0.0* version to use this setup.
+You need to have at least a Server 7.6.6 version and SGW 4.0.0 version to use this setup.
 For more info, see xref:learn:clusters-and-availability/xdcr-active-active-sgw.adoc[XDCR Active-Active with Sync Gateway].
 


### PR DESCRIPTION
Updated the What's New page with the 7.6.10 auto re-prepare feature (Query Service). 
Also included some tweaks to the 7.6.6 section regarding the SGW 4.0 release.

Jira: DOC-13988
Preview: [What's New 7.6.10](https://preview.docs-test.couchbase.com/docs-server-DOC-13988-whats-new-7.6.10/server/current/introduction/whats-new.html#new-features-7610)

