### PR TITLE
DOC-13717 rest api for app telemetry

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -401,6 +401,8 @@ include::cli:partial$cbcli/nav.adoc[]
     **** xref:rest-api:rest-manage-log-collection.adoc[Collecting Logs]
     **** xref:rest-api:rest-client-logs.adoc[Logging Client-Side Errors]
 
+   *** xref:rest-api:application-telemetry.adoc[]
+
   ** xref:rest-api:rest-bucket-intro.adoc[Buckets API]
    *** xref:rest-api:rest-bucket-create.adoc[Creating and Editing Buckets]
    *** xref:rest-api:setting-minimum-replicas.adoc[Setting a Replica-Minimum]

--- a/modules/manage/pages/monitor/set-up-prometheus-for-monitoring.adoc
+++ b/modules/manage/pages/monitor/set-up-prometheus-for-monitoring.adoc
@@ -145,7 +145,12 @@ See xref:rest-api:rest-discovery-api.adoc[Prometheus Discovery API].
 
 You can enable application telemetry to have Couchbase Server collect metrics from your applications that use the Couchbase SDKs. 
 When you enable application telemetry, Couchbase Server collects telemetry data from your applications. 
-It the reports the collected data as metrics through the same Prometheus endpoint that it uses to report its own metrics. 
+
+Couchbase Server reports the collected data as metrics through the same Prometheus endpoint that it uses to report its own metrics. 
 Enabling this feature lets you use Prometheus to monitor the health of both your Couchbase Server cluster and your applications that use the Couchbase SDKs.
+The application telemetry metrics can help you troubleshoot client issues such as poor performance or timeouts.
+
+Application telemetry is disabled by default in Couchbase Server 8.0.
+A future version of Couchbase Server may enable it by default.
 
 See xref:rest-api:application-telemetry.adoc[] to learn how to enable application telemetry.

--- a/modules/manage/pages/monitor/set-up-prometheus-for-monitoring.adoc
+++ b/modules/manage/pages/monitor/set-up-prometheus-for-monitoring.adoc
@@ -147,6 +147,8 @@ You can enable application telemetry to have Couchbase Server collect metrics fr
 When you enable application telemetry, Couchbase Server collects telemetry data from your applications. 
 
 Couchbase Server reports the collected data as metrics through the same Prometheus endpoint that it uses to report its own metrics. 
+The application telemetry metrics are aggregated across all clients instead of being reported separately for each client.
+
 Enabling this feature lets you use Prometheus to monitor the health of both your Couchbase Server cluster and your applications that use the Couchbase SDKs.
 The application telemetry metrics can help you troubleshoot client issues such as poor performance or timeouts.
 

--- a/modules/manage/pages/monitor/set-up-prometheus-for-monitoring.adoc
+++ b/modules/manage/pages/monitor/set-up-prometheus-for-monitoring.adoc
@@ -139,3 +139,12 @@ The `http_sd_configs` section contains its own copy of the `basic_auth` and `tls
 
 You can change the list that the discovery API returns by adding query parameters to the URL in the `http_sd_configs` section. 
 See xref:rest-api:rest-discovery-api.adoc[Prometheus Discovery API].
+
+== Include Application Telemetry in Prometheus Metrics
+
+You can enable application telemetry to have Couchbase Server collect metrics from your applications that use the Couchbase SDKs. 
+When you enable application telemetry, Couchbase Server collects telemetry data from your applications. 
+It the reports the collected data as metrics through the same Prometheus endpoint that it uses to report its own metrics. 
+Enabling this feature lets you use Prometheus to monitor the health of both your Couchbase Server cluster and your applications that use the Couchbase SDKs.
+
+See xref:rest-api:application-telemetry.adoc[] to learn how to enable application telemetry.

--- a/modules/manage/pages/monitor/set-up-prometheus-for-monitoring.adoc
+++ b/modules/manage/pages/monitor/set-up-prometheus-for-monitoring.adoc
@@ -84,7 +84,7 @@ curl  --get -u prometheus:password \
 Add a new job to collect metrics from your Couchbase Database. 
 In this job, add a `file_sd_configs` key entry. Set its value to the path to the file containing the list of nodes you created earlier. 
 +
-The following example defines a new job to collect metrics from a Couchbase Server, where the certificate  and node list files are in the `/etc/prometheus` directory.
+The following example defines a new job to collect metrics from a Couchbase Server, where the certificate and node list files are in the `/etc/prometheus` directory.
 +
 [source, yaml]
 ----
@@ -109,7 +109,7 @@ However, it's easier to just configure Prometheus to call the discovery API itse
 == Configure HTTP Service Discovery
 
 You can configure Prometheus to call the Couchbase Server discovery API itself. 
-With this method, has the benefit that Prometheus defaults to periodically calling the endpoint so it automatically learns of any added or removed nodes. 
+This method has the benefit that Prometheus defaults to periodically calling the endpoint so it automatically learns of any added or removed nodes. 
 
 To use the HTTP service discovery method, add a job to your Prometheus hosts's `prometheus.yml` configuration file to collect data from your Couchbase Database. 
 In this job, add an `http_sd_configs` section that tells Prometheus to call your database's discovery API endpoint. 

--- a/modules/manage/pages/monitor/set-up-prometheus-for-monitoring.adoc
+++ b/modules/manage/pages/monitor/set-up-prometheus-for-monitoring.adoc
@@ -140,6 +140,7 @@ The `http_sd_configs` section contains its own copy of the `basic_auth` and `tls
 You can change the list that the discovery API returns by adding query parameters to the URL in the `http_sd_configs` section. 
 See xref:rest-api:rest-discovery-api.adoc[Prometheus Discovery API].
 
+[#app-telemetry]
 == Include Application Telemetry in Prometheus Metrics
 
 You can enable application telemetry to have Couchbase Server collect metrics from your applications that use the Couchbase SDKs. 

--- a/modules/rest-api/pages/application-telemetry.adoc
+++ b/modules/rest-api/pages/application-telemetry.adoc
@@ -98,7 +98,7 @@ curl -sS -u $USER:$PASSWORD \
      -X GET 'http[s]://{host}:{port}/settings/appTelemetry' 
 ----
 
-.Path and curl Parameters
+==== Path and curl Parameters
 :priv-link: get-privs
 include::partial$user-pw-host-port-params.adoc[]
 
@@ -177,12 +177,12 @@ curl -sS -u $USER:$PASSWORD \
   [-d scrapeIntervalSeconds=<integer>]
 ----
 
-.Path and curl Parameters
+==== Path and curl Parameters
 :priv-link: config-privs
 include::partial$user-pw-host-port-params.adoc[]
 
 
-.REST Parameters
+==== REST Parameters
 `enabled` (boolean, optional)::
 Set to `true` to enable application telemetry or `false` to turn it off.
 

--- a/modules/rest-api/pages/application-telemetry.adoc
+++ b/modules/rest-api/pages/application-telemetry.adoc
@@ -45,7 +45,7 @@ GET /settings/appTelemetry
 [source,bash]
 ----
 curl -sS -u $USER:$PASSWORD \
-     -X GET 'http[s]://<hostname>:<port>/settings/appTelemetry' 
+     -X GET 'http[s]://{host}:{port}/settings/appTelemetry' 
 ----
 
 .Path and curl Parameters
@@ -56,7 +56,7 @@ include::partial$user-pw-host-port-params.adoc[]
 [#get-privs]
 === Required Privileges
 
-Your user account must have at least one of the following roles to get the application telemetry status:
+Your user account must have at least 1 of the following roles to get the application telemetry status:
 
 * xref:learn:security/roles.adoc#full-admin[Full Admin]
 * xref:learn:security/roles.adoc#cluster-admin[Cluster Admin]
@@ -107,7 +107,7 @@ Running the previous command returns a JSON object similar to the following:
 
 By sending a POST request to the `/settings/appTelemetry` endpoint, you can:
 
-* Enable or disable application telemetry.
+* Enable or turn off application telemetry.
 * Set the limit on the number of clients a single node can scrape telemetry data from at the same time.
 * Set how often the nodes scrape telemetry data from clients.
 

--- a/modules/rest-api/pages/application-telemetry.adoc
+++ b/modules/rest-api/pages/application-telemetry.adoc
@@ -12,10 +12,10 @@ Having Couchbase Server collect telemetry information from your applications tha
 This telemetry data is useful to diagnose issues such as poor performance or timeouts.
 
 When you enable application telemetry, Couchbase Server advertises to SDK clients that it can collect telemetry data.
-When an SDK client connects to a cluster that advertises that it can collect telemetry, it opens a WebSocket connection to a node in the cluster.
+When an SDK client connects to a cluster with application telemetry enabled, it opens a WebSocket connection to a node in the cluster.
 Couchbase Server uses this connection to periodically gather telemetry data from the client in Prometheus format.
 
-Couchbase Server reports the collected telemetry data through the Prometheus metrics endpoint, along with its own metrics.
+Couchbase Server reports the collected telemetry data through the same Prometheus metrics endpoint it uses to publish its own metrics.
 See xref:manage:monitor/set-up-prometheus-for-monitoring.adoc[] to learn how to set up Prometheus to collect metrics from your Couchbase Server cluster.
 
 NOTE: A Couchbase Server cluster only supports application telemetry when all of its nodes are running version 8.0 or later. 
@@ -139,15 +139,15 @@ Set to `true` to enable application telemetry or `false` to disable it.
 
 `maxScrapeClientsPerNode` (integer, optional)::
 Set the maximum number of clients from which a single node can scrape telemetry data at the same time.
-If a node reaches this many clients connect to it for telemetry scraping, it rejects new telemetry connections until the number of connected clients drops below the limit.
+If the number of client telemetry connections reaches this threshold, the node rejects new telemetry connections until the number of connect clients drops.
 
 +
 Valid values are from `1` to `1024`. 
 
 +
 The default value is `1024`.
-You can set `maxScrapeClientsPerNode` to a lower value to reduce the overhead on your nodes of collecting telemetry data.
-Howver, lowing it too far could result in clients being unable to find a node to connect to for telemetry scraping. 
+You can set `maxScrapeClientsPerNode` to a lower value to reduce potential overhead on your nodes from collecting telemetry data.
+However, lowering it too far could result in clients being unable to find a node for their telemetry connection. 
 When clients cannot find a node to connect to, their telemetry data is not collected. 
 
 `scrapeIntervalSeconds` (integer, optional)::
@@ -159,7 +159,7 @@ Valid values are `60` to `600`.
 +
 The default value is `60`.
 You can increase this value to reduce the overhead on your nodes of collecting telemetry data.
-However, setting it too high could result in telemetry not being collected before a client disconnects.
+However, setting it too high could result in a loss of telemetry data when clients close their connections.
 
 [#config-privs]
 === Required Privileges

--- a/modules/rest-api/pages/application-telemetry.adoc
+++ b/modules/rest-api/pages/application-telemetry.adoc
@@ -19,19 +19,54 @@ NOTE: Application telemetry is off by default in Couchbase Server 8.0.
 Future versions of Couchbase Server may enable it by default.
 
 Couchbase Server reports the telemetry data it collects through the same Prometheus metrics endpoint it uses to publish its own metrics.
+Couchbase Server reports aggregated application telemetry metrics instead of reporting metrics on a per-client basis.
 See xref:manage:monitor/set-up-prometheus-for-monitoring.adoc[] to learn how to set up Prometheus to collect metrics from your Couchbase Server cluster.
 
 === Prerequisites
 
-You Couchbase Server cluster and your clients must meet the following requirements to use application telemetry:
+Your Couchbase Server cluster and your clients must meet the following requirements to use application telemetry:
 
 * A Couchbase Server cluster only supports application telemetry when all of its nodes are running version 8.0 or later. 
 Earlier versions of Couchbase Server do not support application telemetry.
-Your cluster cannot collect application telemetry if it's running in mixed mode where some nodes are running a pre-8.0 version.
-If you enable application telemetry on a mixed-mode cluster with pre-8.0 nodes, it does not advertise to clients that it can collect telemetry.
+You cannot enable application telemetry if your cluster is running in mixed mode where all nodes are not running the same version of Couchbase Server.
 
-* Your applications must use an SDK that implements version 3.8 or later of the SDK API.
-See the table in xref:java-sdk:project-docs:compatibility.adoc#api-version[API Version] to determine which version of the SDK your application uses implements version 3.8 of the SDK API.
+* Your applications must use a recent SDK version that supports application telemetry.
+The following table lists the SDKs that support application telemetry along with the version where they added support.
+
++
+|===
+| SDK | Minimum Version with Application Telemetry Support
+
+| xref:dotnet-sdk:hello-world:overview.adoc[.NET]    
+| 3.8  
+
+| xref:cxx-sdk:hello-world:overview.adoc[{cpp}]      
+| 1.2  
+
+| xref:go-sdk:hello-world:overview.adoc[Go]          
+| 2.11 
+
+| xref:java-sdk:hello-world:overview.adoc[Java]      
+| 3.9  
+
+| xref:kotlin-sdk:hello-world:overview.adoc[Kotlin]  
+| 3.9  
+
+| xref:nodejs-sdk:hello-world:overview.adoc[Node.js] 
+| 4.6   
+
+| xref:php-sdk:hello-world:overview.adoc[PHP]       
+| 4.4  
+
+| xref:python-sdk:hello-world:overview.adoc[Python]  
+| 4.5  
+
+| xref:ruby-sdk:hello-world:overview.adoc[Ruby]      
+| 3.7  
+
+| xref:scala-sdk:hello-world:overview.adoc[Scala]    
+| 3.9  
+|===
 
 * Your clients must be able to connect to the node's management port to create the WebSocket connection for telemetry data collection.
 The default management port is 8091 for unencrypted connections and 18901 for encrypted connections.
@@ -48,7 +83,7 @@ This API endpoint supports the following methods:
 [#get-status]
 == Get Application Telemetry Status
 
-The following method gets the current state of application telemetry for the cluster.
+The following method gets the current status of application telemetry for the cluster.
 
 ----
 GET /settings/appTelemetry
@@ -122,7 +157,7 @@ Running the previous command returns a JSON object similar to the following:
 By sending a POST request to the `/settings/appTelemetry` endpoint, you can:
 
 * Turn application telemetry on or off.
-* Set the limit on the number of clients from which a single node can scrape telemetry data at the same time.
+* Set the limit on the number of clients  a single node can scrape telemetry data from at the same time.
 * Set how often the nodes scrape telemetry data from clients.
 
 .Configure Application Telemetry
@@ -166,9 +201,20 @@ Valid values are from `1` to `1024`.
 
 +
 The default value is `1024`.
-You can set `maxScrapeClientsPerNode` to a lower value to reduce potential overhead on your nodes from collecting telemetry data.
-However, lowering it too far could result in clients being unable to find a node for their telemetry connection. 
-When clients cannot find a node to connect to, Couchbase Server cannot collect their telemetry data. 
+You can set `maxScrapeClientsPerNode` to a lower value to reduce potential overhead on your nodes.
+A lower setting prevents too many clients connecting to each node.
+
++
+If a node reaches this limit, it starts rejecting new telemetry connections.
+Rejected clients can attempt to connect to another node in the cluster.
+
++
+If all nodes in the cluster reach this limit, newly connected clients are not able to connect to a node to have their telemetry collected.
+
++
+NOTE: You can monitor the number of application telemetry connections by viewing the `cm_app_telemetry_curr_connections` metric.
+See xref:metrics-reference:metrics-reference.adoc[] and xref:manage:monitor/set-up-prometheus-for-monitoring.adoc[] for more information about metrics.
+
 
 `scrapeIntervalSeconds` (integer, optional)::
 Sets how often the nodes scrape telemetry data from clients in seconds.
@@ -232,7 +278,7 @@ If successful, the previous command returns the following JSON object containing
 * See the SDK Telemetry from the Server section of the Collecting Information and Logging page in the documentation for the SDK you use.
 For example:
 
-** xref:cxx-sdk:howtos:collecting-information-and-logging.adoc#sdk-telemetry-from-the-server[C++ SDK]
+** xref:cxx-sdk:howtos:collecting-information-and-logging.adoc#sdk-telemetry-from-the-server[{cpp} SDK]
 ** xref:go-sdk:howtos:collecting-information-and-logging.adoc#sdk-telemetry-from-the-server[Go SDK]
 ** xref:java-sdk:howtos:collecting-information-and-logging.adoc#sdk-telemetry-from-the-server[Java SDK]
 ** xref:python-sdk:howtos:collecting-information-and-logging.adoc#sdk-telemetry-from-the-server[Python SDK]

--- a/modules/rest-api/pages/application-telemetry.adoc
+++ b/modules/rest-api/pages/application-telemetry.adoc
@@ -1,0 +1,222 @@
+= Application Telemetry
+:description: pass:q[You can enable application telemetry that lets Couchbase Server periodically collect information from your clients that use the Couchbase SDK.]
+:page-topic-type: reference
+:page-toclevels: 3
+
+[abstract]
+{description}
+
+== Description
+
+Having Couchbase Server collect telemetry information from your applications that use the Couchbase SDKs can help you troubleshoot client issues.
+This telemetry data is useful to diagnose issues such as poor performance or timeouts.
+
+When you enable application telemetry, Couchbase Server advertises to SDK clients that it can collect telemetry data.
+When an SDK client connects to a cluster that advertises that it can collect telemetry, it opens a WebSocket connection to a node in the cluster.
+Couchbase Server uses this connection to periodically gather telemetry data from the client in Prometheus format.
+
+Couchbase Server reports the collected telemetry data through the Prometheus metrics endpoint, along with its own metrics.
+See xref:manage:monitor/set-up-prometheus-for-monitoring.adoc[] to learn how to set up Prometheus to collect metrics from your Couchbase Server cluster.
+
+NOTE: A Couchbase Server cluster only supports application telemetry when all of its nodes are running version 8.0 or later. 
+Earlier versions of Couchbase Server do not support application telemetry.
+You cannot have the cluster collect application telemetry if the cluster is running in mixed mode with some nodes running a version earlier than 8.0.
+If you enable application telemetry on a cluster running in mixed mode with pre-8.0 nodes, the cluster does not advertise its ability to collect telemetry to clients.
+
+== HTTP Methods 
+
+This API endpoint supports the following methods:
+
+* <<#get-status>>
+* <<#configure-telemetry>>
+
+
+[#get-status]
+== Get Application Telemetry Status
+
+The following method gets the current state of application telemetry for the cluster.
+
+----
+GET /settings/appTelemetry
+----
+
+=== curl Syntax
+
+[source,bash]
+----
+curl -sS -u $USER:$PASSWORD \
+     -X GET 'http[s]://<hostname>:<port>/settings/appTelemetry' 
+----
+
+.Path and curl Parameters
+:priv-link: get-privs
+include::partial$user-pw-host-port-params.adoc[]
+
+
+[#get-privs]
+=== Required Privileges
+
+Your user account must have at least one of the following roles to get the application telemetry status:
+
+* xref:learn:security/roles.adoc#full-admin[Full Admin]
+* xref:learn:security/roles.adoc#cluster-admin[Cluster Admin]
+* xref:learn:security/roles.adoc#read-only-admin[Read-Only Admin]
+
+[#get-status-responses]
+=== Responses
+
+`200 OK`::
+Returned when the call is successful.
+The response body contains a JSON object with the following fields:
+
++
+* `enabled`: whether application telemetry is enabled or not.
+* `maxScrapeClientsPerNode`: the maximum number of clients from which a single node can scrape telemetry data at the same time.
+* `scrapeIntervalSeconds`: how often clients scrape telemetry data from the nodes, in seconds.
+
+`403 Forbidden`::
+Returned if you do not have the proper roles to call this API.
+See <<#get-privs>>.
+
+
+[#gey-state-example]
+=== Examples
+
+The following example gets the cluster's current application telemetry setting from the local node and pipes the result through `jq`.
+
+[source,bash]
+----
+ curl -sX GET -u Administrator:password \
+      'http://localhost:8091/settings/appTelemetry' | jq
+----
+
+Running the previous command returns a JSON object similar to the following:
+
+[source,json]
+----
+{
+  "enabled": false,
+  "maxScrapeClientsPerNode": 1024,
+  "scrapeIntervalSeconds": 60
+}
+----
+
+
+[#configure-telemetry]
+== Configure Application Telemetry
+
+By sending a POST request to the `/settings/appTelemetry` endpoint, you can:
+
+* Enable or disable application telemetry.
+* Set the limit on the number of clients a single node can scrape telemetry data from at the same time.
+* Set how often the nodes scrape telemetry data from clients.
+
+.Configure Application Telemetry
+----
+POST /settings/appTelemetry
+----
+
+
+=== curl Syntax
+
+[source,bash]
+----
+curl -sS -u $USER:$PASSWORD \
+  -X POST http://{host}:{port}/settings/encryptionKeys \
+  [-d enabled=[true|false]] \
+  [-d maxScrapeClientsPerNode=<integer>] \
+  [-d scrapeIntervalSeconds=<integer>]
+----
+
+.Path and curl Parameters
+:priv-link: config-privs
+include::partial$user-pw-host-port-params.adoc[]
+
+
+.REST Parameters
+`enabled` (boolean, optional)::
+Set to `true` to enable application telemetry or `false` to disable it.
+
+`maxScrapeClientsPerNode` (integer, optional)::
+Set the maximum number of clients from which a single node can scrape telemetry data at the same time.
+If a node reaches this many clients connect to it for telemetry scraping, it rejects new telemetry connections until the number of connected clients drops below the limit.
+
++
+Valid values are from `1` to `1024`. 
+
++
+The default value is `1024`.
+You can set `maxScrapeClientsPerNode` to a lower value to reduce the overhead on your nodes of collecting telemetry data.
+Howver, lowing it too far could result in clients being unable to find a node to connect to for telemetry scraping. 
+When clients cannot find a node to connect to, their telemetry data is not collected. 
+
+`scrapeIntervalSeconds` (integer, optional)::
+Sets how often the nodes scrape telemetry data from clients, in seconds.
+
++
+Valid values are `60` to `600`.
+
++
+The default value is `60`.
+You can increase this value to reduce the overhead on your nodes of collecting telemetry data.
+However, setting it too high could result in telemetry not being collected before a client disconnects.
+
+[#config-privs]
+=== Required Privileges
+Your user account must have at least 1 of the following roles to configure application telemetry:
+
+* xref:learn:security/roles.adoc#full-admin[Full Admin]
+* xref:learn:security/roles.adoc#cluster-admin[Cluster Admin]
+
+=== Responses
+
+`200 OK`::
+Returned when the call is successful.
+A successful call also returns a JSON object with the new application telemetry settings.
+This object has the same format as the <<#get-status-responses,response from the GET method>>.
+
+`403 Forbidden`::
+Returned if you do not have the proper roles to call this API.
+See <<#config-privs>> for a list of the required roles.
+
+[#config-examples]
+=== Examples
+
+The following example enables telemetry, sets the maximum number of clients a node can scrape telemetry data from at the same time to `512`, and sets the scrape interval to `90` seconds.
+It pipes the result through `jq` to make it easier to read.
+
+[source,bash]
+----
+curl -X POST -u Administrator:password \
+     http://localhost:8091/settings/appTelemetry \
+     -d enabled=true \
+     -d maxScrapeClientsPerNode=512 \
+     -d scrapeIntervalSeconds=90 | jq
+----
+
+If successful, the previous command returns the following JSON object containing the new state of application telemetry for the cluster:
+
+[source,json]
+----
+{
+  "enabled": true,
+  "maxScrapeClientsPerNode": 512,
+  "scrapeIntervalSeconds": 90
+}
+----
+
+== See Also
+
+* xref:manage:monitor/set-up-prometheus-for-monitoring.adoc[]
+
+* See the SDK Telemetry from the Server section of the Collecting Information and Logging page in the documentation for the SDK you use.
+For example:
+
+** xref:cxx-sdk:howtos:collecting-information-and-logging.adoc#sdk-telemetry-from-the-server[C++ SDK]
+** xref:go-sdk:howtos:collecting-information-and-logging.adoc#sdk-telemetry-from-the-server[Go SDK]
+** xref:java-sdk:howtos:collecting-information-and-logging.adoc#sdk-telemetry-from-the-server[Java SDK]
+** xref:kotlin-sdk:howtos:collecting-information-and-logging.adoc#sdk-telemetry-from-the-server[Python SDK]
+
+
+
+

--- a/modules/rest-api/pages/application-telemetry.adoc
+++ b/modules/rest-api/pages/application-telemetry.adoc
@@ -84,7 +84,7 @@ This API endpoint supports the following methods:
 [#get-status]
 == Get Application Telemetry Status
 
-The following method gets the current status of application telemetry for the cluster.
+The following method gets the current application telemetry settings the cluster.
 
 ----
 GET /settings/appTelemetry
@@ -106,7 +106,7 @@ include::partial$user-pw-host-port-params.adoc[]
 [#get-privs]
 === Required Privileges
 
-Your user account must have at least 1 of the following roles to get the application telemetry status:
+Your user account must have at least 1 of the following roles to get the application telemetry settings:
 
 * xref:learn:security/roles.adoc#full-admin[Full Admin]
 * xref:learn:security/roles.adoc#cluster-admin[Cluster Admin]
@@ -158,7 +158,7 @@ Running the previous command returns a JSON object similar to the following:
 By sending a POST request to the `/settings/appTelemetry` endpoint, you can:
 
 * Turn application telemetry on or off.
-* Set the limit on the number of clients  a single node can scrape telemetry data from at the same time.
+* Set the limit on the number of clients a single node can scrape telemetry data from at the same time.
 * Set how often the nodes scrape telemetry data from clients.
 
 .Configure Application Telemetry
@@ -183,7 +183,7 @@ include::partial$user-pw-host-port-params.adoc[]
 
 
 ==== REST Parameters
-`enabled` (boolean, optional)::
+`enabled` (Boolean, optional)::
 Set to `true` to enable application telemetry or `false` to turn it off.
 
 + 
@@ -202,8 +202,8 @@ Valid values are from `1` to `1024`.
 
 +
 The default value is `1024`.
-You can set `maxScrapeClientsPerNode` to a lower value to reduce potential overhead on your nodes.
-A lower setting prevents too many clients connecting to each node.
+You can set `maxScrapeClientsPerNode` to a lower value to reduce the number of clients that can connect to each node.
+Reducing the number of clients can potentially reduce the overhead of collecting telemetry data on your nodes if you have a large number of clients.
 
 +
 If a node reaches this limit, it starts rejecting new telemetry connections.
@@ -230,7 +230,7 @@ The default value is `60`.
 You can increase this value to reduce the overhead of collecting telemetry data on your nodes.
 However, increasing this value means Couchbase Server will miss collecting more telemetry data from clients before they disconnect.
 For example, suppose you set this value to `300`.
-Then Couchbase Server could lose up to 5 minutes of telemetry data from a client that disconnects just before the next sheduled telemetry collection.
+Then Couchbase Server could lose up to 5 minutes of telemetry data from a client that disconnects just before the next scheduled telemetry collection.
 
 +
 If your applications have short-lived client connections to the cluster, consider keeping this value low to increase the chances of collecting telemetry before the clients disconnect.
@@ -250,7 +250,7 @@ A successful call also returns a JSON object with the new application telemetry 
 This object has the same format as the <<#get-status-responses,response from the GET method>>.
 
 `400 Bad Request`::
-Returned if you attempt to enable application telemetry on a cluster that is running in mixed mode where some nodes are running a version earlier than 8.0. 
+Returned if you attempt to enable application telemetry on a cluster that's running in mixed mode where some nodes are running a version earlier than 8.0. 
 All of the nodes in the cluster must be running version 8.0 or later to enable application telemetry.
 See <<prerequisites>> for more requirements.
 
@@ -276,7 +276,7 @@ curl -X POST -u Administrator:password \
      -d scrapeIntervalSeconds=90 | jq
 ----
 
-If successful, the previous command returns the following JSON object containing the new state of application telemetry for the cluster:
+If successful, the previous command returns the following JSON object containing the new application telemetry settings for the cluster:
 
 [source,json]
 ----

--- a/modules/rest-api/pages/application-telemetry.adoc
+++ b/modules/rest-api/pages/application-telemetry.adoc
@@ -1,5 +1,5 @@
 = Application Telemetry
-:description: pass:q[You can enable application telemetry that lets Couchbase Server periodically collect information from your clients that use the Couchbase SDK.]
+:description: pass:q[You can enable application telemetry to have Couchbase Server periodically collect telemetry from your clients that use the Couchbase SDK.]
 :page-topic-type: reference
 :page-toclevels: 3
 
@@ -8,17 +8,17 @@
 
 == Description
 
-Having Couchbase Server collect telemetry information from your applications that use the Couchbase SDKs can help you troubleshoot client issues.
+Having Couchbase Server collect telemetry from your applications can help you troubleshoot client issues.
 This telemetry data is useful to diagnose issues such as poor performance or timeouts.
 
 When you enable application telemetry, Couchbase Server advertises to SDK clients that it can collect telemetry data.
 When an SDK client connects to a cluster with application telemetry enabled, it opens a WebSocket connection to a node in the cluster.
 Couchbase Server uses this connection to periodically gather telemetry data from the client in Prometheus format.
 
-NOTE: Application telemetry is disabled by default in Couchbase Server 8.0.
+NOTE: Application telemetry is off by default in Couchbase Server 8.0.
 Future versions of Couchbase Server may enable it by default.
 
-Couchbase Server reports the collected telemetry data through the same Prometheus metrics endpoint it uses to publish its own metrics.
+Couchbase Server reports the telemetry data it collects through the same Prometheus metrics endpoint it uses to publish its own metrics.
 See xref:manage:monitor/set-up-prometheus-for-monitoring.adoc[] to learn how to set up Prometheus to collect metrics from your Couchbase Server cluster.
 
 === Prerequisites
@@ -28,9 +28,10 @@ You Couchbase Server cluster and your clients must meet the following requiremen
 * A Couchbase Server cluster only supports application telemetry when all of its nodes are running version 8.0 or later. 
 Earlier versions of Couchbase Server do not support application telemetry.
 Your cluster cannot collect application telemetry if it's running in mixed mode where some nodes are running a pre-8.0 version.
-If you enable application telemetry on a mixed-mode cluster with pre-8.0 nodes, it does not advertise its ability to collect telemetry to clients.
+If you enable application telemetry on a mixed-mode cluster with pre-8.0 nodes, it does not advertise to clients that it can collect telemetry.
 
-* Your applications must use a version of the Couchbase SDK that supports application telemetry to have their telemetry data collected by Couchbase Server.
+* Your applications must use an SDK that implements version 3.8 or later of the SDK API.
+See the table in xref:java-sdk:project-docs:compatibility.adoc#api-version[API Version] to determine which version of the SDK your application uses implements version 3.8 of the SDK API.
 
 * Your clients must be able to connect to the node's management port to create the WebSocket connection for telemetry data collection.
 The default management port is 8091 for unencrypted connections and 18901 for encrypted connections.
@@ -120,8 +121,8 @@ Running the previous command returns a JSON object similar to the following:
 
 By sending a POST request to the `/settings/appTelemetry` endpoint, you can:
 
-* Enable or turn off application telemetry.
-* Set the limit on the number of clients a single node can scrape telemetry data from at the same time.
+* Turn application telemetry on or off.
+* Set the limit on the number of clients from which a single node can scrape telemetry data at the same time.
 * Set how often the nodes scrape telemetry data from clients.
 
 .Configure Application Telemetry
@@ -134,7 +135,7 @@ POST /settings/appTelemetry
 [source,bash]
 ----
 curl -sS -u $USER:$PASSWORD \
-  -X POST http://{host}:{port}/settings/encryptionKeys \
+  -X POST http://{host}:{port}/settings/appTelemetry \
   [-d enabled=[true|false]] \
   [-d maxScrapeClientsPerNode=<integer>] \
   [-d scrapeIntervalSeconds=<integer>]
@@ -158,7 +159,7 @@ NOTE: Future versions of Couchbase Sever may enable application telemetry by def
 
 `maxScrapeClientsPerNode` (integer, optional)::
 Set the maximum number of clients from which a single node can scrape telemetry data at the same time.
-If the number of client telemetry connections reaches this threshold, the node rejects new telemetry connections until the number of connect clients drops.
+If the number of client telemetry connections reaches this threshold, the node rejects new telemetry connections until the number of connected clients drops.
 
 +
 Valid values are from `1` to `1024`. 
@@ -201,7 +202,7 @@ See <<#config-privs>> for a list of the required roles.
 [#config-examples]
 === Examples
 
-The following example enables telemetry, sets the maximum number of clients a node can scrape telemetry data from to `512`, and sets the scrape interval to `90` seconds.
+The following example enables telemetry, limits the node to scraping data from  `512` clients, and sets the scrape interval to `90` seconds.
 It pipes the result through `jq` to make it easier to read.
 
 [source,bash]
@@ -234,8 +235,4 @@ For example:
 ** xref:cxx-sdk:howtos:collecting-information-and-logging.adoc#sdk-telemetry-from-the-server[C++ SDK]
 ** xref:go-sdk:howtos:collecting-information-and-logging.adoc#sdk-telemetry-from-the-server[Go SDK]
 ** xref:java-sdk:howtos:collecting-information-and-logging.adoc#sdk-telemetry-from-the-server[Java SDK]
-** xref:kotlin-sdk:howtos:collecting-information-and-logging.adoc#sdk-telemetry-from-the-server[Python SDK]
-
-
-
-
+** xref:python-sdk:howtos:collecting-information-and-logging.adoc#sdk-telemetry-from-the-server[Python SDK]

--- a/modules/rest-api/pages/application-telemetry.adoc
+++ b/modules/rest-api/pages/application-telemetry.adoc
@@ -85,7 +85,7 @@ The response body contains a JSON object with the following fields:
 
 +
 * `enabled`: whether application telemetry is enabled or not.
-* `maxScrapeClientsPerNode`: the maximum number of clients from which a single node can scrape telemetry data at the same time.
+* `maxScrapeClientsPerNode`: the maximum number of clients a single node can scrape telemetry data from at the same time.
 * `scrapeIntervalSeconds`: how often Couchbase Server scrapes telemetry data from the clients, in seconds.
 
 `403 Forbidden`::
@@ -158,7 +158,7 @@ When you enable application telemetry, Couchbase Server advertises to SDK client
 NOTE: Future versions of Couchbase Sever may enable application telemetry by default.
 
 `maxScrapeClientsPerNode` (integer, optional)::
-Set the maximum number of clients from which a single node can scrape telemetry data at the same time.
+Sets the maximum number of clients a single node can scrape telemetry data from at the same time.
 If the number of client telemetry connections reaches this threshold, the node rejects new telemetry connections until the number of connected clients drops.
 
 +
@@ -171,14 +171,14 @@ However, lowering it too far could result in clients being unable to find a node
 When clients cannot find a node to connect to, Couchbase Server cannot collect their telemetry data. 
 
 `scrapeIntervalSeconds` (integer, optional)::
-Sets how often the nodes scrape telemetry data from clients, in seconds.
+Sets how often the nodes scrape telemetry data from clients in seconds.
 
 +
 Valid values are `60` to `600`.
 
 +
 The default value is `60`.
-You can increase this value to reduce the overhead on your nodes of collecting telemetry data.
+You can increase this value to reduce the overhead of collecting telemetry data on your nodes.
 However, setting it too high could result in a loss of telemetry data when clients close their connections.
 
 [#config-privs]

--- a/modules/rest-api/pages/application-telemetry.adoc
+++ b/modules/rest-api/pages/application-telemetry.adoc
@@ -15,13 +15,26 @@ When you enable application telemetry, Couchbase Server advertises to SDK client
 When an SDK client connects to a cluster with application telemetry enabled, it opens a WebSocket connection to a node in the cluster.
 Couchbase Server uses this connection to periodically gather telemetry data from the client in Prometheus format.
 
+NOTE: Application telemetry is disabled by default in Couchbase Server 8.0.
+Future versions of Couchbase Server may enable it by default.
+
 Couchbase Server reports the collected telemetry data through the same Prometheus metrics endpoint it uses to publish its own metrics.
 See xref:manage:monitor/set-up-prometheus-for-monitoring.adoc[] to learn how to set up Prometheus to collect metrics from your Couchbase Server cluster.
 
-NOTE: A Couchbase Server cluster only supports application telemetry when all of its nodes are running version 8.0 or later. 
+=== Prerequisites
+
+You Couchbase Server cluster and your clients must meet the following requirements to use application telemetry:
+
+* A Couchbase Server cluster only supports application telemetry when all of its nodes are running version 8.0 or later. 
 Earlier versions of Couchbase Server do not support application telemetry.
-You cannot have the cluster collect application telemetry if the cluster is running in mixed mode with some nodes running a version earlier than 8.0.
-If you enable application telemetry on a cluster running in mixed mode with pre-8.0 nodes, the cluster does not advertise its ability to collect telemetry to clients.
+Your cluster cannot collect application telemetry if it's running in mixed mode where some nodes are running a pre-8.0 version.
+If you enable application telemetry on a mixed-mode cluster with pre-8.0 nodes, it does not advertise its ability to collect telemetry to clients.
+
+* Your applications must use a version of the Couchbase SDK that supports application telemetry to have their telemetry data collected by Couchbase Server.
+
+* Your clients must be able to connect to the node's management port to create the WebSocket connection for telemetry data collection.
+The default management port is 8091 for unencrypted connections and 18901 for encrypted connections.
+Make sure any firewall rules between your clients and the nodes allow traffic on the management port.
 
 == HTTP Methods 
 
@@ -72,14 +85,14 @@ The response body contains a JSON object with the following fields:
 +
 * `enabled`: whether application telemetry is enabled or not.
 * `maxScrapeClientsPerNode`: the maximum number of clients from which a single node can scrape telemetry data at the same time.
-* `scrapeIntervalSeconds`: how often clients scrape telemetry data from the nodes, in seconds.
+* `scrapeIntervalSeconds`: how often Couchbase Server scrapes telemetry data from the clients, in seconds.
 
 `403 Forbidden`::
 Returned if you do not have the proper roles to call this API.
 See <<#get-privs>>.
 
 
-[#gey-state-example]
+[#get-state-example]
 === Examples
 
 The following example gets the cluster's current application telemetry setting from the local node and pipes the result through `jq`.
@@ -116,7 +129,6 @@ By sending a POST request to the `/settings/appTelemetry` endpoint, you can:
 POST /settings/appTelemetry
 ----
 
-
 === curl Syntax
 
 [source,bash]
@@ -135,7 +147,14 @@ include::partial$user-pw-host-port-params.adoc[]
 
 .REST Parameters
 `enabled` (boolean, optional)::
-Set to `true` to enable application telemetry or `false` to disable it.
+Set to `true` to enable application telemetry or `false` to turn it off.
+
++ 
+Defaults to `false` (off).
+When you enable application telemetry, Couchbase Server advertises to SDK clients that it can collect telemetry data.
+
++
+NOTE: Future versions of Couchbase Sever may enable application telemetry by default.
 
 `maxScrapeClientsPerNode` (integer, optional)::
 Set the maximum number of clients from which a single node can scrape telemetry data at the same time.
@@ -148,7 +167,7 @@ Valid values are from `1` to `1024`.
 The default value is `1024`.
 You can set `maxScrapeClientsPerNode` to a lower value to reduce potential overhead on your nodes from collecting telemetry data.
 However, lowering it too far could result in clients being unable to find a node for their telemetry connection. 
-When clients cannot find a node to connect to, their telemetry data is not collected. 
+When clients cannot find a node to connect to, Couchbase Server cannot collect their telemetry data. 
 
 `scrapeIntervalSeconds` (integer, optional)::
 Sets how often the nodes scrape telemetry data from clients, in seconds.
@@ -182,7 +201,7 @@ See <<#config-privs>> for a list of the required roles.
 [#config-examples]
 === Examples
 
-The following example enables telemetry, sets the maximum number of clients a node can scrape telemetry data from at the same time to `512`, and sets the scrape interval to `90` seconds.
+The following example enables telemetry, sets the maximum number of clients a node can scrape telemetry data from to `512`, and sets the scrape interval to `90` seconds.
 It pipes the result through `jq` to make it easier to read.
 
 [source,bash]

--- a/modules/rest-api/pages/application-telemetry.adoc
+++ b/modules/rest-api/pages/application-telemetry.adoc
@@ -22,6 +22,7 @@ Couchbase Server reports the telemetry data it collects through the same Prometh
 Couchbase Server reports aggregated application telemetry metrics instead of reporting metrics on a per-client basis.
 See xref:manage:monitor/set-up-prometheus-for-monitoring.adoc[] to learn how to set up Prometheus to collect metrics from your Couchbase Server cluster.
 
+[#prerequisites]
 === Prerequisites
 
 Your Couchbase Server cluster and your clients must meet the following requirements to use application telemetry:
@@ -224,8 +225,15 @@ Valid values are `60` to `600`.
 
 +
 The default value is `60`.
+
++
 You can increase this value to reduce the overhead of collecting telemetry data on your nodes.
-However, setting it too high could result in a loss of telemetry data when clients close their connections.
+However, increasing this value means Couchbase Server will miss collecting more telemetry data from clients before they disconnect.
+For example, suppose you set this value to `300`.
+Then Couchbase Server could lose up to 5 minutes of telemetry data from a client that disconnects just before the next sheduled telemetry collection.
+
++
+If your applications have short-lived client connections to the cluster, consider keeping this value low to increase the chances of collecting telemetry before the clients disconnect.
 
 [#config-privs]
 === Required Privileges
@@ -241,9 +249,17 @@ Returned when the call is successful.
 A successful call also returns a JSON object with the new application telemetry settings.
 This object has the same format as the <<#get-status-responses,response from the GET method>>.
 
+`400 Bad Request`::
+Returned if you attempt to enable application telemetry on a cluster that is running in mixed mode where some nodes are running a version earlier than 8.0. 
+All of the nodes in the cluster must be running version 8.0 or later to enable application telemetry.
+See <<prerequisites>> for more requirements.
+
 `403 Forbidden`::
 Returned if you do not have the proper roles to call this API.
 See <<#config-privs>> for a list of the required roles.
+
+`404 Not Found`::
+Returned if you attempt to call the endpoint on a running a version of Couchbase Server earlier than 8.0. 
 
 [#config-examples]
 === Examples

--- a/modules/rest-api/partials/user-pw-host-port-params.adoc
+++ b/modules/rest-api/partials/user-pw-host-port-params.adoc
@@ -5,9 +5,9 @@ The name of a user who has one of the roles listed in <<{priv-link}>>.
 `PASSWORD`::
 The password for the `user`.
 
-`HOST`::
-Hostname or IP address of a Couchbase Server.
+`host`::
+Hostname or IP address of a Couchbase Server node.
 
-`PORT`::
+`port`::
 Port number for the REST API. 
 Defaults are 8091 for unencrypted and 18901 for encrypted connections.

--- a/preview/DOC-13717_REST_API_for_appTelemetry.yml
+++ b/preview/DOC-13717_REST_API_for_appTelemetry.yml
@@ -32,11 +32,11 @@ sources:
     docs-sdk-python:
       branches: [release/4.6]
     docs-sdk-ruby:
-      branches: [release/3.7]
+      branches: [temp/3.7]
     docs-sdk-nodejs:    
       branches: [release/4.2]
     docs-sdk-php:
-      branches: [release/4.4]
+      branches: [temp/4.5]
     docs-sdk-dotnet:
       branches: [release/3.5]
     docs-sdk-extensions:
@@ -44,4 +44,6 @@ sources:
     docs-sdk-go:
       branches: [release/2.12]
     docs-sdk-kotlin:
+      branches: [release/3.10]
+    docs-sdk-scala:
       branches: [release/3.11]

--- a/preview/DOC-13717_REST_API_for_appTelemetry.yml
+++ b/preview/DOC-13717_REST_API_for_appTelemetry.yml
@@ -1,0 +1,47 @@
+sources:
+    docs-devex:
+      branches: release/8.0
+
+    docs-analytics:
+      branches: release/8.0
+
+    couchbase-cli:
+      branches: morpheus
+      startPaths: docs/
+      
+    backup:
+      branches: morpheus
+      startPaths: docs/
+      
+    #analytics:
+    #  url: ../../docs-includes/docs-analytics
+    #  branches: HEAD
+
+    cb-swagger:
+      url: https://github.com/couchbaselabs/cb-swagger
+      branches: release/8.0
+      start_path: docs
+
+    # Minimal SDK build
+    docs-sdk-common:
+      branches: [release/8.0, release/8.0.1]
+    docs-sdk-cxx:
+      branches: [release/1.2]
+    docs-sdk-java:
+      branches: [release/3.11]
+    docs-sdk-python:
+      branches: [release/4.6]
+    docs-sdk-ruby:
+      branches: [release/3.7]
+    docs-sdk-nodejs:    
+      branches: [release/4.2]
+    docs-sdk-php:
+      branches: [release/4.4]
+    docs-sdk-dotnet:
+      branches: [release/3.5]
+    docs-sdk-extensions:
+      branches: [main]
+    docs-sdk-go:
+      branches: [release/2.11]
+    docs-sdk-kotlin:
+      branches: [release/3.11]

--- a/preview/DOC-13717_REST_API_for_appTelemetry.yml
+++ b/preview/DOC-13717_REST_API_for_appTelemetry.yml
@@ -42,6 +42,6 @@ sources:
     docs-sdk-extensions:
       branches: [main]
     docs-sdk-go:
-      branches: [release/2.11]
+      branches: [release/2.12]
     docs-sdk-kotlin:
       branches: [release/3.11]


### PR DESCRIPTION
This PR adds documentation for the Server `/settings/appTelemetry` REST API  endpoint.

Here's a list of the changes in this PR, with links to a preview. You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence to access the preview.

* Added new [Application Telemetry](https://preview.docs-test.couchbase.com/docs-server-DOC-13717_REST_API_for_appTelemetry/server/current/rest-api/application-telemetry.html) page that explains getting and configuring telemetry settings. 
* Added a short section to [Configure Prometheus to Collect Couchbase Metrics](https://preview.docs-test.couchbase.com/docs-server-DOC-13717_REST_API_for_appTelemetry/server/current/manage/monitor/set-up-prometheus-for-monitoring.html#app-telemetry) explaining that you can add application metrics to the Prometheus endpoint by enabling application telemetry. It seemed like the right place to mention that.

**Note:** I've made some assumptions about the `maxScrapeClientsPerNode` and `scrapeIntervalSeconds` settings, so be sure to pay special attention to their descriptions. 