### PR TITLE
[DOC-14406][AI] Correct service flags in the update-services CLI syntax

### DIFF
--- a/modules/manage/pages/manage-nodes/modify-services-and-rebalance.adoc
+++ b/modules/manage/pages/manage-nodes/modify-services-and-rebalance.adoc
@@ -121,7 +121,7 @@ To modify non-Data services on the existing nodes of a cluster using the CLI, us
 couchbase-cli rebalance -c <network_address> \
 --username <username> \
 --password <password> \
---update-services [--index-[add|remove] <list-of-nodes>] [--n1ql-[add|remove] <list-of-nodes>] [--fts-[add|remove] <list-of-nodes>] [--cbas-[add|remove] <list-of-nodes>] [--eventing-[add|remove] <list-of-nodes>] [--backup-[add|remove] <list-of-nodes>]
+--update-services [--index-[add|remove] <list-of-nodes>] [--query-[add|remove] <list-of-nodes>] [--fts-[add|remove] <list-of-nodes>] [--analytics-[add|remove] <list-of-nodes>] [--eventing-[add|remove] <list-of-nodes>] [--backup-[add|remove] <list-of-nodes>]
 ----
 
 These are the options for modifying non-data services:


### PR DESCRIPTION
Fixes [DOC-14406](https://jira.issues.couchbase.com/browse/DOC-14406).

## What changed

`modules/manage/pages/manage-nodes/modify-services-and-rebalance.adoc`, line 124, in the `couchbase-cli rebalance` syntax block.

```diff
---update-services [--index-[add|remove] ...] [--n1ql-[add|remove] ...] [--fts-...] [--cbas-[add|remove] ...] ...
+--update-services [--index-[add|remove] ...] [--query-[add|remove] ...] [--fts-...] [--analytics-[add|remove] ...] ...
```

The ticket reports `--n1ql-`. `--cbas-` is the same error on the same line and is corrected here too.

## Sources

| Claim | Source |
|---|---|
| The option is `--query-add` / `--query-remove` | `couchbase-cli-rebalance.adoc:19,68` |
| The option is `--analytics-add` / `--analytics-remove` | `couchbase-cli-rebalance.adoc:19,80` |
| `--n1ql-add` is rejected by the tool | Ticket, with terminal output: `ERROR: unrecognized arguments: --n1ql-add` |

The CLI reference lists exactly six service options: `--fts-`, `--index-`, `--query-`, `--backup-`, `--analytics-`, `--eventing-`. Neither `--n1ql-` nor `--cbas-` appears.

## Not changed

The service *names* on this page are correct and untouched. The service is still called `n1ql`, as the tool's own output confirms ("already provides the n1ql service"). Only the command-line options were wrong.

## Verification

```
PASS[docs-server @ DOC-14406 vs baseline release/8.0]: no new build diagnostics.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-14406]: https://couchbasecloud.atlassian.net/browse/DOC-14406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ