### PR TITLE
[DOC-14290]: Document Enforcing CE limitations

### DIFF
--- a/modules/introduction/pages/editions.adoc
+++ b/modules/introduction/pages/editions.adoc
@@ -1,40 +1,70 @@
 = Couchbase Server Editions
 :description: Couchbase Server is available in two editions: Enterprise and Community.
 
+:phone-home: footnote:[Usage information is only sent when you use the Admin GUI. \
+No usage information is sent when you use the command line utilities to administer your cluster.]
+
 [abstract]
 {description}
 
 Each edition offers different features and levels of support.
 
-== Enterprise Edition
+== Couchbase Server Enterprise Edition
 
-The Enterprise Edition (EE) represents the latest, most stable, production-ready release of Couchbase Server. We recommend the Enterprise Edition binaries for commercial production systems running Couchbase Server. The Enterprise Edition contains some unique features that make it the best fit for production deployments running in data centers or public cloud infrastructure.
+The Enterprise Edition (EE) represents the latest, most stable, production-ready release of Couchbase Server. 
+Couchbase recommends the Enterprise Edition binaries for commercial production systems running Couchbase Server. 
+The Enterprise Edition contains some unique features that make it the best fit for production deployments running in data centers or public cloud infrastructure.
 
-A subscription to the Enterprise Edition includes a commercial license, better availability capabilities, enhanced security features, advanced tooling, and higher performance and scale. It also includes technical support with service level commitments via our 24/7 support organization and hot fixes for releases.
+A subscription to the Enterprise Edition includes:
 
-Refer to the https://www.couchbase.com/pricing[pricing^] page for details on Couchbase's Enterprise Edition.
+* a commercial license
+* better availability capabilities 
+* enhanced security features 
+* advanced tooling
+* and higher performance and scale. 
 
-== Community Edition
+It also includes technical support with service level commitments via our 24/7-support organization and hot fixes for releases.
+
+For more information, see the https://www.couchbase.com/pricing[pricing^] page for details on Couchbase's Enterprise Edition.
+
+== Couchbase Server Community Edition
 The Community Edition (CE) is best for noncommercial developers where basic availability, performance, scale, tooling, security capabilities and community support is sufficient.
 
-One important principle for Community Edition and Enterprise Edition is to ensure full portability of applications between the two editions. The capabilities ensure that an application running on Enterprise Edition should transition to Community Edition without code changes and vice versa.
+One important principle for Community Edition and Enterprise Edition is to ensure full portability of applications between the 2 editions. 
+The capabilities ensure that an application running on Enterprise Edition should transition to Community Edition without code changes and vice versa.
 
-The Community Edition license provides the free deployment of Couchbase Community Edition for departmental-scale deployments of up to five node clusters. The Community Edition license has recently been updated to disallow the use of Cross Data Center Replication
-(XDCR), which is now an exclusive Enterprise Edition feature.
-The Community Edition is not subjected to the iterative "test, fix, and verify" quality assurance cycle that is an integral part of the Enterprise Edition release process. The Community Edition does not include the latest bug fixes.
+The Community Edition license provides the free deployment of Couchbase Community Edition for departmental-scale deployments of up to 5 node clusters. 
+
+The Community Edition license has been updated to disallow the use of cross-datacenter replication (XDCR), 
+which is now an exclusive Enterprise Edition feature.
+
+[NOTE]
+.Replicating from a CE server to an EE server
+==== 
+You can still replicate data from a CE server as long as the data is being replicated to an EE installation running XDCR.
+====
+
+Multi-Dimensional Scaling (MDS) is not supported on the Community Edition.
+
+The Community Edition is not subjected to the iterative `test`, `fix`, and `verify` quality assurance cycle that's an integral part of the Enterprise Edition release process. 
+
+The Community Edition does not include the latest bug fixes.
 
 The Community Edition comes with limited concurrency and parallelism and supports a maximum of 4 cores per node.
+
+The Community Edition shares usage information with Couchbase{empty}{phone-home} and notifies you when updates are available.
 
 Documentation, mailing lists, and forums support the Couchbase user community to help troubleshoot issues and answer questions.
 
 == Open Source Project
 
-The Couchbase Server open source project is a platform for innovation. Couchbase is committed to open source development, and the open source project continues to serve as the foundation for both the Community Edition and the Enterprise Edition.
+The Couchbase Server open source project is a platform for innovation. 
+Couchbase is committed to open source development, and the open source project continues to serve as the foundation for both the Community Edition and the Enterprise Edition.
 
-There are many ways to contribute to the open source project:
+To contribute to the open source project, you can:
 
-* Contribute code to our core engine, our SDKs, connectors and other integration components that help us connect to other products through https://github.com/couchbase[github.com/couchbase^]. Find more details on the https://developer.couchbase.com/open-source-projects/[Open Source Projects^] page.
-* Report issues on our tracking system: https://issues.couchbase.com/projects/MB?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page[JIRA^].
-* xref:home:contribute:index.adoc[Contribute to the documentation] either by submitting changes on GitHub or by simply clicking the "Feedback" link in our online documentation.
+* Contribute code to Couchbase's core engine, SDKs, connectors, and other integration components that help to connect to other products through https://github.com/couchbase[github.com/couchbase^]. Find more details on the https://developer.couchbase.com/open-source-projects/[Open Source Projects^] page.
+* Report issues on the Couch tracking system: https://issues.couchbase.com/projects/MB?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page[JIRA^].
+* xref:home:contribute:index.adoc[Contribute to the documentation] either by submitting changes on GitHub or by clicking the "Feedback" link in the xref:intro.adoc[Couchbase online documentation].
 
-For a feature by feature comparison between editions, take a look at https://www.couchbase.com/products/editions[^].
+For a feature-by-feature comparison between editions, take a look at https://www.couchbase.com/products/editions[^].

--- a/modules/manage/pages/manage-xdcr/xdcr-management-overview.adoc
+++ b/modules/manage/pages/manage-xdcr/xdcr-management-overview.adoc
@@ -7,50 +7,58 @@
 
 [#xdcr-summary]
 == What is XDCR?
-Cross Data Center Replication (XDCR) replicates data between clusters: this provides protection against data-center failure, and also provides high-performance data-access for globally distributed, mission-critical applications.
+Cross datacenter Replication (XDCR) replicates data between clusters: this provides protection against datacenter failure, and also provides high-performance data-access for globally distributed, mission-critical applications.
 
-Note that Couchbase has modified the license restrictions to its Couchbase Server Community Edition package, for version 7.0 and higher: in consequence, XDCR is promoted to a commercial-only feature of Enterprise Edition.
-See https://blog.couchbase.com/couchbase-modifies-license-free-community-edition-package/[Couchbase Modifies License of Free Community Edition Package^], for more information on the license restrictions; and see xref:manage:manage-xdcr/xdcr-management-overview.adoc#xdcr-and-community-edition[XDCR and Community Edition], below, for information on how the new restrictions affect the experience of Community-Edition administrators.
+[NOTE]
+====
+Couchbase has modified the license restrictions to its Couchbase Server Community Edition package, for version 7.0 and higher:
+
+XDCR is promoted to a commercial-only feature of Couchbase Server Enterprise Edition.
+
+For more information, see https://blog.couchbase.com/couchbase-modifies-license-free-community-edition-package/[Couchbase Modifies License of Free Community Edition Package^], 
+
+For more information about how the new restrictions affect the experience of Community-Edition administrators., see xref:manage:manage-xdcr/xdcr-management-overview.adoc#xdcr-and-community-edition[XDCR and Community Edition] below. 
+====
 
 XDCR replicates data from a specific bucket on the source cluster to a specific bucket on the target cluster.
-Any bucket (Couchbase or Ephemeral) on any cluster can be specified as a source or a target for one or more XDCR definitions.
-_Scopes_ and _collections_, within source and target buckets, can also be specified.
-Data from the source is pushed to the target bucket by means of an XDCR agent, running on the source cluster, using the Database Change Protocol.
+Any bucket (Couchbase or Ephemeral) on any cluster can be specified as a source or a target for 1 or more XDCR definitions.
+`Scopes` and `collections`, within source and target buckets, can also be specified.
+Data from the source is pushed to the target bucket by an XDCR agent, running on the source cluster, using the Database Change Protocol.
 
-Note that XDCR can only be established between clusters whose numbers of vBuckets are equal: all supported platforms have _1024_ vBuckets except _MacOS_, which has _64_.
+NOTE: XDCR can only be established between clusters whose numbers of vBuckets are equal: all supported platforms have 1024 vBuckets except macOS, which has 64.
 For more information, see xref:learn:buckets-memory-and-storage/vbuckets.adoc[vBuckets].
 
-A complete architectural description of XDCR is provided in xref:learn:clusters-and-availability/xdcr-overview.adoc[Cross Data Center Replication (XDCR)].
-You may wish to familiarize yourself with the information provided there, before performing the routines provided in this section.
+A complete architectural description of XDCR is provided in xref:learn:clusters-and-availability/xdcr-overview.adoc[Cross Datacenter Replication (XDCR)].
+You may want to familiarize yourself with the information provided there before performing the routines provided in this section.
 
-For information on scopes and collections, see xref:learn:data/scopes-and-collections.adoc[Scopes and Collections].
+For information about scopes and collections, see xref:learn:data/scopes-and-collections.adoc[Scopes and Collections].
 
 [#what-xdcr-tasks-can-be-performed]
 == What XDCR Tasks Can Be Performed?
 
 Management of XDCR includes the following:
 
-* _Preparation_: Make sure that you have appropriate permissions for managing XDCR.
+* Preparation: Make sure that you have appropriate permissions for managing XDCR.
 Check platform sizes, configurations, and ports.
 Details are provided in xref:manage:manage-xdcr/prepare-for-xdcr.adoc[Prepare for XDCR].
 
-* _Reference_ management: Remote clusters must be registered as targets for XDCR.
+* Reference management: Remote clusters must be registered as targets for XDCR.
 This requires appropriate administration credentials for the remote cluster, and the existence on that cluster of one or more buckets that can be specified as recipients of replicated data.
-Information on establishing references is provided in xref:manage:manage-xdcr/create-xdcr-reference.adoc[Create a Reference]; and information on deleting them in xref:manage:manage-xdcr/delete-xdcr-reference.adoc[Delete a Reference].
+Information about establishing references is provided in xref:manage:manage-xdcr/create-xdcr-reference.adoc[Create a Reference]; and information about deleting them in xref:manage:manage-xdcr/delete-xdcr-reference.adoc[Delete a Reference].
 
-* _Replication_ management: Once a reference has been registered on the local cluster, it can be specified as the target for a _replication_.
+* Replication management: Once a reference has been registered on the local cluster, it can be specified as the target for a _replication_.
 This requires that an existing source and an existing target bucket also be specified.
 Optionally, filters can be established, so that only documents with matching ids, fields, values, or extended attributes are replicated.
-Additionally, advanced settings can be configured, to ensure optimal performance.
-Information on establishing replications is provided in xref:manage:manage-xdcr/create-xdcr-replication.adoc[Create a Replication]; and information on deleting them in xref:manage:manage-xdcr/delete-xdcr-replication.adoc[Delete a Replication].
+Advanced settings can be configured to ensure optimal performance.
+Information about establishing replications is provided in xref:manage:manage-xdcr/create-xdcr-replication.adoc[Create a Replication]; and information about deleting them in xref:manage:manage-xdcr/delete-xdcr-replication.adoc[Delete a Replication].
 +
 Note that replications can be configured to occur between specific _scopes_ and _collections_; as described in xref:manage:manage-xdcr/replicate-using-scopes-and-collections.adoc[Replicate Using Scopes and Collections].
 
-* _Pausing_ and _Resuming_ replications: Once started, a replication is continuous; mutations on the source being constantly transmitted to the target.
-Occasionally, for purposes of system maintenance, it may be desirable manually to pause a replication, and then resume it.
-Information is provided in xref:manage:manage-xdcr/pause-xdcr-replication.adoc[Pause a Replication]; and xref:manage:manage-xdcr/resume-xdcr-replication.adoc[Resume a Replication].
+* Pausing and Resuming replications: Once started, a replication is continuous mutations on the source being constantly transmitted to the target.
+For purposes of system maintenance, it may be desirable manually to pause a replication and then resume it.
+Information is provided in xref:manage:manage-xdcr/pause-xdcr-replication.adoc[Pause a Replication] and xref:manage:manage-xdcr/resume-xdcr-replication.adoc[Resume a Replication].
 
-* _Recovering Data_: In the event of data-loss, the *cbrecovery* tool can be used to restore data.
+* Recovering Data: In the event of data-loss, the *cbrecovery* tool can be used to restore data.
 The tool accesses remotely replicated buckets, previously created with XDCR, and copies appropriate subsets of their data back onto the original source-cluster.
 Information is provided in xref:manage:manage-xdcr/recover-data-with-xdcr.adoc[Recover Data with XDCR].
 
@@ -58,22 +66,31 @@ Information is provided in xref:manage:manage-xdcr/recover-data-with-xdcr.adoc[R
 == How to Use This Section
 
 This section is divided into multiple subsections, each of which presents step-by-step examples of how to perform a particular XDCR management task.
-In most subsections, three examples are provided, showing how to perform the same task with Couchbase Web Console, CLI, and REST API respectively.
-The subsections are arranged in a sequence, to make it easy to start from the first example, xref:manage:manage-xdcr/prepare-for-xdcr.adoc[Prepare for XDCR], and proceed to the last.
+In most subsections, 3 examples are provided, showing how to perform the same task with Couchbase Web Console, command-line tool, and REST API respectively.
+The subsections are arranged in a sequence to make it easy to start from the first example, xref:manage:manage-xdcr/prepare-for-xdcr.adoc[Prepare for XDCR], and proceed to the last.
 
 [#xdcr-and-community-edition]
 == XDCR and Community Edition
 
 Couchbase has modified the license restrictions to its Couchbase Server Community Edition package, for version 7.0 and higher: in consequence, XDCR is promoted to a commercial-only feature of Enterprise Edition.
 
-Consequently, prior to any attempt to add a remote cluster, the *XDCR* screen displays the following message:
 
-image::manage-xdcr/xdcr-screen-ce.png[,720,align=middle]
+[NOTE]
+.Replicating from a CE server to an EE server
+==== 
+You can still replicate data from a CE server as long as the data is being replicated to an EE installation running XDCR.
+====
 
-The provided link takes the reader to detailed information on the new license restrictions, at https://blog.couchbase.com/couchbase-modifies-license-free-community-edition-package/[Couchbase Modifies License of Free Community Edition Package^].
+Prior to any attempt to add a remote cluster, the *XDCR* screen displays the following message:
+
+image::manage-xdcr/xdcr-screen-ce.png[,720, align=middle]
+
+The provided link takes the reader to detailed information about the new license restrictions, at https://blog.couchbase.com/couchbase-modifies-license-free-community-edition-package/[Couchbase Modifies License of Free Community Edition Package^].
 
 Attempts to establish replications cause the following console message to be displayed:
 
 image::manage-xdcr/xdcr-console-message-ce.png[,400,align=middle]
 
-Community-Edition adminstrators who wish to upgrade to version 7.0 or later, and wish to use XDCR, are recommended to consult https://blog.couchbase.com/couchbase-modifies-license-free-community-edition-package/[Couchbase Modifies License of Free Community Edition Package^], for guidance.
+Community-Edition administrators who want to upgrade to version 7.0 or later and also want to use XDCR are recommended to consult https://blog.couchbase.com/couchbase-modifies-license-free-community-edition-package/[Couchbase Modifies License of Free Community Edition Package^], for guidance.
+
+

--- a/modules/manage/pages/manage-xdcr/xdcr-management-overview.adoc
+++ b/modules/manage/pages/manage-xdcr/xdcr-management-overview.adoc
@@ -1,5 +1,5 @@
 = XDCR Management Overview
-:description: Cross Datacenter Replication (XDCR) provides an easy way to replicate data from one cluster to another.
+:description: Cross datacenter Replication (XDCR) provides an easy way to replicate data from one cluster to another.
 :page-aliases: xdcr:xdcr-intro
 
 [abstract]
@@ -17,7 +17,7 @@ XDCR is promoted to a commercial-only feature of Couchbase Server Enterprise Edi
 
 For more information, see https://blog.couchbase.com/couchbase-modifies-license-free-community-edition-package/[Couchbase Modifies License of Free Community Edition Package^], 
 
-For more information about how the new restrictions affect the experience of Community-Edition administrators., see xref:manage:manage-xdcr/xdcr-management-overview.adoc#xdcr-and-community-edition[XDCR and Community Edition] below. 
+For more information about how the new restrictions affect the experience of Community-Edition administrators, see xref:manage:manage-xdcr/xdcr-management-overview.adoc#xdcr-and-community-edition[XDCR and Community Edition] below. 
 ====
 
 XDCR replicates data from a specific bucket on the source cluster to a specific bucket on the target cluster.
@@ -25,10 +25,17 @@ Any bucket (Couchbase or Ephemeral) on any cluster can be specified as a source 
 `Scopes` and `collections`, within source and target buckets, can also be specified.
 Data from the source is pushed to the target bucket by an XDCR agent, running on the source cluster, using the Database Change Protocol.
 
-NOTE: XDCR can only be established between clusters whose numbers of vBuckets are equal: all supported platforms have 1024 vBuckets except macOS, which has 64.
-For more information, see xref:learn:buckets-memory-and-storage/vbuckets.adoc[vBuckets].
+[NOTE]
+====
+Prior to Server 8.0,
+XDCR could only be established between buckets where the numbers of vBuckets were the same. 
 
-A complete architectural description of XDCR is provided in xref:learn:clusters-and-availability/xdcr-overview.adoc[Cross Datacenter Replication (XDCR)].
+Now, if the cluster versions in the replication topology are 8.0 and later, XDCR can be established between buckets with different numbers of vBuckets. 
+
+While an 8.x cluster can create an XDCR to a 7.x cluster bucket with a different number of vBuckets, a 7.x cluster can only create an XDCR to a bucket with the same number of vBuckets regardless of the target cluster version.
+====
+
+A complete architectural description of XDCR is provided in xref:learn:clusters-and-availability/xdcr-overview.adoc[Cross datacenter Replication (XDCR)].
 You may want to familiarize yourself with the information provided there before performing the routines provided in this section.
 
 For information about scopes and collections, see xref:learn:data/scopes-and-collections.adoc[Scopes and Collections].
@@ -46,20 +53,20 @@ Details are provided in xref:manage:manage-xdcr/prepare-for-xdcr.adoc[Prepare fo
 This requires appropriate administration credentials for the remote cluster, and the existence on that cluster of one or more buckets that can be specified as recipients of replicated data.
 Information about establishing references is provided in xref:manage:manage-xdcr/create-xdcr-reference.adoc[Create a Reference]; and information about deleting them in xref:manage:manage-xdcr/delete-xdcr-reference.adoc[Delete a Reference].
 
-* Replication management: Once a reference has been registered on the local cluster, it can be specified as the target for a _replication_.
+* Replication management: Once a reference has been registered on the local cluster, it can be specified as the target for a replication.
 This requires that an existing source and an existing target bucket also be specified.
 Optionally, filters can be established, so that only documents with matching ids, fields, values, or extended attributes are replicated.
 Advanced settings can be configured to ensure optimal performance.
-Information about establishing replications is provided in xref:manage:manage-xdcr/create-xdcr-replication.adoc[Create a Replication]; and information about deleting them in xref:manage:manage-xdcr/delete-xdcr-replication.adoc[Delete a Replication].
+Information about establishing replications is provided in xref:manage:manage-xdcr/create-xdcr-replication.adoc[Create a Replication] and information about deleting them in xref:manage:manage-xdcr/delete-xdcr-replication.adoc[Delete a Replication].
 +
-Note that replications can be configured to occur between specific _scopes_ and _collections_; as described in xref:manage:manage-xdcr/replicate-using-scopes-and-collections.adoc[Replicate Using Scopes and Collections].
+NOTE: Replications can be configured to occur between specific `scopes` and `collections` as described in xref:manage:manage-xdcr/replicate-using-scopes-and-collections.adoc[Replicate Using Scopes and Collections].
 
-* Pausing and Resuming replications: Once started, a replication is continuous mutations on the source being constantly transmitted to the target.
+* Pausing and Resuming replications: Once started, a replication is continuous; mutations on the source are constantly transmitted to the target.
 For purposes of system maintenance, it may be desirable manually to pause a replication and then resume it.
 Information is provided in xref:manage:manage-xdcr/pause-xdcr-replication.adoc[Pause a Replication] and xref:manage:manage-xdcr/resume-xdcr-replication.adoc[Resume a Replication].
 
-* Recovering Data: In the event of data-loss, the *cbrecovery* tool can be used to restore data.
-The tool accesses remotely replicated buckets, previously created with XDCR, and copies appropriate subsets of their data back onto the original source-cluster.
+* Recovering Data: In the event of data-loss, the `cbrecovery` tool can be used to restore data.
+The tool accesses remotely replicated buckets created with XDCR, and copies appropriate subsets of their data back onto the original source-cluster.
 Information is provided in xref:manage:manage-xdcr/recover-data-with-xdcr.adoc[Recover Data with XDCR].
 
 [#how-to-use-xdcr-management-section]
@@ -89,7 +96,7 @@ The provided link takes the reader to detailed information about the new license
 
 Attempts to establish replications cause the following console message to be displayed:
 
-image::manage-xdcr/xdcr-console-message-ce.png[,400,align=middle]
+image::manage-xdcr/xdcr-console-message-ce.png[,400, align=middle]
 
 Community-Edition administrators who want to upgrade to version 7.0 or later and also want to use XDCR are recommended to consult https://blog.couchbase.com/couchbase-modifies-license-free-community-edition-package/[Couchbase Modifies License of Free Community Edition Package^], for guidance.
 


### PR DESCRIPTION


Updated documentation to reflect the enforcement of Community Edition (CE) limitations. Changes were made to the following files:
- `editions.adoc`
- `xdcr-management-overview.adoc`

----

Preview URLs:

Preview URL:
https://preview.docs-test.couchbase.com/docs-server-DOC-14290--8.1--Document-Enforcing-CE-limitations/server/current/introduction/editions.html

https://preview.docs-test.couchbase.com/docs-server-DOC-14290--8.1--Document-Enforcing-CE-limitations/server/current/manage/manage-xdcr/xdcr-management-overview.html


You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.

