### PR TITLE
Update to metrics for Server 7.6 and change to Handlebars template

### DIFF
--- a/modules/metrics-reference/attachments/cbas_metrics_metadata.json
+++ b/modules/metrics-reference/attachments/cbas_metrics_metadata.json
@@ -2,7 +2,20 @@
   "cbas_active_links": {
     "added": "7.2.4",
     "help": "Number of active links.",
-    "type": "gauge"
+    "type": "gauge",
+    "unit": "number"
+  },
+  "cbas_backup_requests_failed_total": {
+    "added": "7.6.2",
+    "help": "Total number of failed backup requests.",
+    "type": "counter",
+    "unit": "count"
+  },
+  "cbas_backup_requests_total": {
+    "added": "7.6.2",
+    "help": "Total number of backup requests.",
+    "type": "counter",
+    "unit": "count"
   },
   "cbas_direct_memory_used_bytes": {
     "added": "7.0.2",
@@ -30,6 +43,23 @@
     "type": "gauge",
     "unit": "seconds"
   },
+  "cbas_driver_uptime_seconds_total": {
+    "added": "7.6.1",
+    "help": "Total driver uptime in seconds.",
+    "type": "counter",
+    "unit": "seconds"
+  },
+  "cbas_extra_incoming_records_total": {
+    "added": "7.6.6",
+    "help": "Total number of incoming records that were processed multiple times due to DCP snapshot alignment.",
+    "labels": [
+      "bucket",
+      "scope",
+      "link"
+    ],
+    "type": "counter",
+    "unit": "count"
+  },
   "cbas_failed_to_parse_records_count": {
     "added": "7.0.0",
     "deprecated": "7.6.0",
@@ -40,7 +70,8 @@
       "link"
     ],
     "notes": "Will be removed in the 8.0 release. Use cbas_failed_to_parse_records_total",
-    "type": "gauge"
+    "type": "gauge",
+    "unit": "number"
   },
   "cbas_failed_to_parse_records_total": {
     "added": "7.6.0",
@@ -50,12 +81,14 @@
       "scope",
       "link"
     ],
-    "type": "counter"
+    "type": "counter",
+    "unit": "count"
   },
   "cbas_gc_count_total": {
     "added": "7.0.0",
     "help": "Total number of garbage collections.",
-    "type": "counter"
+    "type": "counter",
+    "unit": "count"
   },
   "cbas_gc_time_milliseconds_total": {
     "added": "7.0.0",
@@ -77,6 +110,12 @@
     "type": "gauge",
     "unit": "bytes"
   },
+  "cbas_heap_memory_max_bytes": {
+    "added": "7.2.7",
+    "help": "Heap memory max in bytes.",
+    "type": "gauge",
+    "unit": "bytes"
+  },
   "cbas_heap_memory_used_bytes": {
     "added": "7.0.0",
     "help": "Heap memory used in bytes.",
@@ -89,12 +128,20 @@
     "labels": [
       "code"
     ],
-    "type": "counter"
+    "type": "counter",
+    "unit": "count"
+  },
+  "cbas_http_requests_timeout_total": {
+    "added": "7.6.2",
+    "help": "Total number of HTTP requests timeouts.",
+    "type": "counter",
+    "unit": "count"
   },
   "cbas_http_requests_total": {
     "added": "7.6.0",
     "help": "Total number of http requests.",
-    "type": "counter"
+    "type": "counter",
+    "unit": "count"
   },
   "cbas_incoming_records_count": {
     "added": "7.0.0",
@@ -106,7 +153,8 @@
       "link"
     ],
     "notes": "Will be removed in the 8.0 release. Use cbas_incoming_records_total",
-    "type": "gauge"
+    "type": "gauge",
+    "unit": "count"
   },
   "cbas_incoming_records_total": {
     "added": "7.6.0",
@@ -116,92 +164,167 @@
       "scope",
       "link"
     ],
-    "type": "counter"
+    "type": "counter",
+    "unit": "count"
   },
   "cbas_io_reads_total": {
     "added": "7.0.0",
     "help": "Total number of IO reads.",
-    "type": "counter"
+    "type": "counter",
+    "unit": "count"
   },
   "cbas_io_writes_total": {
     "added": "7.0.0",
     "help": "Total number of IO writes.",
-    "type": "counter"
+    "type": "counter",
+    "unit": "count"
+  },
+  "cbas_jobs_total": {
+    "added": "7.6.2",
+    "help": "Total number of successful, failed, cancelled and rejected jobs.",
+    "labels": [
+      "result"
+    ],
+    "type": "counter",
+    "unit": "count"
+  },
+  "cbas_link_connect_failed_total": {
+    "added": "7.6.2",
+    "help": "Total number of link connect failures.",
+    "labels": [
+      "link",
+      "code"
+    ],
+    "type": "counter",
+    "unit": "count"
+  },
+  "cbas_link_disconnect_failed_total": {
+    "added": "7.6.2",
+    "help": "Total number of link disconnect failures.",
+    "labels": [
+      "link",
+      "code"
+    ],
+    "type": "counter",
+    "unit": "count"
+  },
+  "cbas_link_invalid_credentials_total": {
+    "added": "7.6.2",
+    "help": "Total number of link invalid credentials.",
+    "labels": [
+      "link",
+      "code",
+      "action"
+    ],
+    "type": "counter",
+    "unit": "count"
   },
   "cbas_pending_flush_ops": {
     "added": "7.0.0",
     "help": "Total number of pending flush operations.",
-    "type": "gauge"
+    "type": "gauge",
+    "unit": "number"
   },
   "cbas_pending_merge_ops": {
     "added": "7.0.0",
     "help": "Total number of pending merge operations.",
-    "type": "gauge"
+    "type": "gauge",
+    "unit": "number"
   },
   "cbas_pending_replicate_ops": {
     "added": "7.1.0",
     "help": "Total number of pending replication operations.",
-    "type": "gauge"
+    "type": "gauge",
+    "unit": "number"
   },
   "cbas_pending_requests": {
     "added": "7.2.4",
     "help": "Number of pending requests.",
-    "type": "gauge"
+    "type": "gauge",
+    "unit": "number"
   },
   "cbas_queued_http_requests_size": {
     "added": "7.6.0",
     "help": "Number of queued http requests.",
-    "type": "gauge"
+    "type": "gauge",
+    "unit": "number"
   },
   "cbas_queued_jobs": {
     "added": "7.2.4",
     "help": "Number of queued jobs.",
-    "type": "gauge"
+    "type": "gauge",
+    "unit": "number"
   },
   "cbas_rebalance_cancelled_total": {
     "added": "7.6.0",
     "help": "Total number of cancelled rebalances.",
-    "type": "counter"
+    "type": "counter",
+    "unit": "count"
   },
   "cbas_rebalance_failed_total": {
     "added": "7.6.0",
     "help": "Total number of rebalance failures.",
-    "type": "counter"
+    "type": "counter",
+    "unit": "count"
   },
   "cbas_rebalance_successful_total": {
     "added": "7.6.0",
     "help": "Total number of successful rebalances.",
-    "type": "counter"
+    "type": "counter",
+    "unit": "count"
+  },
+  "cbas_requests_failed_total": {
+    "added": "7.6.2",
+    "help": "Total number of failed requests.",
+    "type": "counter",
+    "unit": "count"
   },
   "cbas_requests_total": {
     "added": "7.2.4",
     "help": "Total number of received requests.",
-    "type": "counter"
+    "type": "counter",
+    "unit": "count"
   },
   "cbas_running_jobs": {
     "added": "7.2.4",
     "help": "Number of running jobs.",
-    "type": "gauge"
+    "type": "gauge",
+    "unit": "number"
+  },
+  "cbas_scan_consistency_timeout_total": {
+    "added": "7.6.2",
+    "help": "Total number of scan consistency timeouts.",
+    "type": "counter",
+    "unit": "count"
   },
   "cbas_system_load_average": {
     "added": "7.0.0",
     "help": "System work load.",
-    "type": "gauge"
+    "type": "gauge",
+    "unit": "number"
   },
   "cbas_thread_count": {
     "added": "7.0.0",
     "help": "Number of threads in use.",
-    "type": "gauge"
+    "type": "gauge",
+    "unit": "number"
   },
   "cbas_virtual_buffer_cache_used_pages": {
     "added": "7.0.0",
     "help": "Total number of used memory pages in the virtual buffer cache.",
-    "type": "gauge"
+    "type": "gauge",
+    "unit": "number"
   },
   "cbas_wrapper_boot_timestamp_seconds": {
     "added": "7.6.0",
     "help": "Analytics wrapper process boot timestamp in seconds since Unix epoch.",
     "type": "gauge",
+    "unit": "seconds"
+  },
+  "cbas_wrapper_uptime_seconds_total": {
+    "added": "7.6.1",
+    "help": "Total wrapper uptime in seconds.",
+    "type": "counter",
     "unit": "seconds"
   }
 }

--- a/modules/metrics-reference/attachments/cm_metrics_metadata.json
+++ b/modules/metrics-reference/attachments/cm_metrics_metadata.json
@@ -48,19 +48,19 @@
     "type": "counter"
   },
   "cm_auto_failover_count": {
-    "added": "7.6.2",
+    "added": "7.2.6",
     "help": "Number of auto-failovers",
     "stability": "committed",
     "type": "gauge"
   },
   "cm_auto_failover_enabled": {
-    "added": "7.6.2",
+    "added": "7.2.6",
     "help": "Indicates if auto-failover is enabled (1 = true, 0 = false)",
     "stability": "committed",
     "type": "gauge"
   },
   "cm_auto_failover_max_count": {
-    "added": "7.6.2",
+    "added": "7.2.6",
     "help": "Maximum number of auto-failovers before being disabled",
     "stability": "committed",
     "type": "gauge"
@@ -152,7 +152,7 @@
     "type": "gauge"
   },
   "cm_failover_total": {
-    "added": "7.6.2",
+    "added": "7.2.6",
     "help": "Number of non-graceful failover results",
     "labels": [
       {
@@ -169,7 +169,7 @@
     "type": "histogram"
   },
   "cm_graceful_failover_total": {
-    "added": "7.6.2",
+    "added": "7.2.6",
     "help": "Number of graceful failover results",
     "labels": [
       {
@@ -224,7 +224,7 @@
     "type": "counter"
   },
   "cm_is_balanced": {
-    "added": "7.6.2",
+    "added": "7.2.6",
     "help": "Indicates if cluster is balanced (1 = true, 0 = false). Only reported by the orchestrator node and only updated once every 30 seconds",
     "stability": "committed",
     "type": "gauge"
@@ -499,13 +499,13 @@
     "type": "counter"
   },
   "cm_rebalance_in_progress": {
-    "added": "7.6.2",
+    "added": "7.2.6",
     "help": "Indicates if a rebalance is running (1 = true, 0 = false). Only reported by the orchestrator node.",
     "stability": "committed",
     "type": "gauge"
   },
   "cm_rebalance_progress": {
-    "added": "7.6.2",
+    "added": "7.2.6",
     "help": "Estimate of the rebalance progress (0 - 1) for each stage. Only reported by the orchestrator node.",
     "labels": [
       {
@@ -524,7 +524,7 @@
     "type": "gauge"
   },
   "cm_rebalance_total": {
-    "added": "7.6.2",
+    "added": "7.2.6",
     "help": "Number of rebalance results",
     "labels": [
       {

--- a/modules/metrics-reference/attachments/fts_metrics_metadata.json
+++ b/modules/metrics-reference/attachments/fts_metrics_metadata.json
@@ -1,5 +1,6 @@
 {
   "fts_avg_grpc_queries_latency": {
+    "added": "7.2.0",
     "help": "Average latency per query, using gRPC for streaming, for an index",
     "labels": [
       "bucket",
@@ -11,6 +12,7 @@
     "unit": "milliseconds"
   },
   "fts_avg_internal_queries_latency": {
+    "added": "7.2.0",
     "help": "Average latency of inter-node queries per unit time for an index",
     "labels": [
       "bucket",
@@ -22,6 +24,7 @@
     "unit": "milliseconds"
   },
   "fts_avg_queries_latency": {
+    "added": "7.2.0",
     "help": "Average latency of queries per unit time for an index",
     "labels": [
       "bucket",
@@ -34,23 +37,109 @@
     "unit": "milliseconds"
   },
   "fts_batch_bytes_added": {
+    "added": "7.2.0",
     "help": "Total number of bytes from batches yet to be indexed.",
     "type": "counter",
     "unit": "bytes"
   },
   "fts_batch_bytes_removed": {
+    "added": "7.2.0",
     "help": "Total number of bytes from batches which have been indexed.",
     "notes": "This stat is associated with the fts_batch_bytes_added stat, in that they represent the completion and queuing of an indexing operation respectively.",
     "type": "counter",
     "unit": "bytes"
   },
+  "fts_boot_timestamp_seconds": {
+    "added": "7.5.0",
+    "help": "The time the service booted in fractional seconds since Unix epoch.",
+    "notes": "This is a metric specific to serverless.",
+    "type": "gauge",
+    "unit": "seconds"
+  },
+  "fts_counter_cu_total": {
+    "added": "7.5.0",
+    "help": "The number of distinct operations recording Compute Units (CUs) with Regulator.",
+    "labels": [
+      "bucket",
+      "for",
+      "unbilled",
+      "variant"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
+  "fts_counter_ru_total": {
+    "added": "7.5.0",
+    "help": "The number of distinct operations recording Read Units (RUs) with Regulator.",
+    "labels": [
+      "bucket",
+      "for",
+      "unbilled",
+      "variant"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
+  "fts_counter_wu_total": {
+    "added": "7.5.0",
+    "help": "The number of distinct operations recording Write Units (WUs) with Regulator.",
+    "labels": [
+      "bucket",
+      "for",
+      "unbilled",
+      "variant"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
+  "fts_credit_cu_total": {
+    "added": "7.5.0",
+    "help": "The number of Compute Units (CUs) refunded.",
+    "labels": [
+      "bucket",
+      "for",
+      "variant"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
+  "fts_credit_ru_total": {
+    "added": "7.5.0",
+    "help": "The number of Read Units (RUs) refunded.",
+    "labels": [
+      "bucket",
+      "for",
+      "variant"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
+  "fts_credit_wu_total": {
+    "added": "7.5.0",
+    "help": "The number of Write Units (WUs) refunded.",
+    "labels": [
+      "bucket",
+      "for",
+      "variant"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
   "fts_curr_batches_blocked_by_herder": {
+    "added": "7.2.0",
     "help": "The difference between the number of batches that have been indexed and the number of batches yet to be indexed",
     "notes": "The app herder blocks indexing of batches till there is sufficient memory i.e. the memory used is below the memory quota",
     "type": "gauge",
     "uiName": "DCP Batches Blocked"
   },
   "fts_doc_count": {
+    "added": "7.2.0",
     "help": "Number of documents in the index",
     "labels": [
       "bucket",
@@ -61,7 +150,47 @@
     "type": "counter",
     "uiName": "Search Docs"
   },
+  "fts_meter_cu_total": {
+    "added": "7.5.0",
+    "help": "The number of Compute Units (CUs) recorded.",
+    "labels": [
+      "bucket",
+      "for",
+      "unbilled",
+      "variant"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
+  "fts_meter_ru_total": {
+    "added": "7.5.0",
+    "help": "The number of Read Units (RUs) recorded.",
+    "labels": [
+      "bucket",
+      "for",
+      "unbilled",
+      "variant"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
+  "fts_meter_wu_total": {
+    "added": "7.5.0",
+    "help": "The number of Write Units (WUs) recorded.",
+    "labels": [
+      "bucket",
+      "for",
+      "unbilled",
+      "variant"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
   "fts_num_batches_introduced": {
+    "added": "7.2.0",
     "help": "Total number of batches introduced as part of indexing.",
     "type": "counter"
   },
@@ -74,6 +203,7 @@
     "unit": "bytes"
   },
   "fts_num_bytes_used_disk": {
+    "added": "7.2.0",
     "help": "The number of bytes used on disk by the index",
     "labels": [
       "bucket",
@@ -86,6 +216,7 @@
     "unit": "bytes"
   },
   "fts_num_bytes_used_disk_by_root": {
+    "added": "7.2.0",
     "help": "The number of bytes used on disk by the root segment",
     "labels": [
       "bucket",
@@ -97,6 +228,7 @@
     "unit": "bytes"
   },
   "fts_num_bytes_used_ram": {
+    "added": "7.2.0",
     "help": "The number of bytes used in memory",
     "notes": "Process level statistic from the Go runtime",
     "type": "gauge",
@@ -104,6 +236,7 @@
     "unit": "bytes"
   },
   "fts_num_files_on_disk": {
+    "added": "7.2.0",
     "help": "The number of files on disk for an index",
     "labels": [
       "bucket",
@@ -120,6 +253,7 @@
     "type": "counter"
   },
   "fts_num_mutations_to_index": {
+    "added": "7.2.0",
     "help": "DCP sequence numbers yet to be indexed for an index",
     "labels": [
       "bucket",
@@ -131,6 +265,7 @@
     "uiName": "Search Mutations Remaining"
   },
   "fts_num_pindexes_actual": {
+    "added": "7.2.0",
     "help": "Total number of pindexes currently",
     "labels": [
       "bucket",
@@ -142,6 +277,7 @@
     "uiName": "Search Partitions"
   },
   "fts_num_pindexes_target": {
+    "added": "7.2.0",
     "help": "Planned/expected number of pindexes",
     "labels": [
       "bucket",
@@ -153,6 +289,7 @@
     "uiName": "Search Partitions Expected"
   },
   "fts_num_recs_to_persist": {
+    "added": "7.2.0",
     "help": "The number of entries (terms, records, dictionary rows, etc) by Bleve not yet persisted to storage",
     "labels": [
       "bucket",
@@ -164,6 +301,7 @@
     "uiName": "Search Records to Persist"
   },
   "fts_num_root_filesegments": {
+    "added": "7.2.0",
     "help": "The number of file segments in the root segment",
     "labels": [
       "bucket",
@@ -175,6 +313,7 @@
     "uiName": "Search Disk Segments"
   },
   "fts_num_root_memorysegments": {
+    "added": "7.2.0",
     "help": "The number of memory segments in the root segment",
     "labels": [
       "bucket",
@@ -185,7 +324,19 @@
     "type": "gauge",
     "uiName": "Search Memory Segments"
   },
+  "fts_op_count_total": {
+    "added": "7.5.0",
+    "help": "The number of distinct operations recorded with Regulator.",
+    "labels": [
+      "bucket",
+      "for"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
   "fts_pct_cpu_gc": {
+    "added": "7.2.0",
     "help": "The percentage of CPU time spent by an index in garbage collection",
     "notes": "Process level statistic from the Go runtime",
     "type": "gauge",
@@ -199,64 +350,112 @@
     "uiName": "Pct RAM Used by Search",
     "unit": "percent"
   },
+  "fts_reject_count_total": {
+    "added": "7.5.0",
+    "help": "The number of times Regulator instructed an operation to be rejected.",
+    "labels": [
+      "bucket",
+      "for"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
+  "fts_throttle_count_total": {
+    "added": "7.5.0",
+    "help": "The number of times Regulator instructed an operation to throttle.",
+    "labels": [
+      "bucket",
+      "for"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
+  "fts_throttle_seconds_total": {
+    "added": "7.5.0",
+    "help": "The total time spent throttling (in seconds).",
+    "labels": [
+      "bucket",
+      "for"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
   "fts_tot_batches_flushed_on_maxops": {
+    "added": "7.2.0",
     "help": "Total number of batches executed due to the batch size being greater than the maximum number of operations per batch",
     "type": "counter"
   },
   "fts_tot_batches_flushed_on_timer": {
+    "added": "7.2.0",
     "help": "Total number of batches executed at regular intervals",
     "type": "counter"
   },
   "fts_tot_bleve_dest_closed": {
+    "added": "7.2.0",
     "help": "Total number of times Bleve destinations closed",
     "type": "counter"
   },
   "fts_tot_bleve_dest_opened": {
+    "added": "7.2.0",
     "help": "The number of times Bleve destinations opened",
     "notes": "Each Bleve destination corresponds to a Bleve index.",
     "type": "counter"
   },
   "fts_tot_grpc_listeners_closed": {
+    "added": "7.2.0",
     "help": "Total number of gRPC listeners closed",
     "type": "counter"
   },
   "fts_tot_grpc_listeners_opened": {
+    "added": "7.2.0",
     "help": "Total number of gRPC listeners opened",
     "type": "counter"
   },
   "fts_tot_grpc_queryreject_on_memquota": {
+    "added": "7.2.0",
     "help": "Total number of gRPC queries rejected due to the memory quota being lesser than the estimated memory required for merging search results from all partitions from the query",
     "type": "counter"
   },
   "fts_tot_grpcs_listeners_closed": {
+    "added": "7.2.0",
     "help": "Total number of gRPC SSL listeners closed",
     "type": "counter"
   },
   "fts_tot_grpcs_listeners_opened": {
+    "added": "7.2.0",
     "help": "Total number of gRPC SSL listeners opened",
     "type": "counter"
   },
   "fts_tot_http_limitlisteners_closed": {
+    "added": "7.2.0",
     "help": "Total number of HTTP limit listeners closed",
     "type": "counter"
   },
   "fts_tot_http_limitlisteners_opened": {
+    "added": "7.2.0",
     "help": "Total number of HTTP limit listeners opened",
     "type": "counter"
   },
   "fts_tot_https_limitlisteners_closed": {
+    "added": "7.2.0",
     "help": "Total number of HTTPS limit listeners closed",
     "type": "counter"
   },
   "fts_tot_https_limitlisteners_opened": {
+    "added": "7.2.0",
     "help": "Total number of HTTPS limit listeners opened",
     "type": "counter"
   },
   "fts_tot_queryreject_on_memquota": {
+    "added": "7.2.0",
     "help": "Total number of queries rejected due to the memory quota being lesser than the estimated memory required for merging search results from all partitions from the query",
     "type": "counter"
   },
   "fts_tot_remote_grpc": {
+    "added": "7.2.0",
     "help": "Total number of remote(i.e. different node) gRPC requests",
     "type": "counter"
   },
@@ -266,14 +465,17 @@
     "type": "counter"
   },
   "fts_tot_remote_grpc_tls": {
+    "added": "7.2.0",
     "help": "Total number of remote(i.e. different node) gRPC SSL requests when adding clients.",
     "type": "counter"
   },
   "fts_tot_remote_http": {
+    "added": "7.2.0",
     "help": "Total number of remote(i.e. different node) HTTP requests",
     "type": "counter"
   },
   "fts_tot_remote_http2": {
+    "added": "7.2.0",
     "help": "Total number of remote(i.e. different node) HTTP SSL requests",
     "type": "counter"
   },
@@ -283,6 +485,7 @@
     "type": "counter"
   },
   "fts_total_bytes_indexed": {
+    "added": "7.2.0",
     "help": "Rate of bytes indexed for an index",
     "labels": [
       "bucket",
@@ -294,6 +497,7 @@
     "uiName": "Search Index Rate"
   },
   "fts_total_bytes_query_results": {
+    "added": "7.2.0",
     "help": "Size of results coming back from full text queries for search results, including the entire size of the JSON sent",
     "labels": [
       "bucket",
@@ -306,6 +510,7 @@
     "unit": "bytes"
   },
   "fts_total_compaction_written_bytes": {
+    "added": "7.2.0",
     "help": "Number of bytes written to disk as a result of compaction",
     "labels": [
       "bucket",
@@ -318,11 +523,13 @@
     "unit": "bytes"
   },
   "fts_total_gc": {
+    "added": "7.2.0",
     "help": "The number of garbage collection events triggered",
     "notes": "Process level statistic from the Go runtime",
     "type": "counter"
   },
   "fts_total_grpc_internal_queries": {
+    "added": "7.2.0",
     "help": "The number of internal gRPC requests from the co-ordinating node for the query to other nodes, for an index",
     "labels": [
       "bucket",
@@ -333,6 +540,7 @@
     "type": "counter"
   },
   "fts_total_grpc_queries": {
+    "added": "7.2.0",
     "help": "The total number of queries, using gRPC for streaming, for an index",
     "labels": [
       "bucket",
@@ -343,6 +551,7 @@
     "type": "counter"
   },
   "fts_total_grpc_queries_error": {
+    "added": "7.2.0",
     "help": "The number of queries that resulted in an error, using gRPC for streaming, for an index",
     "labels": [
       "bucket",
@@ -353,6 +562,7 @@
     "type": "counter"
   },
   "fts_total_grpc_queries_slow": {
+    "added": "7.2.0",
     "help": "The number of queries in the slow query log, using gRPC for streaming, for an index",
     "labels": [
       "bucket",
@@ -363,6 +573,7 @@
     "type": "counter"
   },
   "fts_total_grpc_queries_timeout": {
+    "added": "7.2.0",
     "help": "The number of queries that exceeded the timeout, using gRPC for streaming, for an index",
     "labels": [
       "bucket",
@@ -373,6 +584,7 @@
     "type": "counter"
   },
   "fts_total_internal_queries": {
+    "added": "7.2.0",
     "help": "The number of internal queries from the co-ordinating node to other nodes, per unit time for an index",
     "labels": [
       "bucket",
@@ -394,6 +606,7 @@
     "type": "counter"
   },
   "fts_total_queries": {
+    "added": "7.2.0",
     "help": "The number of full text queries per second for an index",
     "labels": [
       "bucket",
@@ -417,6 +630,7 @@
     "uiName": "Search Query Error DissatisfiedConsistency"
   },
   "fts_total_queries_error": {
+    "added": "7.2.0",
     "help": "The number of FTS queries for an index that resulted in an error",
     "labels": [
       "bucket",
@@ -440,6 +654,7 @@
     "uiName": "Search Query Error PartialResults"
   },
   "fts_total_queries_rejected_by_herder": {
+    "added": "7.2.0",
     "help": "The number of queries rejected by the app herder when the memory used exceeds the application's query quota",
     "type": "counter",
     "uiName": "Rejected Queries"
@@ -451,6 +666,7 @@
     "uiName": "Search Query Error SearchInContext"
   },
   "fts_total_queries_slow": {
+    "added": "7.2.0",
     "help": "The number of FTS queries in the slow query log",
     "labels": [
       "bucket",
@@ -462,6 +678,7 @@
     "uiName": "Search Slow Queries"
   },
   "fts_total_queries_timeout": {
+    "added": "7.2.0",
     "help": "The number of FTS queries for an index that exceeded the timeout",
     "labels": [
       "bucket",
@@ -473,6 +690,7 @@
     "uiName": "Search Query Timeout Rate"
   },
   "fts_total_request_time": {
+    "added": "7.2.0",
     "help": "Total time spent processing query requests for an index",
     "labels": [
       "bucket",
@@ -484,6 +702,7 @@
     "unit": "nanoseconds"
   },
   "fts_total_term_searchers": {
+    "added": "7.2.0",
     "help": "Number of bleve term searchers",
     "labels": [
       "bucket",
@@ -496,6 +715,7 @@
     "uiName": "Term Searchers Start Rate"
   },
   "fts_total_term_searchers_finished": {
+    "added": "7.2.0",
     "help": "Total term searchers that have finished serving a query",
     "labels": [
       "bucket",
@@ -509,5 +729,10 @@
     "added": "7.6.1",
     "help": "The total number of vectors indexed",
     "type": "gauge"
+  },
+  "total_knn_queries_rejected_by_throttler": {
+    "added": "7.6.4",
+    "help": "Total number of http query requests with KNN rejected by the throttler",
+    "type": "counter"
   }
 }

--- a/modules/metrics-reference/attachments/goxdcr_metrics_metadata.json
+++ b/modules/metrics-reference/attachments/goxdcr_metrics_metadata.json
@@ -49,7 +49,7 @@
     "type": "counter"
   },
   "xdcr_binary_filtered_total": {
-    "added": "7.2.1",
+    "added": "7.6.0",
     "help": "Number of documents filtered that were binary documents",
     "labels": [
       "sourceBucketName",
@@ -127,7 +127,7 @@
     "unit": "bytes"
   },
   "xdcr_data_replicated_uncompress_bytes": {
-    "added": "7.6.0",
+    "added": "7.0.0",
     "help": "Theoretical amount of data replicated for a Replication if compression were not used",
     "labels": [
       "sourceBucketName",
@@ -275,6 +275,18 @@
     "stability": "internal",
     "type": "counter"
   },
+  "xdcr_docs_cas_poisoned_total": {
+    "added": "7.6.3",
+    "help": "Total number of documents not replicated because cas is beyond acceptable drift threshold",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
   "xdcr_docs_checked_total": {
     "added": "7.0.0",
     "help": "Across vBuckets for this node, the sum of all sequence numbers that have been considered to be checkpointed",
@@ -299,6 +311,18 @@
       "pipelineType"
     ],
     "notes": "This usually means that one source mutation is now going to exist in two or more target collections, leading to mismatching doc counts between buckets. This can happen when migration mode is turned on, and the migration filtering expression is not specific enough, leading to a single doc matching multiple migration filtering expressions. To prevent this, ensure that the filtering expr are more specific such that each doc is migrated to only one target collection.",
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_docs_compression_skipped_total": {
+    "added": "7.6.6",
+    "help": "Total number of documents whose compression was skipped before replication, due to a larger snappy-compressed size",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
     "stability": "committed",
     "type": "counter"
   },
@@ -443,6 +467,30 @@
     "type": "counter",
     "uiName": "xdcr_docs_received_from_dcp_total"
   },
+  "xdcr_docs_sent_with_subdoc_delete_total": {
+    "added": "7.6.6",
+    "help": "The number of deletes issued using subdoc command instead of delete_with_meta to avoid cas rollback on target",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_docs_sent_with_subdoc_set_total": {
+    "added": "7.6.6",
+    "help": "The number of sets issued using subdoc command instead of set_with_meta to avoid cas rollback on target",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
   "xdcr_docs_unable_to_filter_total": {
     "added": "7.0.0",
     "help": "Number of Document Mutations that couldn't be filtered due to inability to parse the document through Advanced Filtering engine and were not replicated",
@@ -579,7 +627,7 @@
   },
   "xdcr_expiry_target_docs_skipped_total": {
     "added": "7.0.0",
-    "help": "Subset of the number of Document Mutations that originated from the Target that specifically had Expiry flag set",
+    "help": "Subset of the number of mutations (with Expiry flag set) and deletions/expirations that originated from the Target",
     "labels": [
       "sourceBucketName",
       "targetClusterUUID",
@@ -628,6 +676,66 @@
     "stability": "committed",
     "type": "counter"
   },
+  "xdcr_hlv_pruned_at_merge_total": {
+    "added": "7.6.6",
+    "help": "Number of mutations with HLV pruned when it is merged with target document",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_hlv_pruned_total": {
+    "added": "7.6.6",
+    "help": "Number of mutations with HLV pruned",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_hlv_updated_total": {
+    "added": "7.6.6",
+    "help": "Number of mutations with HLV updated",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_import_docs_failed_cr_source_total": {
+    "added": "7.6.6",
+    "help": "Number of mobile import mutations failed Source side Conflict Resolution. This is only counted in LWW buckets when enableCrossClusterVersioning is true",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_import_docs_written_total": {
+    "added": "7.6.6",
+    "help": "Number of import mutations sent",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
   "xdcr_mobile_docs_filtered_total": {
     "added": "7.6.0",
     "help": "Total number of documents filtered and not replicated because the documents were mobile records",
@@ -665,7 +773,7 @@
     "type": "counter"
   },
   "xdcr_pipeline_errors": {
-    "added": "7.2.1",
+    "added": "7.6.0",
     "help": "The number of currently present errors for a specific Replication Pipeline",
     "labels": [
       "sourceBucketName",
@@ -678,7 +786,7 @@
     "type": "gauge"
   },
   "xdcr_pipeline_status": {
-    "added": "7.2.1",
+    "added": "7.6.0",
     "help": "The pipeline status for a specific pipeline, where it could be paused, running or, error",
     "labels": [
       "sourceBucketName",
@@ -816,6 +924,42 @@
     "type": "gauge",
     "unit": "bytes"
   },
+  "xdcr_source_sync_xattr_removed_total": {
+    "added": "7.6.6",
+    "help": "Number of mutations with source mobile extended attributes removed",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
+  "xdcr_subdoc_cmd_docs_cas_changed_total": {
+    "added": "7.6.6",
+    "help": "Number of Subdoc sets and delete operations that failed because the CAS on the Target changed",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "internal",
+    "type": "counter"
+  },
+  "xdcr_subdoc_cmd_docs_skipped_total": {
+    "added": "7.6.6",
+    "help": "Number of document mutations that were not replicated to the target because they resulted in subdoc commands breaching the maximum paths limit.",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "internal",
+    "type": "counter"
+  },
   "xdcr_system_events_received_from_dcp_total": {
     "added": "7.6.0",
     "help": "The number of system events received from source data service",
@@ -842,7 +986,7 @@
     "type": "counter"
   },
   "xdcr_target_eaccess_total": {
-    "added": "7.2.1",
+    "added": "7.6.0",
     "help": "The total number of EACCESS errors returned from the target node.",
     "labels": [
       "sourceBucketName",
@@ -853,8 +997,20 @@
     "stability": "committed",
     "type": "counter"
   },
+  "xdcr_target_sync_xattr_preserved_total": {
+    "added": "7.6.6",
+    "help": "Number of mutations with target mobile extended attributes preserved",
+    "labels": [
+      "sourceBucketName",
+      "targetClusterUUID",
+      "targetBucketName",
+      "pipelineType"
+    ],
+    "stability": "committed",
+    "type": "counter"
+  },
   "xdcr_target_tmpfail_total": {
-    "added": "7.2.1",
+    "added": "7.6.0",
     "help": "The total number of TMPFAIL errors returned from the target node.",
     "labels": [
       "sourceBucketName",

--- a/modules/metrics-reference/attachments/index_metrics_metadata.json
+++ b/modules/metrics-reference/attachments/index_metrics_metadata.json
@@ -99,6 +99,18 @@
     "type": "gauge",
     "unit": "bytes"
   },
+  "index_disk_bytes": {
+    "added": "7.6.4",
+    "help": "Number of bytes read from and written to disk, including insert, get, and delete operations",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index"
+    ],
+    "type": "counter",
+    "unit": "bytes"
+  },
   "index_disk_size": {
     "help": "Total disk space taken up by this index, after compression. This includes index data files, checkpoints etc.",
     "labels": [
@@ -124,7 +136,6 @@
     "uiName": "Index Fragmentation"
   },
   "index_heap_in_use": {
-    "added": "7.6.0",
     "help": "Total heap memory in use by indexer process in the node",
     "notes": "This does not include the actual index pages, but it includes the Golang memory overheads required for index maintenance",
     "type": "gauge",
@@ -197,7 +208,6 @@
     "unit": "bytes"
   },
   "index_net_avg_scan_rate": {
-    "added": "7.6.0",
     "help": "Average index scan rate across all indexes, for this node",
     "type": "gauge"
   },
@@ -240,6 +250,17 @@
     "help": "Total number of indexes, located on this node",
     "type": "gauge"
   },
+  "index_num_items_flushed": {
+    "added": "7.6.4",
+    "help": "Number of documents written from memory to index storage",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index"
+    ],
+    "type": "counter"
+  },
   "index_num_requests": {
     "help": "Number of scan requests received by the index service, for this index",
     "labels": [
@@ -279,6 +300,19 @@
     "added": "7.2.0",
     "help": "Total number of storage instances, located on this node",
     "notes": "For partitioned indexes with replicas, for an index, more than one instance can reside on a single node.",
+    "type": "gauge"
+  },
+  "index_partn_items_count": {
+    "added": "7.6.6",
+    "help": "The actual number of items present in the latest index snapshot, for this partition",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index",
+      "partition"
+    ],
+    "notes": "This metric is valid only for partitioned indexes.",
     "type": "gauge"
   },
   "index_raw_data_size": {
@@ -339,6 +373,17 @@
     "type": "counter",
     "uiName": "Index Scan Bytes",
     "unit": "bytes"
+  },
+  "index_state": {
+    "added": "7.6.6",
+    "help": "The current state of this index; CREATED: 0, READY: 1, INITIAL: 2, CATCHUP: 3, ACTIVE: 4, DELETED: 5, ERROR: 6, NIL: 7, SCHEDULED: 8, RECOVERED: 9. Index is usable only in ACTIVE state",
+    "labels": [
+      "bucket",
+      "scope",
+      "collection",
+      "index"
+    ],
+    "type": "gauge"
   },
   "index_storage_avg_item_size": {
     "added": "7.6.0",
@@ -527,17 +572,14 @@
     "type": "gauge"
   },
   "index_total_mutation_queue_size": {
-    "added": "7.6.0",
     "help": "Total number of index updates queued in the mutation queues, on this node",
     "type": "gauge"
   },
   "index_total_pending_scans": {
-    "added": "7.6.0",
     "help": "Sum of number of pending scans across all indexes, located on this node",
     "type": "gauge"
   },
   "index_total_raw_data_size": {
-    "added": "7.6.0",
     "help": "Sum of encoded, uncompressed size of the index data across all indexes, located on this node",
     "type": "gauge",
     "unit": "bytes"

--- a/modules/metrics-reference/attachments/kv_metrics_metadata.json
+++ b/modules/metrics-reference/attachments/kv_metrics_metadata.json
@@ -65,59 +65,41 @@
   },
   "kv_cmd_lookup": {
     "added": "7.0.0",
-    "help": "The number of lookup operations",
+    "help": "The number of lookup operations. This includes operations such as Get, Gat, Getk, Getq, GetLocked, GetRandomKey, GetReplica, SubdocMultiLookup, SubdocGet and SubdocExists",
     "stability": "committed",
     "type": "counter"
   },
   "kv_cmd_lookup_10s_count": {
     "added": "7.0.0",
-    "help": "The number of lookup operations performed within the last 10 seconds",
+    "help": "The number of lookup operations performed within the last 10 seconds. This aggregates operations like Get, Gat, Getk, Getq, and various Sub-Document lookups",
     "stability": "committed",
     "type": "gauge"
   },
   "kv_cmd_lookup_10s_duration_seconds": {
     "added": "7.0.0",
-    "help": "The total duration of lookup operations performed over the last 10 seconds",
+    "help": "The total duration of lookup operations performed over the last 10 seconds. This aggregates the time for operations like Get, Gat, Getk, Getq, and various Sub-Document lookups",
     "stability": "committed",
     "type": "gauge",
     "unit": "seconds"
   },
   "kv_cmd_mutation": {
     "added": "7.0.0",
-    "help": "The number of mutation operations",
+    "help": "The number of mutation operations. This includes operations such as Add, Append, Decrement, Delete, Gat, Increment, Prepend, Replace, Set, Touch, and various Sub-Document mutations (e.g., SubdocArrayAddUnique, SubdocCounter, SubdocDelete, etc.)",
     "stability": "committed",
     "type": "counter"
   },
   "kv_cmd_mutation_10s_count": {
     "added": "7.0.0",
-    "help": "The number of mutation operations performed within the last 10 seconds",
+    "help": "The number of mutation operations performed within the last 10 seconds. This includes operations like Add, Append, Delete, Replace, and various Sub-Document mutations",
     "stability": "committed",
     "type": "gauge"
   },
   "kv_cmd_mutation_10s_duration_seconds": {
     "added": "7.0.0",
-    "help": "The total duration of mutation operations performed over the last 10 seconds",
+    "help": "The total duration of mutation operations performed over the last 10 seconds. This includes time spent on operations like Add, Append, Delete, Replace, and various Sub-Document mutations",
     "stability": "committed",
     "type": "gauge",
     "unit": "seconds"
-  },
-  "kv_cmd_total_gets": {
-    "added": "7.0.0",
-    "help": "The total number of data retrieval operations (all buckets)",
-    "stability": "committed",
-    "type": "counter"
-  },
-  "kv_cmd_total_ops": {
-    "added": "7.0.0",
-    "help": "The sum of cmd_total_sets and cmd_total_gets (all buckets)",
-    "stability": "committed",
-    "type": "counter"
-  },
-  "kv_cmd_total_sets": {
-    "added": "7.0.0",
-    "help": "The total number of mutation operations (all buckets)",
-    "stability": "committed",
-    "type": "counter"
   },
   "kv_collection_data_size_bytes": {
     "added": "7.0.0",
@@ -152,6 +134,12 @@
     "type": "gauge",
     "unit": "bytes"
   },
+  "kv_collection_metered": {
+    "added": "7.6.0",
+    "help": "Whether metering is enabled for the collection",
+    "stability": "internal",
+    "type": "gauge"
+  },
   "kv_collection_ops": {
     "added": "7.0.0",
     "help": "Per-collection counters of sets/gets/deletes",
@@ -185,6 +173,31 @@
     "stability": "committed",
     "type": "gauge"
   },
+  "kv_cookie_notification_histogram_seconds": {
+    "added": "7.6.10",
+    "help": "Histogram containing the time taken to schedule a notification for a cookie until it is run",
+    "stability": "committed",
+    "type": "histogram",
+    "unit": "seconds"
+  },
+  "kv_credit_cu_total": {
+    "added": "7.6.0",
+    "help": "Total Compute Units refunded for a bucket (CU was charged, but operation failed) since reset",
+    "stability": "internal",
+    "type": "counter"
+  },
+  "kv_credit_ru_total": {
+    "added": "7.6.0",
+    "help": "Total Read Units refunded for a bucket (RU was charged, but operation failed) since reset",
+    "stability": "internal",
+    "type": "counter"
+  },
+  "kv_credit_wu_total": {
+    "added": "7.6.0",
+    "help": "Total Write Units refunded for a bucket (WU was charged, but operation failed) since reset",
+    "stability": "internal",
+    "type": "counter"
+  },
   "kv_curr_connections": {
     "added": "7.0.0",
     "help": "The current number of connections. This includes user, system and daemon connections",
@@ -206,6 +219,12 @@
   "kv_curr_temp_items": {
     "added": "7.0.0",
     "help": "Number of temporary items in memory",
+    "stability": "committed",
+    "type": "gauge"
+  },
+  "kv_current_external_client_connections": {
+    "added": "7.6.5",
+    "help": "The current number of authenticated connections using the labelled SDK",
     "stability": "committed",
     "type": "gauge"
   },
@@ -337,6 +356,13 @@
     "labels": [
       "op"
     ],
+    "stability": "committed",
+    "type": "histogram",
+    "unit": "seconds"
+  },
+  "kv_dispatch_socket_histogram_seconds": {
+    "added": "7.6.10",
+    "help": "Histogram containing the time taken to dispatch a newly created socket to its worker thread",
     "stability": "committed",
     "type": "histogram",
     "unit": "seconds"
@@ -600,6 +626,13 @@
   "kv_ep_checkpoint_computed_max_size_bytes": {
     "added": "7.1.0",
     "help": "Actual max size in bytes of a single Checkpoint",
+    "stability": "committed",
+    "type": "gauge",
+    "unit": "bytes"
+  },
+  "kv_ep_checkpoint_consumer_limit_bytes": {
+    "added": "7.6.2",
+    "help": "Max allocation allowed in all checkpoints (including the dcp consumer buffer quota)",
     "stability": "committed",
     "type": "gauge",
     "unit": "bytes"
@@ -872,6 +905,18 @@
     "type": "gauge",
     "unit": "bytes"
   },
+  "kv_ep_db_tombstones": {
+    "added": "7.6.10",
+    "help": "The number of tombstones in db files (currently tracked only in couchstore)",
+    "stability": "committed",
+    "type": "gauge"
+  },
+  "kv_ep_dcp_backfill_byte_drain_ratio": {
+    "added": "7.0.0",
+    "help": "What ratio of the dcp_backfill_byte_limit must be drained for un-pausing a paused backfill",
+    "stability": "volatile",
+    "type": "gauge"
+  },
   "kv_ep_dcp_backfill_byte_limit": {
     "added": "7.0.0",
     "help": "Max bytes a connection can backfill into memory before backfill is paused",
@@ -968,9 +1013,21 @@
     "stability": "volatile",
     "type": "gauge"
   },
+  "kv_ep_dcp_producer_catch_exceptions": {
+    "added": "7.0.0",
+    "help": "If true, ActiveStream will catch exceptions during item processing and close the stream's related connection (and thus all streams for that connection). If false, exception will be re-thrown.",
+    "stability": "volatile",
+    "type": "gauge"
+  },
+  "kv_ep_dcp_producer_processor_run_duration_us": {
+    "added": "7.0.0",
+    "help": "The approximate maximum runtime in microseconds for ActiveStreamCheckpointProcessorTask",
+    "stability": "volatile",
+    "type": "gauge"
+  },
   "kv_ep_dcp_producer_snapshot_marker_yield_limit": {
     "added": "7.0.0",
-    "help": "The number of snapshots before ActiveStreamCheckpointProcessorTask::run yields.",
+    "help": "Not in use - replaced by dcp_producer_processor_run_duration_us",
     "stability": "volatile",
     "type": "gauge"
   },
@@ -1210,6 +1267,12 @@
     "stability": "volatile",
     "type": "gauge"
   },
+  "kv_ep_flush_batch_max_bytes": {
+    "added": "7.0.0",
+    "help": "Max size (in bytes) of a single flush-batch passed to the KVStore for persistence.",
+    "stability": "volatile",
+    "type": "gauge"
+  },
   "kv_ep_flush_duration_total_seconds": {
     "added": "7.0.0",
     "help": "Cumulative milliseconds spent flushing",
@@ -1311,7 +1374,13 @@
   },
   "kv_ep_ht_size": {
     "added": "7.0.0",
-    "help": "Initial number of slots in HashTable objects.",
+    "help": "The initial and minimum number of slots in HashTable objects.",
+    "stability": "volatile",
+    "type": "gauge"
+  },
+  "kv_ep_ht_temp_items_allowed_percent": {
+    "added": "7.0.0",
+    "help": "",
     "stability": "volatile",
     "type": "gauge"
   },
@@ -1865,7 +1934,7 @@
   },
   "kv_ep_magma_min_value_block_size_threshold": {
     "added": "7.0.0",
-    "help": "Magma creates value blocks for values larger than this size. Value blocks only contain a single KV item and their reads/writes are optimised for memory as it avoids many value copies. Right now compression is turned off for value blocks to reduce memory consumption while building them. This setting should be at least as large as the SeqIndex block size.",
+    "help": "Magma creates value blocks for values larger than this size. Value blocks only contain a single KV item and their reads/writes are optimised for lesser memory consumption as it avoids many value copies. For example, magma block compression is turned off for them as compression requires an output buffer as large as the input buffer. This is fine since for such large docs, per document Snappy compression already should give good enough space savings. This setting should be >= SeqIndex data block size or else it won't take effect.",
     "stability": "volatile",
     "type": "gauge"
   },
@@ -1932,7 +2001,7 @@
   },
   "kv_ep_magma_seq_tree_data_block_size": {
     "added": "7.0.0",
-    "help": "Magma uses SSTables for storage. SSTables are made up of different types of blocks. Data blocks contain the bulk of the data and contain the key, metadata and value for each of the items in the block. Larger block sizes can decrease storage space by better block compression but they require more memory, cpu and io bandwidth to read and write them.",
+    "help": "Magma uses SSTables for storage. SSTables are made up of different types of blocks. Data blocks contain the bulk of the data and contain the key, metadata and value for each of the items in the block. Larger block sizes can decrease storage space by better block compression but they require more memory, cpu and io bandwidth to read and write them. If this is less than magma_min_value_block_size_threshold, Magma will internally auto configure the value block size to be as large as this.",
     "stability": "volatile",
     "type": "gauge"
   },
@@ -2260,6 +2329,12 @@
     "stability": "internal",
     "type": "gauge"
   },
+  "kv_ep_not_locked_returns_tmpfail": {
+    "added": "7.0.0",
+    "help": "Controls which error code should be returned when attempting to unlock an item that is not locked. When value is true, the legacy temporary_failure is used instead of not_locked.",
+    "stability": "volatile",
+    "type": "gauge"
+  },
   "kv_ep_num_access_scanner_runs": {
     "added": "7.0.0",
     "help": "Number of times we ran accesss scanner to snapshot working set",
@@ -2353,6 +2428,12 @@
   "kv_ep_pager_sleep_time_ms": {
     "added": "7.0.0",
     "help": "How long in milliseconds the ItemPager will sleep for when not being requested to run",
+    "stability": "volatile",
+    "type": "gauge"
+  },
+  "kv_ep_paging_visitor_pause_check_count": {
+    "added": "7.0.0",
+    "help": "Expected number of times the PagingVisitor will check the pause condition per vBucket",
     "stability": "volatile",
     "type": "gauge"
   },
@@ -2623,12 +2704,6 @@
     "stability": "volatile",
     "type": "gauge"
   },
-  "kv_ep_warmup_access_log": {
-    "added": "7.1.0",
-    "help": "Number of keys present in access log",
-    "stability": "committed",
-    "type": "gauge"
-  },
   "kv_ep_warmup_backfill_scan_chunk_duration": {
     "added": "7.0.0",
     "help": "The duration (in ms) after which warmup's backfill scans will yield and re-schedule; allowing other tasks on the same threads to run.",
@@ -2644,44 +2719,6 @@
   "kv_ep_warmup_dups": {
     "added": "7.0.0",
     "help": "Duplicates encountered during warmup",
-    "stability": "committed",
-    "type": "gauge"
-  },
-  "kv_ep_warmup_estimate_time_seconds": {
-    "added": "7.1.0",
-    "help": "Total time spent in the estimate item count phase of warmup",
-    "stability": "committed",
-    "type": "gauge",
-    "unit": "seconds"
-  },
-  "kv_ep_warmup_estimated_key_count": {
-    "added": "7.1.0",
-    "help": "Estimated number of keys in database",
-    "stability": "committed",
-    "type": "gauge"
-  },
-  "kv_ep_warmup_estimated_value_count": {
-    "added": "7.1.0",
-    "help": "Estimated number of values in database",
-    "stability": "committed",
-    "type": "gauge"
-  },
-  "kv_ep_warmup_key_count": {
-    "added": "7.1.0",
-    "help": "Number of keys warmed up",
-    "stability": "committed",
-    "type": "gauge"
-  },
-  "kv_ep_warmup_keys_time_seconds": {
-    "added": "7.1.0",
-    "help": "Time (µs) spent by warming keys",
-    "stability": "committed",
-    "type": "gauge",
-    "unit": "seconds"
-  },
-  "kv_ep_warmup_min_item_threshold": {
-    "added": "7.1.0",
-    "help": "The minimum number of items that needs to be warmed up before external data mutations is allowed. This is in % of the number of items.",
     "stability": "committed",
     "type": "gauge"
   },
@@ -2722,10 +2759,10 @@
     "type": "gauge",
     "unit": "seconds"
   },
-  "kv_ep_warmup_value_count": {
-    "added": "7.1.0",
-    "help": "Number of values warmed up",
-    "stability": "committed",
+  "kv_ep_workload_monitor_enabled": {
+    "added": "7.0.0",
+    "help": "",
+    "stability": "volatile",
     "type": "gauge"
   },
   "kv_ep_xattr_enabled": {
@@ -2750,7 +2787,7 @@
   },
   "kv_item_alloc_sizes_bytes": {
     "added": "7.0.0",
-    "help": "Item allocation size counters (in bytes)",
+    "help": "Item allocation size counters for front-end mutations (in bytes)",
     "stability": "committed",
     "type": "histogram",
     "unit": "bytes"
@@ -2793,6 +2830,12 @@
     "stability": "committed",
     "type": "gauge"
   },
+  "kv_magma_flusher_thread_percentage": {
+    "added": "7.6.10",
+    "help": "Percent of magma flusher threads out of total magma threads",
+    "stability": "committed",
+    "type": "gauge"
+  },
   "kv_magma_itr": {
     "added": "7.6.0",
     "help": "Number of items returned by iterators",
@@ -2800,6 +2843,12 @@
       "for",
       "result"
     ],
+    "stability": "committed",
+    "type": "gauge"
+  },
+  "kv_magma_max_default_storage_threads": {
+    "added": "7.6.10",
+    "help": "The number of total magma threads",
     "stability": "committed",
     "type": "gauge"
   },
@@ -2822,12 +2871,6 @@
     "stability": "committed",
     "type": "gauge",
     "unit": "bytes"
-  },
-  "kv_manifest_force": {
-    "added": "7.0.0",
-    "help": "Whether the manifest was set by ns_server with the force flag",
-    "stability": "internal",
-    "type": "gauge"
   },
   "kv_max_system_connections": {
     "added": "7.6.0",
@@ -2912,6 +2955,24 @@
     "type": "gauge",
     "unit": "bytes"
   },
+  "kv_meter_cu_total": {
+    "added": "7.6.0",
+    "help": "Total Compute Units used by a bucket since reset",
+    "stability": "internal",
+    "type": "counter"
+  },
+  "kv_meter_ru_total": {
+    "added": "7.6.0",
+    "help": "Total Read Units used by a bucket since reset",
+    "stability": "internal",
+    "type": "counter"
+  },
+  "kv_meter_wu_total": {
+    "added": "7.6.0",
+    "help": "Total Write Units used by a bucket since reset",
+    "stability": "internal",
+    "type": "counter"
+  },
   "kv_num_high_pri_requests": {
     "added": "7.0.0",
     "help": "Num of async high priority requests",
@@ -2961,28 +3022,10 @@
     "stability": "internal",
     "type": "counter"
   },
-  "kv_rejected_conns": {
-    "added": "7.0.0",
-    "help": "The number of connections rejected due to hitting the maximum number of connections",
-    "stability": "committed",
-    "type": "gauge"
-  },
   "kv_rollback_item_count": {
     "added": "7.0.0",
     "help": "Num of items rolled back",
     "stability": "committed",
-    "type": "gauge"
-  },
-  "kv_scope_collection_count": {
-    "added": "7.0.0",
-    "help": "Number of collections in the scope",
-    "stability": "committed",
-    "type": "gauge"
-  },
-  "kv_scope_data_limit": {
-    "added": "7.1.0",
-    "help": "The configured data limit for the scope (not used)",
-    "stability": "internal",
     "type": "gauge"
   },
   "kv_stat_reset": {
@@ -3064,18 +3107,19 @@
     "stability": "committed",
     "type": "gauge"
   },
+  "kv_task_duration_seconds": {
+    "added": "7.6.2",
+    "help": "Per-task histogram of time taken to run a task",
+    "stability": "committed",
+    "type": "histogram",
+    "unit": "seconds"
+  },
   "kv_thread_cpu_usage_seconds": {
     "added": "7.6.0",
     "help": "Number of seconds the given thread has spent running according to the OS",
     "stability": "committed",
     "type": "gauge",
     "unit": "seconds"
-  },
-  "kv_threads": {
-    "added": "7.0.0",
-    "help": "The number of threads used to serve clients",
-    "stability": "committed",
-    "type": "gauge"
   },
   "kv_throttle_count_total": {
     "added": "7.6.0",
@@ -3208,15 +3252,15 @@
     "stability": "committed",
     "type": "gauge"
   },
-  "kv_vb_evictable_mfu": {
-    "added": "7.6.0",
-    "help": "Histogram of the per-VBucket tracking MFU values of items which are currently evictable",
-    "stability": "committed",
-    "type": "gauge"
-  },
   "kv_vb_expired": {
     "added": "7.0.0",
     "help": "Cumulative count of the number of items which have been expired for this vBucket",
+    "stability": "committed",
+    "type": "gauge"
+  },
+  "kv_vb_ht_avg_size": {
+    "added": "7.2.5",
+    "help": "The average size (number of slots) of the HashTable across all vbuckets",
     "stability": "committed",
     "type": "gauge"
   },
@@ -3233,6 +3277,12 @@
     "stability": "committed",
     "type": "gauge",
     "unit": "bytes"
+  },
+  "kv_vb_ht_max_size": {
+    "added": "7.2.5",
+    "help": "The maximum HashTable size (number of slots) across all vbuckets",
+    "stability": "committed",
+    "type": "gauge"
   },
   "kv_vb_ht_memory_bytes": {
     "added": "7.0.0",

--- a/modules/metrics-reference/attachments/n1ql_metrics_metadata.json
+++ b/modules/metrics-reference/attachments/n1ql_metrics_metadata.json
@@ -35,6 +35,40 @@
     "help": "The total number of potentially auditable requests sent to the query engine.",
     "type": "counter"
   },
+  "n1ql_boot_timestamp_seconds": {
+    "added": "7.6.0",
+    "help": "The time the service booted in fractional seconds since Unix epoch.",
+    "notes": "This is a metric specific to serverless.",
+    "type": "gauge",
+    "unit": "seconds"
+  },
+  "n1ql_bucket_reads": {
+    "added": "7.6.0",
+    "help": "The total number of reads on the bucket.",
+    "labels": [
+      "bucket"
+    ],
+    "notes": "This is a metric specific to provisioned mode.",
+    "type": "gauge"
+  },
+  "n1ql_bucket_retries": {
+    "added": "7.6.0",
+    "help": "The total number of retries on the bucket.",
+    "labels": [
+      "bucket"
+    ],
+    "notes": "This is a metric specific to provisioned mode.",
+    "type": "gauge"
+  },
+  "n1ql_bucket_writes": {
+    "added": "7.6.0",
+    "help": "The total number of writes on the bucket.",
+    "labels": [
+      "bucket"
+    ],
+    "notes": "This is a metric specific to provisioned mode.",
+    "type": "gauge"
+  },
   "n1ql_bulk_get_errors": {
     "added": "7.2.4",
     "help": "Count of errors due to bulk get operations",
@@ -50,6 +84,65 @@
     "help": "Count of CAS mismatch errors",
     "type": "counter"
   },
+  "n1ql_counter_cu_total": {
+    "added": "7.6.0",
+    "help": "The number of distinct operations recording Compute Units (CUs) with Regulator.",
+    "labels": [
+      "bucket",
+      "for",
+      "unbilled",
+      "variant"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
+  "n1ql_credit_cu_total": {
+    "added": "7.6.0",
+    "help": "The number of Compute Units (CUs) refunded.",
+    "labels": [
+      "bucket",
+      "for",
+      "variant"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
+  "n1ql_credit_ru_total": {
+    "added": "7.6.0",
+    "help": "The number of Read Units (RUs) refunded.",
+    "labels": [
+      "bucket",
+      "for",
+      "variant"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
+  "n1ql_credit_wu_total": {
+    "added": "7.6.0",
+    "help": "The number of Write Units (WUs) refunded.",
+    "labels": [
+      "bucket",
+      "for",
+      "variant"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
+  "n1ql_curl_call_errors": {
+    "added": "7.6.2",
+    "help": "The number of CURL() calls made by statements that failed (returned an error).",
+    "type": "counter"
+  },
+  "n1ql_curl_calls": {
+    "added": "7.6.2",
+    "help": "The number of CURL() calls made by statements.",
+    "type": "counter"
+  },
   "n1ql_deletes": {
     "added": "7.0.0",
     "help": "Total number of DELETE operations.",
@@ -61,6 +154,52 @@
     "notes": "In the Couchbase Server UI this metric is computed as a rate, with a display name of \"N1QL Error Rate\" or n1ql_errors. This metric was named query_errors in versions before 7.0.0.",
     "type": "counter",
     "uiName": "N1QL Error Rate"
+  },
+  "n1ql_ffdc_manual": {
+    "added": "7.6.6",
+    "help": "The total number of ffdc captures triggered due to manual invocation of ffdc admin api",
+    "type": "counter"
+  },
+  "n1ql_ffdc_memory_rate": {
+    "added": "7.6.6",
+    "help": "The total number of ffdc captures triggered due to memory usage rate increasing by 20% of the average memory usage over the past 2 hours",
+    "type": "counter"
+  },
+  "n1ql_ffdc_memory_threshold": {
+    "added": "7.6.6",
+    "help": "The total number of ffdc captures triggered due to memory usage exceeding the 80% threshold",
+    "type": "counter"
+  },
+  "n1ql_ffdc_plus_queue_full": {
+    "added": "7.6.6",
+    "help": "The total number of ffdc captures triggered due to the plus-request queue being full",
+    "type": "counter"
+  },
+  "n1ql_ffdc_request_queue_full": {
+    "added": "7.6.6",
+    "help": "The total number of ffdc captures triggered due to the unbounded-request queue being full",
+    "type": "counter"
+  },
+  "n1ql_ffdc_shutdown": {
+    "added": "7.6.6",
+    "help": "The total number of ffdc captures triggered due to shutdown processing exceeding 30 minutes",
+    "type": "counter"
+  },
+  "n1ql_ffdc_sigterm": {
+    "added": "7.6.6",
+    "help": "The total number of ffdc captures triggered by a SIGTERM signal",
+    "notes": "This metric is included for completeness, as a SIGTERM resets all accounting metrics to zero, rendering this metric redundant.",
+    "type": "counter"
+  },
+  "n1ql_ffdc_stalled_queue": {
+    "added": "7.6.6",
+    "help": "The total number of ffdc captures triggered due to no requests being processed when the queued requests exceed three times the number of servicers within the last 30 seconds",
+    "type": "counter"
+  },
+  "n1ql_ffdc_total": {
+    "added": "7.6.6",
+    "help": "The total number of ffdc occurrences",
+    "type": "counter"
   },
   "n1ql_index_scans": {
     "added": "7.0.0",
@@ -111,8 +250,21 @@
   },
   "n1ql_mem_quota_exceeded_errors": {
     "added": "7.2.4",
-    "help": "Count of memory quota exceeded errors",
+    "help": "Count of memory quota exceeded errrors",
     "type": "counter"
+  },
+  "n1ql_meter_cu_total": {
+    "added": "7.6.0",
+    "help": "The number of Compute Units (CUs) recorded.",
+    "labels": [
+      "bucket",
+      "for",
+      "unbilled",
+      "variant"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
   },
   "n1ql_mutations": {
     "added": "7.0.0",
@@ -124,6 +276,23 @@
     "help": "The total size of in use memory in the query node.",
     "type": "gauge",
     "unit": "bytes"
+  },
+  "n1ql_node_rss": {
+    "added": "7.6.1",
+    "help": "The resident set size (RSS) of the query node process.",
+    "type": "gauge",
+    "unit": "bytes"
+  },
+  "n1ql_op_count_total": {
+    "added": "7.6.0",
+    "help": "The number of distinct operations recorded with Regulator.",
+    "labels": [
+      "bucket",
+      "for"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
   },
   "n1ql_prepared": {
     "added": "7.0.0",
@@ -158,6 +327,17 @@
     "help": "Total number of queued requests.",
     "notes": "This metric was named query_queued_requests in versions before 7.0.0.",
     "type": "gauge"
+  },
+  "n1ql_reject_count_total": {
+    "added": "7.6.0",
+    "help": "The number of times Regulator instructed an operation to be rejected.",
+    "labels": [
+      "bucket",
+      "for"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
   },
   "n1ql_request_time": {
     "added": "7.0.0",
@@ -241,6 +421,84 @@
     "added": "7.6.0",
     "help": "Count of temp space related errors",
     "type": "counter"
+  },
+  "n1ql_tenant_kv_throttle_count": {
+    "added": "7.6.0",
+    "help": "The total number of times KV has been throttled for queries on this tenant.",
+    "labels": [
+      "bucket"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "gauge"
+  },
+  "n1ql_tenant_kv_throttle_seconds_total": {
+    "added": "7.6.0",
+    "help": "The total amount of time KV has been throttled for queries on this tenant.",
+    "labels": [
+      "bucket"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "gauge",
+    "unit": "seconds"
+  },
+  "n1ql_tenant_memory": {
+    "added": "7.6.0",
+    "help": "The total size of in use tenant memory.",
+    "labels": [
+      "bucket"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "gauge",
+    "unit": "bytes"
+  },
+  "n1ql_tenant_reads": {
+    "added": "7.6.0",
+    "help": "The total number of reads on the tenant.",
+    "labels": [
+      "bucket"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "gauge"
+  },
+  "n1ql_tenant_retries": {
+    "added": "7.6.0",
+    "help": "The total number of retries on the tenant.",
+    "labels": [
+      "bucket"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "gauge"
+  },
+  "n1ql_tenant_writes": {
+    "added": "7.6.0",
+    "help": "The total number of writes on the tenant.",
+    "labels": [
+      "bucket"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "gauge"
+  },
+  "n1ql_throttle_count_total": {
+    "added": "7.6.0",
+    "help": "The number of times Regulator instructed an operation to throttle.",
+    "labels": [
+      "bucket",
+      "for"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
+  },
+  "n1ql_throttle_seconds_total": {
+    "added": "7.6.0",
+    "help": "The total time spent throttling (in seconds).",
+    "labels": [
+      "bucket",
+      "for"
+    ],
+    "notes": "This is a metric specific to serverless.",
+    "type": "counter",
+    "unit": "seconds"
   },
   "n1ql_timeouts": {
     "added": "7.2.4",

--- a/modules/metrics-reference/partials/metrics.hbs
+++ b/modules/metrics-reference/partials/metrics.hbs
@@ -22,7 +22,7 @@ https://prometheus.io/docs/practices/naming/#base-units[unit] (if present).
 
 {{#each this}}
 {{#if (ne stability "internal")}}
-|`{{@key}}`
+|[[{{@key}}]]`{{@key}}`
 {nbsp}{nbsp}{nbsp}
 [.edition]##{{or added "7.0.0"}}##
 {{~#with deprecated}}[.deprecated]##Deprecated in {{this}}##{{/with~}}


### PR DESCRIPTION
* Updated Metrics for 7.6.10 from build #8026.
* Updated the metrics Handlebars template to add an anchor to each entry. The anchor named the same as the entry, including underscores. This covers [DOC-12159](https://jira.issues.couchbase.com/browse/DOC-12159). Also solves a pain point that will let the server docs link to individual metrics.

[DOC-12159]: https://couchbasecloud.atlassian.net/browse/DOC-12159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ