### PR TITLE
DOC-14245: Encryption at Rest for GSI

### DIFF
--- a/modules/manage/pages/manage-settings/general-settings.adoc
+++ b/modules/manage/pages/manage-settings/general-settings.adoc
@@ -265,6 +265,10 @@ Under *CURL() Function Access*, specify either *Unrestricted* or *Restricted*, t
 When a query has an extremely large corresponding index scan, the indexer buffers the results into a temporary directory.
 Since this method may cause high I/O and works differently on Windows, you can configure backfill settings for the {sqlpp} engine and its embedded GSI client.
 
+In Couchbase Server 8.1 and later, backfill files are encrypted when encryption at rest is enabled.
+For more information, see Encryption at Rest.
+// TODO: Link to encryption at rest concept topic.
+
 * The *Query Temp Disk Path* field enables you to specify the path to which the indexer writes temporary backfill files, to store any transient data during query processing.
 The specified path must already exist.
 Only absolute paths are allowed.

--- a/modules/manage/pages/manage-settings/general-settings.adoc
+++ b/modules/manage/pages/manage-settings/general-settings.adoc
@@ -4,7 +4,9 @@
 :keywords: backfill
 :imagesdir: ../../assets/images
 :page-toclevels: 3
-:totoro: codename Totoro release
+
+// TEMP
+:totoro: the next major release of Couchbase Server
 
 [abstract]
 {description}
@@ -266,7 +268,7 @@ Under *CURL() Function Access*, specify either *Unrestricted* or *Restricted*, t
 When a query has an extremely large corresponding index scan, the indexer buffers the results into a temporary directory.
 Since this method may cause high I/O and works differently on Windows, you can configure backfill settings for the {sqlpp} engine and its embedded GSI client.
 
-In Couchbase Server {totoro} and later, backfill files are encrypted when encryption at rest is enabled.
+In {totoro} and later, backfill files are encrypted when encryption at rest is enabled.
 For more information, see xref:learn:security/native-encryption-at-rest-overview.adoc[].
 
 * The *Query Temp Disk Path* field enables you to specify the path to which the indexer writes temporary backfill files, to store any transient data during query processing.

--- a/modules/manage/pages/manage-settings/general-settings.adoc
+++ b/modules/manage/pages/manage-settings/general-settings.adoc
@@ -4,6 +4,7 @@
 :keywords: backfill
 :imagesdir: ../../assets/images
 :page-toclevels: 3
+:totoro: codename Totoro release
 
 [abstract]
 {description}
@@ -265,7 +266,7 @@ Under *CURL() Function Access*, specify either *Unrestricted* or *Restricted*, t
 When a query has an extremely large corresponding index scan, the indexer buffers the results into a temporary directory.
 Since this method may cause high I/O and works differently on Windows, you can configure backfill settings for the {sqlpp} engine and its embedded GSI client.
 
-In Couchbase Server 8.1 and later, backfill files are encrypted when encryption at rest is enabled.
+In Couchbase Server {totoro} and later, backfill files are encrypted when encryption at rest is enabled.
 For more information, see xref:learn:security/native-encryption-at-rest-overview.adoc[].
 
 * The *Query Temp Disk Path* field enables you to specify the path to which the indexer writes temporary backfill files, to store any transient data during query processing.

--- a/modules/manage/pages/manage-settings/general-settings.adoc
+++ b/modules/manage/pages/manage-settings/general-settings.adoc
@@ -266,8 +266,7 @@ When a query has an extremely large corresponding index scan, the indexer buffer
 Since this method may cause high I/O and works differently on Windows, you can configure backfill settings for the {sqlpp} engine and its embedded GSI client.
 
 In Couchbase Server 8.1 and later, backfill files are encrypted when encryption at rest is enabled.
-For more information, see Encryption at Rest.
-// TODO: Link to encryption at rest concept topic.
+For more information, see xref:learn:security/native-encryption-at-rest-overview.adoc[].
 
 * The *Query Temp Disk Path* field enables you to specify the path to which the indexer writes temporary backfill files, to store any transient data during query processing.
 The specified path must already exist.


### PR DESCRIPTION
Docs issue: DOC-14245

Minor note about encryption of GSI backfill files.

- [x] Needs link to encryption at rest concept topic.

Docs preview: [General Settings › Configure General Settings with the UI › Query Settings](https://preview.docs-test.couchbase.com/docs-devex-DOC-14245-encryption-at-rest-gsi/server/current/manage/manage-settings/general-settings.html#query-settings)

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.

Other pull requests for this ticket:

* https://github.com/couchbaselabs/docs-devex/pull/658