### PR TITLE
[DOC-14424]: Add warning to release note for MB-67762

### DIFF
--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -1,7 +1,7 @@
 = Release Notes for Couchbase Server 7.2
 :stem:
 
-include::partial$docs-server-7.2.9-release-note.adoc[]
+include::partial$MB-67762-warning.adoc[]
 
 include::partial$docs-server-7.2.8-release-note.adoc[]
 

--- a/modules/release-notes/partials/MB-67762-warning.adoc
+++ b/modules/release-notes/partials/MB-67762-warning.adoc
@@ -4,7 +4,7 @@ This is a warning block for issue MB-67762
 [WARNING]
 .Data consistency issue for buckets using Magma storage engine
 ==== 
-If you're using Magma buckets, 
-and you're upgrading from any release prior to 7.2.7, 
+If you're using Magma buckets 
+and upgrading from any release prior to 7.2.7, 
 then follow the upgrade instructions as described in https://jira.issues.couchbase.com/browse/MB-67762[MB-67762]
 ====

--- a/modules/release-notes/partials/MB-67762-warning.adoc
+++ b/modules/release-notes/partials/MB-67762-warning.adoc
@@ -1,0 +1,10 @@
+////
+This is a warning block for issue MB-67762
+////
+[WARNING]
+.Data consistency issue for buckets using Magma storage engine
+==== 
+If you're using Magma buckets, 
+and you're upgrading from any release prior to 7.2.7, 
+then follow the upgrade instructions as described in https://jira.issues.couchbase.com/browse/MB-67762[MB-67762]
+====


### PR DESCRIPTION

Added an admonition to the release note.

Preview URL:
https://preview.docs-test.couchbase.com/docs-server-DOC-14424--7.2--Add-warning-to-release-note-for-MB-67762/server/current/release-notes/relnotes.html
You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.