### PR TITLE
[DOC-14425][AI] Correct "reblance" typo in rebalance docs (release/8.5)

### DIFF
--- a/modules/rebalance-reference/pages/rebalance-reference.adoc
+++ b/modules/rebalance-reference/pages/rebalance-reference.adoc
@@ -16,7 +16,7 @@ On conclusion of the rebalance, the report can be accessed in any of the followi
 
 * By means of the REST API, as described in xref:rest-api:rest-get-cluster-tasks.adoc[Getting Cluster Tasks].
 
-* By accessing the directory `/opt/couchbase/var/lib/couchbase/logs/reblance` on _any_ of the cluster nodes.
+* By accessing the directory `/opt/couchbase/var/lib/couchbase/logs/rebalance` on _any_ of the cluster nodes.
 A rebalance report is maintained here for (up to) the last _five_ rebalances performed.
 Each report is provided as a `*.json` file, whose name indicates the time at which the report was run &#8212; for example, `rebalance_report_2020-03-17T11:10:17Z.json`.
 +

--- a/modules/rest-api/pages/rest-get-rebalance-retry.adoc
+++ b/modules/rest-api/pages/rest-get-rebalance-retry.adoc
@@ -33,7 +33,7 @@ A malformed URI gives `404 Object Not Found`.
 [#example]
 == Example
 
-The following example obtains information on pending reblance-retries.
+The following example obtains information on pending rebalance-retries.
 Note that the command is piped to the https://stedolan.github.io/jq/[jq] tool, to facilitate output-readability.
 
 ----


### PR DESCRIPTION
Companion to #4156. Same fix, applied to `release/8.5`.

## Why a second PR

A comment on [DOC-14425](https://jira.issues.couchbase.com/browse/DOC-14425) states:

> 7.6 and prior are fine, 8.0 needs the change and the pre release/draft Totoro branch since we've created that.

Totoro is the release since renumbered to 8.5. #4156 covered only `release/8.0`, so it delivered half the ticket. This PR covers the rest.

Verified against the branches:

| Branch | `reblance` present | Action |
|---|---|---|
| `release/8.0` | both instances | #4156 |
| `release/8.5` | both instances | this PR |
| `release/7.6` | reported instance **absent** | none, matching the comment |

`release/7.6` does still contain the second, unreported instance in `rest-get-rebalance-retry.adoc`. Left alone, since the comment says 7.6 is fine and the ticket does not cite it. Worth a separate ticket if you disagree.

## What changed

| File | Change |
|---|---|
| `modules/rebalance-reference/pages/rebalance-reference.adoc` | `logs/reblance` -> `logs/rebalance` |
| `modules/rest-api/pages/rest-get-rebalance-retry.adoc` | `pending reblance-retries` -> `pending rebalance-retries` |

No occurrences of `reblance` remain on this branch.

## Verification

```
PASS[docs-server @ DOC-14425-release-8.5 vs baseline release/8.5]: no new build diagnostics.
```

Baselined separately against `release/8.5` (552 diagnostics) rather than `release/8.0` (578), since the two branches differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-14425]: https://couchbasecloud.atlassian.net/browse/DOC-14425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ