### PR TITLE
[DOC-14129]: Magma Compaction rate limiter documentation

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -433,6 +433,7 @@ include::cli:partial$cbcli/nav.adoc[]
    *** xref:rest-api:rest-compact-post.adoc[Performing Compaction Manually]
    *** xref:rest-api:rest-autocompact-global.adoc[Auto-Compaction: Global]
    *** xref:rest-api:rest-autocompact-per-bucket.adoc[Auto-Compaction: Per Bucket]
+   *** xref:rest-api:rest-magma-compaction-rate-limiting.adoc[Magma Compaction Rate Limiting]
    *** xref:rest-api:rest-magma-compression-per-bucket.adoc[Magma Compression]
 
    ** xref:rest-api:rest-rza.adoc[Server Groups API]

--- a/modules/rest-api/pages/rest-magma-compaction-rate-limiting.adoc
+++ b/modules/rest-api/pages/rest-magma-compaction-rate-limiting.adoc
@@ -77,6 +77,25 @@ Running this command returns the global settings:
 -d magma_compaction_rate_limit=500 | jq
 ----
 
+The call executes and returns a JSON object containing the new setting.
+
+[source, json]
+----
+{
+  "max_connections": 20000,
+  "system_connections": 5000,
+  "magma_compaction_rate_limit": 500,
+  "magma_enable_compaction_dataonly_ratelimiting": false
+}
+----
+
+.Setting Compaction for data only rate limiting
+[source,shell]
+----
+curl -u Administrator:password -X POST localhost:8091/pools/default/settings/memcached/global \
+-d magma_enable_compaction_dataonly_ratelimiting=true | jq
+----
+
 The call executes and returns a string containing the new setting.
 
 [source, json]
@@ -86,24 +105,5 @@ The call executes and returns a string containing the new setting.
   "system_connections": 5000,
   "magma_compaction_rate_limit": 500,
   "magma_enable_compaction_dataonly_ratelimiting": true
-}
-----
-
-.Setting Compaction for data only rate limiting
-[source,shell]
-----
-curl -u Administrator:password -X POST localhost:8091/pools/default/settings/memcached/global \
--d magma_enable_compaction_dataonly_ratelimiting=false | jq
-----
-
-The call executes and returns a string containing the new setting.
-
-[source, json]
-----
-{
-  "max_connections": 20000,
-  "system_connections": 5000,
-  "magma_compaction_rate_limit": 500,
-  "magma_enable_compaction_dataonly_ratelimiting": false
 }
 ----

--- a/modules/rest-api/pages/rest-magma-compaction-rate-limiting.adoc
+++ b/modules/rest-api/pages/rest-magma-compaction-rate-limiting.adoc
@@ -6,8 +6,14 @@
 
 == Description
 
-Use these API calls to limit the disk I/O bandwidth (in bytes per second) that Magma Storage Engine Compaction may consume. 
+Use these API calls to limit the disk I/O bandwidth (in *bytes per second*) that the Magma Storage Engine Compaction may consume. 
 The limit is global to the Data Service and shared across all buckets on the node
+
+NOTE: The limit setting is global, 
+even though the application of the setting is on a per-node basis. 
+This allows compactions on each node to consume a maximum of `compaction-rate-limit` bytes per second.
+
+Compaction is a background maintenance activity that reclaims space from stale and deleted data and keeps data files efficient to read. It operates on the same data files that front-end reads and writes use, so large bursts of compaction can consume enough disk I/O to slow front-end operations. Rate limiting smooths those bursts into a steady background rate, keeping front-end performance predictable — at the cost of slower compaction.
 
 Magma supports 2 types of compaction:
 
@@ -20,22 +26,25 @@ Data Log Compactions::
 Data compactions can be de-prioritized compared to LSM Tree compactions.
 The only consequence of slowing these operations is increased space usage.
 
-== Usage
+=== Usage
 
 Rate limiting helps wherever compaction can surge and contend with front-end I/O, for example:
 
-* Short-burst, write-heavy workloads, where spikes in writes drive spikes in compaction.
+* Short burst, write heavy workloads, where spikes in writes drive spikes in compaction.
+
 * Large collection drops, which mark a large amount of data for removal at once.
-* Sudden large number document expirations, such as a batch of items with closer TTL ranges expiring together.
+
+* Sudden large number document expirations, such as a batch of items with closer TTL range expiring together.
 
 The trade-off is that compaction runs more slowly, so disk usage may stay higher for longer. 
-Set the limit low enough to protect front-end write bursts, but high enough that compaction keeps pace with the rate at which data is written.
+Set the limit low enough to protect front-end write bursts, but high enough that compaction keeps pace with the write rate.
+
 
 
 == Recommended Value
 
 A practical starting point is 100 MB/s (104857600 bytes/s), or about 10× your incoming write rate — estimated as writes per second per node × average document size. 
-For example, 10,000 writes/s of 1 KB documents is approximately 10 MB/s incoming, giving a ~100 MB/s limit.
+For example, 10,000 writes/s of 1 KB documents is roughly 10 MB/s incoming, giving a ~100 MB/s limit.
 
 == Settings
 
@@ -46,7 +55,7 @@ For example, 10,000 writes/s of 1 KB documents is approximately 10 MB/s incoming
 | `magma_compaction_rate_limit`
 | Controls the I/O bandwidth
 (given in bytes per second)
-that compactions across all shards consume.
+that compactions on all the shards on one node consume.
 Setting this value to 0 disables compaction rate limiting.
 | stem:[0 … 2^64 - 1] 
 (default: 0)
@@ -78,7 +87,7 @@ Running this command returns the global settings:
 {
   "max_connections": 20000,
   "system_connections": 5000,
-  "magma_enable_compaction_dataonly_ratelimiting": false
+  "magma_compaction_rate_limit": 100
 }
 ----
 
@@ -96,7 +105,6 @@ The call executes and returns a JSON object containing the new setting.
 {
   "max_connections": 20000,
   "system_connections": 5000,
-  "magma_compaction_rate_limit": 500,
-  "magma_enable_compaction_dataonly_ratelimiting": false
+  "magma_compaction_rate_limit": 500
 }
 ----

--- a/modules/rest-api/pages/rest-magma-compaction-rate-limiting.adoc
+++ b/modules/rest-api/pages/rest-magma-compaction-rate-limiting.adoc
@@ -96,7 +96,7 @@ curl -u Administrator:password -X POST localhost:8091/pools/default/settings/mem
 -d magma_enable_compaction_dataonly_ratelimiting=true | jq
 ----
 
-The call executes and returns a string containing the new setting.
+The call executes and returns a JSON object containing the new setting.
 
 [source, json]
 ----

--- a/modules/rest-api/pages/rest-magma-compaction-rate-limiting.adoc
+++ b/modules/rest-api/pages/rest-magma-compaction-rate-limiting.adoc
@@ -30,7 +30,7 @@ The only consequence of slowing these operations is increased space usage.
 | `magma_compaction_rate_limit`
 | Controls the I/O bandwidth
 (given in bytes per second)
-that the compactions across all the shards can take to consume.
+that compactions across all shards can consume.
 Setting this value to 0 disables compaction rate limiting.
 | stem:[0 … 2^64 - 1] 
 (default: 0)

--- a/modules/rest-api/pages/rest-magma-compaction-rate-limiting.adoc
+++ b/modules/rest-api/pages/rest-magma-compaction-rate-limiting.adoc
@@ -6,7 +6,7 @@
 
 == Description
 
-Use these API calls to set the rate limit (in MB per second). 
+Use these API calls to set the rate limit (in bytes per second). 
 This setting is a global rate limit for the Memcached process shared across buckets. 
 The strategy for this rate limiting is to set the block waiting time on the compaction threads to maintain the specified limits. 
 

--- a/modules/rest-api/pages/rest-magma-compaction-rate-limiting.adoc
+++ b/modules/rest-api/pages/rest-magma-compaction-rate-limiting.adoc
@@ -30,14 +30,14 @@ The only consequence of slowing these operations is increased space usage.
 | `magma_compaction_rate_limit`
 | Controls the I/O bandwidth
 (given in bytes per second)
-that compactions across all shards can consume.
+that compactions across all shards consume.
 Setting this value to 0 disables compaction rate limiting.
 | stem:[0 … 2^64 - 1] 
 (default: 0)
 
 | `magma_enable_compaction_dataonly_ratelimiting`
 | Controls whether the compaction rate limiting runs in `data-only` mode.
-(only fragment reduction compactions are rate-limited)
+(Only fragment reduction compactions are rate-limited)
 | `true`, `false` (default:``false``)
 
 |===

--- a/modules/rest-api/pages/rest-magma-compaction-rate-limiting.adoc
+++ b/modules/rest-api/pages/rest-magma-compaction-rate-limiting.adoc
@@ -13,18 +13,9 @@ NOTE: The limit setting is global,
 even though the application of the setting is on a per-node basis. 
 This allows compactions on each node to consume a maximum of `compaction-rate-limit` bytes per second.
 
-Compaction is a background maintenance activity that reclaims space from stale and deleted data and keeps data files efficient to read. It operates on the same data files that front-end reads and writes use, so large bursts of compaction can consume enough disk I/O to slow front-end operations. Rate limiting smooths those bursts into a steady background rate, keeping front-end performance predictable — at the cost of slower compaction.
-
-Magma supports 2 types of compaction:
-
-Log-Structured Merge (LSM) Tree Compactions::
-These compactions are short-running and essential for preserving the structure of the Log-Structured Merge tree.
-Delaying these operations can lead to increased read latency, as the read path may need to use multiple files, resulting in higher read amplification. 
-If this type of compaction is lagging for level-0 of the LSM Tree, the system performs level-0 compaction within the writer threads themselves
-
-Data Log Compactions::
-Data compactions can be de-prioritized compared to LSM Tree compactions.
-The only consequence of slowing these operations is increased space usage.
+Compaction is a background maintenance activity that reclaims space from stale and deleted data and keeps data files efficient to read. 
+It operates on the same data files that front-end reads and writes use, so large bursts of compaction can consume enough disk I/O to slow front-end operations. 
+Rate limiting smooths those bursts into a steady background rate, keeping front-end performance predictable — at the cost of slower compaction.
 
 === Usage
 
@@ -38,7 +29,6 @@ Rate limiting helps wherever compaction can surge and contend with front-end I/O
 
 The trade-off is that compaction runs more slowly, so disk usage may stay higher for longer. 
 Set the limit low enough to protect front-end write bursts, but high enough that compaction keeps pace with the write rate.
-
 
 
 == Recommended Value

--- a/modules/rest-api/pages/rest-magma-compaction-rate-limiting.adoc
+++ b/modules/rest-api/pages/rest-magma-compaction-rate-limiting.adoc
@@ -6,9 +6,8 @@
 
 == Description
 
-Use these API calls to set the rate limit (in bytes per second). 
-This setting is a global rate limit for the Memcached process shared across buckets. 
-The strategy for this rate limiting is to set the block waiting time on the compaction threads to maintain the specified limits. 
+Use these API calls to limit the disk I/O bandwidth (in bytes per second) that Magma Storage Engine Compaction may consume. 
+The limit is global to the Data Service and shared across all buckets on the node
 
 Magma supports 2 types of compaction:
 
@@ -21,9 +20,26 @@ Data Log Compactions::
 Data compactions can be de-prioritized compared to LSM Tree compactions.
 The only consequence of slowing these operations is increased space usage.
 
+== Usage
+
+Rate limiting helps wherever compaction can surge and contend with front-end I/O, for example:
+
+* Short-burst, write-heavy workloads, where spikes in writes drive spikes in compaction.
+* Large collection drops, which mark a large amount of data for removal at once.
+* Sudden large number document expirations, such as a batch of items with closer TTL ranges expiring together.
+
+The trade-off is that compaction runs more slowly, so disk usage may stay higher for longer. 
+Set the limit low enough to protect front-end write bursts, but high enough that compaction keeps pace with the rate at which data is written.
+
+
+== Recommended Value
+
+A practical starting point is 100 MB/s (104857600 bytes/s), or about 10× your incoming write rate — estimated as writes per second per node × average document size. 
+For example, 10,000 writes/s of 1 KB documents is approximately 10 MB/s incoming, giving a ~100 MB/s limit.
+
 == Settings
 
-[cols="3,3,1"]
+[cols="1,2,1"]
 |===
 | Setting | Description| Range
 
@@ -35,10 +51,6 @@ Setting this value to 0 disables compaction rate limiting.
 | stem:[0 … 2^64 - 1] 
 (default: 0)
 
-| `magma_enable_compaction_dataonly_ratelimiting`
-| Controls whether the compaction rate limiting runs in `data-only` mode.
-(Only fragment reduction compactions are rate-limited)
-| `true`, `false` (default:``false``)
 
 |===
 
@@ -86,24 +98,5 @@ The call executes and returns a JSON object containing the new setting.
   "system_connections": 5000,
   "magma_compaction_rate_limit": 500,
   "magma_enable_compaction_dataonly_ratelimiting": false
-}
-----
-
-.Setting Compaction for data only rate limiting
-[source,shell]
-----
-curl -u Administrator:password -X POST localhost:8091/pools/default/settings/memcached/global \
--d magma_enable_compaction_dataonly_ratelimiting=true | jq
-----
-
-The call executes and returns a JSON object containing the new setting.
-
-[source, json]
-----
-{
-  "max_connections": 20000,
-  "system_connections": 5000,
-  "magma_compaction_rate_limit": 500,
-  "magma_enable_compaction_dataonly_ratelimiting": true
 }
 ----

--- a/modules/rest-api/pages/rest-magma-compaction-rate-limiting.adoc
+++ b/modules/rest-api/pages/rest-magma-compaction-rate-limiting.adoc
@@ -1,0 +1,109 @@
+= Magma Compaction Rate Limiting
+:description: This API is used to set the rate limit for Magma compaction threads. 
+:stem: asciimath
+[abstract]
+{description}
+
+== Description
+
+Use these API calls to set the rate limit (in MB per second). 
+This setting is a global rate limit for the Memcached process shared across buckets. 
+The strategy for this rate limiting is to set the block waiting time on the compaction threads to maintain the specified limits. 
+
+Magma supports 2 types of compaction:
+
+Log-Structured Merge (LSM) Tree Compactions::
+These compactions are short-running and essential for preserving the structure of the Log-Structured Merge tree.
+Delaying these operations can lead to increased read latency, as the read path may need to use multiple files, resulting in higher read amplification. 
+If this type of compaction is lagging for level-0 of the LSM Tree, the system performs level-0 compaction within the writer threads themselves
+
+Data Log Compactions::
+Data compactions can be de-prioritized compared to LSM Tree compactions.
+The only consequence of slowing these operations is increased space usage.
+
+== Settings
+
+[cols="3,3,1"]
+|===
+| Setting | Description| Range
+
+| `magma_compaction_rate_limit`
+| Controls the I/O bandwidth
+(given in bytes per second)
+that the compactions across all the shards can take to consume.
+Setting this value to 0 disables compaction rate limiting.
+| stem:[0 … 2^64 - 1] 
+(default: 0)
+
+| `magma_enable_compaction_dataonly_ratelimiting`
+| Controls whether the compaction rate limiting runs in `data-only` mode.
+(only fragment reduction compactions are rate-limited)
+| `true`, `false` (default:``false``)
+
+|===
+
+== HTTP Methods and URIs
+
+[source, shell]
+----
+GET /pools/default/settings/memcached/global 
+POST /pools/default/settings/memcached/global 
+
+----
+
+== Examples
+
+.Retrieve the compaction limit settings
+[source, shell]
+----
+curl -u Administrator:password -X GET http://localhost:8091/pools/default/settings/memcached/global
+----
+
+Running this command returns the global settings:
+
+[source, json]
+----
+{
+  "max_connections": 20000,
+  "system_connections": 5000,
+  "magma_enable_compaction_dataonly_ratelimiting": false
+}
+----
+
+.Setting the compaction rate
+[source, shell]
+----
+ curl -u Administrator:password -X POST localhost:8091/pools/default/settings/memcached/global \
+-d magma_compaction_rate_limit=500 | jq
+----
+
+The call executes and returns a string containing the new setting.
+
+[source, json]
+----
+{
+  "max_connections": 20000,
+  "system_connections": 5000,
+  "magma_compaction_rate_limit": 500,
+  "magma_enable_compaction_dataonly_ratelimiting": true
+}
+----
+
+.Setting Compaction for data only rate limiting
+[source,shell]
+----
+curl -u Administrator:password -X POST localhost:8091/pools/default/settings/memcached/global \
+-d magma_enable_compaction_dataonly_ratelimiting=false | jq
+----
+
+The call executes and returns a string containing the new setting.
+
+[source, json]
+----
+{
+  "max_connections": 20000,
+  "system_connections": 5000,
+  "magma_compaction_rate_limit": 500,
+  "magma_enable_compaction_dataonly_ratelimiting": false
+}
+----

--- a/modules/rest-api/partials/rest-memory-and-storage-table.adoc
+++ b/modules/rest-api/partials/rest-memory-and-storage-table.adoc
@@ -45,4 +45,12 @@
 | `POST`
 | `/pools/default/buckets/[bucket-name]`
 | xref:rest-api:rest-magma-compression-per-bucket.adoc[Magma compression: Per Bucket]
+
+| `GET`
+| /pools/default/settings/memcached/global
+| xref:rest-api:rest-magma-compaction-rate-limiting.adoc[Magma Compaction Rate Limiting]
+
+| `POST`
+| /pools/default/settings/memcached/global 
+| xref:rest-api:rest-magma-compaction-rate-limiting.adoc[Magma Compaction Rate Limiting]
 |===

--- a/modules/rest-api/partials/rest-memory-and-storage-table.adoc
+++ b/modules/rest-api/partials/rest-memory-and-storage-table.adoc
@@ -47,10 +47,10 @@
 | xref:rest-api:rest-magma-compression-per-bucket.adoc[Magma compression: Per Bucket]
 
 | `GET`
-| /pools/default/settings/memcached/global
+| `/pools/default/settings/memcached/global`
 | xref:rest-api:rest-magma-compaction-rate-limiting.adoc[Magma Compaction Rate Limiting]
 
 | `POST`
-| /pools/default/settings/memcached/global 
+| `/pools/default/settings/memcached/global` 
 | xref:rest-api:rest-magma-compaction-rate-limiting.adoc[Magma Compaction Rate Limiting]
 |===


### PR DESCRIPTION

Added page detailing REST call for Magma limit rate for compaction.

preview
----

Preview URL:
https://preview.docs-test.couchbase.com/docs-server-DOC-14129--8.1--Magma-Compaction-rate-limiter-documentation/server/current/rest-api/rest-magma-compaction-rate-limiting.html

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.