### PR TITLE
[DOC-14519][AI] Point durable writes note at the correct section

### DIFF
--- a/modules/introduction/partials/new-features-80.adoc
+++ b/modules/introduction/partials/new-features-80.adoc
@@ -94,7 +94,7 @@ Use this setting only in special cases such as when you're performing a graceful
 Always turn off this setting as soon as possible.
 ====
 
-See xref:learn:clusters-and-availability/automatic-failover.adoc#auto-failover-and-ephemeral-buckets[Auto-Failover and Ephemeral Buckets] for more information about this feature.
+See xref:learn:data/durability.adoc#maintaining-durable-writes[Maintaining Durable Writes During Replica Failovers] for more information about this feature.
 
 ==== Configurable Warmup Behavior (Background Warmup)
 


### PR DESCRIPTION
Partially addresses [DOC-14519](https://jira.issues.couchbase.com/browse/DOC-14519). **Do not close the ticket on merge.**

## What changed

`modules/introduction/partials/new-features-80.adoc` (included by `introduction/whats-new.adoc`), line 97.

The 8.0 "What's New" entry for *Optionally Maintain Durable Write Availability After Losing Majority Due to Failover* linked to a section about ephemeral buckets:

```diff
-See xref:learn:clusters-and-availability/automatic-failover.adoc#auto-failover-and-ephemeral-buckets[Auto-Failover and Ephemeral Buckets] ...
+See xref:learn:data/durability.adoc#maintaining-durable-writes[Maintaining Durable Writes During Replica Failovers] ...
```

The new target is the section that actually describes the feature.

## What this does NOT fix

The ticket reports two problems. The second is that line 83 calls this a **cluster-level** option while the core documentation describes a **bucket-level** setting. The ticket itself says this needs confirming with Engineering before the wording changes, so it is deliberately left alone here.

## Verification

Anchor `[#maintaining-durable-writes]` confirmed present at `modules/learn/pages/data/durability.adoc:373`. Checked by inspection, because Antora validates xref page targets but not `#fragment` anchors.

Build diffed against a clean-tree baseline of `release/8.0`:

```
PASS[docs-server @ DOC-14519]: no new build diagnostics.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-14519]: https://couchbasecloud.atlassian.net/browse/DOC-14519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ