### PR TITLE
[DOC-14424]: Add warning to release note for MB-67762

### DIFF
--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -4,6 +4,8 @@
 :page-toclevels: 2
 :stem:
 
+include::partial$MB-67762-warning.adoc[]
+
 include::partial$docs-server-7.6.11-release-notes.adoc[]
 
 include::partial$docs-server-7.6.10-release-notes.adoc[]

--- a/modules/release-notes/partials/MB-67762-warning.adoc
+++ b/modules/release-notes/partials/MB-67762-warning.adoc
@@ -1,0 +1,10 @@
+////
+This is a warning block for issue MB-67762
+////
+[WARNING]
+.Data consistency issue for buckets using Magma storage engine
+==== 
+If you're using Magma buckets, 
+and you're upgrading from any release prior to 7.6.7, 
+then follow the upgrade instructions as described in https://jira.issues.couchbase.com/browse/MB-67762[MB-67762]
+====

--- a/modules/release-notes/partials/MB-67762-warning.adoc
+++ b/modules/release-notes/partials/MB-67762-warning.adoc
@@ -4,7 +4,7 @@ This is a warning block for issue MB-67762
 [WARNING]
 .Data consistency issue for buckets using Magma storage engine
 ==== 
-If you're using Magma buckets, 
-and you're upgrading from any release prior to 7.6.7, 
+If you're using Magma buckets
+and upgrading from any release prior to 7.6.7, 
 then follow the upgrade instructions as described in https://jira.issues.couchbase.com/browse/MB-67762[MB-67762]
 ====


### PR DESCRIPTION

Added warning to the release note.

Preview URL:

https://preview.docs-test.couchbase.com/docs-server-DOC-14424--7.6--Add-warning-to-release-note-for-MB-67762/server/current/release-notes/relnotes.html



You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.