### PR TITLE
[DOC-14423]: Create release note for Couchbase Server 8.0.2

### DIFF
--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -9,6 +9,8 @@ These release notes are focused on bug fixes and breaking changes.
 
 For information about new features and major improvements made in Couchbase Server 8.0, see xref:introduction:whats-new.adoc[What's New].
 
+include::partial$docs-server-8.0.2-fixes-and-improvements.adoc[]
+'''
 include::partial$docs-server-8.0.1-fixes-and-improvements.adoc[]
 include::partial$docs-server-8.0.1-known-issues.adoc[]
 ''''

--- a/modules/release-notes/partials/docs-server-8.0.2-fixes-and-improvements.adoc
+++ b/modules/release-notes/partials/docs-server-8.0.2-fixes-and-improvements.adoc
@@ -1,0 +1,51 @@
+
+
+
+[#release-802]
+== Release 8.0.2 (June 2026)
+
+Couchbase Server 8.0.2 was released in June 2026.
+This maintenance release contains fixes to issues.
+
+[#dlist-fixed-issues-802]
+== Fixed Issues
+
+
+
+
+[#dlist-fixed-issues-802-cluster-manager]
+=== Cluster Manager
+
+*https://jira.issues.couchbase.com/browse/MB-70951/[MB-70951]*::
+
+The following stats were reported twice by the `/metrics` REST API.
+This has been corrected to only report each once.
+
++
+
+`<count>cm_rest_request_enters_total{}<count>`
+
++
+
+`<count>cm_rest_request_leaves_total{}<count>`
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION

Release note for review.

----

Preview URL:
https://preview.docs-test.couchbase.com/docs-server-DOC-14423-Create-release-note-for-Couchbase-Server-8.0.2/server/current/release-notes/relnotes.html

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.