### PR TITLE
[DOC-14425][AI] Correct "reblance" typo in rebalance docs

### DIFF
--- a/modules/rebalance-reference/pages/rebalance-reference.adoc
+++ b/modules/rebalance-reference/pages/rebalance-reference.adoc
@@ -16,7 +16,7 @@ On conclusion of the rebalance, the report can be accessed in any of the followi
 
 * By means of the REST API, as described in xref:rest-api:rest-get-cluster-tasks.adoc[Getting Cluster Tasks].
 
-* By accessing the directory `/opt/couchbase/var/lib/couchbase/logs/reblance` on _any_ of the cluster nodes.
+* By accessing the directory `/opt/couchbase/var/lib/couchbase/logs/rebalance` on _any_ of the cluster nodes.
 A rebalance report is maintained here for (up to) the last _five_ rebalances performed.
 Each report is provided as a `*.json` file, whose name indicates the time at which the report was run &#8212; for example, `rebalance_report_2020-03-17T11:10:17Z.json`.
 +

--- a/modules/rest-api/pages/rest-get-rebalance-retry.adoc
+++ b/modules/rest-api/pages/rest-get-rebalance-retry.adoc
@@ -33,7 +33,7 @@ A malformed URI gives `404 Object Not Found`.
 [#example]
 == Example
 
-The following example obtains information on pending reblance-retries.
+The following example obtains information on pending rebalance-retries.
 Note that the command is piped to the https://stedolan.github.io/jq/[jq] tool, to facilitate output-readability.
 
 ----


### PR DESCRIPTION
Fixes [DOC-14425](https://jira.issues.couchbase.com/browse/DOC-14425).

## What changed

The rebalance report directory was written as `/opt/couchbase/var/lib/couchbase/logs/reblance`. Corrected to `.../logs/rebalance`.

| File | Line | Change |
|---|---|---|
| `modules/rebalance-reference/pages/rebalance-reference.adoc` | 19 | `logs/reblance` -> `logs/rebalance` (the instance cited in the ticket) |
| `modules/rest-api/pages/rest-get-rebalance-retry.adoc` | 36 | `pending reblance-retries` -> `pending rebalance-retries` |

The second instance was **not** cited in the ticket. It is the same typo, found by searching the repository. No occurrences of `reblance` remain.

## Verification

Built with the production asciidoc attribute set and diffed against a clean-tree baseline of `release/8.0`:

```
PASS[docs-server @ DOC-14425]: no new build diagnostics.
```

No anchors or xref targets were touched, so the known anchor-validation gap does not apply here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-14425]: https://couchbasecloud.atlassian.net/browse/DOC-14425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ