### PR TITLE
DOC-14251: Remove configurable disk priority mention

### DIFF
--- a/modules/learn/pages/buckets-memory-and-storage/memory-and-storage.adoc
+++ b/modules/learn/pages/buckets-memory-and-storage/memory-and-storage.adoc
@@ -17,7 +17,6 @@ Consequently, infrequently used items are written to disk; and are then removed 
 This process, referred to as _ejection_, is managed asynchronously, while the server continues to service active requests.
 Items ejected from _Couchbase_ buckets can subsequently be re-acquired from disk, as necessary.
 A _working-set_ of most frequently used data is tracked and maintained, and the items kept in memory to ensure high performance.
-The priority of disk I/O is configurable per bucket.
 
 [#saving-new-items]
 == Saving New Items


### PR DESCRIPTION
DOC-14251:  Remove configurable disk priority mention, as references to bucket priority (no relationship to bucket rank) has been removed from the documentation.