### PR TITLE
[DOC-13699]: Feedback on Getting System Events | Couchbase Docs

### DIFF
--- a/modules/rest-api/pages/rest-get-system-events.adoc
+++ b/modules/rest-api/pages/rest-get-system-events.adoc
@@ -154,6 +154,105 @@ If the call is successful, the output resembles the following:
 }
 ----
 
+=== Event Filtering
+
+You can filter events by specifying  any of the following parameters:
+[horizontal]
+ component:: Filter events by component name. The component name can be one of the following values:
+`ns_server`, `query`, `indexing`, `search`, `eventing`, `analytics`, `backup`, `xdcr`,
+`data`, `security`, `views`, or  `regulator`
+
+ event_id:: An integer value representing the ID of the event.
+
+ severity:: Filter events by severity level. The filter will accept one of the following for the severity parameter:
+`info`, `warning`, `error`, or `fatal`
+
+=== Filtering Examples
+
+The following call will filter events by the `ns_server` component.
+
+----
+curl -v -X GET  'http://localhost:8091/events?component=ns_server' -u Administrator:password | jq
+----
+
+If the call is successful, then it will return a result similar to this:
+
+----
+{
+  "events": [
+    {
+      "timestamp": "2026-01-14T11:05:27.558Z",
+      "event_id": 1,
+      "component": "ns_server",
+      "description": "Service started",
+      "severity": "info",
+      "node": "cb.local",
+      "otp_node": "ns_1@cb.local",
+      "uuid": "00adda40-bbdc-4c0a-ae78-ae682c4ce085",
+      "extra_attributes": {
+        "name": "ns_server"
+      }
+    },
+    {
+      "timestamp": "2026-01-14T11:05:28.121Z",
+      "event_id": 1,
+      "component": "ns_server",
+      "description": "Service started",
+      "severity": "info",
+      "node": "cb.local",
+      "otp_node": "ns_1@cb.local",
+      "uuid": "e2ba670b-2023-4d3f-8cc1-60e59d68365d",
+      "extra_attributes": {
+        "name": "saslauthd_port"
+      }
+    }
+   ]
+}
+
+----
+
+You can also filter events using a combination of parameters.
+Here, we are filtering for a specific event ID with a severity level of `info`.
+
+----
+curl -v -X GET  'http://localhost:8091/events?event_id=18&severity=info' -u Administrator:password | jq
+----
+
+If successful, then a result similar to the following is returned:
+
+----
+{
+  "events": [
+    {
+      "timestamp": "2026-01-14T11:05:28.548Z",
+      "event_id": 18,
+      "component": "ns_server",
+      "description": "Master selected",
+      "severity": "info",
+      "node": "cb.local",
+      "otp_node": "ns_1@cb.local",
+      "uuid": "b6a4b1d1-7ce7-4e45-ab71-0c8365de1984",
+      "extra_attributes": {
+        "new_master": "ns_1@cb.local"
+      }
+    },
+    {
+      "timestamp": "2026-01-14T11:06:44.709Z",
+      "event_id": 18,
+      "component": "ns_server",
+      "description": "Master selected",
+      "severity": "info",
+      "node": "127.0.0.1",
+      "otp_node": "ns_1@127.0.0.1",
+      "uuid": "6e213fae-136a-4bcc-8339-56abd9e6a749",
+      "extra_attributes": {
+        "new_master": "ns_1@127.0.0.1"
+      }
+    }
+  ]
+}
+----
+
 === Return a Stream of Ongoing Events
 
 The following call returns all previously logged system events that are held in the event log; then, it starts a stream of system events, which are displayed on the console as they occur on the cluster:


### PR DESCRIPTION

Added documentation and examples for event filtering.

----
Preview:
https://preview.docs-test.couchbase.com/docs-server-DOC-13699--8.0--feedback-on-system-events/server/current/rest-api/rest-get-system-events.html

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.
