### PR TITLE
[DOC-14217] Add New Query Settings for Plan Stability - Server 8.5

### DIFF
--- a/modules/manage/pages/manage-settings/query-ui-settings.adoc
+++ b/modules/manage/pages/manage-settings/query-ui-settings.adoc
@@ -201,21 +201,21 @@ Configure the mode and error policy for xref:n1ql:n1ql-manage/query-plan-stabili
 
 | *Plan Stability*
 
-a| Controls whether the Query Service saves execution plans to disk, and for which statement types.
+a| Determines whether to save execution plans to disk, and for which statement types.
 
 Select 1 of the following:
 
-* `Off`: Does not save execution plans to disk.
-* `On Prepared Statements`: Saves execution plans to disk for all prepared statements.
-* `On All Statements`: Saves execution plans to disk for all queries, including prepared statements and ad hoc queries.
-* `Frozen`: Does not save execution plans for new ad hoc queries, but allows the use of existing saved plans.
+* `Off`: Does not save plans to disk.
+* `On Prepared Statements`: Saves plans to disk for all prepared statements.
+* `On All Statements`: Saves plans to disk for all queries, including prepared statements and ad hoc queries.
+* `Frozen`: Does not save plans to disk for new ad hoc queries, but allows the use of existing saved plans.
 
 
 | `Off`
 
 | *Plan Stability Error Policy*
 
-a| Controls how the Query Service handles a query when a saved plan is unavailable.
+a| Determines how to handle a query when a saved plan is unavailable.
 
 Select 1 of the following:
 

--- a/modules/manage/pages/manage-settings/query-ui-settings.adoc
+++ b/modules/manage/pages/manage-settings/query-ui-settings.adoc
@@ -175,7 +175,7 @@ If a query uses a sequential scan and a data node becomes unavailable, the query
 
 == Query Optimization
 
-Configure rules for cost optimizer behavior and replica usage. 
+Configure rules for cost optimizer behavior. 
 
 [cols="1,2,1",options="header"]
 |===
@@ -192,7 +192,7 @@ a| Determines whether to use the xref:n1ql:n1ql-language-reference/cost-based-op
 
 == Plan Stability
 
-Configure settings for xref:n1ql:n1ql-manage/query-plan-stability.adoc[Query Plan Stability]. 
+Configure settings for xref:n1ql:n1ql-manage/query-plan-stability.adoc[Query Plan Stability].
 
 [cols="1,2,1",options="header"]
 |===
@@ -203,11 +203,10 @@ Configure settings for xref:n1ql:n1ql-manage/query-plan-stability.adoc[Query Pla
 a| Controls whether to save query execution plans to disk. 
 
 * *Off*: Does not save execution plans to disk. 
-Prepared statements remain in memory only and are cleared if the query node restart or upgrades. 
-* *On Prepared Statements*: Automatically saves execution plans to disk for all `PREPARE` statements. 
-* *On All Statements*: Automatically saves execution plans to disk for all queries, including `PREPARE` statements and ad-hoc queries.
+* *On Prepared Statements*: Automatically saves execution plans to disk for all prepared statements. 
+* *On All Statements*: Automatically saves execution plans to disk for all queries, including prepared statements and ad-hoc queries.
 
-| *Off*
+| Off
 
 | *Plan Stability Error Policy*
 
@@ -216,6 +215,7 @@ a| Determines how the Query Service behaves when a saved plan is unavailable.
 * *Strict*: Stops execution and returns the error to the application.
 * *Moderate*: Generates a new plan to execute the statement, but keeps the original saved plan.
 * *Flexible*: Generates a new plan to execute the statement and overwrites the saved plan with the new one.
+
 This setting is greyed out if *Plan Stability* is set to *Off*.
 
 For more information, see xref:n1ql:n1ql-manage/query-plan-stability.adoc#error-policies[].

--- a/modules/manage/pages/manage-settings/query-ui-settings.adoc
+++ b/modules/manage/pages/manage-settings/query-ui-settings.adoc
@@ -191,8 +191,9 @@ a| Determines whether to use the xref:n1ql:n1ql-language-reference/cost-based-op
 |===
 
 == Plan Stability
+[.status]#Couchbase Server 8.5#
 
-Configure settings for xref:n1ql:n1ql-manage/query-plan-stability.adoc[Query Plan Stability].
+Configure the mode and error policy for xref:n1ql:n1ql-manage/query-plan-stability.adoc[Query Plan Stability].
 
 [cols="1,2,1",options="header"]
 |===
@@ -200,29 +201,29 @@ Configure settings for xref:n1ql:n1ql-manage/query-plan-stability.adoc[Query Pla
 
 | *Plan Stability*
 
-a| Controls whether to save query execution plans to disk. 
+a| Controls whether the Query Service saves execution plans to disk, and for which statement types.
 
-* *Off*: Does not save execution plans to disk. 
-* *On Prepared Statements*: Automatically saves execution plans to disk for all prepared statements. 
-* *On All Statements*: Automatically saves execution plans to disk for all queries, including prepared statements and ad-hoc queries.
+Select 1 of the following:
 
-| Off
+* `Off`: Does not save execution plans to disk. 
+* `On Prepared Statements`: Saves execution plans to disk for all prepared statements. 
+* `On All Statements`: Saves execution plans to disk for all queries, including prepared statements and ad-hoc queries.
+
+| `Off`
 
 | *Plan Stability Error Policy*
 
-a| Determines how the Query Service behaves when a saved plan is unavailable. 
+a| Controls how the Query Service handles a query when a saved plan is unavailable.
 
-* *Strict*: Stops execution and returns the error to the application.
-* *Moderate*: Generates a new plan to execute the statement, but keeps the original saved plan.
-* *Flexible*: Generates a new plan to execute the statement and overwrites the saved plan with the new one.
+Select 1 of the following:
 
-This setting is greyed out if *Plan Stability* is set to *Off*.
+* `Strict`: Stops execution and returns the error to the application.
+* `Moderate`: Generates a new plan to execute the statement, but keeps the original saved plan.
+* `Flexible`: Generates a new plan to execute the statement and overwrites the saved plan with the new one.
 
-For more information, see xref:n1ql:n1ql-manage/query-plan-stability.adoc#error-policies[].
+For more information, see xref:n1ql:n1ql-manage/query-plan-stability.adoc#error-policies[Error Policies].
 
-| Moderate
-
-Unavailable if Plan Stability is Off
+| `Moderate` (Greyed out if *Plan Stability* is `Off`)
 |===
 
 == Query Settings via CLI

--- a/modules/manage/pages/manage-settings/query-ui-settings.adoc
+++ b/modules/manage/pages/manage-settings/query-ui-settings.adoc
@@ -220,9 +220,9 @@ This setting is greyed out if *Plan Stability* is set to *Off*.
 
 For more information, see xref:n1ql:n1ql-manage/query-plan-stability.adoc#error-policies[].
 
-| *Moderate*
+| Moderate
 
-Unavailable if *Plan Stability* is *Off*.
+Unavailable if Plan Stability is Off
 |===
 
 == Query Settings via CLI

--- a/modules/manage/pages/manage-settings/query-ui-settings.adoc
+++ b/modules/manage/pages/manage-settings/query-ui-settings.adoc
@@ -190,6 +190,41 @@ a| Determines whether to use the xref:n1ql:n1ql-language-reference/cost-based-op
 | Selected (Enabled)
 |===
 
+== Plan Stability
+
+Configure settings for xref:n1ql:n1ql-manage/query-plan-stability.adoc[Query Plan Stability]. 
+
+[cols="1,2,1",options="header"]
+|===
+| Setting | Description | Default Value
+
+| *Plan Stability*
+
+a| Controls whether to save query execution plans to disk. 
+
+* *Off*: Does not save execution plans to disk. 
+Prepared statements remain in memory only and are cleared if the query node restart or upgrades. 
+* *On Prepared Statements*: Automatically saves execution plans to disk for all `PREPARE` statements. 
+* *On All Statements*: Automatically saves execution plans to disk for all queries, including `PREPARE` statements and ad-hoc queries.
+
+| *Off*
+
+| *Plan Stability Error Policy*
+
+a| Determines how the Query Service behaves when a saved plan is unavailable. 
+
+* *Strict*: Stops execution and returns the error to the application.
+* *Moderate*: Generates a new plan to execute the statement, but keeps the original saved plan.
+* *Flexible*: Generates a new plan to execute the statement and overwrites the saved plan with the new one.
+This setting is greyed out if *Plan Stability* is set to *Off*.
+
+For more information, see xref:n1ql:n1ql-manage/query-plan-stability.adoc#error-policies[].
+
+| *Moderate*
+
+Unavailable if *Plan Stability* is *Off*.
+|===
+
 == Query Settings via CLI
 
 You can set all of the cluster-level query settings, except for the CURL access control settings, using the xref:cli:cbcli/couchbase-cli-setting-query.adoc[setting-query] command.

--- a/modules/manage/pages/manage-settings/query-ui-settings.adoc
+++ b/modules/manage/pages/manage-settings/query-ui-settings.adoc
@@ -205,9 +205,11 @@ a| Controls whether the Query Service saves execution plans to disk, and for whi
 
 Select 1 of the following:
 
-* `Off`: Does not save execution plans to disk. 
-* `On Prepared Statements`: Saves execution plans to disk for all prepared statements. 
-* `On All Statements`: Saves execution plans to disk for all queries, including prepared statements and ad-hoc queries.
+* `Off`: Does not save execution plans to disk.
+* `On Prepared Statements`: Saves execution plans to disk for all prepared statements.
+* `On All Statements`: Saves execution plans to disk for all queries, including prepared statements and ad hoc queries.
+* `Frozen`: Does not save execution plans for new ad hoc queries, but allows the use of existing saved plans.
+
 
 | `Off`
 

--- a/preview/DOC-14217-add-plan-stability-settings.yml
+++ b/preview/DOC-14217-add-plan-stability-settings.yml
@@ -1,0 +1,5 @@
+sources:
+    docs-devex:
+      branches: [DOC-14217-query-plan-stability, release/8.5]
+
+  

--- a/preview/DOC-14217-add-plan-stability-settings.yml
+++ b/preview/DOC-14217-add-plan-stability-settings.yml
@@ -1,5 +1,7 @@
 sources:
     docs-devex:
-      branches: [DOC-14217-query-plan-stability, release/8.5]
+      branches: DOC-14217-query-plan-stability
+override:
+  startPage: server:introduction:intro.adoc
 
   

--- a/preview/DOC-14217-add-plan-stability-settings.yml
+++ b/preview/DOC-14217-add-plan-stability-settings.yml
@@ -1,7 +1,27 @@
 sources:
     docs-devex:
       branches: DOC-14217-query-plan-stability
-override:
-  startPage: server:introduction:intro.adoc
 
+#    docs-analytics:
+#      branches: release/8.0
+
+    couchbase-cli:
+      url: https://github.com/couchbaselabs/couchbase-cli-doc
+      branches: master
+      startPaths: docs/
+      
+#    backup:
+#      branches: master
+#      startPaths: docs/
+
+    cb-swagger:
+      url: https://github.com/couchbaselabs/cb-swagger
+      branches: release/8.5
+      start_path: docs
+
+  # Minimal SDK build
+#    docs-sdk-common:
+#      branches: [release/8.0]
+#    docs-sdk-java:
+#      branches: [3.11]
   


### PR DESCRIPTION
Updates the `Manage Settings` > `Query` page to introduce new controls for Query Plan Stability, releasing as part of Couchbase Server 8.5 (Totoro).

Doc ticket: DOC-14217

Doc Preview: [Plan Stability Settings](https://preview.docs-test.couchbase.com/docs-server-DOC-14217-add-plan-stability-settings/server/current/manage/manage-settings/query-ui-settings.html#plan-stability)

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.

Related PR: https://github.com/couchbaselabs/docs-devex/pull/678

