### PR TITLE
DOC-14274: Fix default management port for encrypted connections

### DIFF
--- a/modules/rest-api/pages/application-telemetry.adoc
+++ b/modules/rest-api/pages/application-telemetry.adoc
@@ -70,7 +70,7 @@ The following table lists the SDKs that support application telemetry along with
 |===
 
 * Your clients must be able to connect to the node's management port to create the WebSocket connection for telemetry data collection.
-The default management port is 8091 for unencrypted connections and 18901 for encrypted connections.
+The default management port is 8091 for unencrypted connections and 18091 for encrypted connections.
 Make sure any firewall rules between your clients and the nodes allow traffic on the management port.
 
 == HTTP Methods 


### PR DESCRIPTION
DOC-14274: Updated the default management port for encrypted connections from 18901 to 18091.