### PR TITLE
Removed the 8.0 column from the table for the 7.6 release.

### DIFF
--- a/modules/backup-restore/pages/enterprise-backup-restore.adoc
+++ b/modules/backup-restore/pages/enterprise-backup-restore.adoc
@@ -112,27 +112,25 @@ To prevent such corruption instances, you may be required to create multiple bac
 [#version-compatibility]
 == Version Compatibility
 
-For 6.5 and all later versions, `cbbackupmgr` can be used to back up data either from a cluster running its own version, or from a cluster running a prior, compatible version.
+For 6.5 and all later versions, `cbbackupmgr` can be used to back up data either from a cluster running its own version or from a cluster running a prior, compatible version.
 For example, the 6.6.0 tool can back up data from a cluster running 6.6.0, 6.5.x, 6.0.x, or 5.5.x.
 
 You can also restore to any of the listed versions if the data was backed up from a cluster with the same version or an earlier version as the cluster you're restoring to. 
-For example, a `cbbackupmgr` backup for Couchbase 7.0 can be restored to 7.0, 7.1, 7.2, 7.6, 8.0, (Assuming you're using the latest `cbbackupmgr` version supported for the cluster you're restoring to.)
+For example, a `cbbackupmgr` backup for Couchbase 7.0 can be restored to 7.0, 7.1, 7.2, 7.6 (Assuming you're using the latest `cbbackupmgr` version supported for the cluster you're restoring to.)
 
 The following table lists the compatible cluster-versions for each version of `cbbackupmgr`.
 Unless otherwise specified, 
 backup and restore apply both to local and to cloud data.
 
 .Compatibility Requirements for Backup and Restore
-[cols="2,11*"]
+[cols="2,10*"]
 |===
 
 |
-11+^h| `cbbackupmgr` version →
-
-|
+10+^h| `cbbackupmgr` version →
 | 
 |
-h| 8.0
+h| 
 h| 7.6
 h| 7.2
 h| 7.1
@@ -142,22 +140,10 @@ h| 6.5
 h| 6.0.x
 h| 5.5.x
 
-2.9+^h| Compatible with +
+
+2.8+^h| Compatible with +
 Couchbase Server version: ↓
-
-h| 8.0
-| ✓
-| 
-| 
-| 
-| 
-| 
-|
-|
-
-|
 h| 7.6
-| ✓
 | ✓
 | 
 | 
@@ -171,7 +157,6 @@ h| 7.6
 h| 7.2
 | ✓
 | ✓
-| ✓
 | 
 | 
 | 
@@ -183,7 +168,6 @@ h| 7.1
 | ✓
 | ✓
 | ✓
-| ✓
 | 
 | 
 | 
@@ -191,7 +175,6 @@ h| 7.1
 
 |
 h| 7.0
-| ✓
 | ✓
 | ✓
 | ✓
@@ -202,7 +185,6 @@ h| 7.0
 
 |
 h| 6.6
-|
 | 
 | ✓
 | ✓
@@ -213,7 +195,6 @@ h| 6.6
 
 |
 h| 6.5.x
-|
 | 
 |
 | ✓*
@@ -227,7 +208,6 @@ h| 6.0.x
 |
 |
 |
-|
 | ✓*
 | ✓*
 | ✓
@@ -235,7 +215,6 @@ h| 6.0.x
 
 |
 h| 5.5.x
-|
 |
 |
 |


### PR DESCRIPTION

We're keeping the new layout, but removing the 8.0 column for the 7.6 release.