### PR TITLE
[DOC-14580-Create-release-note-for-Couchbase-Server-8.0.3]:

### DIFF
--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -10,12 +10,18 @@ These release notes are focused on bug fixes and breaking changes.
 For information about new features and major improvements made in Couchbase Server 8.0, see xref:introduction:whats-new.adoc[What's New].
 
 include::partial$docs-server-8.0.3-fixes-and-improvements.adoc[]
+
 '''
+
 include::partial$docs-server-8.0.2-fixes-and-improvements.adoc[]
+
 '''
+
 include::partial$docs-server-8.0.1-fixes-and-improvements.adoc[]
 include::partial$docs-server-8.0.1-known-issues.adoc[]
+
 '''
+
 include::partial$docs-server-8.0.0-fixes-and-improvements.adoc[]
 include::partial$docs-server-8.0.0-breaking-changes.adoc[]
 include::partial$docs-server-8.0.0-known-issues.adoc[]

--- a/modules/release-notes/pages/relnotes.adoc
+++ b/modules/release-notes/pages/relnotes.adoc
@@ -9,11 +9,13 @@ These release notes are focused on bug fixes and breaking changes.
 
 For information about new features and major improvements made in Couchbase Server 8.0, see xref:introduction:whats-new.adoc[What's New].
 
+include::partial$docs-server-8.0.3-fixes-and-improvements.adoc[]
+'''
 include::partial$docs-server-8.0.2-fixes-and-improvements.adoc[]
 '''
 include::partial$docs-server-8.0.1-fixes-and-improvements.adoc[]
 include::partial$docs-server-8.0.1-known-issues.adoc[]
-''''
+'''
 include::partial$docs-server-8.0.0-fixes-and-improvements.adoc[]
 include::partial$docs-server-8.0.0-breaking-changes.adoc[]
 include::partial$docs-server-8.0.0-known-issues.adoc[]

--- a/modules/release-notes/partials/docs-server-8.0.3-fixes-and-improvements.adoc
+++ b/modules/release-notes/partials/docs-server-8.0.3-fixes-and-improvements.adoc
@@ -2,7 +2,7 @@
 == Release 8.0.3 (August 2026)
 
 Couchbase Server 8.0.3 was released in August 2026.
-This maintenance release contains fixes for issues.
+This maintenance release contains fixes for issues listed below.
 
 === Fixed Issues
 {empty}

--- a/modules/release-notes/partials/docs-server-8.0.3-fixes-and-improvements.adoc
+++ b/modules/release-notes/partials/docs-server-8.0.3-fixes-and-improvements.adoc
@@ -1,0 +1,54 @@
+[#release-8-0-3]
+== Release 8.0.3 (August 2026)
+
+Couchbase Server 8.0.3 was released in August 2026.
+This maintenance release contains fixes to issues.
+
+== Fixed Issues
+{empty}
+
+=== Cluster Manager
+
+link:https://jira.issues.couchbase.com/browse/MB-72097[MB-72097]::
+This fix prevents a critical bug where undefined bucket storage properties caused incorrect transitions to Magma during upgrades.
+The issue affected buckets created before version 5.0.0.
+
+link:https://jira.issues.couchbase.com/browse/MB-70951[MB-70951]::
+The /metrics REST API previously reported certain low cardinality statistics twice.
+This update ensures each statistic appears only once in the output.
+
+=== Data Service
+
+link:https://jira.issues.couchbase.com/browse/MB-70640[MB-70640]::
+This fix addresses a rebalance hang observed during node scaling and swap rebalance operations.
+The issue was related to socket receive buffer management on specific Linux kernels.
+
+=== Analytics Service
+
+link:https://jira.issues.couchbase.com/browse/MB-71453[MB-71453]::
+Queries combining LIMIT with index-nested-loop joins could return incorrect results.
+The fix ensures all filter conditions are evaluated before applying the limit.
+
+=== XDCR
+
+link:https://jira.issues.couchbase.com/browse/MB-72305[MB-72305]::
+Upgraded nodes now correctly handle rebalancing when replications or buckets were deleted and recreated.
+This prevents issues with stale manifests and incomplete backfills.
+
+link:https://jira.issues.couchbase.com/browse/MB-71586[MB-71586]::
+The new forwardLocalOnly setting allows XDCR to replicate only local mutations.
+This feature reduces data transfer by identifying mutations originating from source clusters.
+
+link:https://jira.issues.couchbase.com/browse/MB-71257[MB-71257]::
+A race condition causing deadlocks during replication pause or deletion has been resolved.
+The fix ensures goroutines exit properly during rollback operations.
+
+link:https://jira.issues.couchbase.com/browse/MB-71013[MB-71013]::
+XDCR now correctly handles conflict resolution for locked documents on target clusters.
+This fix prevents unnecessary skipping of mutations and potential data loss.
+
+=== Tools
+
+link:https://jira.issues.couchbase.com/browse/MB-70745[MB-70745]::
+Restore operations no longer fail when Cost-Based Optimizer statistics contain keys with double colons.
+This fix applies to indexes using specific string functions.

--- a/modules/release-notes/partials/docs-server-8.0.3-fixes-and-improvements.adoc
+++ b/modules/release-notes/partials/docs-server-8.0.3-fixes-and-improvements.adoc
@@ -4,10 +4,10 @@
 Couchbase Server 8.0.3 was released in August 2026.
 This maintenance release contains fixes for issues.
 
-== Fixed Issues
+=== Fixed Issues
 {empty}
 
-=== Cluster Manager
+==== Cluster Manager
 
 link:https://jira.issues.couchbase.com/browse/MB-72097[MB-72097]::
 This fix prevents a critical bug where undefined bucket storage properties caused incorrect transitions to Magma during upgrades.
@@ -17,19 +17,19 @@ link:https://jira.issues.couchbase.com/browse/MB-70951[MB-70951]::
 The `/metrics` REST API previously reported certain low cardinality statistics twice.
 This update ensures each statistic appears only once in the output.
 
-=== Data Service
+==== Data Service
 
 link:https://jira.issues.couchbase.com/browse/MB-70640[MB-70640]::
 This fix addresses a rebalance hang observed during node scaling and swap rebalance operations.
 The issue was related to socket receive buffer management on specific Linux kernels.
 
-=== Analytics Service
+==== Analytics Service
 
 link:https://jira.issues.couchbase.com/browse/MB-71453[MB-71453]::
 Queries combining LIMIT with index-nested-loop joins could return incorrect results.
 The fix ensures all filter conditions are evaluated before applying the limit.
 
-=== XDCR
+==== XDCR
 
 link:https://jira.issues.couchbase.com/browse/MB-72305[MB-72305]::
 Upgraded nodes now correctly handle rebalancing when replications or buckets were deleted and recreated.
@@ -47,7 +47,7 @@ link:https://jira.issues.couchbase.com/browse/MB-71013[MB-71013]::
 XDCR now correctly handles conflict resolution for locked documents on target clusters.
 This fix prevents unnecessary skipping of mutations and potential data loss.
 
-=== Tools
+==== Tools
 
 link:https://jira.issues.couchbase.com/browse/MB-70745[MB-70745]::
 Restore operations no longer fail when Cost-Based Optimizer statistics contain keys with double colons.

--- a/modules/release-notes/partials/docs-server-8.0.3-fixes-and-improvements.adoc
+++ b/modules/release-notes/partials/docs-server-8.0.3-fixes-and-improvements.adoc
@@ -2,7 +2,7 @@
 == Release 8.0.3 (August 2026)
 
 Couchbase Server 8.0.3 was released in August 2026.
-This maintenance release contains fixes to issues.
+This maintenance release contains fixes for issues.
 
 == Fixed Issues
 {empty}

--- a/modules/release-notes/partials/docs-server-8.0.3-fixes-and-improvements.adoc
+++ b/modules/release-notes/partials/docs-server-8.0.3-fixes-and-improvements.adoc
@@ -14,7 +14,7 @@ This fix prevents a critical bug where undefined bucket storage properties cause
 The issue affected buckets created before version 5.0.0.
 
 link:https://jira.issues.couchbase.com/browse/MB-70951[MB-70951]::
-The /metrics REST API previously reported certain low cardinality statistics twice.
+The `/metrics` REST API previously reported certain low cardinality statistics twice.
 This update ensures each statistic appears only once in the output.
 
 === Data Service

--- a/modules/release-notes/partials/docs-server-8.0.3-fixes-and-improvements.adoc
+++ b/modules/release-notes/partials/docs-server-8.0.3-fixes-and-improvements.adoc
@@ -36,7 +36,7 @@ Upgraded nodes now correctly handle rebalancing when replications or buckets wer
 This prevents issues with stale manifests and incomplete backfills.
 
 link:https://jira.issues.couchbase.com/browse/MB-71586[MB-71586]::
-The new forwardLocalOnly setting allows XDCR to replicate only local mutations.
+The new `forwardLocalOnly` setting allows XDCR to replicate only local mutations.
 This feature reduces data transfer by identifying mutations originating from source clusters.
 
 link:https://jira.issues.couchbase.com/browse/MB-71257[MB-71257]::


### PR DESCRIPTION

Creating release note for Couchbase Server 8.0.3

Preview URL:
https://preview.docs-test.couchbase.com/docs-server-DOC-14580-Create-release-note-for-Couchbase-Server-8.0.3

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.