### PR TITLE
[NO ISSUE] Fix heading levels on the What's New page

### DIFF
--- a/modules/introduction/partials/new_features-76_10.adoc
+++ b/modules/introduction/partials/new_features-76_10.adoc
@@ -4,7 +4,7 @@
 The following new features are provided in this release.
 
 [#new-features-7610-query]
-== Query Service
+=== Query Service
 
 * *https://jira.issues.couchbase.com/browse/MB-69387[MB-69387]:*
 Couchbase Server 7.6.10 now includes an auto-reprepare feature for PREPARE statements. 

--- a/modules/introduction/partials/new_features-76_6.adoc
+++ b/modules/introduction/partials/new_features-76_6.adoc
@@ -8,7 +8,7 @@ The following new features are provided in this release.
 ** Windows Server 2025
 
 [#new-features-766-xdcr]
-== XDCR
+=== XDCR
 
 * *https://jira.issues.couchbase.com/browse/MB-57921[MB-57921]:*
 Created provision to set up XDCR bidirectional replication with Sync Gateway (SGW) 4.0 or a later version.


### PR DESCRIPTION
A tiny update to fix the heading levels on the What's New page. 

Preview: [What's New 7.6](https://preview.docs-test.couchbase.com/docs-server-fix-whats-new-headers/server/current/introduction/whats-new.html#new-features-7610)
