### PR TITLE
[DOC-14595][AI] Document disk_io_optimized for reader and writer threads

### DIFF
--- a/modules/rest-api/pages/rest-reader-writer-thread-config.adoc
+++ b/modules/rest-api/pages/rest-reader-writer-thread-config.adoc
@@ -100,8 +100,8 @@ To set the global thread allocations for Couchbase Server, send a `POST` to the 
 ----
 curl -X POST http[s]://{host}:{port}/pools/default/settings/memcached/global
   -u $USER:$PASSWORD
-  [-d num_reader_threads=<integer>]
-  [-d num_writer_threads=<integer>]
+  [-d num_reader_threads=<integer>|disk_io_optimized]
+  [-d num_writer_threads=<integer>|disk_io_optimized]
   [-d num_nonio_threads=<integer>]
   [-d num_auxio_threads=<integer>]
   [-d num_storage_threads=<integer>]
@@ -118,9 +118,13 @@ include::partial$user_pwd_host_port_params.adoc[]
 
 `num_reader_threads`::
 (optional) Sets the number of threads Couchbase Server uses to read data.
+Accepts an integer, or `disk_io_optimized` to allocate threads equal to the number of CPU cores on the node.
+For guidance on when to choose `disk_io_optimized`, particularly for buckets that use the Magma storage engine, see xref:manage:manage-settings/general-settings.adoc#data-settings[Data Settings].
 
 `num_writer_threads`:: 
 (optional) Sets the number of threads Couchbase Server uses to write data.
+Accepts an integer, or `disk_io_optimized` to allocate threads equal to the number of CPU cores on the node.
+For guidance on when to choose `disk_io_optimized`, particularly for buckets that use the Magma storage engine, see xref:manage:manage-settings/general-settings.adoc#data-settings[Data Settings].
 
 `num_nonio_threads`:: 
 (optional) Sets the number of NonIO threads to be used by Couchbase Server.


### PR DESCRIPTION
Fixes [DOC-14595](https://jira.issues.couchbase.com/browse/DOC-14595).

## What changed

`modules/rest-api/pages/rest-reader-writer-thread-config.adoc` (*Setting Storage Thread Allocations*).

`num_reader_threads` and `num_writer_threads` were described only as taking a number of threads. Neither mentioned `disk_io_optimized`, so a reader working from the REST reference had no way to discover it. Added the accepted value to both parameter descriptions and to the curl syntax block, with a link to *Data Settings* for guidance on when to use it.

## Where the facts came from

Nothing here is invented. Every claim traces to the ticket or to existing pages in this repository:

| Claim | Source |
|---|---|
| `disk_io_optimized` is accepted by both parameters | Ticket, including a working `curl` example |
| It allocates threads equal to the number of CPU cores | `manage/manage-settings/general-settings.adoc:224` |
| Recommended for Magma buckets | `learn/buckets-memory-and-storage/storage-engines.adoc:49` |

I deliberately did **not** add `default` as a documented value. The UI has a *Default* option and the sibling `num_nonio_threads` parameter documents a `default` value, so it is probably accepted here too, but neither the ticket nor this repository states it. Worth a follow-up if someone can confirm.

## Verification

Anchor `[#data-settings]` confirmed at `general-settings.adoc:196`, by inspection, since Antora validates xref page targets but not `#fragment` anchors.

```
PASS[docs-server @ DOC-14595]: no new build diagnostics.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-14595]: https://couchbasecloud.atlassian.net/browse/DOC-14595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ