### PR TITLE
[DOCS-14487]: Feedback on alerts (8.1)

### DIFF
--- a/modules/manage/pages/manage-settings/configure-alerts.adoc
+++ b/modules/manage/pages/manage-settings/configure-alerts.adoc
@@ -8,12 +8,12 @@
 [#configuring-email-alerts]
 == Configuring Alerts
 
-Alerts can be dispatched automatically by Couchbase Server, to highlight specific issues and problems.
-When an issue arises one or both of the following can occur based on user configuration:
+Alerts can be dispatched automatically by Couchbase Server to highlight specific issues and problems.
+When an issue arises, one or both of the following can occur based on user configuration:
 
 * The alert is sent as an email by Couchbase Server to a configured SMTP server.
 From there, the email is forwarded to a configured list of email recipients.
-All cluster-nodes must have network access to the configured SMTP server, for the system to be fully effective.
+All cluster-nodes must have network access to the configured SMTP server for the system to be fully effective.
 
 * The alert appears as a pop-up within the Couchbase Server Web Console of its recipient.
 
@@ -35,7 +35,7 @@ Now, access the *Alerts* panel, by means of the *Alerts* tab, located on the hor
 
 image::manage-settings/emailAlertsTab.png[,140,align=left]
 
-The *Email Alerts* panel now appears, as follows:
+The *Email Alerts* panel now appears as follows:
 
 image::manage-settings/emailAlertsScreenInitial.png[,720,align=left]
 
@@ -80,8 +80,8 @@ The default is the standard SMTP port 25.
 This email address should be one that is valid as a sender address for the SMTP server that you specify.
 
 | Recipients
-| A list of the recipients of each alert message.
-To specify more than one recipient, separate each address by a space, comma (,), or semicolon (;).
+| A list of the recipients for each alert message.
+To specify more than one recipient, separate each address with a comma.
 
 | Send Test Email
 | Click [.ui]*Send Test Email* to send a test email to confirm the settings and configuration of the email server and recipients.
@@ -97,9 +97,9 @@ When you have entered appropriate data into the fields, proceed as follows:
 image::manage-settings/saveEmailAlertsConfiguration.png[,240,align=left]
 +
 Note that when you left-click on btn[Save], the password that you typed into the *Password* field becomes invisible, and the field therefore appears blank.
-This is a security measure imposed by Couchbase Server: the password remains valid, and will be used in authenticating with the email server.
+This is a security measure imposed by Couchbase Server: the password remains valid and will be used in authenticating with the email server.
 +
-Alternatively, left-click on btn:[Cancel/Reset], to remove the configuration.
+Alternatively, left-click on btn:[Cancel/Reset] to remove the configuration.
 . Optionally, left-click on the btn:[Send Test Email] button to send a test email.
 
 [#available-alerts]
@@ -118,7 +118,7 @@ The listed alerts are as follows.
 | The sending node has been failed over automatically.
 | `auto_failover_node`
 
-| Maximum number of auto-failed-over nodes was reached
+| The maximum number of auto-failed-over nodes was reached
 | The auto-failover system stops auto-failover when the maximum number of spare nodes available has been reached.
 | `auto_failover_maximum_reached`
 
@@ -131,7 +131,7 @@ The listed alerts are as follows.
 | `auto_failover_cluster_too_small`
 
 | Node was not auto-failed-over as auto-failover for one or more services running on the node is disabled
-| Auto-failover does not take place on a node as one or more services running on the node is disabled.
+| Auto-failover does not take place on a node as one or more services running on the node are disabled.
 | `auto_failover_disabled`
 
 | Node's IP address has changed unexpectedly
@@ -163,8 +163,8 @@ Couchbase Server automatically attempts to recover from this issue.
 | The indexer RAM limit threshold is approaching warning.
 | `indexer_ram_max_usage`
 
-| Remote mutation timestamp exceeded drift threshold
-| The remote mutation timestamp exceeded drift threshold warning.
+| Remote mutation timestamp exceeded the drift threshold
+| The remote mutation timestamp exceeded the drift threshold warning.
 | `ep_clock_cas_drift_threshold_exceeded`
 
 | Communication issues among some nodes in the cluster
@@ -199,7 +199,7 @@ A critical-level alert is issued when system memory exceeds the critical thresho
 | History size threshold exceeded
 | The mutation history for a specified bucket is greater than an administrator-specified percentage of the administrator-specified change-history size, for a number of vBuckets.
 The size of the change history may need to be increased.
-For information, on establishing change-history size, see xref:rest-api:rest-bucket-create.adoc[Creating and Editing Buckets].
+For information on establishing change-history size, see xref:rest-api:rest-bucket-create.adoc[Creating and Editing Buckets].
 | `history_size_warning`
 
 | Approaching Indexer low resident percentage
@@ -218,8 +218,8 @@ The default value for the timeout period is 1800 seconds (30 minutes).
 | `stuck_rebalance`
 
 | Disk usage is within 10% of maximum for data service mutations
-| The used disk space on the a filesystem containing the Data Service storage path is within 10% of the configured limit. 
-This limit is set either through the Advanced Data Settings in the Couchbase Server Web Console, or by using the `/settings/resourceManagement` REST API endpoint.
+| The used disk space on the filesystem containing the Data Service storage path is within 10% of the configured limit. 
+This limit is set through the Advanced Data Settings in the Couchbase Server Web Console, or by using the `/settings/resourceManagement` REST API endpoint.
 See xref:learn:buckets-memory-and-storage/storage-settings.adoc#filesystem-free-space-and-usage-limits[Filesystem Free Space and Usage Limits] for more information.
 | `disk_guardrail`
 
@@ -248,7 +248,7 @@ couchbase-cli setting-alert -c 10.143.192.101 --username Administrator \
 --alert-memory-threshold
 ----
 
-In this example, cluster `10.143.192.101` is accessed, with administor username and password specified.
+In this example, cluster `10.143.192.101` is accessed with the administrator username and password specified.
 The `enable-email-alert` flag is specified as 1, enabling email alerts.
 Additional flags specify the username and password required by the mail server, as well as email host, port, recipients, and sender.
 The `enable-mail-encrypt` flag specifies encryption as off.


### PR DESCRIPTION

Corrected text to note that only commas are used to delimit a list of email addresses.

Minor fixes to the rest of the text.