### PR TITLE
DOC-11561: Analytics JDK requirements

### DIFF
--- a/modules/install/pages/install-environments.adoc
+++ b/modules/install/pages/install-environments.adoc
@@ -8,10 +8,11 @@
 
 The Analytics Service requires a Java Runtime Environment to be installed. Only https://openjdk.java.net/groups/hotspot/[HotSpot-based JVMs^], which includes the ones provided by OpenJDK and Oracle's JDK, are supported.
 
-OpenJDK 11 is installed when you install Couchbase Server — you do not need to install any additional prerequisites to use the Analytics service.
+OpenJDK 17 is installed when you install Couchbase Server 7.2.0 and later on macOS, or Couchbase Server 7.2.1 and later on all other platforms.
+You do not need to install any additional prerequisites to use the Analytics Service.
 
 However, if necessary, you can specify an alternative JRE for the Analytics Service when you xref:manage:manage-nodes/create-cluster.adoc[initialize a node].
-If you plan to use an alternative JRE for the Analytics service, note that the following versions are supported.
+If you plan to use an alternative JRE for the Analytics Service, note that the following versions are supported.
 
 .Supported Java Runtime Environments
 [cols="100,135"]
@@ -19,8 +20,8 @@ If you plan to use an alternative JRE for the Analytics service, note that the f
 | *Implementation* | *Version*
 
 | Oracle JRE
-| Version 11
+| Version 17
 
 | OpenJDK
-| Version 11
+| Version 17
 |===

--- a/modules/manage/pages/manage-security/configure-client-certificates.adoc
+++ b/modules/manage/pages/manage-security/configure-client-certificates.adoc
@@ -321,7 +321,7 @@ export STOREPASS=storepass
 +
 [source,bash]
 ----
-sudo apt install openjdk-11-jre-headless
+sudo apt install openjdk-17-jre-headless
 ----
 +
 Note that available packages can be found by means of `sudo apt-cache search openjdk`.
@@ -406,7 +406,7 @@ export STOREPASS=storepass
 . If necessary, install a package containing the `keytool` utility:
 +
 ----
-sudo apt install openjdk-11-jre-headless
+sudo apt install openjdk-17-jre-headless
 ----
 
 . Generate the keystore.


### PR DESCRIPTION
Docs issue: DOC-11561

Updates additional installation requirements for Analytics Service. Does a driveby fix of a couple of examples in the client certificate documentation to suggest using a supported version of JRE also.

No doc preview, minimal changes.