### PR TITLE
DOC-14389--confusion-in-cbbackupmgr-compatibility-guide

### DIFF
--- a/modules/backup-restore/pages/enterprise-backup-restore.adoc
+++ b/modules/backup-restore/pages/enterprise-backup-restore.adoc
@@ -31,7 +31,7 @@ Administrators are therefore recommended to define plans for both https://en.wik
 
 All backup is stored in and recovered from a [.term]#Backup Repository#.
 In turn, a [.term]#Backup Repository# is stored in a Backup Archive on the filesystem.
-Each backup job in the [.term]#Backup Repository# stores its backup in two ways:
+Each backup job in the [.term]#Backup Repository# stores its backup in 2 ways:
 
 * All bucket data is stored in a small, secondary database.
 * All bucket creation scripts and configuration files are stored on the filesystem, as files.
@@ -50,7 +50,7 @@ When you use this flag, `cbbackupmgr` backs up just the following:
 * eventing functions
 * Full-Text Search indexes and aliases
 * GSI indexes
-* Query SQL++ UDFs 
+* Query SQL++ User-Defined Functions 
 * scopes and collections definitions (Couchbase Server version 7.6 and later)
 * views
 
@@ -65,17 +65,17 @@ This option is useful for preventing the loss of users and groups in case of dis
 NOTE: Backups that include users contain the user's hashed passwords. 
 
 Other flags let you exclude specific metadata, or select a subset of data to back up.
-See xref:backup-restore:cbbackupmgr-config.adoc[cbbackupmgr config] for a list of the arguments you can use to control what `cbbackupmgr` backs up.
+See xref:backup-restore:cbbackupmgr-config.adoc[cbbackupmgr configuration] for a list of the arguments you can use to control what `cbbackupmgr` backs up.
 
 You can also use command line flags to control how the `cbbackupmgr restore` command restores data.  
 For example, use `--overwrite-users` to have `cbbackupmgr` overwrite existing users and groups in the database if the backup contains a matching user or group. 
 By default, `cbbackupmgr` does not overwrite existing users in the database.
-Instead, it restores just the users in the backup that do not exist in database.
+Instead, it restores just the users in the backup that do not exist in the database.
 See xref:backup-restore:cbbackupmgr-restore.adoc[cbbackupmgr restore] for a list of the arguments you can use to control what `cbbackupmgr` restores.
 
 === Tool Locations
 
-When installed as part of the Couchbase Server install,  `cbbackupmgr` tool is stored with all other tools in the following per platform locations:
+When installed as part of the Couchbase Server installation, the `cbbackupmgr` tool is stored with all other tools in the following per-platform locations:
 
 .Backup Tool Locations
 [cols="1,5"]
@@ -98,7 +98,7 @@ Assumes default installation location
 
 By default, the [.cmd]`cbbackupmgr` tool performs incremental backups to back up only the new data.
 However, on a new cluster and for the first time, this tool generates a full backup.
-Each of the subsequent, incremental backups take a fraction of the time taken by the full backup.
+Each of the subsequent, incremental backups takes a fraction of the time taken by the full backup.
 
 == Archive Repository
 
@@ -114,7 +114,9 @@ To prevent such corruption instances, you may be required to create multiple bac
 
 For 6.5 and all later versions, `cbbackupmgr` can be used to back up data either from a cluster running its own version, or from a cluster running a prior, compatible version.
 For example, the 6.6.0 tool can back up data from a cluster running 6.6.0, 6.5.x, 6.0.x, or 5.5.x.
-It can also be used to restore to any of those versions data backed up from any of those versions.
+
+You can also restore to any of the listed versions if the data was backed up from a cluster with the same version or an earlier version as the cluster you're restoring to. 
+For example, a `cbbackupmgr` backup for Couchbase 7.0 can be restored to 7.0, 7.1, 7.2, 7.6, 8.0, (Assuming you're using the latest `cbbackupmgr` version supported for the cluster you're restoring to.)
 
 The following table lists the compatible cluster-versions for each version of `cbbackupmgr`.
 Unless otherwise specified, 

--- a/modules/backup-restore/pages/enterprise-backup-restore.adoc
+++ b/modules/backup-restore/pages/enterprise-backup-restore.adoc
@@ -7,15 +7,15 @@
 == Understanding cbbackupmgr
 
 The `cbbackupmgr` tool backs up and restores data, scripts, configurations, and more.
-It allows large data sets to be managed with extremely high performance.
+It allows large data sets to be managed with high performance.
 Use of AWS S3 storage is supported.
 
 Only Full Administrators can use `cbbackupmgr`;
- which is available for both Couchbase Server _Enterprise Edition_ and Couchbase Server _Community Edition_.
+ which is available for both Couchbase Server Enterprise Edition and Couchbase Server Community Edition.
 
 [NOTE]
 ====
-`cbbackupmgr` is _not_ backward compatible with backups created by means of `cbbackup`.
+`cbbackupmgr` is not backward compatible with backups created by means of `cbbackup`.
 
 In Couchbase Enterprise Server 7.2 and after, `cbbackupmgr` is available in the `Tools` package that must be downloaded.
 See xref:cli:cli-intro.adoc#server-tools-packages[Server Tools Packages].
@@ -29,12 +29,12 @@ Administrators are therefore recommended to define plans for both https://en.wik
 
 === Backup Repositories
 
-All backup is stored in and recovered from a [.term]_Backup Repository_.
-In turn, a [.term]_Backup Repository_ is stored in a Backup Archive on the filesystem.
-Each backup job in the [.term]_Backup Repository_ stores its backup in two ways:
+All backup is stored in and recovered from a [.term]#Backup Repository#.
+In turn, a [.term]#Backup Repository# is stored in a Backup Archive on the filesystem.
+Each backup job in the [.term]#Backup Repository# stores its backup in two ways:
 
 * All bucket data is stored in a small, secondary database.
-* All bucket creation scripts and configuration files are stored on the file system, as files.
+* All bucket creation scripts and configuration files are stored on the filesystem, as files.
 
 === What's Backed Up
 
@@ -42,13 +42,13 @@ By default, backups include your database's data and metadata.
 
 You can change what the tool backs up and restores by using arguments to the `cbbackupmgr config` command. 
 For example, if you only want to back up your cluster's metadata, use the `--disable-data` command line flag when configuring your backup repository. 
-You may to choose to use this flag if you want to transfer settings to a new database cluster. 
+You may choose to use this flag if you want to transfer settings to a new database cluster. 
 When you use this flag, `cbbackupmgr` backs up just the following:
 
 * analytic collections and indexes for local links and synonyms
 * bucket configuration
 * eventing functions
-* full-text Search indexes and aliases
+* Full-Text Search indexes and aliases
 * GSI indexes
 * Query SQL++ UDFs 
 * scopes and collections definitions (Couchbase Server version 7.6 and later)
@@ -58,7 +58,9 @@ When you use this flag, `cbbackupmgr` backs up just the following:
 NOTE: `cbbackupmgr` does not back up query function libraries such as user-created JavaScript libraries.
 You must back up these libraries separately. 
 
-Another useful flag is `--enable-users` which backs up users and user groups. Users and groups are not backed up by default. This option is useful for preventing the loss of users and groups in case of disaster. 
+Another useful flag is `--enable-users` which backs up users and user groups. 
+Users and groups are not backed up by default. 
+This option is useful for preventing the loss of users and groups in case of disaster. 
 
 NOTE: Backups that include users contain the user's hashed passwords. 
 
@@ -73,7 +75,7 @@ See xref:backup-restore:cbbackupmgr-restore.adoc[cbbackupmgr restore] for a list
 
 === Tool Locations
 
-When installed as part of the Couchbase Server install,  `cbbackupmgr` tool is stored with all other tools in the following _per platform_ locations:
+When installed as part of the Couchbase Server install,  `cbbackupmgr` tool is stored with all other tools in the following per platform locations:
 
 .Backup Tool Locations
 [cols="1,5"]
@@ -101,134 +103,163 @@ Each of the subsequent, incremental backups take a fraction of the time taken by
 == Archive Repository
 
 The backup archive is a directory that contains a set of backup repositories as well as logs for the backup client.
-The backup directory should be modified only by the backup client, and any modifications that are not done by that client might result in a corruption of backup data.
+The backup directory should be modified only by the backup client, and any modifications that are not done by that client might result in corruption of backup data.
 
-Only one backup client can access the backup archive at one time.
+Only one backup client can access the backup archive at a time.
 If multiple instances of the backup client are running on the same archive at the same time, this might result in corruption.
 To prevent such corruption instances, you may be required to create multiple backup archives depending on your use case.
 
 [#version-compatibility]
 == Version Compatibility
 
-For 6.5 and all later versions, `cbbackupmgr` can be used to back up data either from a cluster running its own version, or from a cluster running a prior, _compatible_ version.
+For 6.5 and all later versions, `cbbackupmgr` can be used to back up data either from a cluster running its own version, or from a cluster running a prior, compatible version.
 For example, the 6.6.0 tool can back up data from a cluster running 6.6.0, 6.5.x, 6.0.x, or 5.5.x.
-It can also be used to restore _to_ any of those versions data previously backed up _from_ any of those versions.
+It can also be used to restore to any of those versions data backed up from any of those versions.
 
 The following table lists the compatible cluster-versions for each version of `cbbackupmgr`.
-Unless otherwise specified, backup and restore apply both to _local_ and to _cloud_ data.
+Unless otherwise specified, 
+backup and restore apply both to local and to cloud data.
 
 .Compatibility Requirements for Backup and Restore
-[cols="5,3,3,3,3,3,3,3,3"]
+[cols="2,10*"]
 |===
-| *cbbackupmgr version*
-| *7.6*
-| *7.2*
-| *7.1*
-| *7.0*
-| *6.6*
-| *6.5.x*
-| *6.0.x*
-| *5.5.x*
 
-| 7.6
-| ✓
-| ✓
-| ✓
-| ✓
-| ✓
 |
+10+^h| `cbbackupmgr` version →
+
+|
+|
+h| 8.0
+h| 7.6
+h| 7.2
+h| 7.1
+h| 7.0
+h| 6.6.0 and above
+h| 6.5
+h| 6.0.x
+h| 5.5.x
+
+.9+^h| Compatible with: ↓
+h| 8.0
+| ✓
+| 
+| 
+| 
+| 
+| 
 |
 |
 
-| 7.2
+|
+h| 7.6
+| ✓
+| ✓
+| 
+| 
+| 
+| 
+|
+|
+
+
+|
+h| 7.2
+| ✓
+| ✓
+| ✓
+| 
+| 
+| 
+|
+|
+
+
+|
+h| 7.1
+| ✓
+| ✓
+| ✓
+| ✓
+| 
+| 
+| 
+|
+
+
+|
+h| 7.0
+| ✓
+| ✓
+| ✓
+| ✓
+| ✓
+| 
+| 
+| 
+
+
+|
+h| 6.6
+|
 | 
 | ✓
 | ✓
 | ✓
 | ✓
-|
-|
-|
+| 
+| 
+| 
 
-| 7.1
+
+h| 6.5.x
 |
 | 
-| ✓
-| ✓
-| ✓
-| ✓*
 |
-|
-
-
-| 7.0
-|
-|
-|
-| ✓
-| ✓
-| ✓*
-| ✓*
-|
-
-
-| 6.6.0 and above
-|
-|
-|
-|
-| ✓
 | ✓*
 | ✓*
 | ✓*
+| ✓
+| 
+| 
 
 
-| 6.5
+h| 6.0.x
 |
 |
 |
 |
-|
+| ✓*
+| ✓*
 | ✓
 | ✓
+
+
+|
+h| 5.5.x
+|
+|
+|
+|
+| 
+| ✓*
 | ✓
-
-
-| 6.0.x
-|
-|
-|
-|
-|
-|
 | ✓
-|
-
-
-| 5.5.x
-|
-|
-|
-|
-|
-|
-|
 | ✓
 
 
 |===
 
-+*+ For local backup only — _not_ for cloud.
++*+ For local backup only — not for cloud.
 
 .Restoring metadata and users
-****
+[NOTE]
+====
 * When restoring metadata to a newer Server version,
 if the feature that the metadata applies to no longer exists in the newer Server version, then the metadata may not be restorable.
 
-* If the user roles no longer exist in the version that you wish to restore to, then an error will be logged for the target user.
+* If the user roles no longer exist in the version that you want to restore to, then an error is logged for the target user.
 
-* In general, if you can upgrade _directly_ to the new version, then you should be able to restore the users.
+* In general, if you can upgrade directly to the new version, then you should be able to restore the users.
 If you cannot upgrade directly, then restoring users may cause errors. 
  For example, if some of the user roles no longer exist in the newer Server version.
-
-****
+====

--- a/modules/backup-restore/pages/enterprise-backup-restore.adoc
+++ b/modules/backup-restore/pages/enterprise-backup-restore.adoc
@@ -121,13 +121,14 @@ Unless otherwise specified,
 backup and restore apply both to local and to cloud data.
 
 .Compatibility Requirements for Backup and Restore
-[cols="2,10*"]
+[cols="2,11*"]
 |===
 
 |
-10+^h| `cbbackupmgr` version →
+11+^h| `cbbackupmgr` version →
 
 |
+| 
 |
 h| 8.0
 h| 7.6
@@ -139,7 +140,9 @@ h| 6.5
 h| 6.0.x
 h| 5.5.x
 
-.9+^h| Compatible with: ↓
+2.9+^h| Compatible with +
+Couchbase Server version: ↓
+
 h| 8.0
 | ✓
 | 
@@ -173,7 +176,6 @@ h| 7.2
 |
 |
 
-
 |
 h| 7.1
 | ✓
@@ -184,7 +186,6 @@ h| 7.1
 | 
 | 
 |
-
 
 |
 h| 7.0
@@ -197,7 +198,6 @@ h| 7.0
 | 
 | 
 
-
 |
 h| 6.6
 |
@@ -208,9 +208,8 @@ h| 6.6
 | ✓
 | 
 | 
-| 
 
-
+|
 h| 6.5.x
 |
 | 
@@ -220,9 +219,8 @@ h| 6.5.x
 | ✓*
 | ✓
 | 
+
 | 
-
-
 h| 6.0.x
 |
 |
@@ -232,7 +230,6 @@ h| 6.0.x
 | ✓*
 | ✓
 | ✓
-
 
 |
 h| 5.5.x


### PR DESCRIPTION

Fixing the compatibilty table and cleaniing up the text.

https://preview.docs-test.couchbase.com/docs-server-DOC-14389--confusion-in-cbbackupmgr-compatibility-guide/server/current/backup-restore/enterprise-backup-restore.html
