### PR TITLE
fix-compatibility-table-for-8.0-release

### DIFF
--- a/modules/backup-restore/pages/enterprise-backup-restore.adoc
+++ b/modules/backup-restore/pages/enterprise-backup-restore.adoc
@@ -7,11 +7,11 @@
 == Understanding cbbackupmgr
 
 The `cbbackupmgr` tool backs up and restores data, scripts, configurations, and more.
-It allows large data sets to be managed with extremely high performance.
+It allows large data sets to be managed with high performance.
 Use of AWS S3 storage is supported.
 
 Only Full Administrators can use `cbbackupmgr`;
-which is available for both Couchbase Server _Enterprise Edition_ and Couchbase Server _Community Edition_.
+which is available for both Couchbase Server Enterprise Edition and Couchbase Server Community Edition.
 
 [NOTE]
 ====
@@ -23,14 +23,14 @@ See xref:cli:cli-intro.adoc#server-tools-packages[Server Tools Packages].
 
 === Planning for Disaster Recovery
 
-Backup and restore capabilities are critical to an overall Disaster Recovery Plan, and ensuring thereby business continuity.
-Administrators are therefore recommended to define plans for both https://en.wikipedia.org/wiki/Recovery_time_objective[Recovery Time Objective^] (RTO) and https://en.wikipedia.org/wiki/Recovery_point_objective[Recovery Point Objective^] (RPO), and make use of `cbbackupmgr` correspondingly.
+Backup and restore capabilities are critical to an overall Disaster Recovery Plan and ensuring thereby business continuity.
+Administrators are therefore recommended to define plans for both https://en.wikipedia.org/wiki/Recovery_time_objective[Recovery Time Objective^] (RTO) and https://en.wikipedia.org/wiki/Recovery_point_objective[Recovery Point Objective^] (RPO) and make use of `cbbackupmgr` correspondingly.
 
 === Backup Repositories
 
-All backup is stored in and recovered from a [.term]_Backup Repository_.
-In turn, a [.term]_Backup Repository_ is stored in a Backup Archive on the filesystem.
-Each backup job in the [.term]_Backup Repository_ stores its backup in 2 ways:
+All backup is stored in and recovered from a [.term]Backup Repository.
+In turn, a [.term]Backup Repository is stored in a Backup Archive on the filesystem.
+Each backup job in the [.term]Backup Repository stores its backup in 2 ways:
 
 * You can store all bucket data in a small, secondary database.
 * You can store all bucket creation scripts and configuration files on the filesystem, as files.
@@ -41,15 +41,15 @@ By default, backups include your database's data and metadata.
 
 You can change what the tool backs up and restores by using arguments to the `cbbackupmgr config` command. 
 For example, if you only want to back up your cluster's metadata, use the `--disable-data` command line flag when configuring your backup repository. 
-You may to choose to use this flag if you want to transfer settings to a new database cluster. 
+You may choose to use this flag if you want to transfer settings to a new database cluster. 
 When you use this flag, `cbbackupmgr` backs up just the following:
 
 * analytic collections and indexes for local links and synonyms
 * bucket configuration
 * eventing functions
-* full-text Search indexes and aliases
-* GSI indexes
-* Query SQL++ UDFs 
+* Full-Text Search indexes and aliases
+* Global Secondary Indexes
+* Query SQL++ User-Defined Functions 
 * scopes and collections definitions (Couchbase Server version 7.6 and later)
 * views
 
@@ -57,22 +57,24 @@ When you use this flag, `cbbackupmgr` backs up just the following:
 NOTE: `cbbackupmgr` does not back up query function libraries such as user-created JavaScript libraries.
 You must back up these libraries separately. 
 
-Another useful flag is `--enable-users` which backs up users and user groups. Users and groups are not backed up by default. This option is useful for preventing the loss of users and groups in case of disaster. 
+Another useful flag is `--enable-users` which backs up users and user groups. 
+Users and groups are not backed up by default. 
+This option is useful for preventing the loss of users and groups in case of disaster. 
 
 NOTE: Backups that include users contain the user's hashed passwords. 
 
 Other flags let you exclude specific metadata, or select a subset of data to back up.
-See xref:backup-restore:cbbackupmgr-config.adoc[cbbackupmgr config] for a list of the arguments you can use to control what `cbbackupmgr` backs up.
+See xref:backup-restore:cbbackupmgr-config.adoc[cbbackupmgr configuration] for a list of the arguments you can use to control what `cbbackupmgr` backs up.
 
 You can also use command line flags to control how the `cbbackupmgr restore` command restores data.
 For example, use `--overwrite-users` to have `cbbackupmgr` overwrite existing users and groups in the database if the backup contains a matching user or group. 
 By default, `cbbackupmgr` does not overwrite existing users in the database.
-Instead, it restores just the users in the backup that do not exist in database.
+Instead, it restores just the users in the backup that do not exist in the database.
 See xref:backup-restore:cbbackupmgr-restore.adoc[cbbackupmgr restore] for a list of the arguments you can use to control what `cbbackupmgr` restores.
 
 === Tool Locations
 
-When installed as part of the Couchbase Server install, `cbbackupmgr` tool is stored with all other tools in the following per platform locations:
+When installed as part of the Couchbase Server installation, `cbbackupmgr` tool is stored with all other tools in the following per-platform locations:
 
 .Backup Tool Locations
 [cols="1,5"]
@@ -100,7 +102,7 @@ Each of the subsequent, incremental backups take a fraction of the time taken by
 == Archive Repository
 
 The backup archive is a directory that contains a set of backup repositories as well as logs for the backup client.
-The backup directory should be modified only by the backup client, and any modifications that are not done by that client might result in a corruption of backup data.
+The backup directory should be modified only by the backup client, and any modifications that are not done by that client might result in the corruption of backup data.
 
 Only 1 backup client can access the backup archive at 1 time.
 If multiple instances of the backup client are running on the same archive at the same time, this might result in corruption.
@@ -113,35 +115,45 @@ For 7.2 and later versions, you can use `cbbackupmgr` to back up data either fro
 You can also use it to restore data to any of these versions from backups created on any of them.
 
 The following table lists the compatible cluster-versions for each version of `cbbackupmgr`.
-Unless otherwise specified, backup and restore apply both to _local_ and to _cloud_ data.
+Unless otherwise specified, backup and restore apply both to local and to cloud data.
 
 .Compatibility Requirements for Backup and Restore
-[cols="5,3,3,3"]
-|===
-| *cbbackupmgr version*
-| *8.0*
-| *7.6*
-| *7.2*
-
-| 8.0
-| ✓
-| ✓
-| ✓
-
-| 7.6
-| 
-| ✓
-| ✓
-
-| 7.2
-| 
-| 
-| ✓
-
+[cols="2,5*"]
 |===
 
+|
+5+^h| `cbbackupmgr` version →
+| 
+|
+h| 
+h| 8.0
+h| 7.6
+h| 7.2
 
-== Restoring metadata and users
+
+
+2.3+^h| Compatible with +
+Couchbase Server version: ↓
+h| 8.0
+| ✓
+| 
+|
+
+
+h| 7.6
+| ✓
+| ✓
+| 
+
+
+h| 7.2
+| ✓
+| ✓
+| ✓
+
+|===
+
+== Restoring Metadata and Users
 
 * When restoring metadata to a newer Server version,
 if the feature that the metadata applies to no longer exists in the newer Server version, then the metadata may not be restorable.

--- a/modules/backup-restore/pages/enterprise-backup-restore.adoc
+++ b/modules/backup-restore/pages/enterprise-backup-restore.adoc
@@ -118,7 +118,7 @@ The following table lists the compatible cluster-versions for each version of `c
 Unless otherwise specified, backup and restore apply both to local and to cloud data.
 
 .Compatibility Requirements for Backup and Restore
-[cols="2,5*"]
+[cols="1,5*"]
 |===
 
 |


### PR DESCRIPTION

Making compatibilty table a bit clearer

----

Preview URL

https://preview.docs-test.couchbase.com/docs-server-fix-compatiblity-table-for-8.0-release/server/current/backup-restore/enterprise-backup-restore.html

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.
