### PR TITLE
[fix-release-date-for-8.0.3]: Corrected release date and improved release note clarity

### DIFF
--- a/modules/release-notes/partials/docs-server-8.0.3-fixes-and-improvements.adoc
+++ b/modules/release-notes/partials/docs-server-8.0.3-fixes-and-improvements.adoc
@@ -1,7 +1,7 @@
 [#release-8-0-3]
-== Release 8.0.3 (August 2026)
+== Release 8.0.3 (September 2026)
 
-Couchbase Server 8.0.3 was released in August 2026.
+Couchbase Server 8.0.3 was released in September 2026.
 This maintenance release contains fixes for issues listed below.
 
 === Fixed Issues
@@ -14,7 +14,7 @@ This fix prevents a critical bug where undefined bucket storage properties cause
 The issue affected buckets created before version 5.0.0.
 
 link:https://jira.issues.couchbase.com/browse/MB-70951[MB-70951]::
-The `/metrics` REST API previously reported certain low cardinality statistics twice.
+The `/metrics` REST API reported certain low-cardinality statistics twice.
 This update ensures each statistic appears only once in the output.
 
 ==== Data Service
@@ -32,7 +32,7 @@ The fix ensures all filter conditions are evaluated before applying the limit.
 ==== XDCR
 
 link:https://jira.issues.couchbase.com/browse/MB-72305[MB-72305]::
-Upgraded nodes now correctly handle rebalancing when replications or buckets were deleted and recreated.
+Upgraded nodes now handle rebalancing when replications or buckets were deleted and recreated.
 This prevents issues with stale manifests and incomplete backfills.
 
 link:https://jira.issues.couchbase.com/browse/MB-71586[MB-71586]::
@@ -44,7 +44,7 @@ A race condition causing deadlocks during replication pause or deletion has been
 The fix ensures goroutines exit properly during rollback operations.
 
 link:https://jira.issues.couchbase.com/browse/MB-71013[MB-71013]::
-XDCR now correctly handles conflict resolution for locked documents on target clusters.
+XDCR now handles conflict resolution for locked documents on target clusters.
 This fix prevents unnecessary skipping of mutations and potential data loss.
 
 ==== Tools


### PR DESCRIPTION

Fixed release date (we're now in September), and made a few grammar cleanups.