### PR TITLE
[DOC-14175]: Documented fix for `geopoint` docvalues issue in 7.6.10 release notes (MB-70388)

### DIFF
--- a/modules/release-notes/partials/docs-server-7.6.10-release-notes.adoc
+++ b/modules/release-notes/partials/docs-server-7.6.10-release-notes.adoc
@@ -215,6 +215,11 @@ This has been addressed by denying the sargability for such indexes.
 
 | Issue resolved
 
+| https://jira.issues.couchbase.com/browse/MB-70388[MB-70388]
+
+| The `docvalues` for  `geopoint` fields were not being set internally.
+This meant that the values were computed on demand for every query.
+| Issue resolved.
 
 |===
 


### PR DESCRIPTION

Added fix details.