### PR TITLE
[DOC-14444][AI] Add memory and XDCR criteria for choosing 1024 vBuckets

### DIFF
--- a/modules/learn/pages/buckets-memory-and-storage/storage-engines.adoc
+++ b/modules/learn/pages/buckets-memory-and-storage/storage-engines.adoc
@@ -116,6 +116,11 @@ In this case, the 1024 vBucket configuration is less likely to have data imbalan
 Also, Magma with 1024 vBuckets uses less CPU for operations such as compaction verse the 128 vBucket configuration.
 * Your applications make heavy use of transactions with persistence-based durability.
 * Your dataset will grow beyond Couchstore's 3{nbsp}TB limit.
+* You can allocate at least 1{nbsp}GiB of memory per node to the bucket.
+The 1024 vBucket configuration gives better performance at scale.
+* You need to replicate into the bucket by XDCR from a cluster running a version earlier than Couchbase Server 8.0.
+Those versions require both buckets to have the same number of vBuckets, and do not support 128 vBuckets, so the target bucket must use 1024.
+See xref:learn:clusters-and-availability/xdcr-overview.adoc[] for the full compatibility rules.
 
 When should you choose Couchstore?::
 You should use the Couchstore backend if any of the following are true:


### PR DESCRIPTION
Fixes [DOC-14444](https://jira.issues.couchbase.com/browse/DOC-14444).

## What changed

`modules/learn/pages/buckets-memory-and-storage/storage-engines.adoc`, in *Which Storage Engine Should You Use?*

The ticket asks for two criteria to be highlighted in the Magma 128 vs 1024 vBucket decision. Both were documented elsewhere on the site but missing from the list a reader actually consults when choosing. Added as two bullets to *When to choose Magma with 1024 vBuckets*.

## Sources

| Claim | Source |
|---|---|
| At least 1 GiB per node points to 1024 vBuckets, for better performance at scale | `storage-engines.adoc:30`, and the ticket |
| Pre-8.0 clusters require matching vBucket counts and do not support 128 | `xdcr-overview.adoc:319-334` |
| So an XDCR target replicated into from pre-8.0 must use 1024 | `learn/partials/xdcr-magma-128-vbucket-incompatibility.adoc` |

The ticket phrases the second point as "XDCR replication from a bucket in Server version earlier than 8.0". I used the repository's own wording for the constraint instead, since `xdcr-overview.adoc` states it more precisely and distinguishes direction, which matters here.

The added xref points at the page rather than a section anchor, so there is no anchor to verify by hand.

## Verification

```
PASS[docs-server @ DOC-14444 vs baseline release/8.0]: no new build diagnostics.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-14444]: https://couchbasecloud.atlassian.net/browse/DOC-14444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ